### PR TITLE
Add resolve keybinding (R) to orch monitor

### DIFF
--- a/internal/monitor/dashboard.go
+++ b/internal/monitor/dashboard.go
@@ -226,6 +226,12 @@ func (d *Dashboard) handleDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return d.enterStopMode()
 	case "n":
 		return d.enterNewRunMode()
+	case d.keymap.Resolve:
+		if d.cursor >= 0 && d.cursor < len(d.runs) {
+			run := d.runs[d.cursor].Run
+			return d, d.resolveRunCmd(run)
+		}
+		return d, nil
 	case "up", "k":
 		if d.cursor > 0 {
 			d.cursor--
@@ -526,6 +532,18 @@ func (d *Dashboard) answerCmd(run *model.Run, questionID, text string) tea.Cmd {
 			return errMsg{err: err}
 		}
 		return infoMsg{text: fmt.Sprintf("answered %s for %s#%s", questionID, run.IssueID, run.RunID)}
+	}
+}
+
+func (d *Dashboard) resolveRunCmd(run *model.Run) tea.Cmd {
+	return func() tea.Msg {
+		if run == nil {
+			return errMsg{err: fmt.Errorf("run not found")}
+		}
+		if err := d.monitor.ResolveRun(run); err != nil {
+			return errMsg{err: err}
+		}
+		return infoMsg{text: fmt.Sprintf("resolved %s#%s and issue %s", run.IssueID, run.RunID, run.IssueID)}
 	}
 }
 

--- a/internal/monitor/keymap.go
+++ b/internal/monitor/keymap.go
@@ -11,6 +11,7 @@ type KeyMap struct {
 	Answer  string
 	Stop    string
 	NewRun  string
+	Resolve string
 	Refresh string
 	Quit    string
 	Help    string
@@ -26,6 +27,7 @@ func DefaultKeyMap() KeyMap {
 		Answer:  "a",
 		Stop:    "s",
 		NewRun:  "n",
+		Resolve: "R",
 		Refresh: "r",
 		Quit:    "q",
 		Help:    "?",
@@ -34,6 +36,6 @@ func DefaultKeyMap() KeyMap {
 
 // HelpLine renders the footer help text.
 func (k KeyMap) HelpLine() string {
-	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] answer  [%s] stop  [%s] new  [%s] refresh  [%s] quit  [%s] help",
-		k.Runs, k.Issues, k.Chat, k.Open, k.Answer, k.Stop, k.NewRun, k.Refresh, k.Quit, k.Help)
+	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] answer  [%s] stop  [%s] new  [%s] resolve  [%s] refresh  [%s] quit  [%s] help",
+		k.Runs, k.Issues, k.Chat, k.Open, k.Answer, k.Stop, k.NewRun, k.Resolve, k.Refresh, k.Quit, k.Help)
 }


### PR DESCRIPTION
## Summary
- Added a new keybinding (R) to the orch monitor runs dashboard
- Pressing R on a selected run marks the run as completed (done status) and resolves its corresponding issue
- Updated the help line footer to show the new resolve keybinding

## Changes
- `internal/monitor/keymap.go`: Added `Resolve` field to `KeyMap` struct with default value "R", updated `HelpLine()` to include the resolve keybinding
- `internal/monitor/monitor.go`: Added `ResolveRun()` method that marks the run as done (if not already terminal) and sets the issue status to resolved
- `internal/monitor/dashboard.go`: Added key handler for R key and `resolveRunCmd()` function to execute the resolve action

## Test plan
- [x] Build passes: `go build ./...`
- [x] All tests pass: `go test ./...`
- [ ] Manual testing: Run `orch monitor`, select a run, press R to verify it marks the run as done and resolves the issue

Fixes: orch-032

🤖 Generated with [Claude Code](https://claude.com/claude-code)