### PR TITLE
Detect API limit blocked state

### DIFF
--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -132,7 +132,7 @@ func parseStatus(s string) ([]model.Status, error) {
 	switch status {
 	case model.StatusDone, model.StatusFailed, model.StatusCanceled:
 		return []model.Status{status}, nil
-	case model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusQueued:
+	case model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusBlockedAPI, model.StatusQueued:
 		return nil, fmt.Errorf("cannot delete %s runs (use 'orch stop' first)", status)
 	default:
 		return nil, fmt.Errorf("unknown status: %s", s)
@@ -280,7 +280,7 @@ func deleteRuns(st store.Store, runs []*model.Run, opts *deleteOptions) error {
 	var activeRuns []*model.Run
 	var deletableRuns []*model.Run
 	for _, run := range runs {
-		if run.Status == model.StatusRunning || run.Status == model.StatusBooting || run.Status == model.StatusBlocked {
+		if run.Status == model.StatusRunning || run.Status == model.StatusBooting || run.Status == model.StatusBlocked || run.Status == model.StatusBlockedAPI {
 			activeRuns = append(activeRuns, run)
 		} else {
 			deletableRuns = append(deletableRuns, run)

--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -196,6 +196,7 @@ func runIssueList() error {
 		for _, run := range runsByIssue[issue.ID] {
 			if run.Status == model.StatusRunning ||
 				run.Status == model.StatusBlocked ||
+				run.Status == model.StatusBlockedAPI ||
 				run.Status == model.StatusBooting ||
 				run.Status == model.StatusQueued {
 				info.Runs = append(info.Runs, runSummary{

--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -32,7 +32,7 @@ func newPsCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&opts.Status, "status", nil, "Filter by status (running,blocked,failed,pr_open,done)")
+	cmd.Flags().StringSliceVar(&opts.Status, "status", nil, "Filter by status (running,blocked,blocked_api,failed,pr_open,done)")
 	cmd.Flags().StringVar(&opts.Issue, "issue", "", "Filter by issue ID")
 	cmd.Flags().IntVar(&opts.Limit, "limit", 50, "Maximum number of runs to show")
 	cmd.Flags().StringVar(&opts.Sort, "sort", "updated", "Sort by (updated|started)")
@@ -174,15 +174,16 @@ func outputTable(runs []*model.Run) error {
 func colorStatus(status model.Status) string {
 	// ANSI color codes for terminal
 	colors := map[model.Status]string{
-		model.StatusRunning:  "\033[32m", // green
-		model.StatusBlocked:  "\033[33m", // yellow
-		model.StatusFailed:   "\033[31m", // red
-		model.StatusDone:     "\033[34m", // blue
-		model.StatusPROpen:   "\033[36m", // cyan
-		model.StatusQueued:   "\033[37m", // white
-		model.StatusBooting:  "\033[32m", // green
-		model.StatusCanceled: "\033[90m", // gray
-		model.StatusUnknown:  "\033[35m", // magenta - agent exited unexpectedly
+		model.StatusRunning:    "\033[32m", // green
+		model.StatusBlocked:    "\033[33m", // yellow
+		model.StatusBlockedAPI: "\033[33m", // yellow
+		model.StatusFailed:     "\033[31m", // red
+		model.StatusDone:       "\033[34m", // blue
+		model.StatusPROpen:     "\033[36m", // cyan
+		model.StatusQueued:     "\033[37m", // white
+		model.StatusBooting:    "\033[32m", // green
+		model.StatusCanceled:   "\033[90m", // gray
+		model.StatusUnknown:    "\033[35m", // magenta - agent exited unexpectedly
 	}
 
 	reset := "\033[0m"

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -102,7 +102,7 @@ func runRun(issueID string, opts *runOptions) error {
 		if opts.Reuse {
 			// Try to get latest run
 			latestRun, err := st.GetLatestRun(issueID)
-			if err == nil && latestRun.Status == model.StatusBlocked {
+			if err == nil && (latestRun.Status == model.StatusBlocked || latestRun.Status == model.StatusBlockedAPI) {
 				runID = latestRun.RunID
 			}
 		}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -89,7 +89,7 @@ func runStop(refStr string, opts *stopOptions) error {
 func stopIssueRuns(st store.Store, issueID string, opts *stopOptions) error {
 	runs, err := st.ListRuns(&store.ListRunsFilter{
 		IssueID: issueID,
-		Status:  []model.Status{model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusQueued},
+		Status:  []model.Status{model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusBlockedAPI, model.StatusQueued},
 	})
 	if err != nil {
 		return err
@@ -147,7 +147,9 @@ func runStopAll(opts *stopOptions) error {
 	return nil
 }
 
-func stopRun(st interface{ AppendEvent(ref *model.RunRef, event *model.Event) error }, run *model.Run, opts *stopOptions) error {
+func stopRun(st interface {
+	AppendEvent(ref *model.RunRef, event *model.Event) error
+}, run *model.Run, opts *stopOptions) error {
 	// Skip if already terminal
 	if run.Status == model.StatusDone || run.Status == model.StatusFailed || run.Status == model.StatusCanceled {
 		if !globalOpts.Quiet {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -113,11 +113,11 @@ func (d *Daemon) Stop() {
 	d.wg.Wait()
 }
 
-// monitorAll checks all active runs (running, booting, blocked, pr_open, or unknown)
+// monitorAll checks all active runs (running, booting, blocked, blocked_api, pr_open, or unknown)
 // Non-terminal runs are monitored so we can detect state transitions
 func (d *Daemon) monitorAll() {
 	runs, err := d.store.ListRuns(&store.ListRunsFilter{
-		Status: []model.Status{model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusPROpen, model.StatusUnknown},
+		Status: []model.Status{model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusBlockedAPI, model.StatusPROpen, model.StatusUnknown},
 	})
 	if err != nil {
 		d.logger.Printf("error listing runs: %v", err)

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -1,0 +1,35 @@
+package daemon
+
+import (
+	"io"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/s22625/orch/internal/model"
+)
+
+func TestDetectStatusAPILimited(t *testing.T) {
+	d := &Daemon{
+		logger: log.New(io.Discard, "", 0),
+	}
+	run := &model.Run{IssueID: "orch-016", RunID: "20251221-144231"}
+	state := &RunState{LastOutputAt: time.Now()}
+
+	tests := []string{
+		"Cost limit reached",
+		"Rate limit exceeded",
+		"Rate limit reached",
+		"Quota exceeded",
+		"Resource exhausted",
+		"Insufficient quota",
+	}
+
+	for _, msg := range tests {
+		output := "Error: " + msg
+		status := d.detectStatus(run, output, state, false, true)
+		if status != model.StatusBlockedAPI {
+			t.Fatalf("expected blocked_api for %q, got %q", msg, status)
+		}
+	}
+}

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -25,15 +25,16 @@ const (
 type Status string
 
 const (
-	StatusQueued   Status = "queued"
-	StatusBooting  Status = "booting"
-	StatusRunning  Status = "running"
-	StatusBlocked  Status = "blocked"
-	StatusPROpen   Status = "pr_open"
-	StatusDone     Status = "done"
-	StatusFailed   Status = "failed"
-	StatusCanceled Status = "canceled"
-	StatusUnknown  Status = "unknown" // Agent exited unexpectedly, shell prompt showing
+	StatusQueued     Status = "queued"
+	StatusBooting    Status = "booting"
+	StatusRunning    Status = "running"
+	StatusBlocked    Status = "blocked"
+	StatusBlockedAPI Status = "blocked_api"
+	StatusPROpen     Status = "pr_open"
+	StatusDone       Status = "done"
+	StatusFailed     Status = "failed"
+	StatusCanceled   Status = "canceled"
+	StatusUnknown    Status = "unknown" // Agent exited unexpectedly, shell prompt showing
 )
 
 // Phase values


### PR DESCRIPTION
## Summary
- add blocked_api status and API limit detection in the daemon monitor
- treat blocked_api as an active status in daemon/CLI flows
- add a unit test for API limit detection

## Testing
- go test ./internal/daemon