### PR TITLE
Add configurable branch templates for runs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Agent          string `yaml:"agent"`
 	WorktreeRoot   string `yaml:"worktree_root"`
 	BaseBranch     string `yaml:"base_branch"`
+	BranchTemplate string `yaml:"branch_template"`
 	LogLevel       string `yaml:"log_level"`
 	PromptTemplate string `yaml:"prompt_template"` // Path to custom prompt template
 	NoPR           bool   `yaml:"no_pr"`           // Disable PR instructions by default
@@ -25,6 +26,7 @@ type fileConfig struct {
 	Agent          string `yaml:"agent"`
 	WorktreeRoot   string `yaml:"worktree_root"`
 	BaseBranch     string `yaml:"base_branch"`
+	BranchTemplate string `yaml:"branch_template"`
 	LogLevel       string `yaml:"log_level"`
 	PromptTemplate string `yaml:"prompt_template"`
 	NoPR           *bool  `yaml:"no_pr"`
@@ -172,6 +174,9 @@ func loadFromFile(path string, cfg *Config) error {
 	}
 	if fileCfg.BaseBranch != "" {
 		cfg.BaseBranch = fileCfg.BaseBranch
+	}
+	if fileCfg.BranchTemplate != "" {
+		cfg.BranchTemplate = fileCfg.BranchTemplate
 	}
 	if fileCfg.LogLevel != "" {
 		cfg.LogLevel = fileCfg.LogLevel

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -284,6 +284,41 @@ func TestRepoConfigDir(t *testing.T) {
 	}
 }
 
+func TestBranchTemplateLoad(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ORCH_VAULT", "")
+	t.Setenv("ORCH_AGENT", "")
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".orch"), 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	configData := "branch_template: team/<issue-id>/run-<run-id>\n"
+	if err := os.WriteFile(filepath.Join(repo, ".orch", "config.yaml"), []byte(configData), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if cfg.BranchTemplate != "team/<issue-id>/run-<run-id>" {
+		t.Fatalf("BranchTemplate = %q, want %q", cfg.BranchTemplate, "team/<issue-id>/run-<run-id>")
+	}
+}
+
 func TestExpandPath(t *testing.T) {
 	t.Setenv("HOME", "/home/test")
 

--- a/internal/model/run_test.go
+++ b/internal/model/run_test.go
@@ -134,6 +134,32 @@ func TestGenerateBranchName(t *testing.T) {
 	}
 }
 
+func TestGenerateBranchNameFromTemplate(t *testing.T) {
+	branch, err := GenerateBranchNameFromTemplate("team/<doeff-generated-name>", "plc124", "20231220")
+	if err != nil {
+		t.Fatalf("GenerateBranchNameFromTemplate error: %v", err)
+	}
+	want := "team/plc124/run-20231220"
+	if branch != want {
+		t.Fatalf("GenerateBranchNameFromTemplate() = %v, want %v", branch, want)
+	}
+
+	branch, err = GenerateBranchNameFromTemplate("<default-branch>", "plc124", "20231220")
+	if err != nil {
+		t.Fatalf("GenerateBranchNameFromTemplate default error: %v", err)
+	}
+	want = "issue/plc124/run-20231220"
+	if branch != want {
+		t.Fatalf("GenerateBranchNameFromTemplate default = %v, want %v", branch, want)
+	}
+}
+
+func TestGenerateBranchNameFromTemplateUnknownPlaceholder(t *testing.T) {
+	if _, err := GenerateBranchNameFromTemplate("<unknown-token>", "plc124", "20231220"); err == nil {
+		t.Fatalf("expected error for unknown placeholder")
+	}
+}
+
 func TestGenerateTmuxSession(t *testing.T) {
 	session := GenerateTmuxSession("plc124", "20231220")
 	want := "run-plc124-20231220"

--- a/specs/03-commands.md
+++ b/specs/03-commands.md
@@ -50,7 +50,7 @@
 ### 規約（デフォルト）
 
 - RUN_ID = `YYYYMMDD-HHMMSS`
-- branch = `issue/<ISSUE_ID>/run-<RUN_ID>`
+- branch = `issue/<ISSUE_ID>/run-<RUN_ID>` (branch_template 設定時はそれに従う)
 - worktree_path = `<worktree_root>/<ISSUE_ID>/<RUN_ID>`
 - tmux_session = `run-<ISSUE_ID>-<RUN_ID>`
 

--- a/specs/07-config.md
+++ b/specs/07-config.md
@@ -40,6 +40,17 @@ worktree_root: .git-worktrees
 
 # base branch for new runs
 base_branch: main
+
+# branch template for new runs
+# placeholders:
+# - <issue-id>
+# - <run-id>
+# - <short-id>
+# - <generated-name> (ISSUE_ID/run-RUN_ID)
+# - <doeff-generated-name> (same as <generated-name>)
+# - <default-branch> (issue/ISSUE_ID/run-RUN_ID)
+# - <user-space> (current $USER or $USERNAME)
+branch_template: "<user-space>/issue/<generated-name>"
 ```
 
 ### 自動検出


### PR DESCRIPTION
## Summary
- add branch_template config support with template placeholders for branch naming
- use templates when generating branches for new runs
- add tests and update docs for the new option

## Issue
- orch-069