### PR TITLE
feat(orch-010): show issue summary in orch ps output

### DIFF
--- a/internal/model/issue.go
+++ b/internal/model/issue.go
@@ -4,6 +4,7 @@ package model
 type Issue struct {
 	ID          string
 	Title       string
+	Summary     string            // Short one-line summary for display
 	Body        string
 	Path        string            // File path to issue document
 	Frontmatter map[string]string // YAML frontmatter fields

--- a/internal/store/file/file.go
+++ b/internal/store/file/file.go
@@ -147,9 +147,19 @@ func (s *FileStore) parseIssueFile(path string) (*model.Issue, error) {
 		body = strings.Join(lines[bodyStart:], "\n")
 	}
 
+	// Get summary (fall back to truncated title if not set)
+	summary := frontmatter["summary"]
+	if summary == "" && title != "" {
+		summary = title
+		if len(summary) > 50 {
+			summary = summary[:47] + "..."
+		}
+	}
+
 	return &model.Issue{
 		ID:          issueID,
 		Title:       title,
+		Summary:     summary,
 		Body:        body,
 		Path:        path,
 		Frontmatter: frontmatter,


### PR DESCRIPTION
## Summary
- Add `summary` frontmatter field to issues for quick context in listings
- Display summary column in `orch ps` output (replaces branch column)
- Display summary column in `orch issue list` output
- Add `--summary` flag to `orch issue create`
- Fall back to truncated title if summary not set

## Test plan
- [ ] Create issue with `--summary` flag and verify frontmatter contains summary
- [ ] Run `orch ps` and verify SUMMARY column shows issue summaries
- [ ] Run `orch issue list` and verify SUMMARY column appears
- [ ] Verify long summaries are truncated with "..."
- [ ] Verify issues without summary fall back to truncated title

🤖 Generated with [Claude Code](https://claude.com/claude-code)