### PR TITLE
Send control prompt to monitor chat agents

### DIFF
--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/s22625/orch/internal/agent"
 	"github.com/s22625/orch/internal/config"
@@ -583,7 +584,9 @@ func (m *Monitor) ensurePaneLayout() error {
 		_ = tmux.SetPaneTitle(base.ID, runsPaneTitle)
 		if chatPane, err := tmux.SplitWindow(base.ID, true, 25); err == nil {
 			_ = tmux.SetPaneTitle(chatPane, chatPaneTitle)
-			_ = tmux.SendKeys(chatPane, m.agentChatCommand())
+			launch := m.agentChatLaunch()
+			_ = tmux.SendKeys(chatPane, launch.command)
+			m.sendAgentChatPrompt(chatPane, launch)
 			_ = tmux.SetOption(m.session, chatPaneOption, chatPane)
 		} else {
 			return err
@@ -826,11 +829,18 @@ func (m *Monitor) issuesDashboardCommand() string {
 	return shellJoin(args)
 }
 
-func (m *Monitor) agentChatCommand() string {
+type agentChatLaunch struct {
+	command      string
+	prompt       string
+	injection    agent.InjectionMethod
+	readyPattern string
+}
+
+func (m *Monitor) agentChatLaunch() agentChatLaunch {
 	// Write the control prompt file with dynamic repo context
 	_, err := writeControlPromptFile(m.store)
 	if err != nil {
-		return fallbackChatCommand(fmt.Sprintf("failed to write prompt file: %v", err))
+		return agentChatLaunch{command: fallbackChatCommand(fmt.Sprintf("failed to write prompt file: %v", err))}
 	}
 
 	// Use the instruction to read the prompt file
@@ -848,14 +858,14 @@ func (m *Monitor) agentChatCommand() string {
 	}
 	aType, err := agent.ParseAgentType(agentName)
 	if err != nil {
-		return fallbackChatCommand(err.Error())
+		return agentChatLaunch{command: fallbackChatCommand(err.Error())}
 	}
 	adapter, err := agent.GetAdapter(aType)
 	if err != nil {
-		return fallbackChatCommand(err.Error())
+		return agentChatLaunch{command: fallbackChatCommand(err.Error())}
 	}
 	if !adapter.IsAvailable() {
-		return fallbackChatCommand(fmt.Sprintf("%s CLI not available", agentName))
+		return agentChatLaunch{command: fallbackChatCommand(fmt.Sprintf("%s CLI not available", agentName))}
 	}
 
 	cmd, err := adapter.LaunchCommand(&agent.LaunchConfig{
@@ -864,9 +874,30 @@ func (m *Monitor) agentChatCommand() string {
 		Prompt:    prompt,
 	})
 	if err != nil {
-		return fallbackChatCommand(err.Error())
+		return agentChatLaunch{command: fallbackChatCommand(err.Error())}
 	}
-	return cmd
+
+	return agentChatLaunch{
+		command:      cmd,
+		prompt:       prompt,
+		injection:    adapter.PromptInjection(),
+		readyPattern: adapter.ReadyPattern(),
+	}
+}
+
+func (m *Monitor) sendAgentChatPrompt(pane string, launch agentChatLaunch) {
+	if launch.injection != agent.InjectionTmux || launch.prompt == "" {
+		return
+	}
+	paneID := pane
+	prompt := launch.prompt
+	pattern := launch.readyPattern
+	go func() {
+		if pattern != "" {
+			_ = tmux.WaitForReady(paneID, pattern, 30*time.Second)
+		}
+		_ = tmux.SendKeys(paneID, prompt)
+	}()
 }
 
 func defaultStatuses() []model.Status {


### PR DESCRIPTION
## Summary
- send control prompt via tmux for agents that require prompt injection
- keep adapter-selected prompt behavior consistent for monitor chat panes

## Issue
- orch-056