### PR TITLE
fix: pass resolved vault path to monitor child processes

### DIFF
--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -60,7 +60,7 @@ func runMonitor(opts *monitorOptions) error {
 		Attach:      opts.Attach,
 		ForceNew:    opts.ForceNew,
 		OrchPath:    os.Args[0],
-		GlobalFlags: monitorGlobalFlags(),
+		GlobalFlags: monitorGlobalFlagsWithVault(st.VaultPath()),
 	})
 
 	if opts.Dashboard {
@@ -76,6 +76,26 @@ func runMonitor(opts *monitorOptions) error {
 func monitorGlobalFlags() []string {
 	var flags []string
 	if globalOpts.VaultPath != "" {
+		flags = append(flags, "--vault", globalOpts.VaultPath)
+	}
+	if globalOpts.Backend != "" {
+		flags = append(flags, "--backend", globalOpts.Backend)
+	}
+	if globalOpts.LogLevel != "" {
+		flags = append(flags, "--log-level", globalOpts.LogLevel)
+	}
+	return flags
+}
+
+// monitorGlobalFlagsWithVault returns global flags for child processes,
+// ensuring the vault path is always included (even when loaded from config).
+func monitorGlobalFlagsWithVault(vaultPath string) []string {
+	var flags []string
+	// Use the resolved vault path (from store) to ensure child processes
+	// use the same vault, even when it was loaded from config file
+	if vaultPath != "" {
+		flags = append(flags, "--vault", vaultPath)
+	} else if globalOpts.VaultPath != "" {
 		flags = append(flags, "--vault", globalOpts.VaultPath)
 	}
 	if globalOpts.Backend != "" {


### PR DESCRIPTION
## Summary

Follow-up fix for orch-039. The previous change generated unique session names per project, but child dashboard processes weren't receiving the vault path when it was loaded from config file.

## Changes

- Added `monitorGlobalFlagsWithVault()` function that takes the resolved vault path from the store
- Updated `runMonitor()` to pass the store's vault path to child processes

## Issue

Fixes remaining issue from orch-039: child dashboard processes now correctly use the project's vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)