### PR TITLE
fix: widen issue ID column in monitor dashboards

### DIFF
--- a/internal/monitor/dashboard.go
+++ b/internal/monitor/dashboard.go
@@ -851,7 +851,7 @@ func (d *Dashboard) renderFooter() string {
 func (d *Dashboard) tableWidths() (idxW, idW, issueW, issueStatusW, agentW, statusW, prW, mergedW, updatedW, topicW int) {
 	idxW = 2
 	idW = 6
-	issueW = 10
+	issueW = 14
 	issueStatusW = 8
 	agentW = 6
 	statusW = 10

--- a/internal/monitor/issues_dashboard.go
+++ b/internal/monitor/issues_dashboard.go
@@ -750,7 +750,7 @@ func (d *IssueDashboard) renderFooter() string {
 
 func (d *IssueDashboard) tableWidths() (idxW, idW, statusW, latestW, activeW, summaryW int) {
 	idxW = 2
-	idW = 12
+	idW = 14
 	statusW = 10
 	latestW = 10
 	activeW = 6


### PR DESCRIPTION
## Summary

- Increased issue ID column width to 14 characters in both monitor dashboards to support longer issue IDs (up to `ISSUE-PLC-0000` format)
- Updated runs panel (`dashboard.go`): column width from 10 → 14
- Updated issues panel (`issues_dashboard.go`): column width from 12 → 14

## Related Issue

orch-044

## Test plan

- [x] All existing tests pass
- [x] Build compiles successfully
- [ ] Manual verification: issue IDs up to 14 characters display without truncation in both dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)