### PR TITLE
Detect Gemini idle prompt in daemon

### DIFF
--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -216,6 +216,8 @@ func (d *Daemon) isWaitingForInput(output string) bool {
 		// Permission dialog
 		"No, and tell Claude what to do differently",
 		"tell Claude what to do differently",
+		// Gemini input prompt
+		"Type your message",
 		// Input prompt (with text typed)
 		"↵ send",
 		// Input prompt (empty/idle)

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -56,6 +56,9 @@ func TestPromptDetection(t *testing.T) {
 	if !d.isWaitingForInput("accept edits to continue") {
 		t.Fatal("expected prompt detection")
 	}
+	if !d.isWaitingForInput("Type your message or @path/to/file") {
+		t.Fatal("expected gemini prompt detection")
+	}
 	if d.isWaitingForInput("no prompts here") {
 		t.Fatal("unexpected prompt detection")
 	}


### PR DESCRIPTION
## Summary
- recognize Gemini "Type your message" prompt as idle in daemon monitoring
- cover Gemini prompt detection in daemon tests

Refs: orch-029