### PR TITLE
Add VSCode extension for orch panels

### DIFF
--- a/vscode-orch/package.json
+++ b/vscode-orch/package.json
@@ -1,0 +1,180 @@
+{
+  "name": "vscode-orch",
+  "displayName": "Orch",
+  "description": "Monitor and manage orch issues and runs from VS Code.",
+  "version": "0.0.1",
+  "publisher": "orch",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onView:orchIssues",
+    "onView:orchRuns",
+    "onCommand:orch.refreshIssues",
+    "onCommand:orch.refreshRuns",
+    "onCommand:orch.refreshAll",
+    "onCommand:orch.issue.open",
+    "onCommand:orch.issue.startRun",
+    "onCommand:orch.issue.continueRun",
+    "onCommand:orch.run.attach",
+    "onCommand:orch.run.stop",
+    "onCommand:orch.run.resolve"
+  ],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "views": {
+      "explorer": [
+        {
+          "id": "orchIssues",
+          "name": "Issues"
+        },
+        {
+          "id": "orchRuns",
+          "name": "Runs"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "orch.refreshIssues",
+        "title": "Refresh Issues"
+      },
+      {
+        "command": "orch.refreshRuns",
+        "title": "Refresh Runs"
+      },
+      {
+        "command": "orch.refreshAll",
+        "title": "Refresh Orch Panels"
+      },
+      {
+        "command": "orch.issue.open",
+        "title": "Open Issue"
+      },
+      {
+        "command": "orch.issue.startRun",
+        "title": "Start Run"
+      },
+      {
+        "command": "orch.issue.continueRun",
+        "title": "Continue Run"
+      },
+      {
+        "command": "orch.run.attach",
+        "title": "Attach to Run"
+      },
+      {
+        "command": "orch.run.stop",
+        "title": "Stop Run"
+      },
+      {
+        "command": "orch.run.resolve",
+        "title": "Resolve Run"
+      }
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "orch.refreshIssues",
+          "when": "view == orchIssues",
+          "group": "navigation"
+        },
+        {
+          "command": "orch.refreshRuns",
+          "when": "view == orchRuns",
+          "group": "navigation"
+        },
+        {
+          "command": "orch.refreshAll",
+          "when": "view == orchIssues || view == orchRuns",
+          "group": "navigation@1"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "orch.issue.open",
+          "when": "view == orchIssues && viewItem == orchIssue",
+          "group": "inline"
+        },
+        {
+          "command": "orch.issue.startRun",
+          "when": "view == orchIssues && viewItem == orchIssue",
+          "group": "action"
+        },
+        {
+          "command": "orch.issue.continueRun",
+          "when": "view == orchIssues && viewItem == orchIssue",
+          "group": "action@1"
+        },
+        {
+          "command": "orch.run.attach",
+          "when": "view == orchRuns && viewItem == orchRun",
+          "group": "inline"
+        },
+        {
+          "command": "orch.run.stop",
+          "when": "view == orchRuns && viewItem == orchRun",
+          "group": "action"
+        },
+        {
+          "command": "orch.run.resolve",
+          "when": "view == orchRuns && viewItem == orchRun",
+          "group": "action@1"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "Orch",
+      "properties": {
+        "orch.vaultPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the orch vault (fallback when .orch/config.yaml is missing)."
+        },
+        "orch.refreshInterval": {
+          "type": "number",
+          "default": 30,
+          "description": "Auto-refresh interval in seconds."
+        },
+        "orch.issues.showResolved": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show resolved/closed issues in the Issues panel."
+        },
+        "orch.runs.statusFilter": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string",
+            "enum": [
+              "queued",
+              "booting",
+              "running",
+              "blocked",
+              "blocked_api",
+              "pr_open",
+              "done",
+              "failed",
+              "canceled",
+              "unknown"
+            ]
+          },
+          "description": "Filter runs by status. Empty list shows all statuses."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "vscode:prepublish": "npm run compile"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/vscode-orch/src/commands/attachRun.ts
+++ b/vscode-orch/src/commands/attachRun.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode';
+import { RunTreeItem } from '../providers/runsProvider';
+import { OrchConfig } from '../config';
+import { TerminalManager } from '../terminalManager';
+
+export function registerAttachRunCommand(
+  config: OrchConfig,
+  terminalManager: TerminalManager
+): vscode.Disposable {
+  return vscode.commands.registerCommand('orch.run.attach', async (item?: RunTreeItem) => {
+    if (!item) {
+      vscode.window.showInformationMessage('Select a run from the Orch Runs panel.');
+      return;
+    }
+
+    const runRef = `${item.run.issue_id}#${item.run.run_id}`;
+    const result = terminalManager.getOrCreate(runRef);
+    result.terminal.show(true);
+
+    if (result.created) {
+      const vaultPath = await config.resolveVaultPath();
+      const vaultArg = vaultPath ? ` --vault ${quoteArg(vaultPath)}` : '';
+      result.terminal.sendText(`orch${vaultArg} attach ${runRef}`);
+    }
+  });
+}
+
+function quoteArg(value: string): string {
+  if (!value.includes(' ') && !value.includes('\"')) {
+    return value;
+  }
+  return `\"${value.replace(/\"/g, '\\\\\"')}\"`;
+}

