### PR TITLE
Add pattern-based ready detection for Gemini prompt injection

### DIFF
--- a/internal/agent/adapter.go
+++ b/internal/agent/adapter.go
@@ -88,6 +88,11 @@ type Adapter interface {
 	// PromptInjection returns how the prompt should be sent to the agent
 	// Default implementations should return InjectionArg
 	PromptInjection() InjectionMethod
+
+	// ReadyPattern returns a regex pattern to detect when the agent is ready for input
+	// The pattern is matched against the tmux pane content
+	// Return empty string if no detection is needed (prompt is passed via command line)
+	ReadyPattern() string
 }
 
 // GetAdapter returns the adapter for the given agent type

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -57,4 +57,8 @@ func (a *ClaudeAdapter) PromptInjection() InjectionMethod {
 	return InjectionArg
 }
 
+func (a *ClaudeAdapter) ReadyPattern() string {
+	return "" // Not needed - prompt passed via command line
+}
+
 var _ Adapter = (*ClaudeAdapter)(nil)

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -38,4 +38,8 @@ func (a *CodexAdapter) PromptInjection() InjectionMethod {
 	return InjectionArg
 }
 
+func (a *CodexAdapter) ReadyPattern() string {
+	return "" // Not needed - prompt passed via command line
+}
+
 var _ Adapter = (*CodexAdapter)(nil)

--- a/internal/agent/custom.go
+++ b/internal/agent/custom.go
@@ -27,4 +27,8 @@ func (a *CustomAdapter) PromptInjection() InjectionMethod {
 	return InjectionArg
 }
 
+func (a *CustomAdapter) ReadyPattern() string {
+	return "" // Not needed - prompt passed via command line
+}
+
 var _ Adapter = (*CustomAdapter)(nil)

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -33,4 +33,12 @@ func (a *GeminiAdapter) PromptInjection() InjectionMethod {
 	return InjectionTmux
 }
 
+func (a *GeminiAdapter) ReadyPattern() string {
+	// Gemini shows this prompt when ready for input:
+	// ╭────────────────────────────────────────────────────────╮
+	// │ *   Type your message or @path/to/file                 │
+	// ╰────────────────────────────────────────────────────────╯
+	return "Type your message"
+}
+
 var _ Adapter = (*GeminiAdapter)(nil)

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -22,3 +22,14 @@ func TestGeminiPromptInjection(t *testing.T) {
 		t.Fatalf("PromptInjection() = %v, want %v", adapter.PromptInjection(), InjectionTmux)
 	}
 }
+
+func TestGeminiReadyPattern(t *testing.T) {
+	adapter := &GeminiAdapter{}
+	pattern := adapter.ReadyPattern()
+	if pattern == "" {
+		t.Fatal("ReadyPattern() should not be empty for Gemini")
+	}
+	if pattern != "Type your message" {
+		t.Fatalf("ReadyPattern() = %q, want %q", pattern, "Type your message")
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces fixed delay with pattern-based detection for agent readiness
- Adds `ReadyPattern()` method to `Adapter` interface
- Adds `WaitForReady()` to tmux package that polls pane content for pattern match
- Gemini adapter uses `"Type your message"` pattern (from its input prompt box)
- `run.go` waits up to 30 seconds for pattern before sending prompt

This is more reliable than a fixed delay since it actually detects when Gemini is ready for input.

## Test plan

- [x] All tests pass
- [x] Added test for `GeminiAdapter.ReadyPattern()`
- [ ] Manual test with `orch run --agent gemini`

Fixes: orch-025

🤖 Generated with [Claude Code](https://claude.com/claude-code)