### PR TITLE
feat: add orch send command for sending messages to agent sessions

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -91,6 +91,7 @@ func init() {
 	rootCmd.AddCommand(newRepairCmd())
 	rootCmd.AddCommand(newDeleteCmd())
 	rootCmd.AddCommand(newExecCmd())
+	rootCmd.AddCommand(newSendCmd())
 }
 
 // Execute runs the root command

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/tmux"
+	"github.com/spf13/cobra"
+)
+
+type sendOptions struct {
+	NoEnter bool
+}
+
+func newSendCmd() *cobra.Command {
+	opts := &sendOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "send RUN_REF MESSAGE",
+		Short: "Send a message to a run's agent session",
+		Long: `Send a message to the tmux session for a run.
+
+The message is sent to the agent's input and automatically submitted with Enter.
+Use --no-enter to send text without pressing Enter (useful for multi-part input).
+
+Examples:
+  orch send orch-001 "Please fix the bug in main.go"
+  orch send 66ff6 "Continue with the implementation"
+  orch send orch-001#20251222-100000 "Run the tests"
+  orch send orch-001 --no-enter "partial text"`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSend(args[0], args[1], opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.NoEnter, "no-enter", false, "Send text without pressing Enter")
+
+	return cmd
+}
+
+func runSend(refStr, message string, opts *sendOptions) error {
+	st, err := getStore()
+	if err != nil {
+		return err
+	}
+
+	// Resolve by short ID or run ref
+	run, err := resolveRun(st, refStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "run not found: %s\n", refStr)
+		os.Exit(ExitRunNotFound)
+		return err
+	}
+
+	sessionName := run.TmuxSession
+	if sessionName == "" {
+		// Generate session name if not stored
+		sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
+	}
+
+	// Check if session exists
+	if !tmux.HasSession(sessionName) {
+		fmt.Fprintf(os.Stderr, "session not found: %s\n", sessionName)
+		os.Exit(ExitTmuxError)
+		return fmt.Errorf("session not found: %s", sessionName)
+	}
+
+	// Send the message
+	var sendErr error
+	if opts.NoEnter {
+		sendErr = tmux.SendText(sessionName, message)
+	} else {
+		sendErr = tmux.SendKeys(sessionName, message)
+	}
+
+	if sendErr != nil {
+		fmt.Fprintf(os.Stderr, "failed to send message: %v\n", sendErr)
+		os.Exit(ExitTmuxError)
+		return sendErr
+	}
+
+	if !globalOpts.Quiet {
+		fmt.Printf("sent message to %s#%s\n", run.IssueID, run.RunID)
+	}
+
+	return nil
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -62,9 +62,16 @@ func NewSession(cfg *SessionConfig) error {
 	return nil
 }
 
-// SendKeys sends keys to a tmux session
+// SendKeys sends keys to a tmux session followed by Enter
 func SendKeys(session, keys string) error {
 	cmd := execCommand("tmux", "send-keys", "-t", session, keys, "Enter")
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// SendText sends text to a tmux session without pressing Enter
+func SendText(session, text string) error {
+	cmd := execCommand("tmux", "send-keys", "-t", session, text)
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -97,6 +97,46 @@ func TestHasSessionMissing(t *testing.T) {
 	}
 }
 
+func TestSendText(t *testing.T) {
+	exec := &fakeExecutor{calls: []fakeCall{{exitCode: 0}}}
+	orig := execCommand
+	execCommand = exec.Command
+	t.Cleanup(func() { execCommand = orig })
+
+	if err := SendText("sess", "hello world"); err != nil {
+		t.Fatalf("SendText error: %v", err)
+	}
+
+	if len(exec.recorded) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(exec.recorded))
+	}
+	call := exec.recorded[0]
+	// SendText should NOT include "Enter"
+	if !equalArgs(call.args, []string{"send-keys", "-t", "sess", "hello world"}) {
+		t.Fatalf("send-keys args = %v, want %v", call.args, []string{"send-keys", "-t", "sess", "hello world"})
+	}
+}
+
+func TestSendKeys(t *testing.T) {
+	exec := &fakeExecutor{calls: []fakeCall{{exitCode: 0}}}
+	orig := execCommand
+	execCommand = exec.Command
+	t.Cleanup(func() { execCommand = orig })
+
+	if err := SendKeys("sess", "hello world"); err != nil {
+		t.Fatalf("SendKeys error: %v", err)
+	}
+
+	if len(exec.recorded) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(exec.recorded))
+	}
+	call := exec.recorded[0]
+	// SendKeys should include "Enter"
+	if !equalArgs(call.args, []string{"send-keys", "-t", "sess", "hello world", "Enter"}) {
+		t.Fatalf("send-keys args = %v, want %v", call.args, []string{"send-keys", "-t", "sess", "hello world", "Enter"})
+	}
+}
+
 func TestCapturePane(t *testing.T) {
 	exec := &fakeExecutor{calls: []fakeCall{{output: "line1\nline2\n"}}}
 	orig := execCommand


### PR DESCRIPTION
## Summary

- Add new `orch send RUN_REF MESSAGE` command for sending messages to a run's agent session
- The message is automatically submitted with Enter key
- Add `--no-enter` flag for sending text without pressing Enter (useful for multi-part input)
- Add `SendText()` function to tmux package for sending without Enter
- Add unit tests for both `SendText` and `SendKeys` functions

## Related Issue
orch-046

## Test plan
- [x] All existing tests pass
- [x] New tests added for SendText and SendKeys functions
- [x] Verified `orch send --help` shows correct usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)