### PR TITLE
Add run filter dialog to monitor dashboard

### DIFF
--- a/internal/monitor/dashboard.go
+++ b/internal/monitor/dashboard.go
@@ -22,6 +22,7 @@ const (
 	modeDashboard dashboardMode = iota
 	modeStopSelectRun
 	modeNewSelectIssue
+	modeDashboardFilter
 )
 
 type stopState struct {
@@ -57,6 +58,7 @@ type Dashboard struct {
 
 	stop   stopState
 	newRun newRunState
+	filter runFilterState
 
 	keymap KeyMap
 	styles Styles
@@ -64,6 +66,7 @@ type Dashboard struct {
 	lastRefresh     time.Time
 	refreshing      bool
 	refreshInterval time.Duration
+	filterPreset    int
 }
 
 type refreshMsg struct {
@@ -102,6 +105,7 @@ func NewDashboard(m *Monitor) *Dashboard {
 		styles:          DefaultStyles(),
 		mode:            modeDashboard,
 		refreshInterval: defaultRefreshInterval,
+		filterPreset:    -1,
 	}
 }
 
@@ -195,6 +199,8 @@ func (d *Dashboard) View() string {
 		return d.styles.Box.Render(d.viewStopRuns())
 	case modeNewSelectIssue:
 		return d.styles.Box.Render(d.viewNewRun())
+	case modeDashboardFilter:
+		return d.styles.Box.Render(d.viewFilter())
 	default:
 		return d.styles.Box.Render(d.viewDashboard())
 	}
@@ -212,6 +218,8 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return d.handleStopKey(msg)
 	case modeNewSelectIssue:
 		return d.handleNewRunKey(msg)
+	case modeDashboardFilter:
+		return d.handleFilterKey(msg)
 	default:
 		return d, nil
 	}
@@ -243,6 +251,10 @@ func (d *Dashboard) handleDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return d.enterStopMode()
 	case "n":
 		return d.enterNewRunMode()
+	case d.keymap.Filter, "/":
+		return d.enterFilterMode()
+	case d.keymap.QuickFilter:
+		return d.applyQuickFilterPreset()
 	case d.keymap.Sort:
 		sortKey := d.monitor.CycleRunSort()
 		d.message = fmt.Sprintf("sort: %s", sortKey)
@@ -621,6 +633,9 @@ func (d *Dashboard) selectedRun() *model.Run {
 
 func (d *Dashboard) renderTable(maxRows int) string {
 	if len(d.runs) == 0 {
+		if !d.monitor.RunFilter().IsDefault() {
+			return "No runs found (filters active - press 'f' to adjust)."
+		}
 		return "No runs found."
 	}
 
@@ -769,22 +784,7 @@ func (d *Dashboard) captureLines(width int) []string {
 }
 
 func (d *Dashboard) renderMeta() string {
-	filterParts := []string{}
-	if d.monitor.issueFilter != "" {
-		filterParts = append(filterParts, fmt.Sprintf("issue=%s", d.monitor.issueFilter))
-	}
-	if len(d.monitor.statusFilter) > 0 {
-		var statuses []string
-		for _, s := range d.monitor.statusFilter {
-			statuses = append(statuses, string(s))
-		}
-		filterParts = append(filterParts, fmt.Sprintf("status=%s", strings.Join(statuses, ",")))
-	}
-	filter := "filter: all"
-	if len(filterParts) > 0 {
-		filter = "filter: " + strings.Join(filterParts, " ")
-	}
-
+	filter := d.monitor.RunFilter().Summary()
 	sortLabel := fmt.Sprintf("sort: %s", d.monitor.RunSort())
 	sync := d.renderSyncStatus()
 	nav := d.renderNav()

--- a/internal/monitor/dashboard_filter.go
+++ b/internal/monitor/dashboard_filter.go
@@ -1,0 +1,424 @@
+package monitor
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/s22625/orch/internal/model"
+)
+
+type runFilterState struct {
+	RunFilter
+	cursor int
+}
+
+type filterRowKind int
+
+const (
+	filterRowHeader filterRowKind = iota
+	filterRowStatus
+	filterRowAgent
+	filterRowMerged
+	filterRowPR
+	filterRowIssueStatus
+	filterRowIssueQuery
+	filterRowUpdatedWithin
+	filterRowAction
+)
+
+const (
+	filterActionApply  = "apply"
+	filterActionClear  = "clear"
+	filterActionCancel = "cancel"
+)
+
+type filterRow struct {
+	kind       filterRowKind
+	value      string
+	label      string
+	selectable bool
+}
+
+type runFilterPreset struct {
+	name  string
+	apply func() RunFilter
+}
+
+var runFilterPresets = []runFilterPreset{
+	{
+		name: "only running",
+		apply: func() RunFilter {
+			filter := DefaultRunFilter()
+			filter.Statuses = map[model.Status]bool{
+				model.StatusRunning: true,
+			}
+			return filter
+		},
+	},
+	{
+		name: "needs attention",
+		apply: func() RunFilter {
+			filter := DefaultRunFilter()
+			filter.Statuses = map[model.Status]bool{
+				model.StatusBlocked:    true,
+				model.StatusBlockedAPI: true,
+				model.StatusFailed:     true,
+			}
+			return filter
+		},
+	},
+	{
+		name: "active",
+		apply: func() RunFilter {
+			return DefaultRunFilter()
+		},
+	},
+}
+
+func (d *Dashboard) enterFilterMode() (tea.Model, tea.Cmd) {
+	d.filter = runFilterState{
+		RunFilter: d.monitor.RunFilter().Clone(),
+		cursor:    0,
+	}
+	d.message = ""
+	d.ensureFilterCursor()
+	d.mode = modeDashboardFilter
+	return d, nil
+}
+
+func (d *Dashboard) applyQuickFilterPreset() (tea.Model, tea.Cmd) {
+	if len(runFilterPresets) == 0 {
+		return d, nil
+	}
+	d.filterPreset = (d.filterPreset + 1) % len(runFilterPresets)
+	preset := runFilterPresets[d.filterPreset]
+	d.monitor.SetRunFilter(preset.apply())
+	d.message = fmt.Sprintf("filter preset: %s", preset.name)
+	d.refreshing = true
+	return d, d.refreshCmd()
+}
+
+func (d *Dashboard) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		d.mode = modeDashboard
+		return d, nil
+	case "q":
+		return d.quit()
+	case "up", "k":
+		d.moveFilterCursor(-1)
+		return d, nil
+	case "down", "j":
+		d.moveFilterCursor(1)
+		return d, nil
+	case "enter", " ":
+		return d.activateFilterRow()
+	case "a":
+		return d.applyFilter()
+	case "c":
+		return d.clearFilter()
+	}
+
+	row, ok := d.currentFilterRow()
+	if !ok {
+		return d, nil
+	}
+
+	switch msg.Type {
+	case tea.KeyBackspace, tea.KeyDelete:
+		switch row.kind {
+		case filterRowIssueQuery:
+			d.filter.IssueQuery = trimLastRune(d.filter.IssueQuery)
+			d.filter.IssueRegex = nil
+		case filterRowUpdatedWithin:
+			d.filter.UpdatedWithinRaw = trimLastRune(d.filter.UpdatedWithinRaw)
+			d.filter.UpdatedWithin = 0
+		}
+	case tea.KeyRunes:
+		switch row.kind {
+		case filterRowIssueQuery:
+			d.filter.IssueQuery += string(msg.Runes)
+			d.filter.IssueRegex = nil
+		case filterRowUpdatedWithin:
+			d.filter.UpdatedWithinRaw += string(msg.Runes)
+			d.filter.UpdatedWithin = 0
+		}
+	}
+
+	return d, nil
+}
+
+func (d *Dashboard) activateFilterRow() (tea.Model, tea.Cmd) {
+	row, ok := d.currentFilterRow()
+	if !ok {
+		return d, nil
+	}
+
+	switch row.kind {
+	case filterRowStatus:
+		if row.value == agentFilterAll {
+			d.filter.Statuses = allStatusSet()
+			return d, nil
+		}
+		status := model.Status(row.value)
+		if d.filter.Statuses == nil {
+			d.filter.Statuses = make(map[model.Status]bool)
+		}
+		if d.filter.Statuses[status] {
+			delete(d.filter.Statuses, status)
+		} else {
+			d.filter.Statuses[status] = true
+		}
+	case filterRowAgent:
+		d.filter.Agent = row.value
+	case filterRowMerged:
+		d.filter.Merged = row.value
+	case filterRowPR:
+		d.filter.PR = row.value
+	case filterRowIssueStatus:
+		d.filter.IssueStatus = row.value
+	case filterRowAction:
+		switch row.value {
+		case filterActionApply:
+			return d.applyFilter()
+		case filterActionClear:
+			return d.clearFilter()
+		case filterActionCancel:
+			d.mode = modeDashboard
+			return d, nil
+		}
+	}
+	return d, nil
+}
+
+func (d *Dashboard) applyFilter() (tea.Model, tea.Cmd) {
+	filter := d.filter.RunFilter.Clone()
+	filter.IssueQuery = strings.TrimSpace(filter.IssueQuery)
+	filter.UpdatedWithinRaw = strings.TrimSpace(filter.UpdatedWithinRaw)
+	filter.IssueRegex = nil
+	if re, _, err := compileIssueQuery(filter.IssueQuery); err != nil {
+		d.message = fmt.Sprintf("issue filter: %v", err)
+		return d, nil
+	} else {
+		filter.IssueRegex = re
+	}
+	duration, err := parseFilterDuration(filter.UpdatedWithinRaw)
+	if err != nil {
+		d.message = err.Error()
+		return d, nil
+	}
+	filter.UpdatedWithin = duration
+	d.monitor.SetRunFilter(filter)
+	d.message = ""
+	d.mode = modeDashboard
+	d.refreshing = true
+	return d, d.refreshCmd()
+}
+
+func (d *Dashboard) clearFilter() (tea.Model, tea.Cmd) {
+	d.monitor.SetRunFilter(DefaultRunFilter())
+	d.message = ""
+	d.mode = modeDashboard
+	d.refreshing = true
+	return d, d.refreshCmd()
+}
+
+func (d *Dashboard) viewFilter() string {
+	header := d.styles.Title.Render("FILTER RUNS")
+	lines := []string{header, ""}
+	rows := d.filterRows()
+	for i, row := range rows {
+		line := row.label
+		if row.selectable && i == d.filter.cursor {
+			line = d.styles.Selected.Render(line)
+		}
+		lines = append(lines, truncate(line, d.safeWidth()-2))
+	}
+	if d.message != "" {
+		lines = append(lines, "", d.styles.Faint.Render(d.message))
+	}
+	lines = append(lines, "", "[Enter/Space] toggle/select  [a] apply  [c] clear  [Esc] cancel")
+	return strings.Join(lines, "\n")
+}
+
+func (d *Dashboard) filterRows() []filterRow {
+	var rows []filterRow
+
+	rows = append(rows, filterRow{label: "Status:", selectable: false})
+	allSelected := equalStatusSet(d.filter.Statuses, allStatusSet())
+	rows = append(rows, filterRow{
+		kind:       filterRowStatus,
+		value:      agentFilterAll,
+		label:      fmt.Sprintf("  %s all", checkbox(allSelected)),
+		selectable: true,
+	})
+	for _, status := range runStatusOptions {
+		rows = append(rows, filterRow{
+			kind:       filterRowStatus,
+			value:      string(status),
+			label:      fmt.Sprintf("  %s %s", checkbox(d.filter.Statuses[status]), status),
+			selectable: true,
+		})
+	}
+
+	rows = append(rows, filterRow{label: "", selectable: false})
+	rows = append(rows, filterRow{label: "Agent:", selectable: false})
+	agentOptions := append([]string{agentFilterAll}, runAgentOptions...)
+	for _, agent := range agentOptions {
+		rows = append(rows, filterRow{
+			kind:       filterRowAgent,
+			value:      agent,
+			label:      fmt.Sprintf("  %s %s", checkbox(d.filter.Agent == agent), agent),
+			selectable: true,
+		})
+	}
+
+	rows = append(rows, filterRow{label: "", selectable: false})
+	rows = append(rows, filterRow{label: "Merged:", selectable: false})
+	mergedOptions := []string{mergedFilterAll, mergedFilterConflict, mergedFilterClean, mergedFilterMerged, mergedFilterNoChange}
+	for _, option := range mergedOptions {
+		rows = append(rows, filterRow{
+			kind:       filterRowMerged,
+			value:      option,
+			label:      fmt.Sprintf("  %s %s", checkbox(d.filter.Merged == option), option),
+			selectable: true,
+		})
+	}
+
+	rows = append(rows, filterRow{label: "", selectable: false})
+	rows = append(rows, filterRow{label: "PR:", selectable: false})
+	prOptions := []struct {
+		value string
+		label string
+	}{
+		{prFilterAll, "all"},
+		{prFilterHas, "has PR"},
+		{prFilterNone, "no PR"},
+	}
+	for _, option := range prOptions {
+		rows = append(rows, filterRow{
+			kind:       filterRowPR,
+			value:      option.value,
+			label:      fmt.Sprintf("  %s %s", checkbox(d.filter.PR == option.value), option.label),
+			selectable: true,
+		})
+	}
+
+	rows = append(rows, filterRow{label: "", selectable: false})
+	rows = append(rows, filterRow{label: "Issue status:", selectable: false})
+	for _, option := range runIssueStatusOptions {
+		rows = append(rows, filterRow{
+			kind:       filterRowIssueStatus,
+			value:      option,
+			label:      fmt.Sprintf("  %s %s", checkbox(d.filter.IssueStatus == option), option),
+			selectable: true,
+		})
+	}
+
+	rows = append(rows, filterRow{label: "", selectable: false})
+	rows = append(rows, filterRow{
+		kind:       filterRowIssueQuery,
+		label:      fmt.Sprintf("Issue ID: %s (partial or /regex/)", formatInput(d.filter.IssueQuery)),
+		selectable: true,
+	})
+	rows = append(rows, filterRow{
+		kind:       filterRowUpdatedWithin,
+		label:      fmt.Sprintf("Updated within: %s (e.g. 24h, 7d)", formatInput(d.filter.UpdatedWithinRaw)),
+		selectable: true,
+	})
+
+	rows = append(rows, filterRow{label: "", selectable: false})
+	rows = append(rows, filterRow{
+		kind:       filterRowAction,
+		value:      filterActionApply,
+		label:      "[Apply]",
+		selectable: true,
+	})
+	rows = append(rows, filterRow{
+		kind:       filterRowAction,
+		value:      filterActionClear,
+		label:      "[Clear]",
+		selectable: true,
+	})
+	rows = append(rows, filterRow{
+		kind:       filterRowAction,
+		value:      filterActionCancel,
+		label:      "[Cancel]",
+		selectable: true,
+	})
+
+	return rows
+}
+
+func (d *Dashboard) currentFilterRow() (filterRow, bool) {
+	rows := d.filterRows()
+	if len(rows) == 0 {
+		return filterRow{}, false
+	}
+	if d.filter.cursor < 0 || d.filter.cursor >= len(rows) {
+		return filterRow{}, false
+	}
+	return rows[d.filter.cursor], true
+}
+
+func (d *Dashboard) moveFilterCursor(delta int) {
+	rows := d.filterRows()
+	if len(rows) == 0 {
+		d.filter.cursor = 0
+		return
+	}
+	cursor := d.filter.cursor
+	for i := 0; i < len(rows); i++ {
+		cursor += delta
+		if cursor < 0 {
+			cursor = len(rows) - 1
+		} else if cursor >= len(rows) {
+			cursor = 0
+		}
+		if rows[cursor].selectable {
+			d.filter.cursor = cursor
+			return
+		}
+	}
+}
+
+func (d *Dashboard) ensureFilterCursor() {
+	rows := d.filterRows()
+	if len(rows) == 0 {
+		d.filter.cursor = 0
+		return
+	}
+	if d.filter.cursor >= 0 && d.filter.cursor < len(rows) && rows[d.filter.cursor].selectable {
+		return
+	}
+	for i, row := range rows {
+		if row.selectable {
+			d.filter.cursor = i
+			return
+		}
+	}
+	d.filter.cursor = 0
+}
+
+func checkbox(checked bool) string {
+	if checked {
+		return "[x]"
+	}
+	return "[ ]"
+}
+
+func formatInput(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "[ ]"
+	}
+	return "[" + value + "]"
+}
+
+func trimLastRune(value string) string {
+	if value == "" {
+		return value
+	}
+	runes := []rune(value)
+	return string(runes[:len(runes)-1])
+}

