### PR TITLE
Add blocked_api status for API limit detection

### DIFF
--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -132,7 +132,7 @@ func parseStatus(s string) ([]model.Status, error) {
 	switch status {
 	case model.StatusDone, model.StatusFailed, model.StatusCanceled:
 		return []model.Status{status}, nil
-	case model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusQueued:
+	case model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusBlockedAPI, model.StatusQueued:
 		return nil, fmt.Errorf("cannot delete %s runs (use 'orch stop' first)", status)
 	default:
 		return nil, fmt.Errorf("unknown status: %s", s)
@@ -280,7 +280,7 @@ func deleteRuns(st store.Store, runs []*model.Run, opts *deleteOptions) error {
 	var activeRuns []*model.Run
 	var deletableRuns []*model.Run
 	for _, run := range runs {
-		if run.Status == model.StatusRunning || run.Status == model.StatusBooting || run.Status == model.StatusBlocked {
+		if run.Status == model.StatusRunning || run.Status == model.StatusBooting || run.Status == model.StatusBlocked || run.Status == model.StatusBlockedAPI {
 			activeRuns = append(activeRuns, run)
 		} else {
 			deletableRuns = append(deletableRuns, run)

--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -203,6 +203,7 @@ func runIssueList() error {
 		for _, run := range runsByIssue[issue.ID] {
 			if run.Status == model.StatusRunning ||
 				run.Status == model.StatusBlocked ||
+				run.Status == model.StatusBlockedAPI ||
 				run.Status == model.StatusBooting ||
 				run.Status == model.StatusQueued {
 				info.Runs = append(info.Runs, runSummary{

--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -34,7 +34,7 @@ func newPsCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&opts.Status, "status", nil, "Filter by status (running,blocked,failed,pr_open,done)")
+	cmd.Flags().StringSliceVar(&opts.Status, "status", nil, "Filter by status (running,blocked,blocked_api,failed,pr_open,done)")
 	cmd.Flags().StringVar(&opts.Issue, "issue", "", "Filter by issue ID")
 	cmd.Flags().IntVar(&opts.Limit, "limit", 50, "Maximum number of runs to show")
 	cmd.Flags().StringVar(&opts.Sort, "sort", "updated", "Sort by (updated|started)")
@@ -222,15 +222,16 @@ func formatRelativeTime(when time.Time, now time.Time) string {
 func colorStatus(status model.Status) string {
 	// ANSI color codes for terminal
 	colors := map[model.Status]string{
-		model.StatusRunning:  "\033[32m", // green
-		model.StatusBlocked:  "\033[33m", // yellow
-		model.StatusFailed:   "\033[31m", // red
-		model.StatusDone:     "\033[34m", // blue
-		model.StatusPROpen:   "\033[36m", // cyan
-		model.StatusQueued:   "\033[37m", // white
-		model.StatusBooting:  "\033[32m", // green
-		model.StatusCanceled: "\033[90m", // gray
-		model.StatusUnknown:  "\033[35m", // magenta - agent exited unexpectedly
+		model.StatusRunning:    "\033[32m", // green
+		model.StatusBlocked:    "\033[33m", // yellow
+		model.StatusBlockedAPI: "\033[33m", // yellow
+		model.StatusFailed:     "\033[31m", // red
+		model.StatusDone:       "\033[34m", // blue
+		model.StatusPROpen:     "\033[36m", // cyan
+		model.StatusQueued:     "\033[37m", // white
+		model.StatusBooting:    "\033[32m", // green
+		model.StatusCanceled:   "\033[90m", // gray
+		model.StatusUnknown:    "\033[35m", // magenta - agent exited unexpectedly
 	}
 
 	reset := "\033[0m"

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -49,7 +49,7 @@ The run will be started in a tmux session by default.`,
 	}
 
 	cmd.Flags().BoolVar(&opts.New, "new", true, "Always create a new run (default)")
-	cmd.Flags().BoolVar(&opts.Reuse, "reuse", false, "Reuse the latest run if blocked")
+	cmd.Flags().BoolVar(&opts.Reuse, "reuse", false, "Reuse the latest run if blocked or blocked_api")
 	cmd.Flags().StringVar(&opts.RunID, "run-id", "", "Manually specify run ID")
 	cmd.Flags().StringVar(&opts.Agent, "agent", "claude", "Agent type (claude|codex|gemini|custom)")
 	cmd.Flags().StringVar(&opts.AgentCmd, "agent-cmd", "", "Custom agent command (when --agent=custom)")
@@ -102,7 +102,7 @@ func runRun(issueID string, opts *runOptions) error {
 		if opts.Reuse {
 			// Try to get latest run
 			latestRun, err := st.GetLatestRun(issueID)
-			if err == nil && latestRun.Status == model.StatusBlocked {
+			if err == nil && (latestRun.Status == model.StatusBlocked || latestRun.Status == model.StatusBlockedAPI) {
 				runID = latestRun.RunID
 			}
 		}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -89,7 +89,7 @@ func runStop(refStr string, opts *stopOptions) error {
 func stopIssueRuns(st store.Store, issueID string, opts *stopOptions) error {
 	runs, err := st.ListRuns(&store.ListRunsFilter{
 		IssueID: issueID,
-		Status:  []model.Status{model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusQueued},
+		Status:  []model.Status{model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusBlockedAPI, model.StatusQueued},
 	})
 	if err != nil {
 		return err
@@ -147,7 +147,9 @@ func runStopAll(opts *stopOptions) error {
 	return nil
 }
 
-func stopRun(st interface{ AppendEvent(ref *model.RunRef, event *model.Event) error }, run *model.Run, opts *stopOptions) error {
+func stopRun(st interface {
+	AppendEvent(ref *model.RunRef, event *model.Event) error
+}, run *model.Run, opts *stopOptions) error {
 	// Skip if already terminal
 	if run.Status == model.StatusDone || run.Status == model.StatusFailed || run.Status == model.StatusCanceled {
 		if !globalOpts.Quiet {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -117,7 +117,7 @@ func (d *Daemon) Stop() {
 // Non-terminal runs are monitored so we can detect state transitions
 func (d *Daemon) monitorAll() {
 	runs, err := d.store.ListRuns(&store.ListRunsFilter{
-		Status: []model.Status{model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusPROpen, model.StatusUnknown},
+		Status: []model.Status{model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusBlockedAPI, model.StatusPROpen, model.StatusUnknown},
 	})
 	if err != nil {
 		d.logger.Printf("error listing runs: %v", err)

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -90,10 +90,12 @@ func (d *Daemon) monitorRun(run *model.Run) error {
 // detectStatus analyzes the output to determine the run status
 // Uses claude-squad logic:
 //  1. Agent exited (shell prompt) → Unknown
-//  2. Completion/error patterns → Done/Failed
-//  3. Content changing → Running (agent is actively working)
-//  4. Content stable + has prompt → Blocked (waiting for input)
-//  5. Otherwise → no change
+//  2. Completion patterns → Done
+//  3. API limit patterns → BlockedAPI
+//  4. Error patterns → Failed
+//  5. Content changing → Running (agent is actively working)
+//  6. Content stable + has prompt → Blocked (waiting for input)
+//  7. Otherwise → no change
 func (d *Daemon) detectStatus(run *model.Run, output string, state *RunState, outputChanged, hasPrompt bool) model.Status {
 	// Check for agent exit first (shell prompt showing = agent died/exited)
 	if d.isAgentExited(output) {
@@ -103,6 +105,11 @@ func (d *Daemon) detectStatus(run *model.Run, output string, state *RunState, ou
 	// Check for completion patterns (terminal states)
 	if d.isCompleted(output) {
 		return model.StatusDone
+	}
+
+	// Check for API usage limits (blocked until quota resets)
+	if d.isAPILimited(output) {
+		return model.StatusBlockedAPI
 	}
 
 	// Check for error patterns (terminal states)
@@ -156,6 +163,29 @@ func (d *Daemon) isCompleted(output string) bool {
 	return false
 }
 
+// isAPILimited checks if the output indicates API usage limits
+func (d *Daemon) isAPILimited(output string) bool {
+	lines := getLastLines(output, 10)
+	lowerOutput := strings.ToLower(lines)
+
+	apiLimitPatterns := []string{
+		"cost limit reached",
+		"rate limit exceeded",
+		"rate limit reached",
+		"quota exceeded",
+		"insufficient quota",
+		"resource exhausted",
+	}
+
+	for _, pattern := range apiLimitPatterns {
+		if strings.Contains(lowerOutput, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // isFailed checks if the output indicates the agent failed
 func (d *Daemon) isFailed(output string) bool {
 	lines := getLastLines(output, 10)
@@ -168,7 +198,6 @@ func (d *Daemon) isFailed(output string) bool {
 		"agent crashed",
 		"session terminated",
 		"authentication failed",
-		"rate limit exceeded",
 	}
 
 	for _, pattern := range errorPatterns {
@@ -219,8 +248,8 @@ func (d *Daemon) isAgentExited(output string) bool {
 		"accept edits",
 		"? for shortcuts",
 		"tell Claude what to do differently",
-		"tokens",              // token counter at bottom
-		"Esc to cancel",       // menu option
+		"tokens",               // token counter at bottom
+		"Esc to cancel",        // menu option
 		"to show all projects", // menu option
 	}
 

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -37,6 +37,9 @@ func TestDetectStatus(t *testing.T) {
 	if got := d.detectStatus(run, "Task completed successfully", state, false, false); got != model.StatusDone {
 		t.Fatalf("completed status = %q, want %q", got, model.StatusDone)
 	}
+	if got := d.detectStatus(run, "Error: rate limit exceeded", state, false, false); got != model.StatusBlockedAPI {
+		t.Fatalf("api limited status = %q, want %q", got, model.StatusBlockedAPI)
+	}
 	if got := d.detectStatus(run, "Fatal error: bad things", state, false, false); got != model.StatusFailed {
 		t.Fatalf("failed status = %q, want %q", got, model.StatusFailed)
 	}

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -25,15 +25,16 @@ const (
 type Status string
 
 const (
-	StatusQueued   Status = "queued"
-	StatusBooting  Status = "booting"
-	StatusRunning  Status = "running"
-	StatusBlocked  Status = "blocked"
-	StatusPROpen   Status = "pr_open"
-	StatusDone     Status = "done"
-	StatusFailed   Status = "failed"
-	StatusCanceled Status = "canceled"
-	StatusUnknown  Status = "unknown" // Agent exited unexpectedly, shell prompt showing
+	StatusQueued     Status = "queued"
+	StatusBooting    Status = "booting"
+	StatusRunning    Status = "running"
+	StatusBlocked    Status = "blocked"
+	StatusBlockedAPI Status = "blocked_api"
+	StatusPROpen     Status = "pr_open"
+	StatusDone       Status = "done"
+	StatusFailed     Status = "failed"
+	StatusCanceled   Status = "canceled"
+	StatusUnknown    Status = "unknown" // Agent exited unexpectedly, shell prompt showing
 )
 
 // Phase values


### PR DESCRIPTION
## Summary
- add blocked_api status and detection for API limit messages
- treat blocked_api as active in daemon and CLI flows (ps, stop, tick, run reuse)
- cover API limit detection in monitor tests

Refs: orch-016