### PR TITLE
Normalize Claude rate-limit detection

### DIFF
--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -165,7 +165,7 @@ func (d *Daemon) isCompleted(output string) bool {
 
 // isAPILimited checks if the output indicates API usage limits
 func (d *Daemon) isAPILimited(output string) bool {
-	lines := getLastLines(output, 10)
+	lines := getLastLines(output, 30)
 	lowerOutput := strings.ToLower(lines)
 
 	apiLimitPatterns := []string{
@@ -175,6 +175,9 @@ func (d *Daemon) isAPILimited(output string) bool {
 		"quota exceeded",
 		"insufficient quota",
 		"resource exhausted",
+		"you've hit your limit",
+		"/rate-limit-options",
+		"stop and wait for limit to reset",
 	}
 
 	for _, pattern := range apiLimitPatterns {

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -166,7 +166,7 @@ func (d *Daemon) isCompleted(output string) bool {
 // isAPILimited checks if the output indicates API usage limits
 func (d *Daemon) isAPILimited(output string) bool {
 	lines := getLastLines(output, 30)
-	lowerOutput := strings.ToLower(lines)
+	lowerOutput := normalizeForMatch(lines)
 
 	apiLimitPatterns := []string{
 		"cost limit reached",
@@ -187,6 +187,21 @@ func (d *Daemon) isAPILimited(output string) bool {
 	}
 
 	return false
+}
+
+var normalizeMatchReplacer = strings.NewReplacer(
+	"\u00a0", " ", // non-breaking space
+	"\u2007", " ", // figure space
+	"\u202f", " ", // narrow no-break space
+	"\u2018", "'",
+	"\u2019", "'",
+	"\u201c", "\"",
+	"\u201d", "\"",
+)
+
+func normalizeForMatch(output string) string {
+	output = strings.ToLower(output)
+	return normalizeMatchReplacer.Replace(output)
 }
 
 // isFailed checks if the output indicates the agent failed

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -159,3 +159,14 @@ func TestAPILimitDetection(t *testing.T) {
 		t.Fatalf("detectStatus = %q, want %q", got, model.StatusBlockedAPI)
 	}
 }
+
+func TestAPILimitDetectionNormalizesUnicode(t *testing.T) {
+	d := newTestDaemon()
+
+	if !d.isAPILimited("You\u2019ve hit your limit") {
+		t.Fatal("expected API limit detection with curly apostrophe")
+	}
+	if !d.isAPILimited("Stop\u00a0and wait for limit to reset") {
+		t.Fatal("expected API limit detection with non-breaking space")
+	}
+}


### PR DESCRIPTION
## Summary
- Normalize captured output before API limit matching to handle non-breaking spaces and curly quotes.
- Add tests covering unicode normalization for Claude rate-limit detection.

## Issue
- orch-061