--- a/internal/monitor/keymap.go
+++ b/internal/monitor/keymap.go
@@ -4,42 +4,46 @@ import "fmt"
 
 // KeyMap defines the keyboard shortcuts displayed in the footer.
 type KeyMap struct {
-	Runs    string
-	Issues  string
-	Chat    string
-	Open    string
-	Exec    string
-	Stop    string
-	NewRun  string
-	Resolve string
-	Merge   string
-	Refresh string
-	Sort    string
-	Quit    string
-	Help    string
+	Runs        string
+	Issues      string
+	Chat        string
+	Open        string
+	Exec        string
+	Stop        string
+	NewRun      string
+	Resolve     string
+	Merge       string
+	Refresh     string
+	Sort        string
+	Filter      string
+	QuickFilter string
+	Quit        string
+	Help        string
 }
 
 // DefaultKeyMap returns the default shortcut mapping.
 func DefaultKeyMap() KeyMap {
 	return KeyMap{
-		Runs:    "g",
-		Issues:  "i",
-		Chat:    "c",
-		Open:    "enter",
-		Exec:    "e",
-		Stop:    "s",
-		NewRun:  "n",
-		Resolve: "R",
-		Merge:   "M",
-		Refresh: "r",
-		Sort:    "S",
-		Quit:    "q",
-		Help:    "?",
+		Runs:        "g",
+		Issues:      "i",
+		Chat:        "c",
+		Open:        "enter",
+		Exec:        "e",
+		Stop:        "s",
+		NewRun:      "n",
+		Resolve:     "R",
+		Merge:       "M",
+		Refresh:     "r",
+		Sort:        "S",
+		Filter:      "f",
+		QuickFilter: "F",
+		Quit:        "q",
+		Help:        "?",
 	}
 }
 
 // HelpLine renders the footer help text.
 func (k KeyMap) HelpLine() string {
-	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] exec  [%s] stop  [%s] new  [%s] resolve  [%s] merge  [%s] refresh  [%s] sort  [%s] quit  [%s] help",
-		k.Runs, k.Issues, k.Chat, k.Open, k.Exec, k.Stop, k.NewRun, k.Resolve, k.Merge, k.Refresh, k.Sort, k.Quit, k.Help)
+	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] exec  [%s] stop  [%s] new  [%s] resolve  [%s] merge  [%s] refresh  [%s] sort  [%s] filter  [%s] presets  [%s] quit  [%s] help",
+		k.Runs, k.Issues, k.Chat, k.Open, k.Exec, k.Stop, k.NewRun, k.Resolve, k.Merge, k.Refresh, k.Sort, k.Filter, k.QuickFilter, k.Quit, k.Help)
 }

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -54,19 +54,18 @@ type Options struct {
 
 // Monitor manages tmux windows and dashboard state.
 type Monitor struct {
-	session      string
-	issueFilter  string
-	statusFilter []model.Status
-	runSort      SortKey
-	issueSort    SortKey
-	store        store.Store
-	orchPath     string
-	globalFlags  []string
-	agent        string
-	attach       bool
-	forceNew     bool
-	runs         []*RunWindow
-	dashboard    *Dashboard
+	session     string
+	runFilter   RunFilter
+	runSort     SortKey
+	issueSort   SortKey
+	store       store.Store
+	orchPath    string
+	globalFlags []string
+	agent       string
+	attach      bool
+	forceNew    bool
+	runs        []*RunWindow
+	dashboard   *Dashboard
 }
 
 // RunWindow links a run to a dashboard index.
@@ -92,17 +91,16 @@ func New(st store.Store, opts Options) *Monitor {
 		issueSort = SortByName
 	}
 	return &Monitor{
-		session:      session,
-		issueFilter:  opts.Issue,
-		statusFilter: opts.Statuses,
-		runSort:      runSort,
-		issueSort:    issueSort,
-		store:        st,
-		orchPath:     orchPath,
-		globalFlags:  opts.GlobalFlags,
-		agent:        opts.Agent,
-		attach:       opts.Attach,
-		forceNew:     opts.ForceNew,
+		session:     session,
+		runFilter:   newRunFilter(opts),
+		runSort:     runSort,
+		issueSort:   issueSort,
+		store:       st,
+		orchPath:    orchPath,
+		globalFlags: opts.GlobalFlags,
+		agent:       opts.Agent,
+		attach:      opts.Attach,
+		forceNew:    opts.ForceNew,
 	}
 }
 
