### PR TITLE
Avoid global vault fallback for repo config

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -104,6 +104,7 @@ func Execute() {
 
 // getVaultPath returns the vault path from flags, environment, or config files
 // Precedence: --vault flag > ORCH_VAULT env > .orch/config.yaml > ~/.config/orch/config.yaml
+// Note: if a repo-local config exists but does not set vault, global defaults are ignored.
 func getVaultPath() (string, error) {
 	// 1. Command-line flag (highest precedence)
 	if globalOpts.VaultPath != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,7 @@ func Load() (*Config, error) {
 	// Load repo-local config (higher precedence)
 	repoPath, _ := findRepoConfig()
 	if repoPath != "" {
+		cfg.Vault = ""
 		if err := loadFromFile(repoPath, cfg); err != nil && !os.IsNotExist(err) {
 			return nil, err
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -132,6 +132,51 @@ func TestLoadDefaultVault(t *testing.T) {
 	}
 }
 
+func TestRepoConfigWithoutVaultDoesNotUseGlobal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ORCH_VAULT", "")
+	t.Setenv("ORCH_AGENT", "")
+
+	globalDir := filepath.Join(home, ".config", "orch")
+	if err := os.MkdirAll(globalDir, 0755); err != nil {
+		t.Fatalf("mkdir global: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yaml"), []byte("default_vault: /global\n"), 0644); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".orch"), 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".orch", "config.yaml"), []byte("agent: codex\n"), 0644); err != nil {
+		t.Fatalf("write repo config: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if cfg.Vault != "" {
+		t.Fatalf("Vault = %q, want empty", cfg.Vault)
+	}
+	if cfg.Agent != "codex" {
+		t.Fatalf("Agent = %q, want codex", cfg.Agent)
+	}
+}
+
 func TestRepoConfigDir(t *testing.T) {
 	repo := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repo, ".orch"), 0755); err != nil {


### PR DESCRIPTION
References: orch-049

Summary:
- stop using global/default vault when a repo-local config exists without vault
- clarify vault precedence note in getVaultPath
- add config test for repo config without vault

Tests: go test ./...