### PR TITLE
Add swap agent action to monitor dashboard

### DIFF
--- a/internal/model/run.go
+++ b/internal/model/run.go
@@ -121,7 +121,6 @@ func (r *Run) GetArtifacts() map[string]map[string]string {
 	return artifacts
 }
 
-
 // DeriveState updates Status and artifacts from events
 func (r *Run) DeriveState() {
 	r.Status = r.GetStatus()
@@ -142,6 +141,13 @@ func (r *Run) DeriveState() {
 	}
 	if pr, ok := artifacts["pr"]; ok {
 		r.PRUrl = pr["url"]
+	}
+	if agentInfo, ok := artifacts["agent"]; ok {
+		if name := agentInfo["name"]; name != "" {
+			r.Agent = name
+		} else if name := agentInfo["type"]; name != "" {
+			r.Agent = name
+		}
 	}
 
 	// Derive timestamps

--- a/internal/model/run_test.go
+++ b/internal/model/run_test.go
@@ -97,6 +97,7 @@ func TestRunDeriveState(t *testing.T) {
 		Events: []*Event{
 			{Timestamp: ts, Type: EventTypeStatus, Name: "queued"},
 			{Timestamp: ts.Add(time.Second), Type: EventTypeStatus, Name: "running"},
+			{Timestamp: ts.Add(2 * time.Second), Type: EventTypeArtifact, Name: "agent", Attrs: map[string]string{"name": "codex"}},
 			{Timestamp: ts.Add(3 * time.Second), Type: EventTypeArtifact, Name: "worktree", Attrs: map[string]string{"path": "/tmp/wt"}},
 			{Timestamp: ts.Add(4 * time.Second), Type: EventTypeArtifact, Name: "branch", Attrs: map[string]string{"name": "feature/test"}},
 			{Timestamp: ts.Add(5 * time.Second), Type: EventTypeArtifact, Name: "session", Attrs: map[string]string{"name": "run-plc124"}},
@@ -116,6 +117,9 @@ func TestRunDeriveState(t *testing.T) {
 	}
 	if run.TmuxSession != "run-plc124" {
 		t.Errorf("TmuxSession = %v, want run-plc124", run.TmuxSession)
+	}
+	if run.Agent != "codex" {
+		t.Errorf("Agent = %v, want codex", run.Agent)
 	}
 }
 

--- a/internal/monitor/keymap.go
+++ b/internal/monitor/keymap.go
@@ -9,6 +9,7 @@ type KeyMap struct {
 	Chat    string
 	Open    string
 	Stop    string
+	Swap    string
 	NewRun  string
 	Resolve string
 	Refresh string
@@ -24,6 +25,7 @@ func DefaultKeyMap() KeyMap {
 		Chat:    "c",
 		Open:    "enter",
 		Stop:    "s",
+		Swap:    "a",
 		NewRun:  "n",
 		Resolve: "R",
 		Refresh: "r",
@@ -34,6 +36,6 @@ func DefaultKeyMap() KeyMap {
 
 // HelpLine renders the footer help text.
 func (k KeyMap) HelpLine() string {
-	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] stop  [%s] new  [%s] resolve  [%s] refresh  [%s] quit  [%s] help",
-		k.Runs, k.Issues, k.Chat, k.Open, k.Stop, k.NewRun, k.Resolve, k.Refresh, k.Quit, k.Help)
+	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] stop  [%s] swap  [%s] new  [%s] resolve  [%s] refresh  [%s] quit  [%s] help",
+		k.Runs, k.Issues, k.Chat, k.Open, k.Stop, k.Swap, k.NewRun, k.Resolve, k.Refresh, k.Quit, k.Help)
 }

--- a/internal/monitor/swap_agent.go
+++ b/internal/monitor/swap_agent.go
@@ -1,0 +1,162 @@
+package monitor
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/s22625/orch/internal/agent"
+	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/tmux"
+)
+
+const swapPromptInstruction = "Please read 'ORCH_PROMPT.md' in the current directory and follow the instructions found there."
+
+// SwapAgent replaces the active agent for a run with a new agent type.
+func (m *Monitor) SwapAgent(run *model.Run, agentName string) (string, error) {
+	if run == nil {
+		return "", fmt.Errorf("run not found")
+	}
+	if isTerminalStatus(run.Status) {
+		return "", fmt.Errorf("run %s#%s is %s", run.IssueID, run.RunID, run.Status)
+	}
+
+	agentName = strings.TrimSpace(agentName)
+	if agentName == "" {
+		return "", fmt.Errorf("agent type is required")
+	}
+	if run.WorktreePath == "" {
+		return "", fmt.Errorf("run has no worktree path")
+	}
+	if !tmux.IsTmuxAvailable() {
+		return "", fmt.Errorf("tmux is not available")
+	}
+
+	aType, err := agent.ParseAgentType(agentName)
+	if err != nil {
+		return "", err
+	}
+	if aType == agent.AgentCustom {
+		return "", fmt.Errorf("custom agent requires --agent-cmd")
+	}
+	adapter, err := agent.GetAdapter(aType)
+	if err != nil {
+		return "", err
+	}
+	if !adapter.IsAvailable() {
+		return "", fmt.Errorf("agent %s is not available", agentName)
+	}
+
+	issue, err := m.store.ResolveIssue(run.IssueID)
+	if err != nil {
+		return "", err
+	}
+	prompt := buildSwapPrompt(issue, run)
+
+	sessionName := run.TmuxSession
+	if sessionName == "" {
+		sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
+	}
+
+	launchCfg := &agent.LaunchConfig{
+		Type:      aType,
+		WorkDir:   run.WorktreePath,
+		IssueID:   run.IssueID,
+		RunID:     run.RunID,
+		RunPath:   run.Path,
+		VaultPath: m.store.VaultPath(),
+		Branch:    run.Branch,
+		Prompt:    prompt,
+	}
+	agentCmd, err := adapter.LaunchCommand(launchCfg)
+	if err != nil {
+		return "", err
+	}
+
+	if tmux.HasSession(sessionName) {
+		if err := tmux.KillSession(sessionName); err != nil {
+			return "", err
+		}
+	}
+
+	if err := tmux.NewSession(&tmux.SessionConfig{
+		SessionName: sessionName,
+		WorkDir:     run.WorktreePath,
+		Command:     agentCmd,
+		Env:         launchCfg.Env(),
+	}); err != nil {
+		return "", err
+	}
+
+	if adapter.PromptInjection() == agent.InjectionTmux && launchCfg.Prompt != "" {
+		if pattern := adapter.ReadyPattern(); pattern != "" {
+			if err := tmux.WaitForReady(sessionName, pattern, 30*time.Second); err != nil {
+				return "", err
+			}
+		}
+		if err := tmux.SendKeys(sessionName, launchCfg.Prompt); err != nil {
+			return "", err
+		}
+	}
+
+	if err := m.store.AppendEvent(run.Ref(), model.NewArtifactEvent("agent", map[string]string{"name": agentName})); err != nil {
+		return "", err
+	}
+	if run.TmuxSession == "" {
+		if err := m.store.AppendEvent(run.Ref(), model.NewArtifactEvent("session", map[string]string{"name": sessionName})); err != nil {
+			return "", err
+		}
+	}
+	if windows, err := tmux.ListWindows(sessionName); err == nil {
+		windowID := ""
+		for _, window := range windows {
+			if window.Index == 0 {
+				windowID = window.ID
+				break
+			}
+		}
+		if windowID != "" {
+			if err := m.store.AppendEvent(run.Ref(), model.NewArtifactEvent("window", map[string]string{"id": windowID})); err != nil {
+				return "", err
+			}
+		}
+	}
+	if err := m.store.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("swapped agent to %s for %s#%s", agentName, run.IssueID, run.RunID), nil
+}
+
+func buildSwapPrompt(issue *model.Issue, run *model.Run) string {
+	issueID := "-"
+	title := ""
+	if issue != nil {
+		if issue.ID != "" {
+			issueID = issue.ID
+		}
+		title = issue.Title
+	} else if run != nil && run.IssueID != "" {
+		issueID = run.IssueID
+	}
+
+	prompt := fmt.Sprintf("Swapping agent for issue: %s\n\n", issueID)
+	if title != "" {
+		prompt += fmt.Sprintf("Title: %s\n\n", title)
+	}
+	prompt += swapPromptInstruction + "\n\n"
+
+	if run != nil {
+		if run.RunID != "" {
+			prompt += fmt.Sprintf("Run ID: %s\n", run.RunID)
+		}
+		if run.Agent != "" {
+			prompt += fmt.Sprintf("Previous agent: %s\n", run.Agent)
+		}
+		if run.Status != "" {
+			prompt += fmt.Sprintf("Previous status: %s\n", run.Status)
+		}
+	}
+	prompt += "Please continue from where the previous agent left off.\n"
+	return prompt
+}


### PR DESCRIPTION
Refs: orch-073

Summary:
- add swap agent flow to the monitor run dashboard
- restart run sessions with a new agent and record agent artifacts
- surface agent artifact overrides in run state