--- a/vscode-orch/src/commands/continueRun.ts
+++ b/vscode-orch/src/commands/continueRun.ts
@@ -1,0 +1,37 @@
+import * as vscode from 'vscode';
+import { OrchClient } from '../orch/client';
+import { IssueTreeItem } from '../providers/issuesProvider';
+import { RunsProvider } from '../providers/runsProvider';
+import { pickAgent, pickBranch } from './pickers';
+
+export function registerContinueRunCommand(
+  client: OrchClient,
+  runsProvider: RunsProvider
+): vscode.Disposable {
+  return vscode.commands.registerCommand('orch.issue.continueRun', async (item?: IssueTreeItem) => {
+    if (!item) {
+      vscode.window.showInformationMessage('Select an issue from the Orch Issues panel.');
+      return;
+    }
+
+    const issueId = item.issue.id;
+    const branches = await client.listBranches(issueId);
+    const branch = await pickBranch(branches);
+    if (!branch) {
+      return;
+    }
+
+    const agent = await pickAgent();
+    if (!agent) {
+      return;
+    }
+
+    try {
+      const result = await client.continueRun(issueId, branch, agent);
+      vscode.window.showInformationMessage(`Continued run ${result.issue_id}#${result.run_id}`);
+      runsProvider.refresh();
+    } catch (error) {
+      console.warn('orch: failed to continue run', error);
+    }
+  });
+}

--- a/vscode-orch/src/commands/openIssue.ts
+++ b/vscode-orch/src/commands/openIssue.ts
@@ -1,0 +1,20 @@
+import * as vscode from 'vscode';
+import { IssueTreeItem } from '../providers/issuesProvider';
+
+export function registerOpenIssueCommand(): vscode.Disposable {
+  return vscode.commands.registerCommand('orch.issue.open', async (item?: IssueTreeItem) => {
+    if (!item) {
+      vscode.window.showInformationMessage('Select an issue from the Orch Issues panel.');
+      return;
+    }
+
+    const issuePath = item.issue.path;
+    if (!issuePath) {
+      vscode.window.showErrorMessage('Issue path not available.');
+      return;
+    }
+
+    const uri = vscode.Uri.file(issuePath);
+    await vscode.commands.executeCommand('vscode.open', uri);
+  });
+}

