### PR TITLE
Separate issue resolution from run lifecycle states

### DIFF
--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -85,7 +85,7 @@ Use --dry-run to see what would be deleted without actually deleting.`,
 
 	cmd.Flags().BoolVar(&opts.All, "all", false, "Delete all runs for the specified issue")
 	cmd.Flags().StringVar(&opts.OlderThan, "older-than", "", "Delete runs older than duration (e.g., 7d, 2w, 1m)")
-	cmd.Flags().StringVar(&opts.Status, "status", "", "Only delete runs with specific status (done/failed/canceled/resolved)")
+	cmd.Flags().StringVar(&opts.Status, "status", "", "Only delete runs with specific status (done/failed/canceled/completed)")
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would be deleted without deleting")
 	cmd.Flags().BoolVar(&opts.WithWorktree, "with-worktree", false, "Also remove git worktree")
@@ -130,7 +130,7 @@ func parseStatus(s string) ([]model.Status, error) {
 
 	status := model.Status(s)
 	switch status {
-	case model.StatusDone, model.StatusResolved, model.StatusFailed, model.StatusCanceled:
+	case model.StatusDone, model.StatusCompleted, model.StatusFailed, model.StatusCanceled:
 		return []model.Status{status}, nil
 	case model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusBlockedAPI, model.StatusQueued:
 		return nil, fmt.Errorf("cannot delete %s runs (use 'orch stop' first)", status)

--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -43,14 +43,14 @@ func newPsCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&opts.Status, "status", nil, "Filter by status (queued,booting,running,blocked,blocked_api,pr_open,done,resolved,failed,canceled,unknown)")
+	cmd.Flags().StringSliceVar(&opts.Status, "status", nil, "Filter by status (queued,booting,running,blocked,blocked_api,pr_open,done,completed,failed,canceled,unknown)")
 	cmd.Flags().StringSliceVar(&opts.IssueStatus, "issue-status", nil, "Filter by issue status (open,closed,...)")
 	cmd.Flags().StringVar(&opts.Issue, "issue", "", "Filter by issue ID")
 	cmd.Flags().IntVar(&opts.Limit, "limit", 50, "Maximum number of runs to show")
 	cmd.Flags().StringVar(&opts.Sort, "sort", "updated", "Sort by (updated|started)")
 	cmd.Flags().StringVar(&opts.Since, "since", "", "Only show runs updated since (ISO8601)")
 	cmd.Flags().BoolVar(&opts.AbsoluteTime, "absolute-time", false, "Show absolute timestamps instead of relative")
-	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "Show all runs including resolved")
+	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "Show all runs including completed")
 
 	return cmd
 }
@@ -86,7 +86,7 @@ func runPs(opts *psOptions) error {
 	}
 
 	if len(opts.Status) == 0 && !opts.All {
-		runs = filterResolvedRuns(runs)
+		runs = filterCompletedRuns(runs)
 	}
 
 	issueStatusFilter := make(map[string]bool)
@@ -449,7 +449,7 @@ func colorStatus(status model.Status) string {
 		model.StatusBlockedAPI: "\033[33m", // yellow
 		model.StatusFailed:     "\033[31m", // red
 		model.StatusDone:       "\033[34m", // blue
-		model.StatusResolved:   "\033[90m", // gray
+		model.StatusCompleted:  "\033[90m", // gray
 		model.StatusPROpen:     "\033[36m", // cyan
 		model.StatusQueued:     "\033[37m", // white
 		model.StatusBooting:    "\033[32m", // green
@@ -554,13 +554,13 @@ func mergedBranchesForTarget(repoRoot, target string) (string, map[string]bool, 
 	return target, merged, nil
 }
 
-func filterResolvedRuns(runs []*model.Run) []*model.Run {
+func filterCompletedRuns(runs []*model.Run) []*model.Run {
 	if len(runs) == 0 {
 		return runs
 	}
 	filtered := make([]*model.Run, 0, len(runs))
 	for _, run := range runs {
-		if run.Status != model.StatusResolved {
+		if run.Status != model.StatusCompleted {
 			filtered = append(filtered, run)
 		}
 	}

--- a/internal/cli/ps_test.go
+++ b/internal/cli/ps_test.go
@@ -322,7 +322,7 @@ func TestFormatRelativeTime(t *testing.T) {
 	}
 }
 
-func TestRunPsExcludesResolvedByDefault(t *testing.T) {
+func TestRunPsExcludesCompletedByDefault(t *testing.T) {
 	resetGlobalOpts(t)
 
 	vault := t.TempDir()
@@ -337,12 +337,12 @@ func TestRunPsExcludesResolvedByDefault(t *testing.T) {
 		t.Fatalf("getStore: %v", err)
 	}
 
-	runResolved, err := st.CreateRun("issue-1", "run-1", nil)
+	runCompleted, err := st.CreateRun("issue-1", "run-1", nil)
 	if err != nil {
-		t.Fatalf("CreateRun resolved: %v", err)
+		t.Fatalf("CreateRun completed: %v", err)
 	}
-	if err := st.AppendEvent(runResolved.Ref(), model.NewStatusEvent(model.StatusResolved)); err != nil {
-		t.Fatalf("AppendEvent resolved: %v", err)
+	if err := st.AppendEvent(runCompleted.Ref(), model.NewStatusEvent(model.StatusCompleted)); err != nil {
+		t.Fatalf("AppendEvent completed: %v", err)
 	}
 
 	runActive, err := st.CreateRun("issue-1", "run-2", nil)
@@ -373,7 +373,7 @@ func TestRunPsExcludesResolvedByDefault(t *testing.T) {
 	}
 }
 
-func TestRunPsAllIncludesResolved(t *testing.T) {
+func TestRunPsAllIncludesCompleted(t *testing.T) {
 	resetGlobalOpts(t)
 
 	vault := t.TempDir()
@@ -388,12 +388,12 @@ func TestRunPsAllIncludesResolved(t *testing.T) {
 		t.Fatalf("getStore: %v", err)
 	}
 
-	runResolved, err := st.CreateRun("issue-2", "run-1", nil)
+	runCompleted, err := st.CreateRun("issue-2", "run-1", nil)
 	if err != nil {
-		t.Fatalf("CreateRun resolved: %v", err)
+		t.Fatalf("CreateRun completed: %v", err)
 	}
-	if err := st.AppendEvent(runResolved.Ref(), model.NewStatusEvent(model.StatusResolved)); err != nil {
-		t.Fatalf("AppendEvent resolved: %v", err)
+	if err := st.AppendEvent(runCompleted.Ref(), model.NewStatusEvent(model.StatusCompleted)); err != nil {
+		t.Fatalf("AppendEvent completed: %v", err)
 	}
 
 	runActive, err := st.CreateRun("issue-2", "run-2", nil)

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -45,9 +45,9 @@ func runResolve(refStr string, opts *resolveOptions) error {
 		return err
 	}
 
-	if run.Status == model.StatusResolved {
+	if run.Status == model.StatusCompleted {
 		if !globalOpts.Quiet {
-			fmt.Printf("%s#%s already resolved\n", run.IssueID, run.RunID)
+			fmt.Printf("%s#%s already completed\n", run.IssueID, run.RunID)
 		}
 		return nil
 	}
@@ -56,13 +56,14 @@ func runResolve(refStr string, opts *resolveOptions) error {
 		return fmt.Errorf("run %s#%s is %s; use --force to resolve anyway", run.IssueID, run.RunID, run.Status)
 	}
 
-	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusResolved)); err != nil {
-		return fmt.Errorf("failed to append resolved event: %w", err)
+	// Mark run as completed (operational lifecycle state)
+	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusCompleted)); err != nil {
+		return fmt.Errorf("failed to append completed event: %w", err)
 	}
 
-	// Also mark issue as resolved
-	if err := st.SetIssueStatus(run.IssueID, "resolved"); err != nil {
-		// Log error but don't fail the command since the run was resolved
+	// Mark issue as resolved (issue resolution state)
+	if err := st.SetIssueStatus(run.IssueID, model.IssueStatusResolved); err != nil {
+		// Log error but don't fail the command since the run was completed
 		fmt.Fprintf(os.Stderr, "warning: failed to mark issue as resolved: %v\n", err)
 	}
 

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -40,8 +40,8 @@ func TestRunResolveMarksResolved(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetRun: %v", err)
 	}
-	if updated.Status != model.StatusResolved {
-		t.Fatalf("status = %q, want %q", updated.Status, model.StatusResolved)
+	if updated.Status != model.StatusCompleted {
+		t.Fatalf("status = %q, want %q", updated.Status, model.StatusCompleted)
 	}
 }
 
@@ -80,8 +80,8 @@ func TestRunResolveRequiresForceForActive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetRun: %v", err)
 	}
-	if updated.Status != model.StatusResolved {
-		t.Fatalf("status = %q, want %q", updated.Status, model.StatusResolved)
+	if updated.Status != model.StatusCompleted {
+		t.Fatalf("status = %q, want %q", updated.Status, model.StatusCompleted)
 	}
 }
 

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -151,7 +151,7 @@ func stopRun(st interface {
 	AppendEvent(ref *model.RunRef, event *model.Event) error
 }, run *model.Run, opts *stopOptions) error {
 	// Skip if already terminal
-	if run.Status == model.StatusDone || run.Status == model.StatusResolved || run.Status == model.StatusFailed || run.Status == model.StatusCanceled {
+	if run.Status == model.StatusDone || run.Status == model.StatusCompleted || run.Status == model.StatusFailed || run.Status == model.StatusCanceled {
 		if !globalOpts.Quiet {
 			fmt.Printf("%s#%s already %s\n", run.IssueID, run.RunID, run.Status)
 		}

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -21,7 +21,7 @@ const (
 	EventTypeNote     EventType = "note"
 )
 
-// Status values
+// Status values for run lifecycle (operational states only)
 type Status string
 
 const (
@@ -32,7 +32,7 @@ const (
 	StatusBlockedAPI Status = "blocked_api"
 	StatusPROpen     Status = "pr_open"
 	StatusDone       Status = "done"
-	StatusResolved   Status = "resolved"
+	StatusCompleted  Status = "completed" // Run has been marked as successfully completed
 	StatusFailed     Status = "failed"
 	StatusCanceled   Status = "canceled"
 	StatusUnknown    Status = "unknown" // Agent exited unexpectedly, shell prompt showing

--- a/internal/model/issue.go
+++ b/internal/model/issue.go
@@ -1,5 +1,45 @@
 package model
 
+// IssueStatus represents the resolution state of an issue
+type IssueStatus string
+
+const (
+	IssueStatusOpen     IssueStatus = "open"
+	IssueStatusResolved IssueStatus = "resolved"
+	IssueStatusClosed   IssueStatus = "closed"
+)
+
+// ValidIssueStatuses contains all valid issue status values
+var ValidIssueStatuses = []IssueStatus{
+	IssueStatusOpen,
+	IssueStatusResolved,
+	IssueStatusClosed,
+}
+
+// IsValidIssueStatus checks if a status string is a valid issue status
+func IsValidIssueStatus(s string) bool {
+	for _, status := range ValidIssueStatuses {
+		if string(status) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseIssueStatus converts a string to IssueStatus, returning open for empty/invalid values
+func ParseIssueStatus(s string) IssueStatus {
+	if s == "" {
+		return IssueStatusOpen
+	}
+	status := IssueStatus(s)
+	for _, valid := range ValidIssueStatuses {
+		if status == valid {
+			return status
+		}
+	}
+	return IssueStatusOpen
+}
+
 // Issue represents a specification unit
 type Issue struct {
 	ID          string
@@ -9,4 +49,12 @@ type Issue struct {
 	Body        string
 	Path        string            // File path to issue document
 	Frontmatter map[string]string // YAML frontmatter fields
+}
+
+// Status returns the typed IssueStatus from the frontmatter
+func (i *Issue) Status() IssueStatus {
+	if i == nil || i.Frontmatter == nil {
+		return IssueStatusOpen
+	}
+	return ParseIssueStatus(i.Frontmatter["status"])
 }

--- a/internal/monitor/dashboard.go
+++ b/internal/monitor/dashboard.go
@@ -729,7 +729,7 @@ func (d *Dashboard) renderStats() string {
 		fmt.Sprintf("blocked_api: %d", counts[model.StatusBlockedAPI]),
 		fmt.Sprintf("pr_open: %d", counts[model.StatusPROpen]),
 		fmt.Sprintf("done: %d", counts[model.StatusDone]),
-		fmt.Sprintf("resolved: %d", counts[model.StatusResolved]),
+		fmt.Sprintf("completed: %d", counts[model.StatusCompleted]),
 		fmt.Sprintf("failed: %d", counts[model.StatusFailed]),
 		fmt.Sprintf("canceled: %d", counts[model.StatusCanceled]),
 	}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -622,7 +622,7 @@ func isReservedWindowIndex(index int) bool {
 
 func isTerminalStatus(status model.Status) bool {
 	switch status {
-	case model.StatusDone, model.StatusFailed, model.StatusCanceled, model.StatusResolved:
+	case model.StatusDone, model.StatusFailed, model.StatusCanceled, model.StatusCompleted:
 		return true
 	default:
 		return false

--- a/internal/monitor/styles.go
+++ b/internal/monitor/styles.go
@@ -33,7 +33,7 @@ func DefaultStyles() Styles {
 			model.StatusQueued:     lipgloss.NewStyle().Foreground(lipgloss.Color("7")),
 			model.StatusPROpen:     lipgloss.NewStyle().Foreground(lipgloss.Color("6")),
 			model.StatusDone:       lipgloss.NewStyle().Foreground(lipgloss.Color("4")),
-			model.StatusResolved:   lipgloss.NewStyle().Foreground(lipgloss.Color("8")),
+			model.StatusCompleted:  lipgloss.NewStyle().Foreground(lipgloss.Color("8")),
 			model.StatusFailed:     lipgloss.NewStyle().Foreground(lipgloss.Color("1")),
 			model.StatusCanceled:   lipgloss.NewStyle().Foreground(lipgloss.Color("8")),
 			model.StatusUnknown:    lipgloss.NewStyle().Foreground(lipgloss.Color("5")),

--- a/internal/store/file/file.go
+++ b/internal/store/file/file.go
@@ -523,7 +523,7 @@ func (s *FileStore) ListRuns(filter *store.ListRunsFilter) ([]*model.Run, error)
 }
 
 // SetIssueStatus updates the status of an issue in its frontmatter
-func (s *FileStore) SetIssueStatus(issueID string, status string) error {
+func (s *FileStore) SetIssueStatus(issueID string, status model.IssueStatus) error {
 	issue, err := s.ResolveIssue(issueID)
 	if err != nil {
 		return err
@@ -539,6 +539,7 @@ func (s *FileStore) SetIssueStatus(issueID string, status string) error {
 		return fmt.Errorf("issue file has no frontmatter: %s", issue.Path)
 	}
 
+	statusStr := string(status)
 	var newLines []string
 	newLines = append(newLines, lines[0])
 	foundStatus := false
@@ -550,7 +551,7 @@ func (s *FileStore) SetIssueStatus(issueID string, status string) error {
 			if strings.TrimSpace(line) == "---" {
 				if !foundStatus {
 					// Add status if not found in frontmatter
-					newLines = append(newLines, fmt.Sprintf("status: %s", status))
+					newLines = append(newLines, fmt.Sprintf("status: %s", statusStr))
 				}
 				newLines = append(newLines, line)
 				inFrontmatter = false
@@ -559,7 +560,7 @@ func (s *FileStore) SetIssueStatus(issueID string, status string) error {
 
 			parts := strings.SplitN(line, ":", 2)
 			if len(parts) == 2 && strings.TrimSpace(parts[0]) == "status" {
-				newLines = append(newLines, fmt.Sprintf("status: %s", status))
+				newLines = append(newLines, fmt.Sprintf("status: %s", statusStr))
 				foundStatus = true
 			} else {
 				newLines = append(newLines, line)
@@ -574,7 +575,7 @@ func (s *FileStore) SetIssueStatus(issueID string, status string) error {
 	}
 
 	// Update cache
-	issue.Frontmatter["status"] = status
+	issue.Frontmatter["status"] = statusStr
 	s.cacheDirty = true // Mark dirty to be safe, although we updated the object
 
 	return nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -40,7 +40,7 @@ type Store interface {
 	GetLatestRun(issueID string) (*model.Run, error)
 
 	// SetIssueStatus updates the status of an issue
-	SetIssueStatus(issueID string, status string) error
+	SetIssueStatus(issueID string, status model.IssueStatus) error
 
 	// VaultPath returns the vault root path
 	VaultPath() string


### PR DESCRIPTION
## Summary
- Introduces separate state types for issues and runs to eliminate semantic confusion
- Issues now use `IssueStatus` type with states: `open`, `resolved`, `closed`
- Runs now use `Status` type with operational lifecycle states only, replacing `resolved` with `completed`
- The `orch resolve` command now marks the run as `completed` (operational state) and the issue as `resolved` (resolution state)

## Changes
- Add `IssueStatus` type in `internal/model/issue.go` with validation helpers
- Replace `StatusResolved` with `StatusCompleted` for run lifecycle states
- Update `SetIssueStatus` interface to use typed `IssueStatus` parameter
- Update commands (`resolve`, `ps`, `delete`, `stop`) for new state model
- Update dashboard/monitor to display `completed` status correctly
- Update tests for new state naming

## References
- Issue: state-model-refactor

## Test plan
- [x] All existing tests pass
- [x] Build succeeds
- [x] resolve command marks run as completed and issue as resolved
- [x] ps command filters completed runs by default
- [x] ps --all shows completed runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)