### PR TITLE
Show PR status and number in monitor run panel

### DIFF
--- a/internal/model/run.go
+++ b/internal/model/run.go
@@ -63,6 +63,8 @@ type Run struct {
 	WorktreePath string
 	TmuxSession  string
 	PRUrl        string
+	PRNumber     int    // PR number (e.g., 123)
+	PRState      string // PR state: open, merged, closed
 }
 
 // Ref returns the RunRef for this run

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -589,7 +589,7 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 		}
 		pr := "-"
 		if w.Run.PRUrl != "" || w.Run.Status == model.StatusPROpen {
-			pr = "yes"
+			pr = formatPRInfo(w.Run)
 		}
 		merged := "-"
 		if state, ok := gitStates[w.Run.RunID]; ok {

--- a/internal/monitor/ps_helpers.go
+++ b/internal/monitor/ps_helpers.go
@@ -1,6 +1,7 @@
 package monitor
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/s22625/orch/internal/git"
@@ -56,6 +57,16 @@ func truncateWithEllipsis(text string, max int) string {
 		return text[:max]
 	}
 	return text[:max-3] + "..."
+}
+
+// formatPRInfo returns a display string for PR info showing state and number.
+// Examples: "#123 open", "#45 merged", "#67 closed", or just "yes" if no detailed info.
+func formatPRInfo(run *model.Run) string {
+	if run.PRNumber > 0 && run.PRState != "" {
+		return fmt.Sprintf("#%d %s", run.PRNumber, run.PRState)
+	}
+	// Fallback for when we have a PR URL but no state info yet
+	return "yes"
 }
 
 func gitStatesForRuns(runs []*model.Run, target string) map[string]string {


### PR DESCRIPTION
## Summary
- Added PR number and state (open/merged/closed) display to the monitor run panel's PR column
- Extended the PR cache to fetch and store PR number and state from GitHub's API
- Updated the display format to show "#<number> <state>" (e.g., "#123 merged") instead of just "yes"

## Changes Made
1. **internal/model/run.go**: Added `PRNumber` (int) and `PRState` (string) fields to the Run struct
2. **internal/cli/ps_pr_cache.go**: Extended cache entry and lookup to include number and state from `gh pr list`
3. **internal/monitor/ps_helpers.go**: Added `formatPRInfo()` helper function for display formatting
4. **internal/monitor/monitor.go**: Updated PR column to use the new formatting function

## Test plan
- [x] Build passes (`go build ./...`)
- [x] Tests pass for modified packages (`go test ./internal/model/... ./internal/cli/... ./internal/monitor/...`)
- [ ] Manual testing: Start monitor and verify PR column shows "#<number> <state>" for runs with PRs

Issue: orch-031

🤖 Generated with [Claude Code](https://claude.com/claude-code)