### PR TITLE
Fix 'c' keybinding to open control agent chat pane

### DIFF
--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -181,11 +181,7 @@ func (m *Monitor) SwitchChat() error {
 	if err := tmux.SelectWindow(m.session, dashboardWindowIdx); err != nil {
 		return err
 	}
-	pane, err := m.findChatPane()
-	if err != nil {
-		return err
-	}
-	return tmux.SelectPane(pane)
+	return m.selectPaneByTitle(chatPaneTitle)
 }
 
 // OpenRun links a run session into the monitor and switches to it.
@@ -763,28 +759,6 @@ func (m *Monitor) selectPaneByTitle(title string) error {
 		return err
 	}
 	return tmux.SelectPane(pane)
-}
-
-func (m *Monitor) findChatPane() (string, error) {
-	target := fmt.Sprintf("%s:%d", m.session, dashboardWindowIdx)
-	panes, err := tmux.ListPanes(target)
-	if err != nil {
-		return "", err
-	}
-	if len(panes) == 0 {
-		return "", fmt.Errorf("no panes found in %s", target)
-	}
-	for _, pane := range panes {
-		if pane.Title == chatPaneTitle {
-			return pane.ID, nil
-		}
-	}
-	for _, pane := range panes {
-		if pane.Title != runsPaneTitle && pane.Title != issuesPaneTitle {
-			return pane.ID, nil
-		}
-	}
-	return "", fmt.Errorf("pane not found: %s", chatPaneTitle)
 }
 
 func (m *Monitor) findPaneByTitle(session, title string) (string, error) {


### PR DESCRIPTION
## Summary

- Fixes the 'c' keybinding in monitor/issues panels to correctly open the control agent chat pane
- Removes the `findChatPane()` function with problematic fallback logic that could select wrong panes
- Uses consistent `selectPaneByTitle()` approach matching how `SwitchIssues()` works

## Related Issue

orch-037

## Root Cause

The `findChatPane()` function had fallback logic that would return any pane that wasn't "runs" or "issues". After the recent refactor to use tmux window linking (commit 1618084), this fallback could incorrectly select a pane from the linked run window instead of the actual control agent chat pane.

## Test plan

- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [ ] Manual verification: press 'c' in monitor with a run open - should navigate to control agent chat pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)