### PR TITLE
Add integrated monitor dashboards and agent chat

### DIFF
--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -9,11 +9,12 @@ import (
 )
 
 type monitorOptions struct {
-	Issue     string
-	Status    []string
-	Attach    bool
-	ForceNew  bool
-	Dashboard bool
+	Issue           string
+	Status          []string
+	Attach          bool
+	ForceNew        bool
+	Dashboard       bool
+	IssuesDashboard bool
 }
 
 func newMonitorCmd() *cobra.Command {
@@ -32,7 +33,9 @@ func newMonitorCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Attach, "attach", false, "Attach to existing monitor session if present")
 	cmd.Flags().BoolVar(&opts.ForceNew, "new", false, "Force create a new monitor session")
 	cmd.Flags().BoolVar(&opts.Dashboard, "dashboard", false, "Run dashboard UI (internal)")
+	cmd.Flags().BoolVar(&opts.IssuesDashboard, "issues-dashboard", false, "Run issues dashboard UI (internal)")
 	_ = cmd.Flags().MarkHidden("dashboard")
+	_ = cmd.Flags().MarkHidden("issues-dashboard")
 
 	return cmd
 }
@@ -62,6 +65,9 @@ func runMonitor(opts *monitorOptions) error {
 
 	if opts.Dashboard {
 		return m.RunDashboard()
+	}
+	if opts.IssuesDashboard {
+		return m.RunIssuesDashboard()
 	}
 
 	return m.Start()

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,6 +39,7 @@ var globalOpts = &GlobalOptions{}
 
 // Commands that should NOT auto-start the daemon
 var noDaemonCommands = map[string]bool{
+	"show":       true,
 	"daemon":     true,
 	"repair":     true,
 	"delete":     true,

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -78,6 +78,7 @@ func showJSON(run *model.Run, opts *showOptions) error {
 		IssueID      string           `json:"issue_id"`
 		RunID        string           `json:"run_id"`
 		Status       string           `json:"status"`
+		Phase        string           `json:"phase,omitempty"`
 		Branch       string           `json:"branch,omitempty"`
 		WorktreePath string           `json:"worktree_path,omitempty"`
 		TmuxSession  string           `json:"tmux_session,omitempty"`
@@ -89,6 +90,7 @@ func showJSON(run *model.Run, opts *showOptions) error {
 		IssueID:      run.IssueID,
 		RunID:        run.RunID,
 		Status:       string(run.Status),
+		Phase:        string(run.Phase),
 		Branch:       run.Branch,
 		WorktreePath: run.WorktreePath,
 		TmuxSession:  run.TmuxSession,

--- a/internal/model/run.go
+++ b/internal/model/run.go
@@ -52,6 +52,7 @@ type Run struct {
 
 	// Derived from events
 	Status    Status
+	Phase     Phase
 	Events    []*Event
 	StartedAt time.Time
 	UpdatedAt time.Time
@@ -94,6 +95,17 @@ func (r *Run) GetStatus() Status {
 	return StatusQueued
 }
 
+// GetPhase derives phase from events (last phase event wins).
+func (r *Run) GetPhase() Phase {
+	for i := len(r.Events) - 1; i >= 0; i-- {
+		e := r.Events[i]
+		if e.Type == EventTypePhase {
+			return Phase(e.Name)
+		}
+	}
+	return ""
+}
+
 // GetArtifacts extracts artifacts from events
 func (r *Run) GetArtifacts() map[string]map[string]string {
 	artifacts := make(map[string]map[string]string)
@@ -131,6 +143,7 @@ func (r *Run) UnansweredQuestions() []*Event {
 // DeriveState updates Status and artifacts from events
 func (r *Run) DeriveState() {
 	r.Status = r.GetStatus()
+	r.Phase = r.GetPhase()
 
 	artifacts := r.GetArtifacts()
 	if worktree, ok := artifacts["worktree"]; ok {

--- a/internal/monitor/agent_prompt.go
+++ b/internal/monitor/agent_prompt.go
@@ -1,0 +1,51 @@
+package monitor
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const agentChatPromptTemplate = `You are the orch control agent for this repository.
+You can run orch commands to manage issues and runs.
+
+Protocol:
+- When you need to request a command without running it, output a single line starting with "ORCH_CMD:" followed by the command.
+
+Presets:
+- Create issue: orch issue create <id> --title "<title>" --body "<summary/body>"
+- List issues: orch issue list
+- Start run: orch run <issue-id>
+- List runs: orch ps --status running,blocked
+- Stop run: orch stop <issue-id>#<run-id>
+- Resolve run: orch resolve <issue-id>#<run-id>
+- Open issue: orch open <issue-id>
+
+Issue template:
+---
+type: issue
+id: <issue-id>
+title: <title>
+summary: <one-line summary>
+---
+# <title>
+<details>
+
+Context:
+- Vault: %s
+- CWD: %s
+`
+
+func buildAgentChatPrompt(vaultPath string) string {
+	cwd, _ := os.Getwd()
+	return fmt.Sprintf(agentChatPromptTemplate, vaultPath, cwd)
+}
+
+func fallbackChatCommand(reason string) string {
+	msg := "Agent chat unavailable"
+	if strings.TrimSpace(reason) != "" {
+		msg = fmt.Sprintf("Agent chat unavailable: %s", reason)
+	}
+	cmd := fmt.Sprintf("echo %s; exec ${SHELL:-sh}", shellQuote(msg))
+	return fmt.Sprintf("sh -c %s", shellQuote(cmd))
+}

--- a/internal/monitor/constants.go
+++ b/internal/monitor/constants.go
@@ -1,0 +1,5 @@
+package monitor
+
+import "time"
+
+const defaultRefreshInterval = 2 * time.Second

--- a/internal/monitor/data.go
+++ b/internal/monitor/data.go
@@ -1,0 +1,31 @@
+package monitor
+
+import (
+	"time"
+
+	"github.com/s22625/orch/internal/model"
+)
+
+// RunRow holds display data for a run.
+type RunRow struct {
+	Index   int
+	ShortID string
+	IssueID string
+	Status  model.Status
+	Summary string
+	Updated time.Time
+	Run     *model.Run
+}
+
+// IssueRow holds display data for an issue.
+type IssueRow struct {
+	Index         int
+	ID            string
+	Status        string
+	Summary       string
+	LatestRunID   string
+	LatestStatus  model.Status
+	LatestUpdated time.Time
+	ActiveRuns    int
+	Issue         *model.Issue
+}

--- a/internal/monitor/issue_keymap.go
+++ b/internal/monitor/issue_keymap.go
@@ -1,0 +1,37 @@
+package monitor
+
+import "fmt"
+
+// IssueKeyMap defines shortcuts for the issues dashboard.
+type IssueKeyMap struct {
+	Runs     string
+	Issues   string
+	Chat     string
+	StartRun string
+	Open     string
+	NewIssue string
+	Refresh  string
+	Quit     string
+	Help     string
+}
+
+// DefaultIssueKeyMap returns the default issue dashboard shortcut mapping.
+func DefaultIssueKeyMap() IssueKeyMap {
+	return IssueKeyMap{
+		Runs:     "g",
+		Issues:   "i",
+		Chat:     "c",
+		StartRun: "enter",
+		Open:     "o",
+		NewIssue: "n",
+		Refresh:  "r",
+		Quit:     "q",
+		Help:     "?",
+	}
+}
+
+// HelpLine renders the footer help text.
+func (k IssueKeyMap) HelpLine() string {
+	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] start  [%s] open  [%s] new  [%s] refresh  [%s] quit  [%s] help",
+		k.Runs, k.Issues, k.Chat, k.StartRun, k.Open, k.NewIssue, k.Refresh, k.Quit, k.Help)
+}

--- a/internal/monitor/issues_dashboard.go
+++ b/internal/monitor/issues_dashboard.go
@@ -1,0 +1,486 @@
+package monitor
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type issueDashboardMode int
+
+const (
+	modeIssues issueDashboardMode = iota
+	modeCreateIssue
+)
+
+type createIssueState struct {
+	step    int
+	issueID string
+	title   string
+	input   string
+}
+
+// IssueDashboard is the bubbletea model for the issues UI.
+type IssueDashboard struct {
+	monitor *Monitor
+
+	issues []IssueRow
+	cursor int
+	width  int
+	height int
+
+	mode    issueDashboardMode
+	message string
+	create  createIssueState
+
+	keymap IssueKeyMap
+	styles Styles
+
+	lastRefresh     time.Time
+	refreshing      bool
+	refreshInterval time.Duration
+}
+
+type issuesRefreshMsg struct {
+	rows []IssueRow
+}
+
+type issueTickMsg time.Time
+
+// NewIssueDashboard creates an issue dashboard model.
+func NewIssueDashboard(m *Monitor) *IssueDashboard {
+	return &IssueDashboard{
+		monitor:         m,
+		keymap:          DefaultIssueKeyMap(),
+		styles:          DefaultStyles(),
+		mode:            modeIssues,
+		refreshInterval: defaultRefreshInterval,
+	}
+}
+
+// Run starts the bubbletea program.
+func (d *IssueDashboard) Run() error {
+	program := tea.NewProgram(d, tea.WithAltScreen())
+	_, err := program.Run()
+	return err
+}
+
+// Init implements tea.Model.
+func (d *IssueDashboard) Init() tea.Cmd {
+	d.refreshing = true
+	return tea.Batch(d.refreshCmd(), d.tickCmd())
+}
+
+// Update implements tea.Model.
+func (d *IssueDashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		d.width = msg.Width
+		d.height = msg.Height
+		return d, nil
+	case issuesRefreshMsg:
+		d.issues = msg.rows
+		d.refreshing = false
+		d.lastRefresh = time.Now()
+		if d.cursor >= len(d.issues) {
+			d.cursor = len(d.issues) - 1
+			if d.cursor < 0 {
+				d.cursor = 0
+			}
+		}
+		return d, nil
+	case infoMsg:
+		d.message = msg.text
+		d.refreshing = true
+		return d, d.refreshCmd()
+	case errMsg:
+		d.message = msg.err.Error()
+		d.refreshing = false
+		return d, nil
+	case issueTickMsg:
+		if d.refreshing {
+			return d, d.tickCmd()
+		}
+		d.refreshing = true
+		return d, tea.Batch(d.refreshCmd(), d.tickCmd())
+	case tea.KeyMsg:
+		return d.handleKey(msg)
+	default:
+		return d, nil
+	}
+}
+
+// View implements tea.Model.
+func (d *IssueDashboard) View() string {
+	switch d.mode {
+	case modeCreateIssue:
+		return d.styles.Box.Render(d.viewCreateIssue())
+	default:
+		return d.styles.Box.Render(d.viewIssues())
+	}
+}
+
+func (d *IssueDashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.Type == tea.KeyCtrlC {
+		return d.quit()
+	}
+
+	switch d.mode {
+	case modeCreateIssue:
+		return d.handleCreateIssueKey(msg)
+	default:
+		return d.handleIssuesKey(msg)
+	}
+}
+
+func (d *IssueDashboard) handleIssuesKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q":
+		return d.quit()
+	case d.keymap.Runs:
+		if err := d.monitor.SwitchRuns(); err != nil {
+			d.message = err.Error()
+		}
+		return d, nil
+	case d.keymap.Issues:
+		return d, nil
+	case d.keymap.Chat:
+		if err := d.monitor.SwitchChat(); err != nil {
+			d.message = err.Error()
+		}
+		return d, nil
+	case "r":
+		d.refreshing = true
+		return d, d.refreshCmd()
+	case "o":
+		if row := d.currentIssue(); row != nil {
+			return d, d.openIssueCmd(row.ID)
+		}
+		return d, nil
+	case "n":
+		d.mode = modeCreateIssue
+		d.create = createIssueState{}
+		return d, nil
+	case "enter":
+		if row := d.currentIssue(); row != nil {
+			return d, d.startRunCmd(row.ID)
+		}
+		return d, nil
+	case "up", "k":
+		if d.cursor > 0 {
+			d.cursor--
+		}
+		return d, nil
+	case "down", "j":
+		if d.cursor < len(d.issues)-1 {
+			d.cursor++
+		}
+		return d, nil
+	case "?":
+		d.message = d.keymap.HelpLine()
+		return d, nil
+	}
+	return d, nil
+}
+
+func (d *IssueDashboard) handleCreateIssueKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		d.mode = modeIssues
+		return d, nil
+	case "enter":
+		switch d.create.step {
+		case 0:
+			issueID := strings.TrimSpace(d.create.input)
+			if issueID == "" {
+				d.message = "issue id is required"
+				return d, nil
+			}
+			d.create.issueID = issueID
+			d.create.input = ""
+			d.create.step = 1
+			return d, nil
+		case 1:
+			d.create.title = strings.TrimSpace(d.create.input)
+			issueID := d.create.issueID
+			title := d.create.title
+			d.mode = modeIssues
+			d.create = createIssueState{}
+			return d, d.createIssueCmd(issueID, title)
+		}
+	}
+
+	switch msg.Type {
+	case tea.KeyBackspace, tea.KeyDelete:
+		if len(d.create.input) > 0 {
+			runes := []rune(d.create.input)
+			d.create.input = string(runes[:len(runes)-1])
+		}
+		return d, nil
+	case tea.KeyRunes:
+		d.create.input += string(msg.Runes)
+		return d, nil
+	default:
+		return d, nil
+	}
+}
+
+func (d *IssueDashboard) quit() (tea.Model, tea.Cmd) {
+	_ = d.monitor.Quit()
+	return d, tea.Quit
+}
+
+func (d *IssueDashboard) refreshCmd() tea.Cmd {
+	return func() tea.Msg {
+		rows, err := d.monitor.RefreshIssues()
+		if err != nil {
+			return errMsg{err: err}
+		}
+		return issuesRefreshMsg{rows: rows}
+	}
+}
+
+func (d *IssueDashboard) tickCmd() tea.Cmd {
+	return tea.Tick(d.refreshInterval, func(t time.Time) tea.Msg {
+		return issueTickMsg(t)
+	})
+}
+
+func (d *IssueDashboard) startRunCmd(issueID string) tea.Cmd {
+	return func() tea.Msg {
+		output, err := d.monitor.StartRun(issueID)
+		if err != nil {
+			return errMsg{err: fmt.Errorf("%s", output)}
+		}
+		return infoMsg{text: output}
+	}
+}
+
+func (d *IssueDashboard) openIssueCmd(issueID string) tea.Cmd {
+	return func() tea.Msg {
+		output, err := d.monitor.OpenIssue(issueID)
+		if err != nil {
+			return errMsg{err: fmt.Errorf("%s", output)}
+		}
+		return infoMsg{text: output}
+	}
+}
+
+func (d *IssueDashboard) createIssueCmd(issueID, title string) tea.Cmd {
+	return func() tea.Msg {
+		output, err := d.monitor.CreateIssue(issueID, title)
+		if err != nil {
+			return errMsg{err: fmt.Errorf("%s", output)}
+		}
+		return infoMsg{text: output}
+	}
+}
+
+func (d *IssueDashboard) viewIssues() string {
+	title := d.styles.Title.Render("ORCH ISSUES")
+	meta := d.renderMeta()
+	table := d.renderTable()
+	details := d.renderDetails()
+	footer := d.renderFooter()
+	message := ""
+	if d.message != "" {
+		message = d.styles.Faint.Render(d.message)
+	}
+
+	lines := []string{
+		title,
+		"",
+		meta,
+		"",
+		table,
+		"",
+		details,
+	}
+	if message != "" {
+		lines = append(lines, "", message)
+	}
+	lines = append(lines, "", footer)
+	return strings.Join(lines, "\n")
+}
+
+func (d *IssueDashboard) viewCreateIssue() string {
+	header := d.styles.Title.Render("NEW ISSUE")
+	lines := []string{header, ""}
+	switch d.create.step {
+	case 0:
+		lines = append(lines, "Issue ID:", fmt.Sprintf("> %s", d.create.input))
+		lines = append(lines, "", "[Enter] next  [Esc] cancel")
+	case 1:
+		lines = append(lines, "Title (optional):", fmt.Sprintf("> %s", d.create.input))
+		lines = append(lines, "", "[Enter] create  [Esc] cancel")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (d *IssueDashboard) renderMeta() string {
+	sync := d.renderSyncStatus()
+	total := fmt.Sprintf("issues: %d", len(d.issues))
+	return strings.Join([]string{total, sync}, "  ")
+}
+
+func (d *IssueDashboard) renderSyncStatus() string {
+	if d.refreshing {
+		return "sync: syncing..."
+	}
+	if d.lastRefresh.IsZero() {
+		return "sync: pending"
+	}
+	ago := formatRelativeTime(d.lastRefresh, time.Now())
+	label := fmt.Sprintf("sync: %s", ago)
+	if time.Since(d.lastRefresh) > d.refreshInterval*3 {
+		label += " (stale)"
+	}
+	return label
+}
+
+func (d *IssueDashboard) renderTable() string {
+	if len(d.issues) == 0 {
+		return "No issues found."
+	}
+
+	idxW, idW, statusW, latestW, activeW, summaryW := d.tableWidths()
+
+	header := d.renderRow(idxW, idW, statusW, latestW, activeW, summaryW,
+		"#", "ID", "STATUS", "LATEST", "ACTIVE", "SUMMARY", true, nil)
+
+	var rows []string
+	for i, row := range d.issues {
+		latest := "-"
+		if row.LatestRunID != "" {
+			latest = string(row.LatestStatus)
+		}
+		r := d.renderRow(idxW, idW, statusW, latestW, activeW, summaryW,
+			fmt.Sprintf("%d", row.Index),
+			row.ID,
+			row.Status,
+			latest,
+			fmt.Sprintf("%d", row.ActiveRuns),
+			row.Summary,
+			false,
+			&row,
+		)
+		if i == d.cursor {
+			r = d.styles.Selected.Render(r)
+		}
+		rows = append(rows, r)
+	}
+
+	return strings.Join(append([]string{header}, rows...), "\n")
+}
+
+func (d *IssueDashboard) renderRow(idxW, idW, statusW, latestW, activeW, summaryW int, idx, id, status, latest, active, summary string, header bool, row *IssueRow) string {
+	baseStyle := d.styles.Text
+	headerStyle := d.styles.Header
+
+	idxCol := d.pad(idx, idxW, baseStyle)
+	idCol := d.pad(id, idW, baseStyle)
+	statusCol := d.pad(status, statusW, baseStyle)
+	latestCol := d.pad(latest, latestW, baseStyle)
+	activeCol := d.pad(active, activeW, baseStyle)
+	summaryCol := d.pad(summary, summaryW, baseStyle)
+
+	if header {
+		idxCol = d.pad(idx, idxW, headerStyle)
+		idCol = d.pad(id, idW, headerStyle)
+		statusCol = d.pad(status, statusW, headerStyle)
+		latestCol = d.pad(latest, latestW, headerStyle)
+		activeCol = d.pad(active, activeW, headerStyle)
+		summaryCol = d.pad(summary, summaryW, headerStyle)
+	}
+
+	if row != nil && row.LatestStatus != "" {
+		if style, ok := d.styles.Status[row.LatestStatus]; ok {
+			latestCol = d.pad(latest, latestW, style)
+		}
+	}
+
+	return strings.Join([]string{idxCol, idCol, statusCol, latestCol, activeCol, summaryCol}, "  ")
+}
+
+func (d *IssueDashboard) renderDetails() string {
+	issue := d.currentIssue()
+	if issue == nil || issue.Issue == nil {
+		return "No issue selected."
+	}
+
+	title := issue.Issue.Title
+	if strings.TrimSpace(title) == "" {
+		title = issue.Issue.ID
+	}
+
+	lines := []string{
+		d.styles.Header.Render("DETAILS"),
+		fmt.Sprintf("ID: %s", issue.ID),
+		fmt.Sprintf("Title: %s", title),
+		fmt.Sprintf("Status: %s", issue.Status),
+		fmt.Sprintf("Active runs: %d", issue.ActiveRuns),
+	}
+
+	latest := "-"
+	if issue.LatestRunID != "" {
+		latest = fmt.Sprintf("%s (%s)", issue.LatestRunID, issue.LatestStatus)
+	}
+	if issue.LatestRunID != "" {
+		updated := formatRelativeTime(issue.LatestUpdated, time.Now())
+		lines = append(lines, fmt.Sprintf("Latest run: %s, %s", latest, updated))
+	} else {
+		lines = append(lines, fmt.Sprintf("Latest run: %s", latest))
+	}
+
+	summary := issue.Summary
+	if summary == "-" {
+		summary = ""
+	}
+	if strings.TrimSpace(summary) != "" {
+		lines = append(lines, "Summary:")
+		lines = append(lines, wrapText(summary, d.safeWidth()-2)...)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (d *IssueDashboard) renderFooter() string {
+	return d.keymap.HelpLine()
+}
+
+func (d *IssueDashboard) tableWidths() (idxW, idW, statusW, latestW, activeW, summaryW int) {
+	idxW = 2
+	idW = 12
+	statusW = 10
+	latestW = 10
+	activeW = 6
+
+	contentWidth := d.safeWidth()
+	fixed := idxW + idW + statusW + latestW + activeW + 10
+	summaryW = contentWidth - fixed
+	if summaryW < 20 {
+		summaryW = 20
+	}
+	return
+}
+
+func (d *IssueDashboard) safeWidth() int {
+	if d.width > 2 {
+		return d.width - 2
+	}
+	return 80
+}
+
+func (d *IssueDashboard) pad(s string, width int, style lipgloss.Style) string {
+	return style.Width(width).Render(truncate(s, width))
+}
+
+func (d *IssueDashboard) currentIssue() *IssueRow {
+	if d.cursor < 0 || d.cursor >= len(d.issues) {
+		return nil
+	}
+	return &d.issues[d.cursor]
+}

--- a/internal/monitor/keymap.go
+++ b/internal/monitor/keymap.go
@@ -4,6 +4,9 @@ import "fmt"
 
 // KeyMap defines the keyboard shortcuts displayed in the footer.
 type KeyMap struct {
+	Runs    string
+	Issues  string
+	Chat    string
 	Attach  string
 	Answer  string
 	Stop    string
@@ -16,6 +19,9 @@ type KeyMap struct {
 // DefaultKeyMap returns the default shortcut mapping.
 func DefaultKeyMap() KeyMap {
 	return KeyMap{
+		Runs:    "g",
+		Issues:  "i",
+		Chat:    "c",
 		Attach:  "1-9",
 		Answer:  "a",
 		Stop:    "s",
@@ -28,6 +34,6 @@ func DefaultKeyMap() KeyMap {
 
 // HelpLine renders the footer help text.
 func (k KeyMap) HelpLine() string {
-	return fmt.Sprintf("[%s] attach  [%s] answer  [%s] stop  [%s] new  [%s] refresh  [%s] quit  [%s] help",
-		k.Attach, k.Answer, k.Stop, k.NewRun, k.Refresh, k.Quit, k.Help)
+	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] attach  [%s] answer  [%s] stop  [%s] new  [%s] refresh  [%s] quit  [%s] help",
+		k.Runs, k.Issues, k.Chat, k.Attach, k.Answer, k.Stop, k.NewRun, k.Refresh, k.Quit, k.Help)
 }

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -5,14 +5,29 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 
+	"github.com/s22625/orch/internal/agent"
+	"github.com/s22625/orch/internal/config"
 	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/store"
 	"github.com/s22625/orch/internal/tmux"
 )
 
-const defaultSessionName = "orch-monitor"
+const (
+	defaultSessionName = "orch-monitor"
+	runsWindowIndex    = 0
+	issuesWindowIndex  = 1
+	agentWindowIndex   = 2
+	runWindowOffset    = 3
+)
+
+const (
+	runsWindowName   = "runs"
+	issuesWindowName = "issues"
+	agentWindowName  = "agent"
+)
 
 // Options configures the monitor behavior.
 type Options struct {
@@ -91,6 +106,10 @@ func (m *Monitor) Start() error {
 		}
 	}
 
+	if err := m.ensureAuxWindows(); err != nil {
+		return err
+	}
+
 	runs, err := m.loadRuns()
 	if err != nil {
 		return err
@@ -110,6 +129,12 @@ func (m *Monitor) RunDashboard() error {
 	return d.Run()
 }
 
+// RunIssuesDashboard launches the issues dashboard.
+func (m *Monitor) RunIssuesDashboard() error {
+	d := NewIssueDashboard(m)
+	return d.Run()
+}
+
 // Refresh reloads runs and syncs tmux windows.
 func (m *Monitor) Refresh() ([]RunRow, error) {
 	runs, err := m.loadRuns()
@@ -125,9 +150,37 @@ func (m *Monitor) Refresh() ([]RunRow, error) {
 	return m.buildRunRows(runs)
 }
 
+// RefreshIssues reloads issue data for the issues dashboard.
+func (m *Monitor) RefreshIssues() ([]IssueRow, error) {
+	issues, err := m.store.ListIssues()
+	if err != nil {
+		return nil, err
+	}
+	runs, err := m.store.ListRuns(nil)
+	if err != nil {
+		return nil, err
+	}
+	return m.buildIssueRows(issues, runs), nil
+}
+
 // SwitchWindow selects a tmux window by index.
 func (m *Monitor) SwitchWindow(index int) error {
 	return tmux.SelectWindow(m.session, index)
+}
+
+// SwitchRuns switches to the runs dashboard window.
+func (m *Monitor) SwitchRuns() error {
+	return m.SwitchWindow(runsWindowIndex)
+}
+
+// SwitchIssues switches to the issues dashboard window.
+func (m *Monitor) SwitchIssues() error {
+	return m.SwitchWindow(issuesWindowIndex)
+}
+
+// SwitchChat switches to the agent chat window.
+func (m *Monitor) SwitchChat() error {
+	return m.SwitchWindow(agentWindowIndex)
 }
 
 // Quit terminates the monitor tmux session.
@@ -185,17 +238,68 @@ func (m *Monitor) StartRun(issueID string) (string, error) {
 	return output, nil
 }
 
+// OpenIssue opens an issue via orch open.
+func (m *Monitor) OpenIssue(issueID string) (string, error) {
+	args := append([]string{}, m.globalFlags...)
+	args = append(args, "open", issueID)
+
+	cmd := exec.Command(m.orchPath, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	output := strings.TrimSpace(strings.TrimSpace(stdout.String()) + "\n" + strings.TrimSpace(stderr.String()))
+	if err != nil {
+		if strings.TrimSpace(output) == "" {
+			output = err.Error()
+		}
+		return output, err
+	}
+	if strings.TrimSpace(output) == "" {
+		output = fmt.Sprintf("opened %s", issueID)
+	}
+	return output, nil
+}
+
+// CreateIssue creates a new issue via orch issue create.
+func (m *Monitor) CreateIssue(issueID, title string) (string, error) {
+	args := append([]string{}, m.globalFlags...)
+	args = append(args, "issue", "create", issueID)
+	if strings.TrimSpace(title) != "" {
+		args = append(args, "--title", title)
+	}
+
+	cmd := exec.Command(m.orchPath, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	output := strings.TrimSpace(strings.TrimSpace(stdout.String()) + "\n" + strings.TrimSpace(stderr.String()))
+	if err != nil {
+		if strings.TrimSpace(output) == "" {
+			output = err.Error()
+		}
+		return output, err
+	}
+	if strings.TrimSpace(output) == "" {
+		output = fmt.Sprintf("created issue %s", issueID)
+	}
+	return output, nil
+}
+
 // ListIssues fetches issues from the store.
 func (m *Monitor) ListIssues() ([]*model.Issue, error) {
 	return m.store.ListIssues()
 }
 
 func (m *Monitor) createSession() error {
-	cmd := m.dashboardCommand()
+	cmd := m.runsDashboardCommand()
 	cfg := &tmux.SessionConfig{
 		SessionName: m.session,
 		Command:     cmd,
-		WindowName:  "dashboard",
+		WindowName:  runsWindowName,
 	}
 	if err := tmux.NewSession(cfg); err != nil {
 		return fmt.Errorf("failed to create monitor session: %w", err)
@@ -208,6 +312,57 @@ func (m *Monitor) attachSession() error {
 		return tmux.SwitchClient(m.session)
 	}
 	return tmux.AttachSession(m.session)
+}
+
+func (m *Monitor) ensureAuxWindows() error {
+	if !tmux.HasSession(m.session) {
+		return nil
+	}
+
+	windows, err := tmux.ListWindows(m.session)
+	if err != nil {
+		return err
+	}
+
+	indexToName := make(map[int]string, len(windows))
+	nameToIndex := make(map[string]int, len(windows))
+	for _, w := range windows {
+		indexToName[w.Index] = w.Name
+		nameToIndex[w.Name] = w.Index
+	}
+
+	if name, ok := indexToName[issuesWindowIndex]; ok && name != issuesWindowName {
+		_ = tmux.UnlinkWindow(m.session, issuesWindowIndex)
+		delete(indexToName, issuesWindowIndex)
+	}
+	if _, ok := nameToIndex[issuesWindowName]; !ok {
+		if err := tmux.NewWindow(m.session, issuesWindowName, "", m.issuesDashboardCommand()); err != nil {
+			return err
+		}
+	}
+	if index, ok := nameToIndex[issuesWindowName]; !ok || index != issuesWindowIndex {
+		if err := tmux.MoveWindow(m.session, issuesWindowName, issuesWindowIndex); err != nil {
+			return err
+		}
+	}
+
+	if name, ok := indexToName[agentWindowIndex]; ok && name != agentWindowName {
+		_ = tmux.UnlinkWindow(m.session, agentWindowIndex)
+		delete(indexToName, agentWindowIndex)
+	}
+	if _, ok := nameToIndex[agentWindowName]; !ok {
+		workDir, _ := os.Getwd()
+		if err := tmux.NewWindow(m.session, agentWindowName, workDir, m.agentChatCommand()); err != nil {
+			return err
+		}
+	}
+	if index, ok := nameToIndex[agentWindowName]; !ok || index != agentWindowIndex {
+		if err := tmux.MoveWindow(m.session, agentWindowName, agentWindowIndex); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (m *Monitor) loadRuns() ([]*RunWindow, error) {
@@ -234,7 +389,7 @@ func (m *Monitor) loadRuns() ([]*RunWindow, error) {
 			sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
 		}
 		runWindows = append(runWindows, &RunWindow{
-			Index:        i + 1,
+			Index:        runWindowOffset + i,
 			Run:          run,
 			AgentSession: sessionName,
 		})
@@ -255,7 +410,7 @@ func (m *Monitor) syncWindows(windows []*RunWindow) error {
 	}
 
 	for _, w := range existing {
-		if w.Index == 0 {
+		if isReservedWindowIndex(w.Index) {
 			continue
 		}
 		if _, ok := desired[w.Index]; !ok {
@@ -329,7 +484,62 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 	return rows, nil
 }
 
-func (m *Monitor) dashboardCommand() string {
+func (m *Monitor) buildIssueRows(issues []*model.Issue, runs []*model.Run) []IssueRow {
+	sort.Slice(issues, func(i, j int) bool {
+		return issues[i].ID < issues[j].ID
+	})
+
+	runsByIssue := make(map[string][]*model.Run)
+	for _, run := range runs {
+		runsByIssue[run.IssueID] = append(runsByIssue[run.IssueID], run)
+	}
+
+	rows := make([]IssueRow, 0, len(issues))
+	for i, issue := range issues {
+		status := "-"
+		if issue.Frontmatter != nil && issue.Frontmatter["status"] != "" {
+			status = issue.Frontmatter["status"]
+		}
+
+		summary := issue.Summary
+		if strings.TrimSpace(summary) == "" {
+			summary = issue.Title
+		}
+		if strings.TrimSpace(summary) == "" {
+			summary = "-"
+		}
+
+		var latest *model.Run
+		activeCount := 0
+		for _, run := range runsByIssue[issue.ID] {
+			if latest == nil || run.UpdatedAt.After(latest.UpdatedAt) {
+				latest = run
+			}
+			if isActiveStatus(run.Status) {
+				activeCount++
+			}
+		}
+
+		row := IssueRow{
+			Index:      i + 1,
+			ID:         issue.ID,
+			Status:     status,
+			Summary:    summary,
+			ActiveRuns: activeCount,
+			Issue:      issue,
+		}
+		if latest != nil {
+			row.LatestRunID = latest.RunID
+			row.LatestStatus = latest.Status
+			row.LatestUpdated = latest.UpdatedAt
+		}
+		rows = append(rows, row)
+	}
+
+	return rows
+}
+
+func (m *Monitor) runsDashboardCommand() string {
 	args := append([]string{m.orchPath}, m.globalFlags...)
 	args = append(args, "monitor", "--dashboard")
 	if m.issueFilter != "" {
@@ -339,6 +549,47 @@ func (m *Monitor) dashboardCommand() string {
 		args = append(args, "--status", string(status))
 	}
 	return shellJoin(args)
+}
+
+func (m *Monitor) issuesDashboardCommand() string {
+	args := append([]string{m.orchPath}, m.globalFlags...)
+	args = append(args, "monitor", "--issues-dashboard")
+	return shellJoin(args)
+}
+
+func (m *Monitor) agentChatCommand() string {
+	prompt := buildAgentChatPrompt(m.store.VaultPath())
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fallbackChatCommand("failed to load config")
+	}
+
+	agentName := cfg.Agent
+	if agentName == "" {
+		agentName = "claude"
+	}
+	aType, err := agent.ParseAgentType(agentName)
+	if err != nil {
+		return fallbackChatCommand(err.Error())
+	}
+	adapter, err := agent.GetAdapter(aType)
+	if err != nil {
+		return fallbackChatCommand(err.Error())
+	}
+	if !adapter.IsAvailable() {
+		return fallbackChatCommand(fmt.Sprintf("%s CLI not available", agentName))
+	}
+
+	cmd, err := adapter.LaunchCommand(&agent.LaunchConfig{
+		Type:      aType,
+		VaultPath: m.store.VaultPath(),
+		Prompt:    prompt,
+	})
+	if err != nil {
+		return fallbackChatCommand(err.Error())
+	}
+	return cmd
 }
 
 func defaultStatuses() []model.Status {
@@ -352,9 +603,27 @@ func defaultStatuses() []model.Status {
 	}
 }
 
+func isReservedWindowIndex(index int) bool {
+	switch index {
+	case runsWindowIndex, issuesWindowIndex, agentWindowIndex:
+		return true
+	default:
+		return false
+	}
+}
+
 func isTerminalStatus(status model.Status) bool {
 	switch status {
-	case model.StatusDone, model.StatusFailed, model.StatusCanceled:
+	case model.StatusDone, model.StatusFailed, model.StatusCanceled, model.StatusResolved:
+		return true
+	default:
+		return false
+	}
+}
+
+func isActiveStatus(status model.Status) bool {
+	switch status {
+	case model.StatusRunning, model.StatusBlocked, model.StatusBlockedAPI, model.StatusBooting, model.StatusQueued, model.StatusPROpen:
 		return true
 	default:
 		return false

--- a/internal/monitor/styles.go
+++ b/internal/monitor/styles.go
@@ -33,6 +33,7 @@ func DefaultStyles() Styles {
 			model.StatusQueued:     lipgloss.NewStyle().Foreground(lipgloss.Color("7")),
 			model.StatusPROpen:     lipgloss.NewStyle().Foreground(lipgloss.Color("6")),
 			model.StatusDone:       lipgloss.NewStyle().Foreground(lipgloss.Color("4")),
+			model.StatusResolved:   lipgloss.NewStyle().Foreground(lipgloss.Color("8")),
 			model.StatusFailed:     lipgloss.NewStyle().Foreground(lipgloss.Color("1")),
 			model.StatusCanceled:   lipgloss.NewStyle().Foreground(lipgloss.Color("8")),
 			model.StatusUnknown:    lipgloss.NewStyle().Foreground(lipgloss.Color("5")),

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -189,6 +189,15 @@ func ListWindows(session string) ([]Window, error) {
 	return windows, nil
 }
 
+// MoveWindow moves a window to a new index.
+func MoveWindow(session, source string, index int) error {
+	src := fmt.Sprintf("%s:%s", session, source)
+	target := fmt.Sprintf("%s:%d", session, index)
+	cmd := execCommand("tmux", "move-window", "-s", src, "-t", target)
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
 // LinkWindow links an existing window into a session.
 func LinkWindow(sourceSession string, sourceWindow int, targetSession string, targetIndex int) error {
 	source := fmt.Sprintf("%s:%d", sourceSession, sourceWindow)

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -176,6 +176,25 @@ func TestNewSessionSendsKeys(t *testing.T) {
 	}
 }
 
+func TestMoveWindow(t *testing.T) {
+	exec := &fakeExecutor{calls: []fakeCall{{exitCode: 0}}}
+	orig := execCommand
+	execCommand = exec.Command
+	t.Cleanup(func() { execCommand = orig })
+
+	if err := MoveWindow("sess", "issues", 1); err != nil {
+		t.Fatalf("MoveWindow error: %v", err)
+	}
+
+	if len(exec.recorded) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(exec.recorded))
+	}
+	call := exec.recorded[0]
+	if !equalArgs(call.args, []string{"move-window", "-s", "sess:issues", "-t", "sess:1"}) {
+		t.Fatalf("move-window args = %v", call.args)
+	}
+}
+
 func equalArgs(got, want []string) bool {
 	if len(got) != len(want) {
 		return false


### PR DESCRIPTION
## Summary
- add run and issue dashboards with auto-refresh and navigation
- add agent chat window and prompt presets for orch workflows
- expose phase in show JSON and avoid daemon side effects on show

## Issue
- orch-023