### PR TITLE
Fix Gemini CLI interactive session termination

### DIFF
--- a/internal/agent/adapter.go
+++ b/internal/agent/adapter.go
@@ -5,6 +5,16 @@ import (
 	"os"
 )
 
+// InjectionMethod specifies how the prompt should be sent to the agent
+type InjectionMethod string
+
+const (
+	// InjectionArg means the prompt is passed as a command-line argument (default)
+	InjectionArg InjectionMethod = "arg"
+	// InjectionTmux means the prompt should be sent via tmux send-keys after the session starts
+	InjectionTmux InjectionMethod = "tmux"
+)
+
 // AgentType represents the type of agent
 type AgentType string
 
@@ -74,6 +84,10 @@ type Adapter interface {
 
 	// IsAvailable checks if the agent CLI is available
 	IsAvailable() bool
+
+	// PromptInjection returns how the prompt should be sent to the agent
+	// Default implementations should return InjectionArg
+	PromptInjection() InjectionMethod
 }
 
 // GetAdapter returns the adapter for the given agent type

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -53,4 +53,8 @@ func doubleQuote(s string) string {
 	return "\"" + s + "\""
 }
 
+func (a *ClaudeAdapter) PromptInjection() InjectionMethod {
+	return InjectionArg
+}
+
 var _ Adapter = (*ClaudeAdapter)(nil)

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -34,4 +34,8 @@ func (a *CodexAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 	return strings.Join(args, " "), nil
 }
 
+func (a *CodexAdapter) PromptInjection() InjectionMethod {
+	return InjectionArg
+}
+
 var _ Adapter = (*CodexAdapter)(nil)

--- a/internal/agent/custom.go
+++ b/internal/agent/custom.go
@@ -23,4 +23,8 @@ func (a *CustomAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 	return cfg.CustomCmd, nil
 }
 
+func (a *CustomAdapter) PromptInjection() InjectionMethod {
+	return InjectionArg
+}
+
 var _ Adapter = (*CustomAdapter)(nil)

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -22,16 +21,16 @@ func (a *GeminiAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 	var args []string
 
 	// gemini CLI with yolo mode
+	// Note: We don't pass -p flag here because Gemini exits after processing
+	// the prompt. Instead, the prompt is sent via tmux send-keys to keep
+	// the interactive session open. See PromptInjection() method.
 	args = append(args, "gemini", "--yolo")
 
-	// Add the prompt
-	if cfg.Prompt != "" {
-		// Escape the prompt for shell
-		escapedPrompt := strings.ReplaceAll(cfg.Prompt, "'", "'\"'\"'")
-		args = append(args, "-p", fmt.Sprintf("'%s'", escapedPrompt))
-	}
-
 	return strings.Join(args, " "), nil
+}
+
+func (a *GeminiAdapter) PromptInjection() InjectionMethod {
+	return InjectionTmux
 }
 
 var _ Adapter = (*GeminiAdapter)(nil)

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -9,8 +9,16 @@ func TestGeminiLaunchCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LaunchCommand error: %v", err)
 	}
-	want := `gemini --yolo -p 'hello '"'"'world'"'"''`
+	// Gemini now launches without -p flag; prompt is sent via tmux send-keys
+	want := `gemini --yolo`
 	if cmd != want {
 		t.Fatalf("command = %q, want %q", cmd, want)
+	}
+}
+
+func TestGeminiPromptInjection(t *testing.T) {
+	adapter := &GeminiAdapter{}
+	if adapter.PromptInjection() != InjectionTmux {
+		t.Fatalf("PromptInjection() = %v, want %v", adapter.PromptInjection(), InjectionTmux)
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -282,6 +282,14 @@ func runRun(issueID string, opts *runOptions) error {
 			return exitWithCode(fmt.Errorf("failed to create tmux session: %w", err), ExitTmuxError)
 		}
 
+		// If the agent uses tmux send-keys for prompt injection, send the prompt now
+		if adapter.PromptInjection() == agent.InjectionTmux && launchCfg.Prompt != "" {
+			if err := tmux.SendKeys(tmuxSession, launchCfg.Prompt); err != nil {
+				st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+				return exitWithCode(fmt.Errorf("failed to send prompt to session: %w", err), ExitTmuxError)
+			}
+		}
+
 		// Record session artifact
 		st.AppendEvent(run.Ref(), model.NewArtifactEvent("session", map[string]string{
 			"name": tmuxSession,


### PR DESCRIPTION
## Summary

- Adds `InjectionMethod` type to specify how prompts are sent to agents (`InjectionArg` or `InjectionTmux`)
- Updates `Adapter` interface with `PromptInjection()` method
- Gemini adapter now uses `InjectionTmux` instead of `-p` flag, which caused session termination
- `run.go` sends prompt via `tmux send-keys` for agents using `InjectionTmux`

## Test plan

- [x] All existing tests pass
- [x] Added new test for `GeminiAdapter.PromptInjection()`
- [ ] Manual testing with `orch run` using Gemini agent

Fixes: orch-025

🤖 Generated with [Claude Code](https://claude.com/claude-code)