### PR TITLE
Add monitor --agent flag

### DIFF
--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -11,6 +11,7 @@ import (
 type monitorOptions struct {
 	Issue           string
 	Status          []string
+	Agent           string
 	Attach          bool
 	ForceNew        bool
 	Dashboard       bool
@@ -30,6 +31,7 @@ func newMonitorCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.Issue, "issue", "", "Filter to specific issue")
 	cmd.Flags().StringSliceVar(&opts.Status, "status", nil, "Filter by status")
+	cmd.Flags().StringVarP(&opts.Agent, "agent", "a", "", "Control agent to launch in monitor chat pane")
 	cmd.Flags().BoolVar(&opts.Attach, "attach", false, "Attach to existing monitor session if present")
 	cmd.Flags().BoolVar(&opts.ForceNew, "new", false, "Force create a new monitor session")
 	cmd.Flags().BoolVar(&opts.Dashboard, "dashboard", false, "Run dashboard UI (internal)")
@@ -57,6 +59,7 @@ func runMonitor(opts *monitorOptions) error {
 	m := monitor.New(st, monitor.Options{
 		Issue:       opts.Issue,
 		Statuses:    statuses,
+		Agent:       opts.Agent,
 		Attach:      opts.Attach,
 		ForceNew:    opts.ForceNew,
 		OrchPath:    os.Args[0],

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -43,6 +43,7 @@ type Options struct {
 	Session     string
 	Issue       string
 	Statuses    []model.Status
+	Agent       string
 	Attach      bool
 	ForceNew    bool
 	OrchPath    string
@@ -57,6 +58,7 @@ type Monitor struct {
 	store        store.Store
 	orchPath     string
 	globalFlags  []string
+	agent        string
 	attach       bool
 	forceNew     bool
 	runs         []*RunWindow
@@ -84,6 +86,7 @@ func New(st store.Store, opts Options) *Monitor {
 		store:        st,
 		orchPath:     orchPath,
 		globalFlags:  opts.GlobalFlags,
+		agent:        opts.Agent,
 		attach:       opts.Attach,
 		forceNew:     opts.ForceNew,
 	}
@@ -833,12 +836,13 @@ func (m *Monitor) agentChatCommand() string {
 	// Use the instruction to read the prompt file
 	prompt := GetControlPromptInstruction()
 
-	cfg, err := config.Load()
-	if err != nil {
-		return fallbackChatCommand("failed to load config")
+	agentName := strings.TrimSpace(m.agent)
+	if agentName == "" {
+		cfg, err := config.Load()
+		if err == nil {
+			agentName = cfg.Agent
+		}
 	}
-
-	agentName := cfg.Agent
 	if agentName == "" {
 		agentName = "claude"
 	}


### PR DESCRIPTION
## Summary
- add --agent/-a flag to the monitor command and pass it into monitor options
- prefer CLI-selected agent for the chat pane with config/default fallback

## Issue
- orch-056