### PR TITLE
Add agent selection when starting run from monitor issues panel

### DIFF
--- a/internal/monitor/dashboard.go
+++ b/internal/monitor/dashboard.go
@@ -503,7 +503,8 @@ func (d *Dashboard) loadIssuesCmd() tea.Cmd {
 
 func (d *Dashboard) startRunCmd(issueID string) tea.Cmd {
 	return func() tea.Msg {
-		output, err := d.monitor.StartRun(issueID)
+		// Use empty agent type to use default agent
+		output, err := d.monitor.StartRun(issueID, "")
 		if err != nil {
 			return errMsg{err: fmt.Errorf("%s", output)}
 		}


### PR DESCRIPTION
## Summary

- Added agent selection UI that appears when starting a run from the issues panel
- Users can select from available agents (claude, codex, gemini, custom) before starting a run
- Selection via cursor keys (up/down) or number keys (1-9)
- Only shows agents that are actually available (CLI installed)

## Changes Made

- Added `modeSelectAgent` mode and `selectAgentState` to issues dashboard
- Implemented `handleSelectAgentKey` for keyboard navigation and selection
- Implemented `viewSelectAgent` for the agent selection UI
- Updated `StartRun` to accept an agent type parameter
- Added `GetAvailableAgents` method to Monitor for listing installed agents
- Agent selection is also available when pressing 'r' from the run selection view

## Test plan

- [x] Build passes
- [x] All tests pass
- [ ] Manual testing: Press 'r' on an issue in the issues panel to verify agent selection UI appears
- [ ] Manual testing: Select an agent and verify the run starts with the selected agent

Resolves: orch-040

🤖 Generated with [Claude Code](https://claude.com/claude-code)