### PR TITLE
Add model/thinking selection and display controls

### DIFF
--- a/internal/agent/adapter.go
+++ b/internal/agent/adapter.go
@@ -56,6 +56,7 @@ type LaunchConfig struct {
 	SessionName string // For agents that support session naming
 	Profile     string // Profile name for agents that support it (e.g., claude --profile)
 	Model       string // Model name for agents that support it (e.g., --model)
+	Thinking    string // Model-specific reasoning/thinking configuration (e.g., xhigh)
 }
 
 // Env returns the environment variables to pass to the agent
@@ -70,6 +71,9 @@ func (c *LaunchConfig) Env() []string {
 	}
 	if c.Model != "" {
 		env = append(env, fmt.Sprintf("ORCH_MODEL=%s", c.Model))
+	}
+	if c.Thinking != "" {
+		env = append(env, fmt.Sprintf("ORCH_THINKING=%s", c.Thinking))
 	}
 	// Ensure HOME is passed for OAuth credentials in ~/.claude.json
 	if home := os.Getenv("HOME"); home != "" {

--- a/internal/agent/adapter.go
+++ b/internal/agent/adapter.go
@@ -55,6 +55,7 @@ type LaunchConfig struct {
 	Resume      bool   // Whether to resume an existing session
 	SessionName string // For agents that support session naming
 	Profile     string // Profile name for agents that support it (e.g., claude --profile)
+	Model       string // Model name for agents that support it (e.g., --model)
 }
 
 // Env returns the environment variables to pass to the agent
@@ -66,6 +67,9 @@ func (c *LaunchConfig) Env() []string {
 		fmt.Sprintf("ORCH_WORKTREE_PATH=%s", c.WorkDir),
 		fmt.Sprintf("ORCH_BRANCH=%s", c.Branch),
 		fmt.Sprintf("ORCH_VAULT=%s", c.VaultPath),
+	}
+	if c.Model != "" {
+		env = append(env, fmt.Sprintf("ORCH_MODEL=%s", c.Model))
 	}
 	// Ensure HOME is passed for OAuth credentials in ~/.claude.json
 	if home := os.Getenv("HOME"); home != "" {

--- a/internal/agent/adapter_test.go
+++ b/internal/agent/adapter_test.go
@@ -41,6 +41,7 @@ func TestLaunchConfigEnv(t *testing.T) {
 		Branch:    "branch",
 		VaultPath: "/vault",
 		Model:     "claude-3-5-sonnet-20241022",
+		Thinking:  "medium",
 	}
 
 	env := cfg.Env()
@@ -51,6 +52,7 @@ func TestLaunchConfigEnv(t *testing.T) {
 	assertEnvContains(t, env, "ORCH_BRANCH=branch")
 	assertEnvContains(t, env, "ORCH_VAULT=/vault")
 	assertEnvContains(t, env, "ORCH_MODEL=claude-3-5-sonnet-20241022")
+	assertEnvContains(t, env, "ORCH_THINKING=medium")
 	assertEnvContains(t, env, "HOME=/tmp/home")
 }
 

--- a/internal/agent/adapter_test.go
+++ b/internal/agent/adapter_test.go
@@ -40,6 +40,7 @@ func TestLaunchConfigEnv(t *testing.T) {
 		WorkDir:   "/work",
 		Branch:    "branch",
 		VaultPath: "/vault",
+		Model:     "claude-3-5-sonnet-20241022",
 	}
 
 	env := cfg.Env()
@@ -49,6 +50,7 @@ func TestLaunchConfigEnv(t *testing.T) {
 	assertEnvContains(t, env, "ORCH_WORKTREE_PATH=/work")
 	assertEnvContains(t, env, "ORCH_BRANCH=branch")
 	assertEnvContains(t, env, "ORCH_VAULT=/vault")
+	assertEnvContains(t, env, "ORCH_MODEL=claude-3-5-sonnet-20241022")
 	assertEnvContains(t, env, "HOME=/tmp/home")
 }
 

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -30,6 +30,11 @@ func (a *ClaudeAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 		args = append(args, "--profile", cfg.Profile)
 	}
 
+	// Add model if specified
+	if cfg.Model != "" {
+		args = append(args, "--model", cfg.Model)
+	}
+
 	// Add resume flag if applicable
 	if cfg.Resume && cfg.SessionName != "" {
 		args = append(args, "--resume", cfg.SessionName)

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -16,6 +16,7 @@ func TestClaudeLaunchCommand(t *testing.T) {
 	cfg := &LaunchConfig{
 		Prompt:      "hello",
 		Profile:     "work",
+		Model:       "sonnet",
 		Resume:      true,
 		SessionName: "session-1",
 	}
@@ -24,7 +25,7 @@ func TestClaudeLaunchCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LaunchCommand error: %v", err)
 	}
-	want := "claude --dangerously-skip-permissions --profile work --resume session-1 \"hello\""
+	want := "claude --dangerously-skip-permissions --profile work --model sonnet --resume session-1 \"hello\""
 	if cmd != want {
 		t.Fatalf("command = %q, want %q", cmd, want)
 	}

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -24,6 +24,11 @@ func (a *CodexAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 	// codex CLI with yolo mode
 	args = append(args, "codex", "--yolo")
 
+	// Add model if specified
+	if cfg.Model != "" {
+		args = append(args, "--model", cfg.Model)
+	}
+
 	// Add the prompt
 	if cfg.Prompt != "" {
 		// Escape the prompt for shell

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -28,6 +28,9 @@ func (a *CodexAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 	if cfg.Model != "" {
 		args = append(args, "--model", cfg.Model)
 	}
+	if cfg.Thinking != "" {
+		args = append(args, "-c", fmt.Sprintf("model_reasoning_effort=%s", cfg.Thinking))
+	}
 
 	// Add the prompt
 	if cfg.Prompt != "" {

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -4,12 +4,12 @@ import "testing"
 
 func TestCodexLaunchCommand(t *testing.T) {
 	adapter := &CodexAdapter{}
-	cfg := &LaunchConfig{Prompt: "hello 'world'"}
+	cfg := &LaunchConfig{Prompt: "hello 'world'", Model: "o1"}
 	cmd, err := adapter.LaunchCommand(cfg)
 	if err != nil {
 		t.Fatalf("LaunchCommand error: %v", err)
 	}
-	want := `codex --yolo 'hello '"'"'world'"'"''`
+	want := `codex --yolo --model o1 'hello '"'"'world'"'"''`
 	if cmd != want {
 		t.Fatalf("command = %q, want %q", cmd, want)
 	}

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -4,12 +4,12 @@ import "testing"
 
 func TestCodexLaunchCommand(t *testing.T) {
 	adapter := &CodexAdapter{}
-	cfg := &LaunchConfig{Prompt: "hello 'world'", Model: "o1"}
+	cfg := &LaunchConfig{Prompt: "hello 'world'", Model: "o1", Thinking: "xhigh"}
 	cmd, err := adapter.LaunchCommand(cfg)
 	if err != nil {
 		t.Fatalf("LaunchCommand error: %v", err)
 	}
-	want := `codex --yolo --model o1 'hello '"'"'world'"'"''`
+	want := `codex --yolo --model o1 -c model_reasoning_effort=xhigh 'hello '"'"'world'"'"''`
 	if cmd != want {
 		t.Fatalf("command = %q, want %q", cmd, want)
 	}

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -22,6 +22,9 @@ func (a *GeminiAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 
 	// gemini CLI with yolo mode
 	args = append(args, "gemini", "--yolo")
+	if cfg.Model != "" {
+		args = append(args, "--model", cfg.Model)
+	}
 	if cfg.Prompt != "" {
 		args = append(args, "--prompt-interactive", doubleQuote(cfg.Prompt))
 	}

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -4,12 +4,12 @@ import "testing"
 
 func TestGeminiLaunchCommand(t *testing.T) {
 	adapter := &GeminiAdapter{}
-	cfg := &LaunchConfig{Prompt: "hello 'world'"}
+	cfg := &LaunchConfig{Prompt: "hello 'world'", Model: "gemini-1.5-pro"}
 	cmd, err := adapter.LaunchCommand(cfg)
 	if err != nil {
 		t.Fatalf("LaunchCommand error: %v", err)
 	}
-	want := `gemini --yolo --prompt-interactive "hello 'world'"`
+	want := `gemini --yolo --model gemini-1.5-pro --prompt-interactive "hello 'world'"`
 	if cmd != want {
 		t.Fatalf("command = %q, want %q", cmd, want)
 	}

--- a/internal/agent/models.go
+++ b/internal/agent/models.go
@@ -6,7 +6,13 @@ func KnownModels(agentType AgentType) []string {
 	switch agentType {
 	case AgentCodex:
 		return []string{
+			"gpt-5.2-codex",
+			"gpt-5.2",
+			"gpt-5.1-codex-max",
+			"gpt-5.1-codex",
+			"gpt-5.1",
 			"o3",
+			"o4-mini",
 			"o1",
 			"gpt-4o",
 			"gpt-4o-mini",
@@ -16,6 +22,7 @@ func KnownModels(agentType AgentType) []string {
 			"sonnet",
 			"opus",
 			"haiku",
+			"claude-sonnet-4-5-20250929",
 			"claude-3-5-sonnet-20241022",
 			"claude-3-opus-latest",
 			"claude-3-5-haiku-20241022",

--- a/internal/agent/models.go
+++ b/internal/agent/models.go
@@ -1,0 +1,32 @@
+package agent
+
+// KnownModels returns a list of commonly available model names for an agent.
+// The list is intentionally small; callers should allow custom input.
+func KnownModels(agentType AgentType) []string {
+	switch agentType {
+	case AgentCodex:
+		return []string{
+			"o3",
+			"o1",
+			"gpt-4o",
+			"gpt-4o-mini",
+		}
+	case AgentClaude:
+		return []string{
+			"sonnet",
+			"opus",
+			"haiku",
+			"claude-3-5-sonnet-20241022",
+			"claude-3-opus-latest",
+			"claude-3-5-haiku-20241022",
+		}
+	case AgentGemini:
+		return []string{
+			"gemini-1.5-pro",
+			"gemini-1.5-flash",
+			"gemini-2.0-flash-exp",
+		}
+	default:
+		return nil
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -25,6 +25,7 @@ type runOptions struct {
 	AgentCmd       string
 	AgentProfile   string
 	Model          string
+	Thinking       string
 	BaseBranch     string
 	Branch         string
 	WorktreeRoot   string
@@ -58,6 +59,7 @@ The run will be started in a tmux session by default.`,
 	cmd.Flags().StringVar(&opts.AgentCmd, "agent-cmd", "", "Custom agent command (when --agent=custom)")
 	cmd.Flags().StringVar(&opts.AgentProfile, "profile", "", "Agent profile (e.g., claude --profile)")
 	cmd.Flags().StringVar(&opts.Model, "model", "", "Agent model (e.g., gpt-4o, claude-3-5-sonnet-20241022, gemini-1.5-pro)")
+	cmd.Flags().StringVar(&opts.Thinking, "thinking", "", "Model reasoning effort (codex only: minimal|low|medium|high|xhigh)")
 	cmd.Flags().StringVar(&opts.BaseBranch, "base-branch", "main", "Base branch for worktree")
 	cmd.Flags().StringVar(&opts.Branch, "branch", "", "Branch name (default: issue/<ID>/run-<RUN_ID>)")
 	cmd.Flags().StringVar(&opts.WorktreeRoot, "worktree-root", ".git-worktrees", "Root directory for worktrees")
@@ -154,6 +156,9 @@ func runRun(issueID string, opts *runOptions) error {
 	if opts.DryRun {
 		// Build the command that would be run (for display purposes)
 		agentType, _ := agent.ParseAgentType(opts.Agent)
+		if opts.Thinking != "" && agentType != agent.AgentCodex && agentType != agent.AgentCustom {
+			return exitWithCode(fmt.Errorf("thinking is only supported for codex and custom agents"), ExitAgentError)
+		}
 		adapter, _ := agent.GetAdapter(agentType)
 		launchCfg := &agent.LaunchConfig{
 			Type:      agentType,
@@ -166,6 +171,7 @@ func runRun(issueID string, opts *runOptions) error {
 			Prompt:    promptFileInstruction,
 			Profile:   opts.AgentProfile,
 			Model:     opts.Model,
+			Thinking:  opts.Thinking,
 		}
 		agentCmd, _ := adapter.LaunchCommand(launchCfg)
 
@@ -190,6 +196,9 @@ func runRun(issueID string, opts *runOptions) error {
 	}
 	if opts.Model != "" {
 		metadata["model"] = opts.Model
+	}
+	if opts.Thinking != "" {
+		metadata["thinking"] = opts.Thinking
 	}
 	run, err := st.CreateRun(issueID, runID, metadata)
 	if err != nil {
@@ -233,6 +242,9 @@ func runRun(issueID string, opts *runOptions) error {
 	if err != nil {
 		return exitWithCode(err, ExitAgentError)
 	}
+	if opts.Thinking != "" && agentType != agent.AgentCodex && agentType != agent.AgentCustom {
+		return exitWithCode(fmt.Errorf("thinking is only supported for codex and custom agents"), ExitAgentError)
+	}
 
 	adapter, err := agent.GetAdapter(agentType)
 	if err != nil {
@@ -265,6 +277,7 @@ func runRun(issueID string, opts *runOptions) error {
 		Prompt:    promptFileInstruction,
 		Profile:   opts.AgentProfile,
 		Model:     opts.Model,
+		Thinking:  opts.Thinking,
 	}
 
 	agentCmd, err := adapter.LaunchCommand(launchCfg)

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -71,6 +71,8 @@ func showJSON(run *model.Run, opts *showOptions) error {
 		Status        string        `json:"status"`
 		Phase         string        `json:"phase,omitempty"`
 		ContinuedFrom string        `json:"continued_from,omitempty"`
+		Model         string        `json:"model,omitempty"`
+		Thinking      string        `json:"thinking,omitempty"`
 		Branch        string        `json:"branch,omitempty"`
 		WorktreePath  string        `json:"worktree_path,omitempty"`
 		TmuxSession   string        `json:"tmux_session,omitempty"`
@@ -83,6 +85,8 @@ func showJSON(run *model.Run, opts *showOptions) error {
 		Status:        string(run.Status),
 		Phase:         string(run.Phase),
 		ContinuedFrom: run.ContinuedFrom,
+		Model:         run.Model,
+		Thinking:      run.Thinking,
 		Branch:        run.Branch,
 		WorktreePath:  run.WorktreePath,
 		TmuxSession:   run.TmuxSession,
@@ -120,6 +124,12 @@ func showHuman(run *model.Run, opts *showOptions) error {
 	if !opts.EventsOnly {
 		if run.Branch != "" {
 			fmt.Printf("Branch:   %s\n", run.Branch)
+		}
+		if run.Model != "" {
+			fmt.Printf("Model:    %s\n", run.Model)
+		}
+		if run.Thinking != "" {
+			fmt.Printf("Thinking: %s\n", run.Thinking)
 		}
 		if run.WorktreePath != "" {
 			fmt.Printf("Worktree: %s\n", run.WorktreePath)

--- a/internal/model/alias.go
+++ b/internal/model/alias.go
@@ -1,0 +1,100 @@
+package model
+
+import (
+	"strings"
+	"unicode"
+)
+
+// ShortModelAlias returns a compact model identifier for display.
+func ShortModelAlias(model string) string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return ""
+	}
+
+	base := model
+	for _, prefix := range []string{"gpt-", "claude-", "gemini-"} {
+		if strings.HasPrefix(base, prefix) {
+			base = strings.TrimPrefix(base, prefix)
+			break
+		}
+	}
+
+	base = strings.TrimSuffix(base, "-latest")
+
+	parts := strings.Split(base, "-")
+	if len(parts) > 1 {
+		last := parts[len(parts)-1]
+		if isDateToken(last) {
+			parts = parts[:len(parts)-1]
+			base = strings.Join(parts, "-")
+		}
+	}
+
+	if len(parts) >= 3 && isFamilyToken(parts[0]) && isDigits(parts[1]) && isDigits(parts[2]) {
+		version := parts[1] + "." + parts[2]
+		rest := parts[3:]
+		base = version + "-" + parts[0]
+		if len(rest) > 0 {
+			base += "-" + strings.Join(rest, "-")
+		}
+		return base
+	}
+
+	if len(parts) >= 2 && isDigits(parts[0]) && isDigits(parts[1]) {
+		version := parts[0] + "." + parts[1]
+		rest := parts[2:]
+		base = version
+		if len(rest) > 0 {
+			base += "-" + strings.Join(rest, "-")
+		}
+	}
+
+	return base
+}
+
+// ShortThinkingAlias returns a compact thinking/reasoning label for display.
+func ShortThinkingAlias(thinking string) string {
+	return strings.ToLower(strings.TrimSpace(thinking))
+}
+
+// ModelThinkingAlias combines model and thinking aliases for display.
+func ModelThinkingAlias(model, thinking string) string {
+	modelAlias := ShortModelAlias(model)
+	thinkingAlias := ShortThinkingAlias(thinking)
+	if modelAlias == "" {
+		return thinkingAlias
+	}
+	if thinkingAlias == "" {
+		return modelAlias
+	}
+	return modelAlias + "-" + thinkingAlias
+}
+
+func isDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isDateToken(value string) bool {
+	if len(value) != 8 {
+		return false
+	}
+	return isDigits(value)
+}
+
+func isFamilyToken(value string) bool {
+	switch value {
+	case "sonnet", "opus", "haiku":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/model/alias_test.go
+++ b/internal/model/alias_test.go
@@ -1,0 +1,32 @@
+package model
+
+import "testing"
+
+func TestShortModelAlias(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"gpt-5.2-codex", "5.2-codex"},
+		{"gpt-4o-mini", "4o-mini"},
+		{"claude-3-5-sonnet-20241022", "3.5-sonnet"},
+		{"claude-3-opus-latest", "3-opus"},
+		{"claude-sonnet-4-5-20250929", "4.5-sonnet"},
+		{"gemini-1.5-pro", "1.5-pro"},
+		{"o3", "o3"},
+		{"", ""},
+	}
+
+	for _, tc := range cases {
+		if got := ShortModelAlias(tc.input); got != tc.want {
+			t.Fatalf("ShortModelAlias(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestModelThinkingAlias(t *testing.T) {
+	got := ModelThinkingAlias("gpt-5.2-codex", "xhigh")
+	if got != "5.2-codex-xhigh" {
+		t.Fatalf("ModelThinkingAlias = %q, want %q", got, "5.2-codex-xhigh")
+	}
+}

--- a/internal/model/run.go
+++ b/internal/model/run.go
@@ -59,6 +59,7 @@ type Run struct {
 
 	// Artifacts (from events)
 	Agent        string
+	Model        string
 	Branch       string
 	WorktreePath string
 	TmuxSession  string

--- a/internal/model/run.go
+++ b/internal/model/run.go
@@ -60,6 +60,7 @@ type Run struct {
 	// Artifacts (from events)
 	Agent        string
 	Model        string
+	Thinking     string
 	Branch       string
 	WorktreePath string
 	TmuxSession  string

--- a/internal/monitor/data.go
+++ b/internal/monitor/data.go
@@ -13,6 +13,8 @@ type RunRow struct {
 	IssueID     string
 	IssueStatus string
 	Agent       string
+	Model       string
+	Thinking    string
 	Status      model.Status
 	PR          string // PR display string (e.g., "#123" or "-")
 	PRState     string // PR state: open, merged, closed, or empty

--- a/internal/monitor/issues_dashboard.go
+++ b/internal/monitor/issues_dashboard.go
@@ -19,6 +19,8 @@ const (
 	modeCreateIssue
 	modeSelectRun
 	modeSelectAgent
+	modeSelectModel
+	modeCustomModel
 	modeFilter
 	modeContinueBranch
 	modeContinueAgent
@@ -44,6 +46,14 @@ type selectAgentState struct {
 	issueID string
 	agents  []string
 	cursor  int
+}
+
+type selectModelState struct {
+	issueID string
+	agent   string
+	models  []string
+	cursor  int
+	input   string
 }
 
 // filterState holds the current filter settings for the issue list
@@ -95,6 +105,7 @@ type IssueDashboard struct {
 	create      createIssueState
 	selectRun   selectRunState
 	selectAgent selectAgentState
+	selectModel selectModelState
 	filter      filterState
 	continue_   continueState
 
@@ -233,6 +244,10 @@ func (d *IssueDashboard) View() string {
 		return d.styles.Box.Render(d.viewSelectRun())
 	case modeSelectAgent:
 		return d.styles.Box.Render(d.viewSelectAgent())
+	case modeSelectModel:
+		return d.styles.Box.Render(d.viewSelectModel())
+	case modeCustomModel:
+		return d.styles.Box.Render(d.viewCustomModel())
 	case modeFilter:
 		return d.styles.Box.Render(d.viewFilter())
 	case modeContinueBranch:
@@ -258,6 +273,10 @@ func (d *IssueDashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return d.handleSelectRunKey(msg)
 	case modeSelectAgent:
 		return d.handleSelectAgentKey(msg)
+	case modeSelectModel:
+		return d.handleSelectModelKey(msg)
+	case modeCustomModel:
+		return d.handleCustomModelKey(msg)
 	case modeFilter:
 		return d.handleFilterKey(msg)
 	case modeContinueBranch:
@@ -442,8 +461,14 @@ func (d *IssueDashboard) handleSelectAgentKey(msg tea.KeyMsg) (tea.Model, tea.Cm
 		if d.selectAgent.cursor >= 0 && d.selectAgent.cursor < len(d.selectAgent.agents) {
 			agentType := d.selectAgent.agents[d.selectAgent.cursor]
 			issueID := d.selectAgent.issueID
-			d.mode = modeIssues
-			return d, d.startRunCmd(issueID, agentType)
+			d.selectModel = selectModelState{
+				issueID: issueID,
+				agent:   agentType,
+				models:  modelOptionsForAgent(agentType),
+				cursor:  0,
+			}
+			d.mode = modeSelectModel
+			return d, nil
 		}
 		return d, nil
 	case "up", "k":
@@ -461,12 +486,104 @@ func (d *IssueDashboard) handleSelectAgentKey(msg tea.KeyMsg) (tea.Model, tea.Cm
 		if idx >= 0 && idx < len(d.selectAgent.agents) {
 			agentType := d.selectAgent.agents[idx]
 			issueID := d.selectAgent.issueID
-			d.mode = modeIssues
-			return d, d.startRunCmd(issueID, agentType)
+			d.selectModel = selectModelState{
+				issueID: issueID,
+				agent:   agentType,
+				models:  modelOptionsForAgent(agentType),
+				cursor:  0,
+			}
+			d.mode = modeSelectModel
+			return d, nil
 		}
 		return d, nil
 	}
 	return d, nil
+}
+
+func (d *IssueDashboard) handleSelectModelKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		d.mode = modeSelectAgent
+		return d, nil
+	case "q":
+		return d.quit()
+	case "enter":
+		if d.selectModel.cursor >= 0 && d.selectModel.cursor < len(d.selectModel.models) {
+			selection := d.selectModel.models[d.selectModel.cursor]
+			modelName, needsCustom := modelSelectionValue(selection)
+			if needsCustom {
+				d.selectModel.input = ""
+				d.mode = modeCustomModel
+				return d, nil
+			}
+			issueID := d.selectModel.issueID
+			agentType := d.selectModel.agent
+			d.mode = modeIssues
+			return d, d.startRunCmd(issueID, agentType, modelName)
+		}
+		return d, nil
+	case "up", "k":
+		if d.selectModel.cursor > 0 {
+			d.selectModel.cursor--
+		}
+		return d, nil
+	case "down", "j":
+		if d.selectModel.cursor < len(d.selectModel.models)-1 {
+			d.selectModel.cursor++
+		}
+		return d, nil
+	case "1", "2", "3", "4", "5", "6", "7", "8", "9":
+		idx := int(msg.String()[0] - '1')
+		if idx >= 0 && idx < len(d.selectModel.models) {
+			selection := d.selectModel.models[idx]
+			modelName, needsCustom := modelSelectionValue(selection)
+			if needsCustom {
+				d.selectModel.input = ""
+				d.mode = modeCustomModel
+				return d, nil
+			}
+			issueID := d.selectModel.issueID
+			agentType := d.selectModel.agent
+			d.mode = modeIssues
+			return d, d.startRunCmd(issueID, agentType, modelName)
+		}
+		return d, nil
+	}
+	return d, nil
+}
+
+func (d *IssueDashboard) handleCustomModelKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		d.mode = modeSelectModel
+		return d, nil
+	case "q":
+		return d.quit()
+	case "enter":
+		modelName := strings.TrimSpace(d.selectModel.input)
+		if modelName == "" {
+			d.message = "model is required"
+			return d, nil
+		}
+		issueID := d.selectModel.issueID
+		agentType := d.selectModel.agent
+		d.mode = modeIssues
+		return d, d.startRunCmd(issueID, agentType, modelName)
+	}
+
+	switch msg.Type {
+	case tea.KeyBackspace, tea.KeyDelete:
+		if len(d.selectModel.input) > 0 {
+			runes := []rune(d.selectModel.input)
+			d.selectModel.input = string(runes[:len(runes)-1])
+		}
+		return d, nil
+	case tea.KeyRunes:
+		d.selectModel.input += string(msg.Runes)
+		return d, nil
+	default:
+		return d, nil
+	}
 }
 
 func (d *IssueDashboard) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -531,9 +648,9 @@ func (d *IssueDashboard) loadIssueRunsCmd(issueID string) tea.Cmd {
 	}
 }
 
-func (d *IssueDashboard) startRunCmd(issueID, agentType string) tea.Cmd {
+func (d *IssueDashboard) startRunCmd(issueID, agentType, modelName string) tea.Cmd {
 	return func() tea.Msg {
-		output, err := d.monitor.StartRun(issueID, agentType)
+		output, err := d.monitor.StartRun(issueID, agentType, modelName)
 		if err != nil {
 			return errMsg{err: fmt.Errorf("%s", output)}
 		}
@@ -697,6 +814,57 @@ func (d *IssueDashboard) viewSelectAgent() string {
 	}
 
 	lines = append(lines, "", "[Enter/1-9] select agent  [Esc] back")
+	return strings.Join(lines, "\n")
+}
+
+func (d *IssueDashboard) viewSelectModel() string {
+	header := d.styles.Title.Render("SELECT MODEL")
+	lines := []string{header, ""}
+
+	issueID := d.selectModel.issueID
+	if strings.TrimSpace(issueID) == "" {
+		issueID = "-"
+	}
+	agentName := d.selectModel.agent
+	if strings.TrimSpace(agentName) == "" {
+		agentName = defaultRunAgent()
+	}
+	lines = append(lines, fmt.Sprintf("Issue: %s", issueID), fmt.Sprintf("Agent: %s", agentName), "")
+
+	if len(d.selectModel.models) == 0 {
+		lines = append(lines, "No models available.")
+		lines = append(lines, "", "[Esc] back")
+		return strings.Join(lines, "\n")
+	}
+
+	lines = append(lines, "Select a model for the run:", "")
+	for i, modelName := range d.selectModel.models {
+		label := fmt.Sprintf("  [%d] %s", i+1, modelName)
+		if i == d.selectModel.cursor {
+			label = d.styles.Selected.Render(label)
+		}
+		lines = append(lines, label)
+	}
+
+	lines = append(lines, "", "[Enter/1-9] select model  [Esc] back")
+	return strings.Join(lines, "\n")
+}
+
+func (d *IssueDashboard) viewCustomModel() string {
+	header := d.styles.Title.Render("CUSTOM MODEL")
+	lines := []string{header, ""}
+
+	issueID := d.selectModel.issueID
+	if strings.TrimSpace(issueID) == "" {
+		issueID = "-"
+	}
+	agentName := d.selectModel.agent
+	if strings.TrimSpace(agentName) == "" {
+		agentName = defaultRunAgent()
+	}
+	lines = append(lines, fmt.Sprintf("Issue: %s", issueID), fmt.Sprintf("Agent: %s", agentName), "")
+	lines = append(lines, "Model:", fmt.Sprintf("> %s", d.selectModel.input))
+	lines = append(lines, "", "[Enter] start  [Esc] back")
 	return strings.Join(lines, "\n")
 }
 

--- a/internal/monitor/keymap.go
+++ b/internal/monitor/keymap.go
@@ -4,42 +4,44 @@ import "fmt"
 
 // KeyMap defines the keyboard shortcuts displayed in the footer.
 type KeyMap struct {
-	Runs    string
-	Issues  string
-	Chat    string
-	Open    string
-	Exec    string
-	Stop    string
-	NewRun  string
-	Resolve string
-	Merge   string
-	Refresh string
-	Sort    string
-	Quit    string
-	Help    string
+	Runs        string
+	Issues      string
+	Chat        string
+	Open        string
+	Exec        string
+	Stop        string
+	NewRun      string
+	Resolve     string
+	Merge       string
+	AgentDetail string
+	Refresh     string
+	Sort        string
+	Quit        string
+	Help        string
 }
 
 // DefaultKeyMap returns the default shortcut mapping.
 func DefaultKeyMap() KeyMap {
 	return KeyMap{
-		Runs:    "g",
-		Issues:  "i",
-		Chat:    "c",
-		Open:    "enter",
-		Exec:    "e",
-		Stop:    "s",
-		NewRun:  "n",
-		Resolve: "R",
-		Merge:   "M",
-		Refresh: "r",
-		Sort:    "S",
-		Quit:    "q",
-		Help:    "?",
+		Runs:        "g",
+		Issues:      "i",
+		Chat:        "c",
+		Open:        "enter",
+		Exec:        "e",
+		Stop:        "s",
+		NewRun:      "n",
+		Resolve:     "R",
+		Merge:       "M",
+		AgentDetail: "m",
+		Refresh:     "r",
+		Sort:        "S",
+		Quit:        "q",
+		Help:        "?",
 	}
 }
 
 // HelpLine renders the footer help text.
 func (k KeyMap) HelpLine() string {
-	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] exec  [%s] stop  [%s] new  [%s] resolve  [%s] merge  [%s] refresh  [%s] sort  [%s] quit  [%s] help",
-		k.Runs, k.Issues, k.Chat, k.Open, k.Exec, k.Stop, k.NewRun, k.Resolve, k.Merge, k.Refresh, k.Sort, k.Quit, k.Help)
+	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] exec  [%s] stop  [%s] new  [%s] resolve  [%s] merge  [%s] model  [%s] refresh  [%s] sort  [%s] quit  [%s] help",
+		k.Runs, k.Issues, k.Chat, k.Open, k.Exec, k.Stop, k.NewRun, k.Resolve, k.Merge, k.AgentDetail, k.Refresh, k.Sort, k.Quit, k.Help)
 }

--- a/internal/monitor/model_options.go
+++ b/internal/monitor/model_options.go
@@ -1,0 +1,45 @@
+package monitor
+
+import (
+	"strings"
+
+	"github.com/s22625/orch/internal/agent"
+)
+
+const (
+	modelOptionDefault = "default"
+	modelOptionCustom  = "custom..."
+)
+
+func defaultRunAgent() string {
+	return string(agent.AgentClaude)
+}
+
+func modelOptionsForAgent(agentName string) []string {
+	agentName = strings.TrimSpace(agentName)
+	if agentName == "" {
+		agentName = defaultRunAgent()
+	}
+
+	var models []string
+	if aType, err := agent.ParseAgentType(agentName); err == nil {
+		models = agent.KnownModels(aType)
+	}
+
+	options := make([]string, 0, len(models)+2)
+	options = append(options, modelOptionDefault)
+	options = append(options, models...)
+	options = append(options, modelOptionCustom)
+	return options
+}
+
+func modelSelectionValue(selection string) (string, bool) {
+	switch selection {
+	case modelOptionDefault:
+		return "", false
+	case modelOptionCustom:
+		return "", true
+	default:
+		return selection, false
+	}
+}

--- a/internal/monitor/model_options.go
+++ b/internal/monitor/model_options.go
@@ -7,8 +7,10 @@ import (
 )
 
 const (
-	modelOptionDefault = "default"
-	modelOptionCustom  = "custom..."
+	modelOptionDefault    = "default"
+	modelOptionCustom     = "custom..."
+	thinkingOptionDefault = "default"
+	thinkingOptionCustom  = "custom..."
 )
 
 func defaultRunAgent() string {
@@ -38,6 +40,39 @@ func modelSelectionValue(selection string) (string, bool) {
 	case modelOptionDefault:
 		return "", false
 	case modelOptionCustom:
+		return "", true
+	default:
+		return selection, false
+	}
+}
+
+func thinkingOptionsForAgent(agentName string) []string {
+	agentName = strings.TrimSpace(agentName)
+	if agentName == "" {
+		agentName = defaultRunAgent()
+	}
+
+	aType, err := agent.ParseAgentType(agentName)
+	if err != nil || aType != agent.AgentCodex {
+		return nil
+	}
+
+	return []string{
+		thinkingOptionDefault,
+		"minimal",
+		"low",
+		"medium",
+		"high",
+		"xhigh",
+		thinkingOptionCustom,
+	}
+}
+
+func thinkingSelectionValue(selection string) (string, bool) {
+	switch selection {
+	case thinkingOptionDefault:
+		return "", false
+	case thinkingOptionCustom:
 		return "", true
 	default:
 		return selection, false

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -358,11 +358,14 @@ func (m *Monitor) StopRun(run *model.Run) error {
 }
 
 // StartRun launches a new run by invoking the orch binary.
-func (m *Monitor) StartRun(issueID string, agentType string) (string, error) {
+func (m *Monitor) StartRun(issueID string, agentType string, modelName string) (string, error) {
 	args := append([]string{}, m.globalFlags...)
 	args = append(args, "run", issueID)
 	if agentType != "" {
 		args = append(args, "--agent", agentType)
+	}
+	if strings.TrimSpace(modelName) != "" {
+		args = append(args, "--model", modelName)
 	}
 
 	cmd := exec.Command(m.orchPath, args...)

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -358,7 +358,7 @@ func (m *Monitor) StopRun(run *model.Run) error {
 }
 
 // StartRun launches a new run by invoking the orch binary.
-func (m *Monitor) StartRun(issueID string, agentType string, modelName string) (string, error) {
+func (m *Monitor) StartRun(issueID string, agentType string, modelName string, thinking string) (string, error) {
 	args := append([]string{}, m.globalFlags...)
 	args = append(args, "run", issueID)
 	if agentType != "" {
@@ -366,6 +366,9 @@ func (m *Monitor) StartRun(issueID string, agentType string, modelName string) (
 	}
 	if strings.TrimSpace(modelName) != "" {
 		args = append(args, "--model", modelName)
+	}
+	if strings.TrimSpace(thinking) != "" {
+		args = append(args, "--thinking", thinking)
 	}
 
 	cmd := exec.Command(m.orchPath, args...)
@@ -786,6 +789,8 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 			IssueID:     w.Run.IssueID,
 			IssueStatus: issueStatus,
 			Agent:       agent,
+			Model:       w.Run.Model,
+			Thinking:    w.Run.Thinking,
 			Status:      w.Run.Status,
 			PR:          prDisplay,
 			PRState:     prState,

--- a/internal/store/file/file.go
+++ b/internal/store/file/file.go
@@ -559,6 +559,8 @@ func (s *FileStore) loadRun(issueID, runID, path string) (*model.Run, error) {
 					switch key {
 					case "agent":
 						run.Agent = value
+					case "model":
+						run.Model = value
 					case "continued_from":
 						run.ContinuedFrom = value
 					}

--- a/internal/store/file/file.go
+++ b/internal/store/file/file.go
@@ -561,6 +561,8 @@ func (s *FileStore) loadRun(issueID, runID, path string) (*model.Run, error) {
 						run.Agent = value
 					case "model":
 						run.Model = value
+					case "thinking":
+						run.Thinking = value
 					case "continued_from":
 						run.ContinuedFrom = value
 					}

--- a/internal/store/file/file_test.go
+++ b/internal/store/file/file_test.go
@@ -150,6 +150,7 @@ func TestCreateRun(t *testing.T) {
 	s, _ := New(vault)
 	metadata := map[string]string{
 		"agent":          "claude",
+		"model":          "claude-3-5-sonnet-20241022",
 		"continued_from": "test123#20231220-090000",
 	}
 	run, err := s.CreateRun("test123", "20231220-100000", metadata)
@@ -175,6 +176,9 @@ func TestCreateRun(t *testing.T) {
 	}
 	if loaded.Agent != metadata["agent"] {
 		t.Errorf("Agent = %v, want %v", loaded.Agent, metadata["agent"])
+	}
+	if loaded.Model != metadata["model"] {
+		t.Errorf("Model = %v, want %v", loaded.Model, metadata["model"])
 	}
 	if loaded.ContinuedFrom != metadata["continued_from"] {
 		t.Errorf("ContinuedFrom = %v, want %v", loaded.ContinuedFrom, metadata["continued_from"])

--- a/internal/store/file/file_test.go
+++ b/internal/store/file/file_test.go
@@ -151,6 +151,7 @@ func TestCreateRun(t *testing.T) {
 	metadata := map[string]string{
 		"agent":          "claude",
 		"model":          "claude-3-5-sonnet-20241022",
+		"thinking":       "medium",
 		"continued_from": "test123#20231220-090000",
 	}
 	run, err := s.CreateRun("test123", "20231220-100000", metadata)
@@ -179,6 +180,9 @@ func TestCreateRun(t *testing.T) {
 	}
 	if loaded.Model != metadata["model"] {
 		t.Errorf("Model = %v, want %v", loaded.Model, metadata["model"])
+	}
+	if loaded.Thinking != metadata["thinking"] {
+		t.Errorf("Thinking = %v, want %v", loaded.Thinking, metadata["thinking"])
 	}
 	if loaded.ContinuedFrom != metadata["continued_from"] {
 		t.Errorf("ContinuedFrom = %v, want %v", loaded.ContinuedFrom, metadata["continued_from"])

--- a/specs/03-commands.md
+++ b/specs/03-commands.md
@@ -39,6 +39,7 @@
 | `--run-id <RUN_ID>` | 手動指定 |
 | `--agent claude\|codex\|gemini\|custom:` | agent種別 |
 | `--agent-cmd` | custom時の起動コマンド |
+| `--model <MODEL>` | agent model (e.g., gpt-4o, claude-3-5-sonnet-20241022, gemini-1.5-pro) |
 | `--base-branch main` | デフォルトmain |
 | `--branch` | 省略時は規約生成 |
 | `--worktree-root` | 例: .git-worktrees |

--- a/specs/03-commands.md
+++ b/specs/03-commands.md
@@ -40,6 +40,7 @@
 | `--agent claude\|codex\|gemini\|custom:` | agent種別 |
 | `--agent-cmd` | custom時の起動コマンド |
 | `--model <MODEL>` | agent model (e.g., gpt-4o, claude-3-5-sonnet-20241022, gemini-1.5-pro) |
+| `--thinking <EFFORT>` | codex reasoning effort (minimal\|low\|medium\|high\|xhigh) |
 | `--base-branch main` | デフォルトmain |
 | `--branch` | 省略時は規約生成 |
 | `--worktree-root` | 例: .git-worktrees |
@@ -75,6 +76,8 @@
 | `--agent claude\|codex\|gemini\|custom` | agent種別（省略時: 元runのagent、無い場合はclaude） |
 | `--agent-cmd` | custom時の起動コマンド |
 | `--profile` | agentのprofile指定 |
+| `--model <MODEL>` | agent model (e.g., gpt-4o, claude-3-5-sonnet-20241022, gemini-1.5-pro) |
+| `--thinking <EFFORT>` | codex reasoning effort (minimal\|low\|medium\|high\|xhigh) |
 | `--tmux / --no-tmux` | デフォルトtmux |
 | `--tmux-session` | 省略時は規約生成 |
 | `--prompt-template` | プロンプトテンプレート |
@@ -109,11 +112,18 @@ runs一覧を表示（人間/機械）
 | `--since <timestamp>` | 指定日時以降 |
 | `--absolute-time` | 相対時間ではなく絶対時刻で表示 |
 | `--all` | resolved を含めて表示 |
+| `--agent-detail` | MODEL/THINK列を追加表示 |
 
 ### TSV列（固定順）
 
 ```
 issue_id, issue_status, run_id, short_id, agent, status, updated_at, pr_url, branch, worktree_path, tmux_session
+```
+
+`--agent-detail` 指定時は `agent` の後に `model, thinking` を追加:
+
+```
+issue_id, issue_status, run_id, short_id, agent, model, thinking, status, updated_at, pr_url, branch, worktree_path, tmux_session
 ```
 
 ---
@@ -161,6 +171,8 @@ blocked等のrunを再開するトリガ（質問が解消されていれば次�
 |-----------|------|
 | `--only-blocked` | default on when --all |
 | `--agent …` | 再開時のagent指定 |
+| `--model <MODEL>` | 再開時のmodel指定 |
+| `--thinking <EFFORT>` | codex reasoning effort (minimal\|low\|medium\|high\|xhigh) |
 | `--max N` | --all時の最大処理件数 |
 
 ### 挙動


### PR DESCRIPTION
## Summary
- add --thinking config for codex and persist model/thinking metadata
- add monitor model/thinking selection flow plus toggleable model/thinking columns
- add model/thinking fields to ps/show output with compact aliases

## Testing
- go test ./...

Refs: orch-066