### PR TITLE
feat: support partial short IDs for run references

### DIFF
--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -49,12 +49,16 @@ func runOpen(refStr string, opts *openOptions) error {
 
 	var path string
 
-	// Try as short ID first
+	// Try as short ID prefix first (2-6 hex chars)
 	if shortIDRegex.MatchString(refStr) {
 		run, err := st.GetRunByShortID(refStr)
 		if err == nil {
 			path = run.Path
+		} else if len(refStr) == 6 {
+			// For full 6-char short ID that failed, report the error
+			return err
 		}
+		// For shorter prefixes, fall through to try as regular ref
 	}
 
 	if path == "" {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -140,22 +140,26 @@ func getStore() (store.Store, error) {
 	}
 }
 
-// shortIDRegex matches a 6-char hex string (git-style short ID)
-var shortIDRegex = regexp.MustCompile(`^[0-9a-f]{6}$`)
+// shortIDRegex matches a 2-6 char hex string (git-style short ID prefix)
+var shortIDRegex = regexp.MustCompile(`^[0-9a-f]{2,6}$`)
 
 // resolveRun resolves a run by short ID or run reference (issue#run or issue)
 // Accepts:
-//   - 6-char hex short ID (e.g., "a3b4c5")
+//   - 2-6 char hex short ID prefix (e.g., "a3", "a3b4", "a3b4c5")
 //   - Full run ref (e.g., "my-task#20231220-100000")
 //   - Issue ID for latest run (e.g., "my-task")
 func resolveRun(st store.Store, refStr string) (*model.Run, error) {
-	// First, try as a short ID (6-char hex)
+	// First, try as a short ID prefix (2-6 hex chars)
 	if shortIDRegex.MatchString(refStr) {
 		run, err := st.GetRunByShortID(refStr)
 		if err == nil {
 			return run, nil
 		}
-		// Fall through to try as regular ref
+		// If it's exactly 6 chars and failed, report the short ID error
+		// For shorter prefixes, fall through to try as regular ref
+		if len(refStr) == 6 {
+			return nil, err
+		}
 	}
 
 	// Try as a regular run reference

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -52,13 +52,17 @@ func runStop(refStr string, opts *stopOptions) error {
 		return err
 	}
 
-	// Try as short ID first
+	// Try as short ID prefix first (2-6 hex chars)
 	if shortIDRegex.MatchString(refStr) {
 		run, err := st.GetRunByShortID(refStr)
 		if err == nil {
 			return stopRun(st, run, opts)
 		}
-		// Fall through to try as regular ref
+		// If it's a full 6-char short ID that failed, report the error
+		// For shorter prefixes, fall through to try as regular ref
+		if len(refStr) == 6 {
+			return err
+		}
 	}
 
 	ref, err := model.ParseRunRef(refStr)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,7 +32,8 @@ type Store interface {
 	// GetRun retrieves a run by reference
 	GetRun(ref *model.RunRef) (*model.Run, error)
 
-	// GetRunByShortID finds a run by its 6-char short ID
+	// GetRunByShortID finds a run by its short ID prefix (2-6 hex chars)
+	// Returns an error if no match found or if multiple runs match (ambiguous)
 	GetRunByShortID(shortID string) (*model.Run, error)
 
 	// GetLatestRun retrieves the latest run for an issue


### PR DESCRIPTION
## Summary

- Allow users to specify 2-6 character hex prefixes when referencing runs, similar to how git handles commit hashes
- Update `shortIDRegex` to accept 2-6 hex characters instead of exactly 6
- Modify `GetRunByShortID` to match by prefix instead of exact match
- Add detailed error messages for ambiguous matches listing matching runs with a hint to use more characters

## Examples

```bash
orch attach 31909e   # Works - full 6-char short ID
orch attach 3190     # Works - if unambiguous  
orch attach 319      # Works - if unambiguous
orch attach 31       # Works - if unambiguous
orch attach 3        # Error - too short (minimum 2 chars)
orch attach 31       # Error with details if ambiguous
```

## Test plan

- [x] Unit tests pass for partial short ID matching (2, 4, 6 char prefixes)
- [x] Unit tests pass for not found error cases
- [x] Unit tests pass for ambiguous prefix error handling
- [x] Manual testing confirms `orch show e8d4` works with 4-char prefix
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)