### PR TITLE
feat(orch-007): prompt agent to create PR at end of run

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,11 +9,13 @@ import (
 
 // Config holds orch configuration
 type Config struct {
-	Vault        string `yaml:"vault"`
-	Agent        string `yaml:"agent"`
-	WorktreeRoot string `yaml:"worktree_root"`
-	BaseBranch   string `yaml:"base_branch"`
-	LogLevel     string `yaml:"log_level"`
+	Vault          string `yaml:"vault"`
+	Agent          string `yaml:"agent"`
+	WorktreeRoot   string `yaml:"worktree_root"`
+	BaseBranch     string `yaml:"base_branch"`
+	LogLevel       string `yaml:"log_level"`
+	PromptTemplate string `yaml:"prompt_template"` // Path to custom prompt template
+	NoPR           bool   `yaml:"no_pr"`           // Disable PR instructions by default
 }
 
 // configFile is the name of the config file
@@ -120,6 +122,12 @@ func loadFromFile(path string, cfg *Config) error {
 	if fileCfg.LogLevel != "" {
 		cfg.LogLevel = fileCfg.LogLevel
 	}
+	if fileCfg.PromptTemplate != "" {
+		cfg.PromptTemplate = fileCfg.PromptTemplate
+	}
+	// NoPR is a boolean, so we need special handling - yaml will parse it
+	// For now, let the yaml directly merge it
+	cfg.NoPR = fileCfg.NoPR
 
 	return nil
 }
@@ -140,6 +148,12 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("ORCH_LOG_LEVEL"); v != "" {
 		cfg.LogLevel = v
+	}
+	if v := os.Getenv("ORCH_PROMPT_TEMPLATE"); v != "" {
+		cfg.PromptTemplate = v
+	}
+	if v := os.Getenv("ORCH_NO_PR"); v != "" {
+		cfg.NoPR = v == "true" || v == "1" || v == "yes"
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -39,6 +39,7 @@ type RunState struct {
 	LastOutputAt time.Time
 	LastCheckAt  time.Time
 	OutputHash   string // Simple hash to detect changes
+	PRRecorded   bool   // Whether PR artifact has been recorded
 }
 
 // New creates a new Daemon instance
@@ -112,11 +113,11 @@ func (d *Daemon) Stop() {
 	d.wg.Wait()
 }
 
-// monitorAll checks all active runs (running, booting, blocked, or unknown)
+// monitorAll checks all active runs (running, booting, blocked, pr_open, or unknown)
 // Non-terminal runs are monitored so we can detect state transitions
 func (d *Daemon) monitorAll() {
 	runs, err := d.store.ListRuns(&store.ListRunsFilter{
-		Status: []model.Status{model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusUnknown},
+		Status: []model.Status{model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusPROpen, model.StatusUnknown},
 	})
 	if err != nil {
 		d.logger.Printf("error listing runs: %v", err)


### PR DESCRIPTION
## Summary

- Update `buildAgentPrompt` to include PR creation instructions by default
- Add `--no-pr` flag to skip PR instructions in agent prompt
- Add `--prompt-template` flag for custom prompt template files
- Add `prompt_template` and `no_pr` config options in `.orch/config.yaml`
- Support `ORCH_PROMPT_TEMPLATE` and `ORCH_NO_PR` environment variables
- Add daemon monitoring for PR creation events with automatic artifact recording

## Changes

The default prompt now instructs the agent to:
1. Implement the changes described in the issue
2. Run tests to verify changes work correctly
3. Create a pull request with proper title and body referencing the issue

### New Flags

- `--no-pr` - Skip PR creation instructions in agent prompt
- `--prompt-template <file>` - Custom prompt template file

### Configuration

New config options in `.orch/config.yaml`:
```yaml
prompt_template: path/to/template.txt  # Custom prompt template
no_pr: false                           # Disable PR instructions by default
```

### PR Detection

When an agent creates a PR, the daemon will detect the PR URL in the output and:
- Record a PR artifact event: `artifact | pr | url=https://github.com/...`
- Update status to: `status | pr_open`

## Test Plan

- [x] Build passes (`go build ./...`)
- [x] Static analysis passes (`go vet ./...`)
- [x] Model tests pass
- [x] New flags appear in `orch run --help`

Closes: orch-007

🤖 Generated with [Claude Code](https://claude.com/claude-code)