### PR TITLE
Fix issue panel auto-refresh in dashboard

### DIFF
--- a/internal/store/file/file.go
+++ b/internal/store/file/file.go
@@ -210,10 +210,9 @@ func (s *FileStore) ResolveIssue(issueID string) (*model.Issue, error) {
 
 // ListIssues returns all issues in the vault
 func (s *FileStore) ListIssues() ([]*model.Issue, error) {
-	if s.cacheDirty {
-		if err := s.scanIssues(); err != nil {
-			return nil, err
-		}
+	// Always rescan issues from disk to ensure fresh data for auto-refresh
+	if err := s.scanIssues(); err != nil {
+		return nil, err
 	}
 
 	issues := make([]*model.Issue, 0, len(s.issueCache))


### PR DESCRIPTION
## Summary
- Fixed issue panel not refreshing automatically in the dashboard
- The root cause was that `ListIssues()` used cached data and only refreshed when `cacheDirty` was true
- Now `ListIssues()` always rescans issues from disk, ensuring fresh data during auto-refresh cycles

## Issue Reference
Fixes: orch-030

## Test plan
- [x] Build passes: `go build ./...`
- [x] Store tests pass: `go test ./internal/store/file/...`
- [x] Monitor tests pass: `go test ./internal/monitor/...`
- [ ] Manual testing: Open the issues dashboard and verify it auto-refreshes when issue status changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)