### PR TITLE
feat: separate issue resolution from run lifecycle states

### DIFF
--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -85,7 +85,7 @@ Use --dry-run to see what would be deleted without actually deleting.`,
 
 	cmd.Flags().BoolVar(&opts.All, "all", false, "Delete all runs for the specified issue")
 	cmd.Flags().StringVar(&opts.OlderThan, "older-than", "", "Delete runs older than duration (e.g., 7d, 2w, 1m)")
-	cmd.Flags().StringVar(&opts.Status, "status", "", "Only delete runs with specific status (done/failed/canceled/resolved)")
+	cmd.Flags().StringVar(&opts.Status, "status", "", "Only delete runs with specific status (done/failed/canceled)")
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would be deleted without deleting")
 	cmd.Flags().BoolVar(&opts.WithWorktree, "with-worktree", false, "Also remove git worktree")
@@ -130,7 +130,7 @@ func parseStatus(s string) ([]model.Status, error) {
 
 	status := model.Status(s)
 	switch status {
-	case model.StatusDone, model.StatusResolved, model.StatusFailed, model.StatusCanceled:
+	case model.StatusDone, model.StatusFailed, model.StatusCanceled:
 		return []model.Status{status}, nil
 	case model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusBlockedAPI, model.StatusQueued:
 		return nil, fmt.Errorf("cannot delete %s runs (use 'orch stop' first)", status)

--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -195,7 +195,7 @@ func runIssueList() error {
 			ID:      issue.ID,
 			Title:   issue.Title,
 			Summary: issue.Summary,
-			Status:  issue.Frontmatter["status"],
+			Status:  string(issue.Status),
 			Path:    issue.Path,
 		}
 

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -16,58 +17,71 @@ func newResolveCmd() *cobra.Command {
 	opts := &resolveOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "resolve RUN_REF",
-		Short: "Resolve a run",
-		Long: `Mark a run as resolved and hide it from default 'orch ps' output.
+		Use:   "resolve ISSUE_ID",
+		Short: "Mark an issue as resolved",
+		Long: `Mark an issue as resolved. This indicates the issue specification has been
+completed and no further work is needed.
 
-RUN_REF can be ISSUE_ID#RUN_ID, ISSUE_ID (latest), or a short ID.`,
+This updates the issue's status in its frontmatter from 'open' to 'resolved'.
+Note: This does not change run statuses - runs have their own lifecycle states.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runResolve(args[0], opts)
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.Force, "force", false, "Resolve even if run is not done or pr_open")
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "Resolve even if no completed runs exist")
 
 	return cmd
 }
 
