### PR TITLE
Write run prompts to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 # orch run logs (when using repo as vault)
 /runs/
 /.orch/daemon.*
+ORCH_PROMPT.md


### PR DESCRIPTION
## Summary\n- write the full agent prompt to ORCH_PROMPT.md in the run worktree\n- pass a static instruction prompt to adapters\n- ignore ORCH_PROMPT.md in git\n\nRefs orch-026