### PR TITLE
Add capture-all command for consolidated agent output

### DIFF
--- a/internal/cli/capture_all.go
+++ b/internal/cli/capture_all.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/store"
+	"github.com/s22625/orch/internal/tmux"
+	"github.com/spf13/cobra"
+)
+
+type captureAllOptions struct {
+	Lines int
+}
+
+var captureAllHasSession = tmux.HasSession
+var captureAllCapturePane = tmux.CapturePane
+
+func newCaptureAllCmd() *cobra.Command {
+	opts := &captureAllOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "capture-all",
+		Short: "Capture output from all running agents",
+		Long: `Capture the latest output from all running agents.
+
+Returns captured text agent-by-agent with status headers.
+Useful for monitoring all active agents at once.
+
+Examples:
+  # Capture last 100 lines (default) from all running agents
+  orch capture-all
+
+  # Capture last 500 lines
+  orch capture-all --lines 500
+
+  # Output as JSON for scripting
+  orch capture-all --json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCaptureAll(opts)
+		},
+	}
+
+	cmd.Flags().IntVar(&opts.Lines, "lines", 100, "Number of lines to capture per agent")
+
+	return cmd
+}
+
+type captureAllItem struct {
+	OK          bool   `json:"ok"`
+	IssueID     string `json:"issue_id"`
+	RunID       string `json:"run_id"`
+	Status      string `json:"status"`
+	TmuxSession string `json:"tmux_session"`
+	Lines       int    `json:"lines"`
+	Content     string `json:"content,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+func runCaptureAll(opts *captureAllOptions) error {
+	st, err := getStore()
+	if err != nil {
+		return err
+	}
+
+	runs, err := st.ListRuns(&store.ListRunsFilter{
+		Status: captureAllStatuses(),
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(runs) == 0 {
+		if globalOpts.JSON {
+			return outputCaptureAllJSON([]captureAllItem{}, true)
+		}
+		if !globalOpts.Quiet {
+			fmt.Println("No running agents found")
+		}
+		return nil
+	}
+
+	items := make([]captureAllItem, 0, len(runs))
+	overallOK := true
+	for _, run := range runs {
+		item := captureAllItemForRun(run, opts.Lines)
+		if !item.OK {
+			overallOK = false
+		}
+		items = append(items, item)
+	}
+
+	if globalOpts.JSON {
+		return outputCaptureAllJSON(items, overallOK)
+	}
+
+	outputCaptureAllPlain(items)
+	return nil
+}
+
+func captureAllStatuses() []model.Status {
+	return []model.Status{
+		model.StatusRunning,
+		model.StatusBooting,
+		model.StatusBlocked,
+		model.StatusBlockedAPI,
+		model.StatusPROpen,
+		model.StatusUnknown,
+	}
+}
+
+func captureAllItemForRun(run *model.Run, lines int) captureAllItem {
+	sessionName := run.TmuxSession
+	if sessionName == "" {
+		sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
+	}
+
+	item := captureAllItem{
+		IssueID:     run.IssueID,
+		RunID:       run.RunID,
+		Status:      string(run.Status),
+		TmuxSession: sessionName,
+		Lines:       lines,
+	}
+
+	if !captureAllHasSession(sessionName) {
+		item.Error = fmt.Sprintf("tmux session %q not found (run may not be active)", sessionName)
+		return item
+	}
+
+	content, err := captureAllCapturePane(sessionName, lines)
+	if err != nil {
+		item.Error = fmt.Sprintf("failed to capture pane: %v", err)
+		return item
+	}
+
+	item.OK = true
+	item.Content = content
+	return item
+}
+
+func outputCaptureAllJSON(items []captureAllItem, ok bool) error {
+	output := struct {
+		OK    bool             `json:"ok"`
+		Items []captureAllItem `json:"items"`
+	}{
+		OK:    ok,
+		Items: items,
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(output)
+}
+
+func outputCaptureAllPlain(items []captureAllItem) {
+	for i, item := range items {
+		if i > 0 {
+			fmt.Println()
+		}
+		fmt.Printf("=== %s#%s [%s] ===\n", item.IssueID, item.RunID, item.Status)
+		if item.OK {
+			fmt.Print(item.Content)
+			if !strings.HasSuffix(item.Content, "\n") {
+				fmt.Println()
+			}
+			continue
+		}
+		fmt.Printf("error: %s\n", item.Error)
+	}
+}

--- a/internal/cli/capture_all_test.go
+++ b/internal/cli/capture_all_test.go
@@ -1,0 +1,240 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/s22625/orch/internal/model"
+)
+
+func TestNewCaptureAllCmd(t *testing.T) {
+	cmd := newCaptureAllCmd()
+
+	if cmd.Use != "capture-all" {
+		t.Errorf("unexpected use: %s", cmd.Use)
+	}
+
+	if cmd.Short != "Capture output from all running agents" {
+		t.Errorf("unexpected short: %s", cmd.Short)
+	}
+
+	linesFlag := cmd.Flags().Lookup("lines")
+	if linesFlag == nil {
+		t.Error("missing --lines flag")
+	}
+
+	if linesFlag.DefValue != "100" {
+		t.Errorf("unexpected default for --lines: %s", linesFlag.DefValue)
+	}
+
+	if err := cmd.Args(cmd, []string{}); err != nil {
+		t.Errorf("unexpected error with no args: %v", err)
+	}
+
+	if err := cmd.Args(cmd, []string{"extra"}); err == nil {
+		t.Error("expected error with args")
+	}
+}
+
+func TestRunCaptureAllJSON(t *testing.T) {
+	resetGlobalOpts(t)
+
+	vault := t.TempDir()
+	globalOpts.VaultPath = vault
+	globalOpts.Backend = "file"
+	globalOpts.JSON = true
+	globalOpts.Quiet = true
+
+	writeIssue(t, vault, "issue-1")
+	writeIssue(t, vault, "issue-2")
+	writeIssue(t, vault, "issue-3")
+
+	st, err := getStore()
+	if err != nil {
+		t.Fatalf("getStore: %v", err)
+	}
+
+	run1, err := st.CreateRun("issue-1", "run-1", nil)
+	if err != nil {
+		t.Fatalf("create run1: %v", err)
+	}
+	run2, err := st.CreateRun("issue-2", "run-2", nil)
+	if err != nil {
+		t.Fatalf("create run2: %v", err)
+	}
+	run3, err := st.CreateRun("issue-3", "run-3", nil)
+	if err != nil {
+		t.Fatalf("create run3: %v", err)
+	}
+
+	if err := st.AppendEvent(run1.Ref(), model.NewStatusEvent(model.StatusRunning)); err != nil {
+		t.Fatalf("status run1: %v", err)
+	}
+	if err := st.AppendEvent(run2.Ref(), model.NewStatusEvent(model.StatusBlocked)); err != nil {
+		t.Fatalf("status run2: %v", err)
+	}
+	if err := st.AppendEvent(run3.Ref(), model.NewStatusEvent(model.StatusDone)); err != nil {
+		t.Fatalf("status run3: %v", err)
+	}
+
+	outputs := map[string]string{
+		model.GenerateTmuxSession("issue-1", "run-1"): "run-1 output\n",
+	}
+
+	origHasSession := captureAllHasSession
+	origCapturePane := captureAllCapturePane
+	t.Cleanup(func() {
+		captureAllHasSession = origHasSession
+		captureAllCapturePane = origCapturePane
+	})
+
+	var capturedLines []int
+	captureAllHasSession = func(session string) bool {
+		_, ok := outputs[session]
+		return ok
+	}
+	captureAllCapturePane = func(session string, lines int) (string, error) {
+		capturedLines = append(capturedLines, lines)
+		return outputs[session], nil
+	}
+
+	out := captureStdout(t, func() {
+		if err := runCaptureAll(&captureAllOptions{Lines: 5}); err != nil {
+			t.Fatalf("runCaptureAll: %v", err)
+		}
+	})
+
+	var got struct {
+		OK    bool             `json:"ok"`
+		Items []captureAllItem `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+
+	if got.OK {
+		t.Fatalf("expected ok=false with missing session")
+	}
+	if len(got.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(got.Items))
+	}
+	if len(capturedLines) != 1 || capturedLines[0] != 5 {
+		t.Fatalf("unexpected lines captured: %v", capturedLines)
+	}
+
+	items := make(map[string]captureAllItem, len(got.Items))
+	for _, item := range got.Items {
+		items[item.IssueID] = item
+	}
+
+	item1, ok := items["issue-1"]
+	if !ok {
+		t.Fatalf("missing issue-1 item")
+	}
+	if !item1.OK {
+		t.Fatalf("issue-1 should be ok")
+	}
+	if item1.RunID != "run-1" {
+		t.Fatalf("issue-1 run_id = %q, want run-1", item1.RunID)
+	}
+	if item1.Status != string(model.StatusRunning) {
+		t.Fatalf("issue-1 status = %q, want %q", item1.Status, model.StatusRunning)
+	}
+	if item1.Content != "run-1 output\n" {
+		t.Fatalf("issue-1 content = %q", item1.Content)
+	}
+	if item1.Lines != 5 {
+		t.Fatalf("issue-1 lines = %d, want 5", item1.Lines)
+	}
+	if item1.TmuxSession != model.GenerateTmuxSession("issue-1", "run-1") {
+		t.Fatalf("issue-1 tmux_session = %q", item1.TmuxSession)
+	}
+
+	item2, ok := items["issue-2"]
+	if !ok {
+		t.Fatalf("missing issue-2 item")
+	}
+	if item2.OK {
+		t.Fatalf("issue-2 should not be ok")
+	}
+	if item2.RunID != "run-2" {
+		t.Fatalf("issue-2 run_id = %q, want run-2", item2.RunID)
+	}
+	if item2.Status != string(model.StatusBlocked) {
+		t.Fatalf("issue-2 status = %q, want %q", item2.Status, model.StatusBlocked)
+	}
+	if !strings.Contains(item2.Error, "tmux session") {
+		t.Fatalf("issue-2 error = %q", item2.Error)
+	}
+}
+
+func TestRunCaptureAllPlain(t *testing.T) {
+	resetGlobalOpts(t)
+
+	vault := t.TempDir()
+	globalOpts.VaultPath = vault
+	globalOpts.Backend = "file"
+
+	writeIssue(t, vault, "issue-1")
+	writeIssue(t, vault, "issue-2")
+
+	st, err := getStore()
+	if err != nil {
+		t.Fatalf("getStore: %v", err)
+	}
+
+	run1, err := st.CreateRun("issue-1", "run-1", nil)
+	if err != nil {
+		t.Fatalf("create run1: %v", err)
+	}
+	run2, err := st.CreateRun("issue-2", "run-2", nil)
+	if err != nil {
+		t.Fatalf("create run2: %v", err)
+	}
+
+	if err := st.AppendEvent(run1.Ref(), model.NewStatusEvent(model.StatusRunning)); err != nil {
+		t.Fatalf("status run1: %v", err)
+	}
+	if err := st.AppendEvent(run2.Ref(), model.NewStatusEvent(model.StatusBlocked)); err != nil {
+		t.Fatalf("status run2: %v", err)
+	}
+
+	outputs := map[string]string{
+		model.GenerateTmuxSession("issue-1", "run-1"): "run-1 output\n",
+	}
+
+	origHasSession := captureAllHasSession
+	origCapturePane := captureAllCapturePane
+	t.Cleanup(func() {
+		captureAllHasSession = origHasSession
+		captureAllCapturePane = origCapturePane
+	})
+
+	captureAllHasSession = func(session string) bool {
+		_, ok := outputs[session]
+		return ok
+	}
+	captureAllCapturePane = func(session string, lines int) (string, error) {
+		return outputs[session], nil
+	}
+
+	out := captureStdout(t, func() {
+		if err := runCaptureAll(&captureAllOptions{Lines: 5}); err != nil {
+			t.Fatalf("runCaptureAll: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "=== issue-1#run-1 [running] ===") {
+		t.Fatalf("missing issue-1 header: %q", out)
+	}
+	if !strings.Contains(out, "run-1 output") {
+		t.Fatalf("missing issue-1 output: %q", out)
+	}
+	if !strings.Contains(out, "=== issue-2#run-2 [blocked] ===") {
+		t.Fatalf("missing issue-2 header: %q", out)
+	}
+	if !strings.Contains(out, "error: tmux session") {
+		t.Fatalf("missing issue-2 error: %q", out)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -92,6 +92,7 @@ func init() {
 	rootCmd.AddCommand(newExecCmd())
 	rootCmd.AddCommand(newSendCmd())
 	rootCmd.AddCommand(newCaptureCmd())
+	rootCmd.AddCommand(newCaptureAllCmd())
 }
 
 // Execute runs the root command


### PR DESCRIPTION
Refs: orch-054

## Summary
- add `orch capture-all` to capture output for all active runs with status headers/JSON
- continue on per-run tmux errors so partial captures still return
- add CLI tests covering configuration, JSON, and plain output