--- a/vscode-orch/src/commands/pickers.ts
+++ b/vscode-orch/src/commands/pickers.ts
@@ -1,0 +1,44 @@
+import * as vscode from 'vscode';
+
+export async function pickAgent(): Promise<string | undefined> {
+  const options: vscode.QuickPickItem[] = [
+    { label: 'claude', description: 'Anthropic Claude' },
+    { label: 'codex', description: 'OpenAI Codex' },
+    { label: 'gemini', description: 'Google Gemini' }
+  ];
+
+  const pick = await vscode.window.showQuickPick(options, {
+    placeHolder: 'Select an agent'
+  });
+  return pick?.label;
+}
+
+export async function pickBranch(branches: string[]): Promise<string | undefined> {
+  if (branches.length === 0) {
+    return vscode.window.showInputBox({
+      prompt: 'Enter branch name to continue from',
+      placeHolder: 'issue/<id>/run-<run-id>'
+    });
+  }
+
+  const manualLabel = 'Enter branch name...';
+  const items: vscode.QuickPickItem[] = branches.map((branch) => ({ label: branch }));
+  items.push({ label: manualLabel });
+
+  const pick = await vscode.window.showQuickPick(items, {
+    placeHolder: 'Select a branch to continue from'
+  });
+
+  if (!pick) {
+    return undefined;
+  }
+
+  if (pick.label === manualLabel) {
+    return vscode.window.showInputBox({
+      prompt: 'Enter branch name to continue from',
+      placeHolder: 'issue/<id>/run-<run-id>'
+    });
+  }
+
+  return pick.label;
+}

--- a/vscode-orch/src/commands/resolveRun.ts
+++ b/vscode-orch/src/commands/resolveRun.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode';
+import { OrchClient } from '../orch/client';
+import { RunTreeItem, RunsProvider } from '../providers/runsProvider';
+
+export function registerResolveRunCommand(
+  client: OrchClient,
+  runsProvider: RunsProvider
+): vscode.Disposable {
+  return vscode.commands.registerCommand('orch.run.resolve', async (item?: RunTreeItem) => {
+    if (!item) {
+      vscode.window.showInformationMessage('Select a run from the Orch Runs panel.');
+      return;
+    }
+
+    const runRef = `${item.run.issue_id}#${item.run.run_id}`;
+    const choice = await vscode.window.showWarningMessage(
+      `Resolve run ${runRef}?`,
+      { modal: true },
+      'Resolve'
+    );
+    if (choice !== 'Resolve') {
+      return;
+    }
+
+    try {
+      await client.resolveRun(runRef);
+      vscode.window.showInformationMessage(`Resolved run ${runRef}`);
+      runsProvider.refresh();
+    } catch (error) {
+      console.warn('orch: failed to resolve run', error);
+    }
+  });
+}

--- a/vscode-orch/src/commands/startRun.ts
+++ b/vscode-orch/src/commands/startRun.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+import { OrchClient } from '../orch/client';
+import { IssueTreeItem } from '../providers/issuesProvider';
+import { RunsProvider } from '../providers/runsProvider';
+import { pickAgent } from './pickers';
+
+export function registerStartRunCommand(
+  client: OrchClient,
+  runsProvider: RunsProvider
+): vscode.Disposable {
+  return vscode.commands.registerCommand('orch.issue.startRun', async (item?: IssueTreeItem) => {
+    if (!item) {
+      vscode.window.showInformationMessage('Select an issue from the Orch Issues panel.');
+      return;
+    }
+
+    const agent = await pickAgent();
+    if (!agent) {
+      return;
+    }
+
+    try {
+      const result = await client.startRun(item.issue.id, agent);
+      vscode.window.showInformationMessage(`Started run ${result.issue_id}#${result.run_id}`);
+      runsProvider.refresh();
+    } catch (error) {
+      console.warn('orch: failed to start run', error);
+    }
+  });
+}

--- a/vscode-orch/src/commands/stopRun.ts
+++ b/vscode-orch/src/commands/stopRun.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode';
+import { OrchClient } from '../orch/client';
+import { RunTreeItem, RunsProvider } from '../providers/runsProvider';
+
+export function registerStopRunCommand(
+  client: OrchClient,
+  runsProvider: RunsProvider
+): vscode.Disposable {
+  return vscode.commands.registerCommand('orch.run.stop', async (item?: RunTreeItem) => {
+    if (!item) {
+      vscode.window.showInformationMessage('Select a run from the Orch Runs panel.');
+      return;
+    }
+
+    const runRef = `${item.run.issue_id}#${item.run.run_id}`;
+    const choice = await vscode.window.showWarningMessage(
+      `Stop run ${runRef}?`,
+      { modal: true },
+      'Stop'
+    );
+    if (choice !== 'Stop') {
+      return;
+    }
+
+    try {
+      await client.stopRun(runRef);
+      vscode.window.showInformationMessage(`Stopped run ${runRef}`);
+      runsProvider.refresh();
+    } catch (error) {
+      console.warn('orch: failed to stop run', error);
+    }
+  });
+}

