### PR TITLE
Adjust issues dashboard ID column width

### DIFF
--- a/internal/monitor/dashboard.go
+++ b/internal/monitor/dashboard.go
@@ -852,7 +852,7 @@ func (d *Dashboard) renderFooter() string {
 func (d *Dashboard) tableWidths() (idxW, idW, issueW, issueStatusW, agentW, statusW, prW, mergedW, updatedW, topicW int) {
 	idxW = 2
 	idW = 6
-	issueW = 10
+	issueW = 14
 	issueStatusW = 8
 	agentW = 6
 	statusW = 10

--- a/internal/monitor/issues_dashboard.go
+++ b/internal/monitor/issues_dashboard.go
@@ -751,7 +751,7 @@ func (d *IssueDashboard) renderFooter() string {
 
 func (d *IssueDashboard) tableWidths() (idxW, idW, statusW, latestW, activeW, summaryW int) {
 	idxW = 2
-	idW = 12
+	idW = 14
 	statusW = 10
 	latestW = 10
 	activeW = 6


### PR DESCRIPTION
## Summary
- size the issues dashboard ID column to the widest issue ID using display width
- preserve a minimum summary column width to keep the table readable

## Issue
- refs orch-043