-func runResolve(refStr string, opts *resolveOptions) error {
+func runResolve(issueID string, opts *resolveOptions) error {
 	st, err := getStore()
 	if err != nil {
 		return err
 	}
 
-	run, err := resolveRun(st, refStr)
+	issue, err := st.ResolveIssue(issueID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "run not found: %s\n", refStr)
+		fmt.Fprintf(os.Stderr, "issue not found: %s\n", issueID)
 		os.Exit(ExitRunNotFound)
 		return err
 	}
 
-	if run.Status == model.StatusResolved {
+	if issue.Status == model.IssueStatusResolved {
 		if !globalOpts.Quiet {
-			fmt.Printf("%s#%s already resolved\n", run.IssueID, run.RunID)
+			fmt.Printf("issue %s already resolved\n", issueID)
 		}
 		return nil
 	}
 
-	if !opts.Force && run.Status != model.StatusDone && run.Status != model.StatusPROpen {
-		return fmt.Errorf("run %s#%s is %s; use --force to resolve anyway", run.IssueID, run.RunID, run.Status)
+	// Check if there are any completed runs (done or pr_open) unless --force is used
+	if !opts.Force {
+		filter := store.ListRunsFilter{IssueID: issueID}
+		runs, err := st.ListRuns(&filter)
+		if err != nil {
+			return fmt.Errorf("failed to list runs: %w", err)
+		}
+
+		hasCompletedRun := false
+		for _, run := range runs {
+			if run.Status == model.StatusDone || run.Status == model.StatusPROpen {
+				hasCompletedRun = true
+				break
+			}
+		}
+
+		if !hasCompletedRun {
+			return fmt.Errorf("issue %s has no completed runs; use --force to resolve anyway", issueID)
+		}
 	}
 
-	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusResolved)); err != nil {
-		return fmt.Errorf("failed to append resolved event: %w", err)
-	}
-
-	// Also mark issue as resolved
-	if err := st.SetIssueStatus(run.IssueID, "resolved"); err != nil {
-		// Log error but don't fail the command since the run was resolved
-		fmt.Fprintf(os.Stderr, "warning: failed to mark issue as resolved: %v\n", err)
+	if err := st.SetIssueStatus(issueID, model.IssueStatusResolved); err != nil {
+		return fmt.Errorf("failed to mark issue as resolved: %w", err)
 	}
 
 	if !globalOpts.Quiet {
-		fmt.Printf("resolved: %s#%s\n", run.IssueID, run.RunID)
+		fmt.Printf("resolved: %s\n", issueID)
 	}
 
 	return nil

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -151,7 +151,7 @@ func stopRun(st interface {
 	AppendEvent(ref *model.RunRef, event *model.Event) error
 }, run *model.Run, opts *stopOptions) error {
 	// Skip if already terminal
-	if run.Status == model.StatusDone || run.Status == model.StatusResolved || run.Status == model.StatusFailed || run.Status == model.StatusCanceled {
+	if run.Status == model.StatusDone || run.Status == model.StatusFailed || run.Status == model.StatusCanceled {
 		if !globalOpts.Quiet {
 			fmt.Printf("%s#%s already %s\n", run.IssueID, run.RunID, run.Status)
 		}

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -21,7 +21,7 @@ const (
 	EventTypeNote     EventType = "note"
 )
 
-// Status values
+// Status represents run operational lifecycle states
 type Status string
 
 const (
@@ -32,11 +32,43 @@ const (
 	StatusBlockedAPI Status = "blocked_api"
 	StatusPROpen     Status = "pr_open"
 	StatusDone       Status = "done"
-	StatusResolved   Status = "resolved"
 	StatusFailed     Status = "failed"
 	StatusCanceled   Status = "canceled"
 	StatusUnknown    Status = "unknown" // Agent exited unexpectedly, shell prompt showing
 )
+
+// IssueStatus represents issue resolution states
+type IssueStatus string
+
+const (
+	IssueStatusOpen     IssueStatus = "open"     // Issue is active, work in progress
+	IssueStatusResolved IssueStatus = "resolved" // Issue specification has been resolved
+	IssueStatusClosed   IssueStatus = "closed"   // Issue is closed/archived
+)
+
+// ParseIssueStatus converts a string to IssueStatus, returning IssueStatusOpen for unknown values
+func ParseIssueStatus(s string) IssueStatus {
+	switch s {
+	case string(IssueStatusOpen):
+		return IssueStatusOpen
+	case string(IssueStatusResolved):
+		return IssueStatusResolved
+	case string(IssueStatusClosed):
+		return IssueStatusClosed
+	default:
+		return IssueStatusOpen // Default to open for backwards compatibility
+	}
+}
+
+// IsValidIssueStatus checks if a string is a valid IssueStatus
+func IsValidIssueStatus(s string) bool {
+	switch s {
+	case string(IssueStatusOpen), string(IssueStatusResolved), string(IssueStatusClosed):
+		return true
+	default:
+		return false
+	}
+}
 
 // Phase values
 type Phase string

--- a/internal/model/issue.go
+++ b/internal/model/issue.go
@@ -4,8 +4,9 @@ package model
 type Issue struct {
 	ID          string
 	Title       string
-	Topic       string // Short topic for ps display
-	Summary     string // Short one-line summary for display
+	Topic       string      // Short topic for ps display
+	Summary     string      // Short one-line summary for display
+	Status      IssueStatus // Issue resolution status (open/resolved/closed)
 	Body        string
 	Path        string            // File path to issue document
 	Frontmatter map[string]string // YAML frontmatter fields

--- a/internal/monitor/agent_prompt.go
+++ b/internal/monitor/agent_prompt.go
@@ -159,9 +159,9 @@ func buildControlAgentPrompt(st store.Store) (string, error) {
 	// Build issue info list
 	issueInfos := make([]IssueInfo, 0, len(issues))
 	for _, issue := range issues {
-		status := "open"
-		if issue.Frontmatter != nil && issue.Frontmatter["status"] != "" {
-			status = issue.Frontmatter["status"]
+		status := string(issue.Status)
+		if status == "" {
+			status = string(model.IssueStatusOpen)
 		}
 		title := issue.Title
 		if title == "" {

--- a/internal/monitor/dashboard.go
+++ b/internal/monitor/dashboard.go
@@ -724,7 +724,6 @@ func (d *Dashboard) renderStats() string {
 		fmt.Sprintf("blocked_api: %d", counts[model.StatusBlockedAPI]),
 		fmt.Sprintf("pr_open: %d", counts[model.StatusPROpen]),
 		fmt.Sprintf("done: %d", counts[model.StatusDone]),
-		fmt.Sprintf("resolved: %d", counts[model.StatusResolved]),
 		fmt.Sprintf("failed: %d", counts[model.StatusFailed]),
 		fmt.Sprintf("canceled: %d", counts[model.StatusCanceled]),
 	}

--- a/internal/monitor/issues_dashboard.go
+++ b/internal/monitor/issues_dashboard.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/s22625/orch/internal/model"
 )
 
 type issueDashboardMode int
@@ -276,7 +277,7 @@ func (d *IssueDashboard) openIssueCmd(issueID string) tea.Cmd {
 
 func (d *IssueDashboard) resolveIssueCmd(issueID string) tea.Cmd {
 	return func() tea.Msg {
-		if err := d.monitor.SetIssueStatus(issueID, "resolved"); err != nil {
+		if err := d.monitor.SetIssueStatus(issueID, model.IssueStatusResolved); err != nil {
 			return errMsg{err: err}
 		}
 		return infoMsg{text: fmt.Sprintf("resolved issue %s", issueID)}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -371,7 +371,7 @@ func (m *Monitor) CreateIssue(issueID, title string) (string, error) {
 }
 
 // SetIssueStatus updates the issue status in the store.
-func (m *Monitor) SetIssueStatus(issueID, status string) error {
+func (m *Monitor) SetIssueStatus(issueID string, status model.IssueStatus) error {
 	return m.store.SetIssueStatus(issueID, status)
 }
 
@@ -541,9 +541,9 @@ func (m *Monitor) buildIssueRows(issues []*model.Issue, runs []*model.Run) []Iss
 
 	rows := make([]IssueRow, 0, len(issues))
 	for i, issue := range issues {
-		status := "-"
-		if issue.Frontmatter != nil && issue.Frontmatter["status"] != "" {
-			status = issue.Frontmatter["status"]
+		status := string(issue.Status)
+		if status == "" {
+			status = string(model.IssueStatusOpen)
 		}
 
 		summary := issue.Summary
@@ -657,7 +657,7 @@ func defaultStatuses() []model.Status {
 
 func isTerminalStatus(status model.Status) bool {
 	switch status {
-	case model.StatusDone, model.StatusFailed, model.StatusCanceled, model.StatusResolved:
+	case model.StatusDone, model.StatusFailed, model.StatusCanceled:
 		return true
 	default:
 		return false

--- a/internal/monitor/styles.go
+++ b/internal/monitor/styles.go
@@ -33,7 +33,6 @@ func DefaultStyles() Styles {
 			model.StatusQueued:     lipgloss.NewStyle().Foreground(lipgloss.Color("7")),
 			model.StatusPROpen:     lipgloss.NewStyle().Foreground(lipgloss.Color("6")),
 			model.StatusDone:       lipgloss.NewStyle().Foreground(lipgloss.Color("4")),
-			model.StatusResolved:   lipgloss.NewStyle().Foreground(lipgloss.Color("8")),
 			model.StatusFailed:     lipgloss.NewStyle().Foreground(lipgloss.Color("1")),
 			model.StatusCanceled:   lipgloss.NewStyle().Foreground(lipgloss.Color("8")),
 			model.StatusUnknown:    lipgloss.NewStyle().Foreground(lipgloss.Color("5")),

--- a/internal/store/file/file_test.go
+++ b/internal/store/file/file_test.go
@@ -460,21 +460,21 @@ status: open
 	createTestIssue(t, vault, "test123", content)
 
 	s, _ := New(vault)
-	if err := s.SetIssueStatus("test123", "resolved"); err != nil {
+	if err := s.SetIssueStatus("test123", model.IssueStatusResolved); err != nil {
 		t.Fatalf("SetIssueStatus() error = %v", err)
 	}
 
 	// Verify cache
 	issue, _ := s.ResolveIssue("test123")
-	if issue.Frontmatter["status"] != "resolved" {
-		t.Errorf("expected cached status resolved, got %s", issue.Frontmatter["status"])
+	if issue.Status != model.IssueStatusResolved {
+		t.Errorf("expected cached status resolved, got %s", issue.Status)
 	}
 
 	// Verify file content
 	reloaded, _ := New(vault) // New store to force re-read
 	issue2, _ := reloaded.ResolveIssue("test123")
-	if issue2.Frontmatter["status"] != "resolved" {
-		t.Errorf("expected reloaded status resolved, got %s", issue2.Frontmatter["status"])
+	if issue2.Status != model.IssueStatusResolved {
+		t.Errorf("expected reloaded status resolved, got %s", issue2.Status)
 	}
 }
 
@@ -490,12 +490,12 @@ id: test123
 	createTestIssue(t, vault, "test123", content)
 
 	s, _ := New(vault)
-	if err := s.SetIssueStatus("test123", "resolved"); err != nil {
+	if err := s.SetIssueStatus("test123", model.IssueStatusResolved); err != nil {
 		t.Fatalf("SetIssueStatus() error = %v", err)
 	}
 
 	issue, _ := s.ResolveIssue("test123")
-	if issue.Frontmatter["status"] != "resolved" {
-		t.Errorf("expected status resolved, got %s", issue.Frontmatter["status"])
+	if issue.Status != model.IssueStatusResolved {
+		t.Errorf("expected status resolved, got %s", issue.Status)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,7 +21,7 @@ type Store interface {
 	ListIssues() ([]*model.Issue, error)
 
 	// SetIssueStatus updates an issue's status in frontmatter
-	SetIssueStatus(issueID string, status string) error
+	SetIssueStatus(issueID string, status model.IssueStatus) error
 
 	// CreateRun creates a new run for an issue
 	CreateRun(issueID, runID string, metadata map[string]string) (*model.Run, error)


### PR DESCRIPTION
## Summary
- Introduced dedicated `IssueStatus` type (open/resolved/closed) for issue resolution states
- Removed `StatusResolved` from run `Status` type - runs now only have operational lifecycle states
- Refactored `resolve` command to operate on issues instead of runs
- Updated `orch ps` to hide runs from resolved issues by default (use `--all` to show)

## Changes
- **internal/model/event.go**: Added `IssueStatus` enum with `open`, `resolved`, `closed` states and helper functions
- **internal/model/issue.go**: Added typed `Status` field to Issue struct
- **internal/store/**: Updated interface and implementation to use `IssueStatus` type
- **internal/cli/resolve.go**: Refactored to mark issues (not runs) as resolved
- **internal/cli/ps.go**: Updated to filter by issue status instead of run status
- **internal/cli/delete.go, stop.go**: Removed `StatusResolved` references
- **internal/monitor/**: Updated dashboard and styles for new state model
- **Tests**: Updated all affected test files

## Test plan
- [x] All existing tests pass
- [x] `go build ./...` succeeds
- [x] New `IssueStatus` enum properly distinguishes issue states from run states

Resolves: state-model-refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)