--- a/vscode-orch/src/config.ts
+++ b/vscode-orch/src/config.ts
@@ -1,0 +1,144 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const DEFAULT_REFRESH_SECONDS = 30;
+
+export class OrchConfig {
+  private refreshIntervalSeconds = DEFAULT_REFRESH_SECONDS;
+  private showResolvedIssues = false;
+  private runStatusFilter: string[] = [];
+  private vaultPathSetting = '';
+  private readonly changeEmitter = new vscode.EventEmitter<void>();
+  private readonly configListener: vscode.Disposable;
+
+  constructor() {
+    this.reload();
+    this.configListener = vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration('orch')) {
+        this.reload();
+        this.changeEmitter.fire();
+      }
+    });
+  }
+
+  dispose(): void {
+    this.configListener.dispose();
+    this.changeEmitter.dispose();
+  }
+
+  get onDidChange(): vscode.Event<void> {
+    return this.changeEmitter.event;
+  }
+
+  getRefreshIntervalMs(): number {
+    const seconds = Number.isFinite(this.refreshIntervalSeconds)
+      ? this.refreshIntervalSeconds
+      : DEFAULT_REFRESH_SECONDS;
+    return Math.max(0, Math.floor(seconds * 1000));
+  }
+
+  getShowResolvedIssues(): boolean {
+    return this.showResolvedIssues;
+  }
+
+  getRunStatusFilter(): string[] {
+    return [...this.runStatusFilter];
+  }
+
+  getWorkspaceRoot(): string | undefined {
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    return folder?.uri.fsPath;
+  }
+
+  async resolveVaultPath(): Promise<string | undefined> {
+    const workspaceRoot = this.getWorkspaceRoot();
+    if (!workspaceRoot) {
+      return this.vaultPathSetting ? expandPath(this.vaultPathSetting, '') : undefined;
+    }
+
+    const orchDir = path.join(workspaceRoot, '.orch');
+    try {
+      if (fs.existsSync(orchDir) && fs.statSync(orchDir).isDirectory()) {
+        const configPath = path.join(orchDir, 'config.yaml');
+        if (fs.existsSync(configPath)) {
+          const content = fs.readFileSync(configPath, 'utf8');
+          const vaultValue = parseVaultFromConfig(content);
+          if (vaultValue) {
+            return expandPath(vaultValue, workspaceRoot);
+          }
+        }
+      }
+    } catch (error) {
+      console.warn('orch: failed to inspect .orch/config.yaml', error);
+    }
+
+    if (this.vaultPathSetting) {
+      return expandPath(this.vaultPathSetting, workspaceRoot);
+    }
+
+    return undefined;
+  }
+
+  private reload(): void {
+    const config = vscode.workspace.getConfiguration('orch');
+    this.refreshIntervalSeconds = config.get<number>('refreshInterval', DEFAULT_REFRESH_SECONDS);
+    this.showResolvedIssues = config.get<boolean>('issues.showResolved', false);
+    this.runStatusFilter = config.get<string[]>('runs.statusFilter', []) || [];
+    this.vaultPathSetting = config.get<string>('vaultPath', '') || '';
+  }
+}
+
+function parseVaultFromConfig(content: string): string | undefined {
+  const lines = content.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = stripComments(line).trim();
+    if (!trimmed) {
+      continue;
+    }
+    const match = trimmed.match(/^vault\s*:\s*(.*)$/);
+    if (!match) {
+      continue;
+    }
+    let value = match[1].trim();
+    if (!value) {
+      return undefined;
+    }
+    value = stripQuotes(value);
+    return value || undefined;
+  }
+  return undefined;
+}
+
+function stripComments(line: string): string {
+  const index = line.indexOf('#');
+  if (index === -1) {
+    return line;
+  }
+  return line.slice(0, index);
+}
+
+function stripQuotes(value: string): string {
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1).trim();
+  }
+  return value;
+}
+
+function expandPath(input: string, baseDir: string): string {
+  let expanded = input.trim();
+  if (!expanded) {
+    return expanded;
+  }
+  if (expanded.startsWith('~')) {
+    expanded = path.join(os.homedir(), expanded.slice(1));
+  }
+  if (path.isAbsolute(expanded)) {
+    return expanded;
+  }
+  if (!baseDir) {
+    return expanded;
+  }
+  return path.resolve(baseDir, expanded);
+}

