### PR TITLE
fix: resolve worktree paths correctly when running from inside a worktree

### DIFF
--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -78,10 +78,17 @@ func runAttach(refStr string, opts *attachOptions) error {
 		}
 	}
 
-	// Attach to session
-	if err := tmux.AttachSession(sessionName); err != nil {
-		os.Exit(ExitTmuxError)
-		return err
+	// Attach to session - use switch-client if already inside tmux
+	if tmux.IsInsideTmux() {
+		if err := tmux.SwitchClient(sessionName); err != nil {
+			os.Exit(ExitTmuxError)
+			return err
+		}
+	} else {
+		if err := tmux.AttachSession(sessionName); err != nil {
+			os.Exit(ExitTmuxError)
+			return err
+		}
 	}
 
 	return nil

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -124,17 +124,17 @@ func runRun(issueID string, opts *runOptions) error {
 		tmuxSession = model.GenerateTmuxSession(issueID, runID)
 	}
 
-	// Find repo root
+	// Find repo root - use main repo root to handle running from inside worktrees
 	repoRoot := opts.RepoRoot
 	if repoRoot == "" {
-		repoRoot, err = git.FindRepoRoot("")
+		repoRoot, err = git.FindMainRepoRoot("")
 		if err != nil {
 			return exitWithCode(fmt.Errorf("could not find git repository: %w", err), ExitWorktreeError)
 		}
 	}
 
-	// Compute worktree path
-	worktreePath := fmt.Sprintf("%s/%s/%s", opts.WorktreeRoot, issueID, runID)
+	// Compute worktree path (absolute to ensure correct directory regardless of cwd)
+	worktreePath := filepath.Join(repoRoot, opts.WorktreeRoot, issueID, runID)
 
 	result := &runResult{
 		OK:           true,

--- a/internal/store/file/file.go
+++ b/internal/store/file/file.go
@@ -433,6 +433,13 @@ func (s *FileStore) loadRun(issueID, runID, path string) (*model.Run, error) {
 	}
 
 	run.DeriveState()
+
+	// Resolve relative worktree paths against the vault path
+	// This handles runs created before worktree paths were made absolute
+	if run.WorktreePath != "" && !filepath.IsAbs(run.WorktreePath) {
+		run.WorktreePath = filepath.Join(s.vaultPath, run.WorktreePath)
+	}
+
 	return run, nil
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -149,6 +149,11 @@ func IsTmuxAvailable() bool {
 	return cmd.Run() == nil
 }
 
+// IsInsideTmux returns true if we're currently inside a tmux session
+func IsInsideTmux() bool {
+	return os.Getenv("TMUX") != ""
+}
+
 // Window describes a tmux window.
 type Window struct {
 	Index int


### PR DESCRIPTION
## Summary
- Fix `orch run` creating worktrees in wrong location when invoked from inside a worktree
- Use `git.FindMainRepoRoot()` to always get the main repository root
- Make worktree paths absolute to prevent directory resolution issues
- Add backwards-compatibility for existing runs with relative paths

## Problem
When `orch monitor` was started from inside a worktree (e.g., orch-023), and then created a new run (orch-028), the worktree was created nested inside the current worktree instead of at the main repo root. This caused `orch attach orch-028` to attach to the wrong session.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Verified `FindMainRepoRoot` returns correct path from inside worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)