@@ -223,7 +221,23 @@ func (m *Monitor) Refresh() ([]RunRow, error) {
 		return nil, err
 	}
 	m.runs = runs
-	return m.buildRunRows(runs)
+	rows, err := m.buildRunRows(runs)
+	if err != nil {
+		return nil, err
+	}
+	filtered := m.runFilter.FilterRows(rows, time.Now())
+	reindexRunRows(filtered)
+	return filtered, nil
+}
+
+// RunFilter returns the active run filter.
+func (m *Monitor) RunFilter() RunFilter {
+	return m.runFilter.Clone()
+}
+
+// SetRunFilter updates the active run filter.
+func (m *Monitor) SetRunFilter(filter RunFilter) {
+	m.runFilter = normalizeRunFilter(filter)
 }
 
 // RefreshIssues reloads issue data for the issues dashboard.
@@ -647,15 +661,19 @@ func (m *Monitor) ensurePaneLayout() error {
 
 func (m *Monitor) loadRuns() ([]*RunWindow, error) {
 	filter := &store.ListRunsFilter{
-		IssueID: m.issueFilter,
-		Limit:   100,
+		Limit: 100,
 	}
 
-	statuses := m.statusFilter
-	if len(statuses) == 0 {
-		statuses = defaultStatuses()
+	if len(m.runFilter.Statuses) == 0 {
+		return []*RunWindow{}, nil
 	}
-	filter.Status = statuses
+	filter.Status = statusSlice(m.runFilter.Statuses)
+	if m.runFilter.UpdatedWithin > 0 {
+		filter.Since = time.Now().Add(-m.runFilter.UpdatedWithin).Format(time.RFC3339)
+	}
+	if !m.runFilter.IsDefault() {
+		filter.Limit = 0
+	}
 
 	runs, err := m.store.ListRuns(filter)
 	if err != nil {
@@ -852,10 +870,10 @@ func (m *Monitor) buildIssueRows(issues []*model.Issue, runs []*model.Run) []Iss
 func (m *Monitor) runsDashboardCommand() string {
 	args := append([]string{m.orchPath}, m.globalFlags...)
 	args = append(args, "monitor", "--dashboard")
-	if m.issueFilter != "" {
-		args = append(args, "--issue", m.issueFilter)
+	if m.runFilter.IssueQuery != "" {
+		args = append(args, "--issue", m.runFilter.IssueQuery)
 	}
-	for _, status := range m.statusFilter {
+	for _, status := range statusSlice(m.runFilter.Statuses) {
 		args = append(args, "--status", string(status))
 	}
 	if m.runSort != "" {

--- a/internal/monitor/run_filter.go
+++ b/internal/monitor/run_filter.go
@@ -1,0 +1,387 @@
+package monitor
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/s22625/orch/internal/model"
+)
+
+const (
+	agentFilterAll       = "all"
+	mergedFilterAll      = "all"
+	mergedFilterClean    = "clean"
+	mergedFilterConflict = "conflict"
+	mergedFilterMerged   = "merged"
+	mergedFilterNoChange = "no change"
+	prFilterAll          = "all"
+	prFilterHas          = "has"
+	prFilterNone         = "none"
+	issueStatusAll       = "all"
+	issueStatusOpen      = "open"
+	issueStatusResolved  = "resolved"
+)
+
+var runStatusOptions = []model.Status{
+	model.StatusRunning,
+	model.StatusBlocked,
+	model.StatusBlockedAPI,
+	model.StatusQueued,
+	model.StatusBooting,
+	model.StatusPROpen,
+	model.StatusDone,
+	model.StatusFailed,
+	model.StatusCanceled,
+	model.StatusUnknown,
+}
+
+var runAgentOptions = []string{
+	"claude",
+	"codex",
+	"gemini",
+	"custom",
+}
+
+var runIssueStatusOptions = []string{
+	issueStatusAll,
+	issueStatusOpen,
+	issueStatusResolved,
+}
+
+// RunFilter holds the active filter settings for the runs dashboard.
+type RunFilter struct {
+	Statuses         map[model.Status]bool
+	Agent            string
+	IssueQuery       string
+	IssueRegex       *regexp.Regexp
+	Merged           string
+	PR               string
+	UpdatedWithin    time.Duration
+	UpdatedWithinRaw string
+	IssueStatus      string
+}
+
+func defaultStatusSet() map[model.Status]bool {
+	set := make(map[model.Status]bool, len(runStatusOptions))
+	for _, status := range defaultStatuses() {
+		set[status] = true
+	}
+	return set
+}
+
+func allStatusSet() map[model.Status]bool {
+	set := make(map[model.Status]bool, len(runStatusOptions))
+	for _, status := range runStatusOptions {
+		set[status] = true
+	}
+	return set
+}
+
+// DefaultRunFilter returns the baseline filter configuration.
+func DefaultRunFilter() RunFilter {
+	return RunFilter{
+		Statuses:    defaultStatusSet(),
+		Agent:       agentFilterAll,
+		Merged:      mergedFilterAll,
+		PR:          prFilterAll,
+		IssueStatus: issueStatusAll,
+	}
+}
+
+func newRunFilter(opts Options) RunFilter {
+	filter := DefaultRunFilter()
+	if len(opts.Statuses) > 0 {
+		filter.Statuses = make(map[model.Status]bool, len(opts.Statuses))
+		for _, status := range opts.Statuses {
+			filter.Statuses[status] = true
+		}
+	}
+	if strings.TrimSpace(opts.Issue) != "" {
+		filter.IssueQuery = opts.Issue
+	}
+	return normalizeRunFilter(filter)
+}
+
+func normalizeRunFilter(filter RunFilter) RunFilter {
+	if filter.Statuses == nil {
+		filter.Statuses = defaultStatusSet()
+	}
+	filter.Agent = strings.ToLower(strings.TrimSpace(filter.Agent))
+	if filter.Agent == "" {
+		filter.Agent = agentFilterAll
+	}
+	filter.Merged = strings.ToLower(strings.TrimSpace(filter.Merged))
+	if filter.Merged == "" {
+		filter.Merged = mergedFilterAll
+	}
+	filter.PR = strings.ToLower(strings.TrimSpace(filter.PR))
+	if filter.PR == "" {
+		filter.PR = prFilterAll
+	}
+	filter.IssueStatus = strings.ToLower(strings.TrimSpace(filter.IssueStatus))
+	if filter.IssueStatus == "" {
+		filter.IssueStatus = issueStatusAll
+	}
+	filter.IssueQuery = strings.TrimSpace(filter.IssueQuery)
+	filter.UpdatedWithinRaw = strings.TrimSpace(filter.UpdatedWithinRaw)
+	return filter
+}
+
+// Clone copies the filter and its maps for safe editing.
+func (f RunFilter) Clone() RunFilter {
+	clone := f
+	clone.Statuses = copyStatusSet(f.Statuses)
+	return clone
+}
+
+// IsDefault returns true when the filter matches the default dashboard filter.
+func (f RunFilter) IsDefault() bool {
+	f = normalizeRunFilter(f)
+	if !equalStatusSet(f.Statuses, defaultStatusSet()) {
+		return false
+	}
+	if f.Agent != agentFilterAll {
+		return false
+	}
+	if f.IssueQuery != "" {
+		return false
+	}
+	if f.Merged != mergedFilterAll {
+		return false
+	}
+	if f.PR != prFilterAll {
+		return false
+	}
+	if f.IssueStatus != issueStatusAll {
+		return false
+	}
+	if f.UpdatedWithin > 0 {
+		return false
+	}
+	if f.UpdatedWithinRaw != "" {
+		return false
+	}
+	return true
+}
+
+// Summary returns a human-readable summary of the filter state.
+func (f RunFilter) Summary() string {
+	f = normalizeRunFilter(f)
+	var parts []string
+
+	if statusLabel := f.statusSummary(); statusLabel != "" {
+		parts = append(parts, statusLabel)
+	}
+	if f.Agent != agentFilterAll {
+		parts = append(parts, fmt.Sprintf("agent=%s", f.Agent))
+	}
+	if f.Merged != mergedFilterAll {
+		parts = append(parts, fmt.Sprintf("merged=%s", f.Merged))
+	}
+	if f.PR != prFilterAll {
+		parts = append(parts, fmt.Sprintf("pr=%s", f.PR))
+	}
+	if f.IssueStatus != issueStatusAll {
+		parts = append(parts, fmt.Sprintf("issue_status=%s", f.IssueStatus))
+	}
+	if f.IssueQuery != "" {
+		parts = append(parts, fmt.Sprintf("issue=%s", f.IssueQuery))
+	}
+	if f.UpdatedWithin > 0 {
+		label := f.UpdatedWithinRaw
+		if label == "" {
+			label = f.UpdatedWithin.String()
+		}
+		parts = append(parts, fmt.Sprintf("updated<=%s", label))
+	}
+
+	if len(parts) == 0 {
+		return "filter: all"
+	}
+	return "filter: " + strings.Join(parts, " ")
+}
+
+func (f RunFilter) statusSummary() string {
+	if len(f.Statuses) == 0 {
+		return "status=none"
+	}
+	if equalStatusSet(f.Statuses, defaultStatusSet()) {
+		return "status=active"
+	}
+	if equalStatusSet(f.Statuses, allStatusSet()) {
+		return ""
+	}
+	var statuses []string
+	for _, status := range runStatusOptions {
+		if f.Statuses[status] {
+			statuses = append(statuses, string(status))
+		}
+	}
+	if len(statuses) == 0 {
+		return "status=none"
+	}
+	return fmt.Sprintf("status=%s", strings.Join(statuses, ","))
+}
+
+func copyStatusSet(in map[model.Status]bool) map[model.Status]bool {
+	if in == nil {
+		return nil
+	}
+	out := make(map[model.Status]bool, len(in))
+	for k, v := range in {
+		if v {
+			out[k] = true
+		}
+	}
+	return out
+}
+
+func equalStatusSet(a, b map[model.Status]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if !b[k] {
+			return false
+		}
+	}
+	return true
+}
+
+func statusSlice(set map[model.Status]bool) []model.Status {
+	if len(set) == 0 {
+		return nil
+	}
+	slice := make([]model.Status, 0, len(set))
+	for status := range set {
+		slice = append(slice, status)
+	}
+	sort.Slice(slice, func(i, j int) bool {
+		return runStatusRank(slice[i]) < runStatusRank(slice[j])
+	})
+	return slice
+}
+
+func compileIssueQuery(raw string) (*regexp.Regexp, bool, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, false, nil
+	}
+	if strings.HasPrefix(trimmed, "/") && strings.HasSuffix(trimmed, "/") && len(trimmed) > 2 {
+		pattern := trimmed[1 : len(trimmed)-1]
+		if strings.TrimSpace(pattern) == "" {
+			return nil, true, fmt.Errorf("regex pattern is empty")
+		}
+		re, err := regexp.Compile("(?i)" + pattern)
+		if err != nil {
+			return nil, true, err
+		}
+		return re, true, nil
+	}
+	return nil, false, nil
+}
+
+func parseFilterDuration(raw string) (time.Duration, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return 0, nil
+	}
+	if d, err := time.ParseDuration(trimmed); err == nil {
+		if d <= 0 {
+			return 0, fmt.Errorf("duration must be positive")
+		}
+		return d, nil
+	}
+	re := regexp.MustCompile(`^(\d+)([dwDW])$`)
+	matches := re.FindStringSubmatch(trimmed)
+	if matches == nil {
+		return 0, fmt.Errorf("invalid duration format: %s (use 24h, 7d, or 2w)", trimmed)
+	}
+	value, _ := strconv.Atoi(matches[1])
+	unit := strings.ToLower(matches[2])
+	switch unit {
+	case "d":
+		return time.Duration(value) * 24 * time.Hour, nil
+	case "w":
+		return time.Duration(value) * 7 * 24 * time.Hour, nil
+	default:
+		return 0, fmt.Errorf("unknown duration unit: %s", unit)
+	}
+}
+
+// FilterRows applies the filter to a list of run rows.
+func (f RunFilter) FilterRows(rows []RunRow, now time.Time) []RunRow {
+	f = normalizeRunFilter(f)
+	if len(f.Statuses) == 0 {
+		return nil
+	}
+	cutoff := time.Time{}
+	if f.UpdatedWithin > 0 {
+		cutoff = now.Add(-f.UpdatedWithin)
+	}
+	query := strings.ToLower(f.IssueQuery)
+
+	var filtered []RunRow
+	for _, row := range rows {
+		if !f.Statuses[row.Status] {
+			continue
+		}
+		if f.Agent != agentFilterAll {
+			agent := ""
+			if row.Run != nil {
+				agent = row.Run.Agent
+			}
+			if agent == "" {
+				agent = row.Agent
+			}
+			agent = strings.ToLower(strings.TrimSpace(agent))
+			if agent != f.Agent {
+				continue
+			}
+		}
+		if f.IssueQuery != "" {
+			if f.IssueRegex != nil {
+				if !f.IssueRegex.MatchString(row.IssueID) {
+					continue
+				}
+			} else if !strings.Contains(strings.ToLower(row.IssueID), query) {
+				continue
+			}
+		}
+		if f.Merged != mergedFilterAll {
+			if strings.ToLower(row.Merged) != f.Merged {
+				continue
+			}
+		}
+		if f.PR != prFilterAll {
+			hasPR := row.PR != "" && row.PR != "-"
+			if f.PR == prFilterHas && !hasPR {
+				continue
+			}
+			if f.PR == prFilterNone && hasPR {
+				continue
+			}
+		}
+		if f.IssueStatus != issueStatusAll {
+			status := model.ParseIssueStatus(row.IssueStatus)
+			if string(status) != f.IssueStatus {
+				continue
+			}
+		}
+		if !cutoff.IsZero() && row.Updated.Before(cutoff) {
+			continue
+		}
+		filtered = append(filtered, row)
+	}
+	return filtered
+}
+
+func reindexRunRows(rows []RunRow) {
+	for i := range rows {
+		rows[i].Index = i + 1
+	}
+}

--- a/internal/monitor/run_filter_test.go
+++ b/internal/monitor/run_filter_test.go
@@ -1,0 +1,132 @@
+package monitor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/s22625/orch/internal/model"
+)
+
+func TestParseFilterDuration(t *testing.T) {
+	tests := []struct {
+		raw     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{raw: "24h", want: 24 * time.Hour},
+		{raw: "7d", want: 7 * 24 * time.Hour},
+		{raw: "2w", want: 14 * 24 * time.Hour},
+		{raw: "0h", wantErr: true},
+		{raw: "bad", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		got, err := parseFilterDuration(tt.raw)
+		if tt.wantErr {
+			if err == nil {
+				t.Fatalf("parseFilterDuration(%q) expected error, got nil", tt.raw)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("parseFilterDuration(%q) unexpected error: %v", tt.raw, err)
+		}
+		if got != tt.want {
+			t.Fatalf("parseFilterDuration(%q) = %v, want %v", tt.raw, got, tt.want)
+		}
+	}
+}
+
+func TestCompileIssueQuery(t *testing.T) {
+	re, isRegex, err := compileIssueQuery("/orch-\\d+/")
+	if err != nil {
+		t.Fatalf("compileIssueQuery returned error: %v", err)
+	}
+	if !isRegex {
+		t.Fatal("compileIssueQuery expected regex true")
+	}
+	if re == nil || !re.MatchString("orch-123") {
+		t.Fatal("compiled regex did not match expected input")
+	}
+	if re.MatchString("misc") {
+		t.Fatal("compiled regex matched unexpected input")
+	}
+}
+
+func TestRunFilterRows(t *testing.T) {
+	now := time.Now()
+	rows := []RunRow{
+		{
+			IssueID:     "orch-1",
+			Status:      model.StatusRunning,
+			Agent:       "codex",
+			PR:          "#12",
+			Merged:      "clean",
+			Updated:     now.Add(-1 * time.Hour),
+			IssueStatus: "open",
+			Run:         &model.Run{Agent: "codex"},
+		},
+		{
+			IssueID:     "orch-2",
+			Status:      model.StatusBlocked,
+			Agent:       "claude",
+			PR:          "-",
+			Merged:      "conflict",
+			Updated:     now.Add(-48 * time.Hour),
+			IssueStatus: "resolved",
+			Run:         &model.Run{Agent: "claude"},
+		},
+		{
+			IssueID:     "misc",
+			Status:      model.StatusDone,
+			Agent:       "gemini",
+			PR:          "-",
+			Merged:      "no change",
+			Updated:     now.Add(-2 * time.Hour),
+			IssueStatus: "open",
+			Run:         &model.Run{Agent: "gemini"},
+		},
+	}
+
+	filter := DefaultRunFilter()
+	filter.Statuses = map[model.Status]bool{
+		model.StatusRunning: true,
+		model.StatusBlocked: true,
+	}
+	filter.Agent = "codex"
+	filter.Merged = mergedFilterClean
+	filter.PR = prFilterHas
+	filter.IssueStatus = issueStatusOpen
+	filter.IssueQuery = "orch"
+	filter.UpdatedWithin = 24 * time.Hour
+
+	filtered := filter.FilterRows(rows, now)
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(filtered))
+	}
+	if filtered[0].IssueID != "orch-1" {
+		t.Fatalf("expected orch-1, got %s", filtered[0].IssueID)
+	}
+}
+
+func TestRunFilterRowsRegex(t *testing.T) {
+	now := time.Now()
+	re, _, err := compileIssueQuery("/orch-\\d+/")
+	if err != nil {
+		t.Fatalf("compileIssueQuery error: %v", err)
+	}
+	filter := DefaultRunFilter()
+	filter.Statuses = map[model.Status]bool{model.StatusRunning: true}
+	filter.IssueQuery = "/orch-\\d+/"
+	filter.IssueRegex = re
+
+	rows := []RunRow{
+		{IssueID: "orch-123", Status: model.StatusRunning, Updated: now},
+		{IssueID: "misc", Status: model.StatusRunning, Updated: now},
+	}
+
+	filtered := filter.FilterRows(rows, now)
+	if len(filtered) != 1 || filtered[0].IssueID != "orch-123" {
+		t.Fatalf("expected regex filter to match orch-123, got %+v", filtered)
+	}
+}


### PR DESCRIPTION
## Summary
- add interactive runs filter dialog with status, agent, merged/PR, issue query, time range, and issue status filters
- show active filter summary in the dashboard header with quick presets and clear
- apply filters in monitor refresh and add filter parsing/matching tests

Refs: orch-079