--- a/vscode-orch/src/extension.ts
+++ b/vscode-orch/src/extension.ts
@@ -1,0 +1,76 @@
+import * as vscode from 'vscode';
+import { OrchConfig } from './config';
+import { OrchClient } from './orch/client';
+import { IssuesProvider } from './providers/issuesProvider';
+import { RunsProvider } from './providers/runsProvider';
+import { registerOpenIssueCommand } from './commands/openIssue';
+import { registerStartRunCommand } from './commands/startRun';
+import { registerContinueRunCommand } from './commands/continueRun';
+import { registerAttachRunCommand } from './commands/attachRun';
+import { registerStopRunCommand } from './commands/stopRun';
+import { registerResolveRunCommand } from './commands/resolveRun';
+import { TerminalManager } from './terminalManager';
+
+export function activate(context: vscode.ExtensionContext): void {
+  const config = new OrchConfig();
+  const client = new OrchClient(config);
+  const issuesProvider = new IssuesProvider(client, config);
+  const runsProvider = new RunsProvider(client, config);
+  const terminalManager = new TerminalManager(config.getWorkspaceRoot());
+
+  context.subscriptions.push(
+    config,
+    terminalManager,
+    vscode.window.registerTreeDataProvider('orchIssues', issuesProvider),
+    vscode.window.registerTreeDataProvider('orchRuns', runsProvider),
+    registerOpenIssueCommand(),
+    registerStartRunCommand(client, runsProvider),
+    registerContinueRunCommand(client, runsProvider),
+    registerAttachRunCommand(config, terminalManager),
+    registerStopRunCommand(client, runsProvider),
+    registerResolveRunCommand(client, runsProvider),
+    vscode.commands.registerCommand('orch.refreshIssues', () => issuesProvider.refresh()),
+    vscode.commands.registerCommand('orch.refreshRuns', () => runsProvider.refresh()),
+    vscode.commands.registerCommand('orch.refreshAll', () => {
+      issuesProvider.refresh();
+      runsProvider.refresh();
+    })
+  );
+
+  let refreshTimer = startRefreshTimer(config, issuesProvider, runsProvider);
+  context.subscriptions.push({
+    dispose: () => {
+      if (refreshTimer) {
+        clearInterval(refreshTimer);
+      }
+    }
+  });
+
+  context.subscriptions.push(
+    config.onDidChange(() => {
+      if (refreshTimer) {
+        clearInterval(refreshTimer);
+      }
+      refreshTimer = startRefreshTimer(config, issuesProvider, runsProvider);
+      issuesProvider.refresh();
+      runsProvider.refresh();
+    })
+  );
+}
+
+export function deactivate(): void {}
+
+function startRefreshTimer(
+  config: OrchConfig,
+  issuesProvider: IssuesProvider,
+  runsProvider: RunsProvider
+): NodeJS.Timeout | undefined {
+  const interval = config.getRefreshIntervalMs();
+  if (interval <= 0) {
+    return undefined;
+  }
+  return setInterval(() => {
+    issuesProvider.refresh();
+    runsProvider.refresh();
+  }, interval);
+}

