### PR TITLE
Fix monitor content width with box frame

### DIFF
--- a/internal/monitor/dashboard.go
+++ b/internal/monitor/dashboard.go
@@ -869,15 +869,17 @@ func (d *Dashboard) tableWidths() (idxW, idW, issueW, issueStatusW, agentW, stat
 }
 
 func (d *Dashboard) safeWidth() int {
-	if d.width > 2 {
-		return d.width - 2
+	frame := d.styles.Box.GetHorizontalFrameSize()
+	if d.width > frame {
+		return d.width - frame
 	}
 	return 80
 }
 
 func (d *Dashboard) safeHeight() int {
-	if d.height > 2 {
-		return d.height - 2
+	frame := d.styles.Box.GetVerticalFrameSize()
+	if d.height > frame {
+		return d.height - frame
 	}
 	return 24
 }

--- a/internal/monitor/issues_dashboard.go
+++ b/internal/monitor/issues_dashboard.go
@@ -783,15 +783,17 @@ func (d *IssueDashboard) tableWidths() (idxW, idW, statusW, latestW, activeW, su
 }
 
 func (d *IssueDashboard) safeWidth() int {
-	if d.width > 2 {
-		return d.width - 2
+	frame := d.styles.Box.GetHorizontalFrameSize()
+	if d.width > frame {
+		return d.width - frame
 	}
 	return 80
 }
 
 func (d *IssueDashboard) safeHeight() int {
-	if d.height > 2 {
-		return d.height - 2
+	frame := d.styles.Box.GetVerticalFrameSize()
+	if d.height > frame {
+		return d.height - frame
 	}
 	return 24
 }


### PR DESCRIPTION
## Summary
- compute safe content width/height using lipgloss box frame size
- prevent table rows from overflowing the bordered monitor layouts

## Issue
- refs orch-043