### PR TITLE
Pass prompt to gemini interactive sessions

### DIFF
--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -43,16 +43,6 @@ func (a *ClaudeAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 	return strings.Join(args, " "), nil
 }
 
-// doubleQuote wraps a string in double quotes, escaping special characters
-func doubleQuote(s string) string {
-	// Escape backslashes, double quotes, backticks, and dollar signs
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, "\"", "\\\"")
-	s = strings.ReplaceAll(s, "`", "\\`")
-	s = strings.ReplaceAll(s, "$", "\\$")
-	return "\"" + s + "\""
-}
-
 func (a *ClaudeAdapter) PromptInjection() InjectionMethod {
 	return InjectionArg
 }

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -21,24 +21,20 @@ func (a *GeminiAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 	var args []string
 
 	// gemini CLI with yolo mode
-	// Note: We don't pass -p flag here because Gemini exits after processing
-	// the prompt. Instead, the prompt is sent via tmux send-keys to keep
-	// the interactive session open. See PromptInjection() method.
 	args = append(args, "gemini", "--yolo")
+	if cfg.Prompt != "" {
+		args = append(args, "--prompt-interactive", doubleQuote(cfg.Prompt))
+	}
 
 	return strings.Join(args, " "), nil
 }
 
 func (a *GeminiAdapter) PromptInjection() InjectionMethod {
-	return InjectionTmux
+	return InjectionArg
 }
 
 func (a *GeminiAdapter) ReadyPattern() string {
-	// Gemini shows this prompt when ready for input:
-	// ╭────────────────────────────────────────────────────────╮
-	// │ *   Type your message or @path/to/file                 │
-	// ╰────────────────────────────────────────────────────────╯
-	return "Type your message"
+	return "" // Prompt passed via command line.
 }
 
 var _ Adapter = (*GeminiAdapter)(nil)

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -9,8 +9,7 @@ func TestGeminiLaunchCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LaunchCommand error: %v", err)
 	}
-	// Gemini now launches without -p flag; prompt is sent via tmux send-keys
-	want := `gemini --yolo`
+	want := `gemini --yolo --prompt-interactive "hello 'world'"`
 	if cmd != want {
 		t.Fatalf("command = %q, want %q", cmd, want)
 	}
@@ -18,18 +17,15 @@ func TestGeminiLaunchCommand(t *testing.T) {
 
 func TestGeminiPromptInjection(t *testing.T) {
 	adapter := &GeminiAdapter{}
-	if adapter.PromptInjection() != InjectionTmux {
-		t.Fatalf("PromptInjection() = %v, want %v", adapter.PromptInjection(), InjectionTmux)
+	if adapter.PromptInjection() != InjectionArg {
+		t.Fatalf("PromptInjection() = %v, want %v", adapter.PromptInjection(), InjectionArg)
 	}
 }
 
 func TestGeminiReadyPattern(t *testing.T) {
 	adapter := &GeminiAdapter{}
 	pattern := adapter.ReadyPattern()
-	if pattern == "" {
-		t.Fatal("ReadyPattern() should not be empty for Gemini")
-	}
-	if pattern != "Type your message" {
-		t.Fatalf("ReadyPattern() = %q, want %q", pattern, "Type your message")
+	if pattern != "" {
+		t.Fatalf("ReadyPattern() = %q, want %q", pattern, "")
 	}
 }

--- a/internal/agent/quote.go
+++ b/internal/agent/quote.go
@@ -1,0 +1,13 @@
+package agent
+
+import "strings"
+
+// doubleQuote wraps a string in double quotes, escaping special characters.
+func doubleQuote(s string) string {
+	// Escape backslashes, double quotes, backticks, and dollar signs.
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
+	s = strings.ReplaceAll(s, "`", "\\`")
+	s = strings.ReplaceAll(s, "$", "\\$")
+	return "\"" + s + "\""
+}


### PR DESCRIPTION
## Summary
- send prompts to Gemini via --prompt-interactive to keep interactive sessions open
- share prompt quoting helper across adapters

## Issue
- orch-056