### PR TITLE
Add tmux-based agent communication commands (send/capture)

### DIFF
--- a/internal/cli/capture.go
+++ b/internal/cli/capture.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/tmux"
+	"github.com/spf13/cobra"
+)
+
+type captureOptions struct {
+	Lines int
+}
+
+func newCaptureCmd() *cobra.Command {
+	opts := &captureOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "capture <RUN_REF>",
+		Short: "Capture output from a running agent",
+		Long: `Capture the latest output from an agent's tmux pane.
+
+Returns the captured text to stdout for programmatic consumption.
+Useful for monitoring agent status or building automation workflows.
+
+Examples:
+  # Capture last 100 lines (default) from an agent
+  orch capture orch-023#20231220-100000
+
+  # Capture using short ID
+  orch capture a3b4c5
+
+  # Capture last 500 lines
+  orch capture orch-023 --lines 500
+
+  # Output as JSON for scripting
+  orch capture orch-023 --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCapture(args[0], opts)
+		},
+	}
+
+	cmd.Flags().IntVar(&opts.Lines, "lines", 100, "Number of lines to capture")
+
+	return cmd
+}
+
+type captureResult struct {
+	OK          bool   `json:"ok"`
+	IssueID     string `json:"issue_id"`
+	RunID       string `json:"run_id"`
+	TmuxSession string `json:"tmux_session"`
+	Lines       int    `json:"lines"`
+	Content     string `json:"content"`
+}
+
+func runCapture(refStr string, opts *captureOptions) error {
+	st, err := getStore()
+	if err != nil {
+		return err
+	}
+
+	// Resolve the run
+	run, err := resolveRun(st, refStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(ExitRunNotFound)
+		return err
+	}
+
+	// Get tmux session name
+	sessionName := run.TmuxSession
+	if sessionName == "" {
+		sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
+	}
+
+	// Check if session exists
+	if !tmux.HasSession(sessionName) {
+		err := fmt.Errorf("tmux session %q not found (run may not be active)", sessionName)
+		if globalOpts.JSON {
+			result := map[string]interface{}{
+				"ok":    false,
+				"error": err.Error(),
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			enc.Encode(result)
+		} else {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		}
+		os.Exit(ExitTmuxError)
+		return err
+	}
+
+	// Capture the pane content
+	content, err := tmux.CapturePane(sessionName, opts.Lines)
+	if err != nil {
+		if globalOpts.JSON {
+			result := map[string]interface{}{
+				"ok":    false,
+				"error": err.Error(),
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			enc.Encode(result)
+		} else {
+			fmt.Fprintf(os.Stderr, "error: failed to capture pane: %v\n", err)
+		}
+		os.Exit(ExitTmuxError)
+		return err
+	}
+
+	// Output result
+	if globalOpts.JSON {
+		result := &captureResult{
+			OK:          true,
+			IssueID:     run.IssueID,
+			RunID:       run.RunID,
+			TmuxSession: sessionName,
+			Lines:       opts.Lines,
+			Content:     content,
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	// Plain text output - just print the content
+	fmt.Print(content)
+
+	return nil
+}

--- a/internal/cli/capture_test.go
+++ b/internal/cli/capture_test.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestNewCaptureCmd(t *testing.T) {
+	cmd := newCaptureCmd()
+
+	if cmd.Use != "capture <RUN_REF>" {
+		t.Errorf("unexpected use: %s", cmd.Use)
+	}
+
+	if cmd.Short != "Capture output from a running agent" {
+		t.Errorf("unexpected short: %s", cmd.Short)
+	}
+
+	// Verify flags
+	linesFlag := cmd.Flags().Lookup("lines")
+	if linesFlag == nil {
+		t.Error("missing --lines flag")
+	}
+
+	if linesFlag.DefValue != "100" {
+		t.Errorf("unexpected default for --lines: %s", linesFlag.DefValue)
+	}
+}
+
+func TestCaptureCmdRequiresArgs(t *testing.T) {
+	cmd := newCaptureCmd()
+
+	// Should require exactly 1 arg
+	if err := cmd.Args(cmd, []string{}); err == nil {
+		t.Error("expected error with no args")
+	}
+
+	if err := cmd.Args(cmd, []string{"ref"}); err != nil {
+		t.Errorf("unexpected error with 1 arg: %v", err)
+	}
+
+	if err := cmd.Args(cmd, []string{"ref", "extra"}); err == nil {
+		t.Error("expected error with 2 args")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -91,6 +91,8 @@ func init() {
 	rootCmd.AddCommand(newRepairCmd())
 	rootCmd.AddCommand(newDeleteCmd())
 	rootCmd.AddCommand(newExecCmd())
+	rootCmd.AddCommand(newSendCmd())
+	rootCmd.AddCommand(newCaptureCmd())
 }
 
 // Execute runs the root command

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/tmux"
+	"github.com/spf13/cobra"
+)
+
+type sendOptions struct {
+	NoEnter bool
+}
+
+func newSendCmd() *cobra.Command {
+	opts := &sendOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "send <RUN_REF> <MESSAGE>",
+		Short: "Send a message to a running agent",
+		Long: `Send a message to a running agent via tmux.
+
+The message is sent to the agent's tmux session using send-keys.
+By default, Enter is pressed after the message to submit it.
+
+Examples:
+  # Send a message to an agent
+  orch send orch-023#20231220-100000 "Please focus on the UI tests first"
+
+  # Send using short ID
+  orch send a3b4c5 "Continue with the implementation"
+
+  # Send text without pressing Enter
+  orch send orch-023 "partial input" --no-enter`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSend(args[0], args[1], opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.NoEnter, "no-enter", false, "Don't press Enter after sending the message")
+
+	return cmd
+}
+
+type sendResult struct {
+	OK          bool   `json:"ok"`
+	IssueID     string `json:"issue_id"`
+	RunID       string `json:"run_id"`
+	TmuxSession string `json:"tmux_session"`
+	Message     string `json:"message"`
+}
+
+func runSend(refStr, message string, opts *sendOptions) error {
+	st, err := getStore()
+	if err != nil {
+		return err
+	}
+
+	// Resolve the run
+	run, err := resolveRun(st, refStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(ExitRunNotFound)
+		return err
+	}
+
+	// Get tmux session name
+	sessionName := run.TmuxSession
+	if sessionName == "" {
+		sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
+	}
+
+	// Check if session exists
+	if !tmux.HasSession(sessionName) {
+		err := fmt.Errorf("tmux session %q not found (run may not be active)", sessionName)
+		if globalOpts.JSON {
+			result := map[string]interface{}{
+				"ok":    false,
+				"error": err.Error(),
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			enc.Encode(result)
+		} else {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		}
+		os.Exit(ExitTmuxError)
+		return err
+	}
+
+	// Send the message
+	if opts.NoEnter {
+		err = tmux.SendKeysLiteral(sessionName, message)
+	} else {
+		err = tmux.SendKeys(sessionName, message)
+	}
+
+	if err != nil {
+		if globalOpts.JSON {
+			result := map[string]interface{}{
+				"ok":    false,
+				"error": err.Error(),
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			enc.Encode(result)
+		} else {
+			fmt.Fprintf(os.Stderr, "error: failed to send message: %v\n", err)
+		}
+		os.Exit(ExitTmuxError)
+		return err
+	}
+
+	// Output result
+	result := &sendResult{
+		OK:          true,
+		IssueID:     run.IssueID,
+		RunID:       run.RunID,
+		TmuxSession: sessionName,
+		Message:     message,
+	}
+
+	if globalOpts.JSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	if !globalOpts.Quiet {
+		fmt.Printf("Sent message to %s#%s\n", run.IssueID, run.RunID)
+	}
+
+	return nil
+}

--- a/internal/cli/send_test.go
+++ b/internal/cli/send_test.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestNewSendCmd(t *testing.T) {
+	cmd := newSendCmd()
+
+	if cmd.Use != "send <RUN_REF> <MESSAGE>" {
+		t.Errorf("unexpected use: %s", cmd.Use)
+	}
+
+	if cmd.Short != "Send a message to a running agent" {
+		t.Errorf("unexpected short: %s", cmd.Short)
+	}
+
+	// Verify flags
+	noEnterFlag := cmd.Flags().Lookup("no-enter")
+	if noEnterFlag == nil {
+		t.Error("missing --no-enter flag")
+	}
+}
+
+func TestSendCmdRequiresArgs(t *testing.T) {
+	cmd := newSendCmd()
+
+	// Should require exactly 2 args
+	if err := cmd.Args(cmd, []string{}); err == nil {
+		t.Error("expected error with no args")
+	}
+
+	if err := cmd.Args(cmd, []string{"ref"}); err == nil {
+		t.Error("expected error with 1 arg")
+	}
+
+	if err := cmd.Args(cmd, []string{"ref", "message"}); err != nil {
+		t.Errorf("unexpected error with 2 args: %v", err)
+	}
+
+	if err := cmd.Args(cmd, []string{"ref", "message", "extra"}); err == nil {
+		t.Error("expected error with 3 args")
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -62,9 +62,17 @@ func NewSession(cfg *SessionConfig) error {
 	return nil
 }
 
-// SendKeys sends keys to a tmux session
+// SendKeys sends keys to a tmux session followed by Enter
 func SendKeys(session, keys string) error {
 	cmd := execCommand("tmux", "send-keys", "-t", session, keys, "Enter")
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// SendKeysLiteral sends keys to a tmux session without pressing Enter
+// Uses -l flag to send keys literally (without interpreting special keys)
+func SendKeysLiteral(session, keys string) error {
+	cmd := execCommand("tmux", "send-keys", "-t", session, "-l", keys)
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }


### PR DESCRIPTION
## Summary

- Adds `orch send <run-ref> <message>` command to send messages to agents via tmux
- Adds `orch capture <run-ref>` command to capture output from agent's tmux pane
- Adds `SendKeysLiteral` function to tmux package for sending text without pressing Enter

## Changes

### New Commands

**`orch send`**
- Send messages to running agents via tmux send-keys
- Supports `--no-enter` flag to send partial input without pressing Enter
- Supports short ID, issue#run, or issue references

**`orch capture`**
- Capture latest output from agent's tmux pane
- Supports `--lines N` flag (default: 100)
- Plain text output by default, JSON with `--json` flag

### Other Changes
- Added `SendKeysLiteral` function to tmux package
- Added tests for new commands and tmux functions
- Updated `SetPaneTitle` test to match current behavior

## Test plan

- [x] All existing tests pass
- [x] New command tests pass
- [x] Commands visible in `orch --help`
- [x] Command-specific help works correctly
- [x] Build completes successfully

References: orch-033

🤖 Generated with [Claude Code](https://claude.com/claude-code)