### PR TITLE
Add continue run dialogue to monitor issue dashboard

### DIFF
--- a/internal/monitor/issue_keymap.go
+++ b/internal/monitor/issue_keymap.go
@@ -4,36 +4,38 @@ import "fmt"
 
 // IssueKeyMap defines shortcuts for the issues dashboard.
 type IssueKeyMap struct {
-	Runs     string
-	Issues   string
-	Chat     string
-	OpenRun  string
-	StartRun string
-	Open     string
-	Resolve  string
-	Filter   string
-	Quit     string
-	Help     string
+	Runs        string
+	Issues      string
+	Chat        string
+	OpenRun     string
+	StartRun    string
+	ContinueRun string
+	Open        string
+	Resolve     string
+	Filter      string
+	Quit        string
+	Help        string
 }
 
 // DefaultIssueKeyMap returns the default issue dashboard shortcut mapping.
 func DefaultIssueKeyMap() IssueKeyMap {
 	return IssueKeyMap{
-		Runs:     "g",
-		Issues:   "i",
-		Chat:     "c",
-		OpenRun:  "enter",
-		StartRun: "r",
-		Open:     "o",
-		Resolve:  "x",
-		Filter:   "f",
-		Quit:     "q",
-		Help:     "?",
+		Runs:        "g",
+		Issues:      "i",
+		Chat:        "c",
+		OpenRun:     "enter",
+		StartRun:    "r",
+		ContinueRun: "C",
+		Open:        "o",
+		Resolve:     "x",
+		Filter:      "f",
+		Quit:        "q",
+		Help:        "?",
 	}
 }
 
 // HelpLine renders the footer help text.
 func (k IssueKeyMap) HelpLine() string {
-	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open run  [%s] start run  [%s] open  [%s] resolve  [%s] filter  [%s] quit  [%s] help",
-		k.Runs, k.Issues, k.Chat, k.OpenRun, k.StartRun, k.Open, k.Resolve, k.Filter, k.Quit, k.Help)
+	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open run  [%s] start run  [%s] continue  [%s] open  [%s] resolve  [%s] filter  [%s] quit  [%s] help",
+		k.Runs, k.Issues, k.Chat, k.OpenRun, k.StartRun, k.ContinueRun, k.Open, k.Resolve, k.Filter, k.Quit, k.Help)
 }


### PR DESCRIPTION
## Summary
- Add interactive continue run dialogue to the issue dashboard with 'C' keybinding
- Implement three-step flow: branch selection, agent selection, and optional prompt input
- Execute `orch continue` command with selected options

## Changes
- **issue_keymap.go**: Add `ContinueRun` keybinding (default: 'C') and update help line
- **issues_dashboard.go**: Add three new modes for the continue dialogue flow
  - `modeContinueBranch`: Select from branches that contain the issue ID
  - `modeContinueAgent`: Select which agent to use
  - `modeContinuePrompt`: Enter optional follow-up prompt
- **monitor.go**: Add `ListBranchesForIssue` and `ContinueRun` methods
- **monitor_test.go**: Add tests for branch filtering logic

## How it works
1. User selects an issue in the dashboard and presses 'C'
2. Dashboard shows list of branches containing the issue ID (sorted by most recent)
3. After selecting a branch, user selects an agent
4. User can optionally enter a follow-up prompt
5. The continue command is executed with the selected options

## Test plan
- [x] Build succeeds
- [x] All existing tests pass
- [x] New unit tests for `filterBranchesForIssue` pass
- [ ] Manual testing: trigger continue dialogue from issue dashboard
- [ ] Manual testing: verify branch filtering works correctly
- [ ] Manual testing: verify cancellation at each step works

Fixes: orch-047

🤖 Generated with [Claude Code](https://claude.com/claude-code)