### PR TITLE
Fix monitor chat pane selection

### DIFF
--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -181,7 +181,11 @@ func (m *Monitor) SwitchChat() error {
 	if err := m.CloseRunPane(); err != nil {
 		return err
 	}
-	return m.selectPaneByTitle(chatPaneTitle)
+	pane, err := m.findChatPane()
+	if err != nil {
+		return err
+	}
+	return tmux.SelectPane(pane)
 }
 
 // OpenRun links a run session into the monitor and switches to it.
@@ -212,7 +216,7 @@ func (m *Monitor) OpenRun(run *model.Run) error {
 		return err
 	}
 
-	chatPane, err := m.findPaneByTitle(m.session, chatPaneTitle)
+	chatPane, err := m.findChatPane()
 	if err != nil {
 		return err
 	}
@@ -693,6 +697,28 @@ func (m *Monitor) selectPaneByTitle(title string) error {
 		return err
 	}
 	return tmux.SelectPane(pane)
+}
+
+func (m *Monitor) findChatPane() (string, error) {
+	target := fmt.Sprintf("%s:%d", m.session, dashboardWindowIdx)
+	panes, err := tmux.ListPanes(target)
+	if err != nil {
+		return "", err
+	}
+	if len(panes) == 0 {
+		return "", fmt.Errorf("no panes found in %s", target)
+	}
+	for _, pane := range panes {
+		if pane.Title == chatPaneTitle {
+			return pane.ID, nil
+		}
+	}
+	for _, pane := range panes {
+		if pane.Title != runsPaneTitle && pane.Title != issuesPaneTitle {
+			return pane.ID, nil
+		}
+	}
+	return "", fmt.Errorf("pane not found: %s", chatPaneTitle)
 }
 
 func (m *Monitor) findPaneByTitle(session, title string) (string, error) {


### PR DESCRIPTION
## Summary
- fall back to non-dashboard pane when chat title is missing
- use chat-pane lookup for switching and run swaps

Refs: orch-023