### PR TITLE
Add resolve command and hide resolved runs

### DIFF
--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -85,7 +85,7 @@ Use --dry-run to see what would be deleted without actually deleting.`,
 
 	cmd.Flags().BoolVar(&opts.All, "all", false, "Delete all runs for the specified issue")
 	cmd.Flags().StringVar(&opts.OlderThan, "older-than", "", "Delete runs older than duration (e.g., 7d, 2w, 1m)")
-	cmd.Flags().StringVar(&opts.Status, "status", "", "Only delete runs with specific status (done/failed/canceled)")
+	cmd.Flags().StringVar(&opts.Status, "status", "", "Only delete runs with specific status (done/failed/canceled/resolved)")
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would be deleted without deleting")
 	cmd.Flags().BoolVar(&opts.WithWorktree, "with-worktree", false, "Also remove git worktree")
@@ -130,7 +130,7 @@ func parseStatus(s string) ([]model.Status, error) {
 
 	status := model.Status(s)
 	switch status {
-	case model.StatusDone, model.StatusFailed, model.StatusCanceled:
+	case model.StatusDone, model.StatusResolved, model.StatusFailed, model.StatusCanceled:
 		return []model.Status{status}, nil
 	case model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusBlockedAPI, model.StatusQueued:
 		return nil, fmt.Errorf("cannot delete %s runs (use 'orch stop' first)", status)

--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -21,6 +21,7 @@ type psOptions struct {
 	Sort         string
 	Since        string
 	AbsoluteTime bool
+	All          bool
 }
 
 func newPsCmd() *cobra.Command {
@@ -35,12 +36,13 @@ func newPsCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&opts.Status, "status", nil, "Filter by status (running,blocked,blocked_api,failed,pr_open,done)")
+	cmd.Flags().StringSliceVar(&opts.Status, "status", nil, "Filter by status (queued,booting,running,blocked,blocked_api,pr_open,done,resolved,failed,canceled,unknown)")
 	cmd.Flags().StringVar(&opts.Issue, "issue", "", "Filter by issue ID")
 	cmd.Flags().IntVar(&opts.Limit, "limit", 50, "Maximum number of runs to show")
 	cmd.Flags().StringVar(&opts.Sort, "sort", "updated", "Sort by (updated|started)")
 	cmd.Flags().StringVar(&opts.Since, "since", "", "Only show runs updated since (ISO8601)")
 	cmd.Flags().BoolVar(&opts.AbsoluteTime, "absolute-time", false, "Show absolute timestamps instead of relative")
+	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "Show all runs including resolved")
 
 	return cmd
 }
@@ -52,19 +54,31 @@ func runPs(opts *psOptions) error {
 	}
 
 	// Build filter
+	requestedLimit := opts.Limit
 	filter := &store.ListRunsFilter{
 		IssueID: opts.Issue,
 		Limit:   opts.Limit,
 		Since:   opts.Since,
 	}
 
-	for _, s := range opts.Status {
-		filter.Status = append(filter.Status, model.Status(s))
+	if len(opts.Status) > 0 {
+		for _, s := range opts.Status {
+			filter.Status = append(filter.Status, model.Status(s))
+		}
+	} else if !opts.All {
+		filter.Limit = 0
 	}
 
 	runs, err := st.ListRuns(filter)
 	if err != nil {
 		return err
+	}
+
+	if len(opts.Status) == 0 && !opts.All {
+		runs = filterResolvedRuns(runs)
+		if requestedLimit > 0 && len(runs) > requestedLimit {
+			runs = runs[:requestedLimit]
+		}
 	}
 
 	// Output based on format
@@ -286,6 +300,7 @@ func colorStatus(status model.Status) string {
 		model.StatusBlockedAPI: "\033[33m", // yellow
 		model.StatusFailed:     "\033[31m", // red
 		model.StatusDone:       "\033[34m", // blue
+		model.StatusResolved:   "\033[90m", // gray
 		model.StatusPROpen:     "\033[36m", // cyan
 		model.StatusQueued:     "\033[37m", // white
 		model.StatusBooting:    "\033[32m", // green
@@ -344,6 +359,19 @@ func mergedBranchesForRuns(runs []*model.Run) map[string]bool {
 	}
 
 	return mergedForRuns
+}
+
+func filterResolvedRuns(runs []*model.Run) []*model.Run {
+	if len(runs) == 0 {
+		return runs
+	}
+	filtered := make([]*model.Run, 0, len(runs))
+	for _, run := range runs {
+		if run.Status != model.StatusResolved {
+			filtered = append(filtered, run)
+		}
+	}
+	return filtered
 }
 
 // parseStatusList parses a comma-separated status list

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/s22625/orch/internal/model"
+	"github.com/spf13/cobra"
+)
+
+type resolveOptions struct {
+	Force bool
+}
+
+func newResolveCmd() *cobra.Command {
+	opts := &resolveOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "resolve RUN_REF",
+		Short: "Resolve a run",
+		Long: `Mark a run as resolved and hide it from default 'orch ps' output.
+
+RUN_REF can be ISSUE_ID#RUN_ID, ISSUE_ID (latest), or a short ID.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runResolve(args[0], opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "Resolve even if run is not done or pr_open")
+
+	return cmd
+}
+
+func runResolve(refStr string, opts *resolveOptions) error {
+	st, err := getStore()
+	if err != nil {
+		return err
+	}
+
+	run, err := resolveRun(st, refStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "run not found: %s\n", refStr)
+		os.Exit(ExitRunNotFound)
+		return err
+	}
+
+	if run.Status == model.StatusResolved {
+		if !globalOpts.Quiet {
+			fmt.Printf("%s#%s already resolved\n", run.IssueID, run.RunID)
+		}
+		return nil
+	}
+
+	if !opts.Force && run.Status != model.StatusDone && run.Status != model.StatusPROpen {
+		return fmt.Errorf("run %s#%s is %s; use --force to resolve anyway", run.IssueID, run.RunID, run.Status)
+	}
+
+	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusResolved)); err != nil {
+		return fmt.Errorf("failed to append resolved event: %w", err)
+	}
+
+	if !globalOpts.Quiet {
+		fmt.Printf("resolved: %s#%s\n", run.IssueID, run.RunID)
+	}
+
+	return nil
+}

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/s22625/orch/internal/model"
+)
+
+func TestRunResolveMarksResolved(t *testing.T) {
+	resetGlobalOpts(t)
+
+	vault := t.TempDir()
+	globalOpts.VaultPath = vault
+	globalOpts.Backend = "file"
+	globalOpts.Quiet = true
+
+	writeIssue(t, vault, "issue-1")
+
+	st, err := getStore()
+	if err != nil {
+		t.Fatalf("getStore: %v", err)
+	}
+
+	run, err := st.CreateRun("issue-1", "run-1", nil)
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusDone)); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	if err := runResolve("issue-1#run-1", &resolveOptions{}); err != nil {
+		t.Fatalf("runResolve: %v", err)
+	}
+
+	updated, err := st.GetRun(run.Ref())
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if updated.Status != model.StatusResolved {
+		t.Fatalf("status = %q, want %q", updated.Status, model.StatusResolved)
+	}
+}
+
+func TestRunResolveRequiresForceForActive(t *testing.T) {
+	resetGlobalOpts(t)
+
+	vault := t.TempDir()
+	globalOpts.VaultPath = vault
+	globalOpts.Backend = "file"
+	globalOpts.Quiet = true
+
+	writeIssue(t, vault, "issue-2")
+
+	st, err := getStore()
+	if err != nil {
+		t.Fatalf("getStore: %v", err)
+	}
+
+	run, err := st.CreateRun("issue-2", "run-1", nil)
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	if err := runResolve("issue-2#run-1", &resolveOptions{}); err == nil {
+		t.Fatal("expected error without --force")
+	}
+
+	if err := runResolve("issue-2#run-1", &resolveOptions{Force: true}); err != nil {
+		t.Fatalf("runResolve --force: %v", err)
+	}
+
+	updated, err := st.GetRun(run.Ref())
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if updated.Status != model.StatusResolved {
+		t.Fatalf("status = %q, want %q", updated.Status, model.StatusResolved)
+	}
+}
+
+func writeIssue(t *testing.T, vaultPath, issueID string) {
+	t.Helper()
+
+	issuesDir := filepath.Join(vaultPath, "issues")
+	if err := os.MkdirAll(issuesDir, 0755); err != nil {
+		t.Fatalf("mkdir issues: %v", err)
+	}
+
+	issuePath := filepath.Join(issuesDir, issueID+".md")
+	content := fmt.Sprintf("---\ntype: issue\nid: %s\ntitle: %s\n---\n# %s\n", issueID, issueID, issueID)
+	if err := os.WriteFile(issuePath, []byte(content), 0644); err != nil {
+		t.Fatalf("write issue: %v", err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -15,14 +15,14 @@ import (
 
 // Exit codes as per spec
 const (
-	ExitOK            = 0
-	ExitIssueNotFound = 2
-	ExitWorktreeError = 3
-	ExitTmuxError     = 4
-	ExitAgentError    = 5
-	ExitRunNotFound   = 6
+	ExitOK               = 0
+	ExitIssueNotFound    = 2
+	ExitWorktreeError    = 3
+	ExitTmuxError        = 4
+	ExitAgentError       = 5
+	ExitRunNotFound      = 6
 	ExitQuestionNotFound = 7
-	ExitInternalError = 10
+	ExitInternalError    = 10
 )
 
 // GlobalOptions holds options shared across all commands
@@ -84,6 +84,7 @@ func init() {
 	rootCmd.AddCommand(newTickCmd())
 	rootCmd.AddCommand(newOpenCmd())
 	rootCmd.AddCommand(newStopCmd())
+	rootCmd.AddCommand(newResolveCmd())
 	rootCmd.AddCommand(newDaemonCmd())
 	rootCmd.AddCommand(newRepairCmd())
 	rootCmd.AddCommand(newDeleteCmd())

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -151,7 +151,7 @@ func stopRun(st interface {
 	AppendEvent(ref *model.RunRef, event *model.Event) error
 }, run *model.Run, opts *stopOptions) error {
 	// Skip if already terminal
-	if run.Status == model.StatusDone || run.Status == model.StatusFailed || run.Status == model.StatusCanceled {
+	if run.Status == model.StatusDone || run.Status == model.StatusResolved || run.Status == model.StatusFailed || run.Status == model.StatusCanceled {
 		if !globalOpts.Quiet {
 			fmt.Printf("%s#%s already %s\n", run.IssueID, run.RunID, run.Status)
 		}

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -32,6 +32,7 @@ const (
 	StatusBlockedAPI Status = "blocked_api"
 	StatusPROpen     Status = "pr_open"
 	StatusDone       Status = "done"
+	StatusResolved   Status = "resolved"
 	StatusFailed     Status = "failed"
 	StatusCanceled   Status = "canceled"
 	StatusUnknown    Status = "unknown" // Agent exited unexpectedly, shell prompt showing


### PR DESCRIPTION
## Summary
- add resolved run status and resolve command
- hide resolved runs from `orch ps` by default with --all to show
- add tests for resolve and ps filtering

Refs: orch-022