--- a/vscode-orch/src/providers/issuesProvider.ts
+++ b/vscode-orch/src/providers/issuesProvider.ts
@@ -1,0 +1,77 @@
+import * as vscode from 'vscode';
+import { OrchClient, IssueInfo } from '../orch/client';
+import { OrchConfig } from '../config';
+
+export class IssuesProvider implements vscode.TreeDataProvider<IssueTreeItem> {
+  private readonly changeEmitter = new vscode.EventEmitter<void>();
+
+  constructor(private readonly client: OrchClient, private readonly config: OrchConfig) {}
+
+  get onDidChangeTreeData(): vscode.Event<void> {
+    return this.changeEmitter.event;
+  }
+
+  refresh(): void {
+    this.client.invalidateIssues();
+    this.changeEmitter.fire();
+  }
+
+  getTreeItem(element: IssueTreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  async getChildren(): Promise<IssueTreeItem[]> {
+    const includeResolved = this.config.getShowResolvedIssues();
+    const issues = await this.client.listIssues(includeResolved);
+    return issues.map((issue) => new IssueTreeItem(issue));
+  }
+}
+
+export class IssueTreeItem extends vscode.TreeItem {
+  readonly issue: IssueInfo;
+
+  constructor(issue: IssueInfo) {
+    super(buildLabel(issue), vscode.TreeItemCollapsibleState.None);
+    this.issue = issue;
+    this.contextValue = 'orchIssue';
+    this.description = buildDescription(issue);
+    this.tooltip = buildTooltip(issue);
+    this.iconPath = iconForStatus(issue.status);
+    this.command = {
+      command: 'orch.issue.open',
+      title: 'Open Issue',
+      arguments: [this]
+    };
+  }
+}
+
+function buildLabel(issue: IssueInfo): string {
+  const detail = issue.summary || issue.title || '';
+  if (!detail) {
+    return issue.id;
+  }
+  return `${issue.id} - ${detail}`;
+}
+
+function buildDescription(issue: IssueInfo): string {
+  if (issue.summary && issue.summary !== issue.title) {
+    return issue.title || '';
+  }
+  return '';
+}
+
+function buildTooltip(issue: IssueInfo): string {
+  const parts = [issue.title || issue.summary || issue.id, `Status: ${issue.status}`];
+  return parts.filter(Boolean).join('\n');
+}
+
+function iconForStatus(status: string): vscode.ThemeIcon {
+  switch (status) {
+    case 'resolved':
+      return new vscode.ThemeIcon('issue-closed', new vscode.ThemeColor('charts.green'));
+    case 'closed':
+      return new vscode.ThemeIcon('issue-closed', new vscode.ThemeColor('charts.gray'));
+    default:
+      return new vscode.ThemeIcon('issue-opened', new vscode.ThemeColor('charts.blue'));
+  }
+}

--- a/vscode-orch/src/providers/runsProvider.ts
+++ b/vscode-orch/src/providers/runsProvider.ts
@@ -1,0 +1,92 @@
+import * as vscode from 'vscode';
+import { OrchClient, RunInfo } from '../orch/client';
+import { OrchConfig } from '../config';
+
+export class RunsProvider implements vscode.TreeDataProvider<RunTreeItem> {
+  private readonly changeEmitter = new vscode.EventEmitter<void>();
+
+  constructor(private readonly client: OrchClient, private readonly config: OrchConfig) {}
+
+  get onDidChangeTreeData(): vscode.Event<void> {
+    return this.changeEmitter.event;
+  }
+
+  refresh(): void {
+    this.client.invalidateRuns();
+    this.changeEmitter.fire();
+  }
+
+  getTreeItem(element: RunTreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  async getChildren(): Promise<RunTreeItem[]> {
+    const statusFilter = this.config.getRunStatusFilter();
+    const runs = await this.client.listRuns(statusFilter);
+    return runs.map((run) => new RunTreeItem(run));
+  }
+}
+
+export class RunTreeItem extends vscode.TreeItem {
+  readonly run: RunInfo;
+
+  constructor(run: RunInfo) {
+    super(formatLabel(run), vscode.TreeItemCollapsibleState.None);
+    this.run = run;
+    this.contextValue = 'orchRun';
+    this.description = formatDescription(run);
+    this.tooltip = formatTooltip(run);
+    this.iconPath = iconForStatus(run.status);
+    this.command = {
+      command: 'orch.run.attach',
+      title: 'Attach to Run',
+      arguments: [this]
+    };
+  }
+}
+
+function formatLabel(run: RunInfo): string {
+  const shortId = run.short_id || run.run_id;
+  return `${run.issue_id}#${shortId}`;
+}
+
+function formatDescription(run: RunInfo): string {
+  const updated = run.updated_ago ? ` | ${run.updated_ago}` : '';
+  return `${run.status}${updated}`;
+}
+
+function formatTooltip(run: RunInfo): string {
+  const lines = [
+    `${run.issue_id}#${run.run_id}`,
+    `Status: ${run.status}`,
+    run.agent ? `Agent: ${run.agent}` : '',
+    run.branch ? `Branch: ${run.branch}` : '',
+    run.updated_at ? `Updated: ${run.updated_at}` : ''
+  ];
+  return lines.filter(Boolean).join('\n');
+}
+
+function iconForStatus(status: string): vscode.ThemeIcon {
+  switch (status) {
+    case 'running':
+      return new vscode.ThemeIcon('play-circle', new vscode.ThemeColor('charts.green'));
+    case 'blocked':
+    case 'blocked_api':
+      return new vscode.ThemeIcon('warning', new vscode.ThemeColor('charts.yellow'));
+    case 'queued':
+    case 'booting':
+      return new vscode.ThemeIcon('clock', new vscode.ThemeColor('charts.blue'));
+    case 'pr_open':
+      return new vscode.ThemeIcon('git-pull-request', new vscode.ThemeColor('charts.blue'));
+    case 'done':
+      return new vscode.ThemeIcon('check', new vscode.ThemeColor('charts.green'));
+    case 'failed':
+      return new vscode.ThemeIcon('error', new vscode.ThemeColor('charts.red'));
+    case 'canceled':
+      return new vscode.ThemeIcon('circle-slash', new vscode.ThemeColor('charts.gray'));
+    case 'unknown':
+      return new vscode.ThemeIcon('question', new vscode.ThemeColor('charts.orange'));
+    default:
+      return new vscode.ThemeIcon('circle-outline');
+  }
+}

--- a/vscode-orch/src/terminalManager.ts
+++ b/vscode-orch/src/terminalManager.ts
@@ -1,0 +1,36 @@
+import * as vscode from 'vscode';
+
+export class TerminalManager implements vscode.Disposable {
+  private readonly terminals = new Map<string, vscode.Terminal>();
+  private readonly closeListener: vscode.Disposable;
+
+  constructor(private readonly workspaceRoot?: string) {
+    this.closeListener = vscode.window.onDidCloseTerminal((terminal) => {
+      for (const [key, value] of this.terminals.entries()) {
+        if (value === terminal) {
+          this.terminals.delete(key);
+          break;
+        }
+      }
+    });
+  }
+
+  dispose(): void {
+    this.closeListener.dispose();
+    this.terminals.clear();
+  }
+
+  getOrCreate(runRef: string): { terminal: vscode.Terminal; created: boolean } {
+    const existing = this.terminals.get(runRef);
+    if (existing) {
+      return { terminal: existing, created: false };
+    }
+
+    const terminal = vscode.window.createTerminal({
+      name: `orch: ${runRef}`,
+      cwd: this.workspaceRoot
+    });
+    this.terminals.set(runRef, terminal);
+    return { terminal, created: true };
+  }
+}

--- a/vscode-orch/tsconfig.json
+++ b/vscode-orch/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add VSCode extension scaffold with issues and runs tree views
- implement orch CLI wrapper, refresh/caching, and terminal attach commands
- add configurable filters and vault detection

Refs orch-048