### PR TITLE
Show branch/worktree in orch ps and monitor

### DIFF
--- a/internal/cli/ps_test.go
+++ b/internal/cli/ps_test.go
@@ -197,12 +197,14 @@ func TestOutputTableShowsPRColumn(t *testing.T) {
 
 	header := lines[0]
 	statusIdx := strings.Index(header, "STATUS")
+	branchIdx := strings.Index(header, "BRANCH")
+	worktreeIdx := strings.Index(header, "WORKTREE")
 	prIdx := strings.Index(header, "PR")
 	mergedIdx := strings.Index(header, "MERGED")
-	if statusIdx == -1 || prIdx == -1 || mergedIdx == -1 {
+	if statusIdx == -1 || branchIdx == -1 || worktreeIdx == -1 || prIdx == -1 || mergedIdx == -1 {
 		t.Fatalf("missing columns in header: %q", header)
 	}
-	if !(statusIdx < prIdx && prIdx < mergedIdx) {
+	if !(statusIdx < branchIdx && branchIdx < worktreeIdx && worktreeIdx < prIdx && prIdx < mergedIdx) {
 		t.Fatalf("unexpected header order: %q", header)
 	}
 

--- a/internal/monitor/constants.go
+++ b/internal/monitor/constants.go
@@ -5,4 +5,7 @@ import "time"
 const (
 	defaultRefreshInterval = 2 * time.Second
 	defaultCaptureLines    = 200
+	runTableBranchWidth    = 8
+	runTableWorktreeWidth  = 16
+	runDetailsMaxLines     = 4
 )

--- a/internal/monitor/data.go
+++ b/internal/monitor/data.go
@@ -14,6 +14,8 @@ type RunRow struct {
 	IssueStatus string
 	Agent       string
 	Status      model.Status
+	Branch      string
+	Worktree    string
 	PR          string // PR display string (e.g., "#123" or "-")
 	PRState     string // PR state: open, merged, closed, or empty
 	Merged      string

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -777,6 +777,8 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 				shortID += "*"
 			}
 		}
+		branch := formatBranchDisplay(w.Run.Branch, runTableBranchWidth)
+		worktree := formatWorktreeDisplay(w.Run.WorktreePath, runTableWorktreeWidth)
 		rows = append(rows, RunRow{
 			Index:       w.Index,
 			ShortID:     shortID,
@@ -784,6 +786,8 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 			IssueStatus: issueStatus,
 			Agent:       agent,
 			Status:      w.Run.Status,
+			Branch:      branch,
+			Worktree:    worktree,
 			PR:          prDisplay,
 			PRState:     prState,
 			Merged:      merged,

--- a/internal/monitor/ps_helpers.go
+++ b/internal/monitor/ps_helpers.go
@@ -1,6 +1,8 @@
 package monitor
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/s22625/orch/internal/git"
@@ -56,6 +58,69 @@ func truncateWithEllipsis(text string, max int) string {
 		return text[:max]
 	}
 	return text[:max-3] + "..."
+}
+
+func formatBranchDisplay(branch string, max int) string {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return "-"
+	}
+	if max <= 0 {
+		return branch
+	}
+	return truncateWithEllipsis(branch, max)
+}
+
+func formatWorktreeDisplay(path string, max int) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "-"
+	}
+	if max <= 0 {
+		return path
+	}
+	path = abbreviateHome(path)
+	short := shortenPath(path)
+	return truncateLeading(short, max)
+}
+
+func abbreviateHome(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return path
+	}
+	if path == home {
+		return "~"
+	}
+	homePrefix := home + string(os.PathSeparator)
+	if strings.HasPrefix(path, homePrefix) {
+		return "~" + path[len(home):]
+	}
+	return path
+}
+
+func shortenPath(path string) string {
+	cleaned := filepath.Clean(path)
+	sep := string(os.PathSeparator)
+	parts := strings.Split(cleaned, sep)
+	if len(parts) < 2 {
+		return cleaned
+	}
+	suffix := filepath.Join(parts[len(parts)-2], parts[len(parts)-1])
+	if suffix == cleaned {
+		return cleaned
+	}
+	return "..." + sep + suffix
+}
+
+func truncateLeading(text string, max int) string {
+	if len(text) <= max {
+		return text
+	}
+	if max <= 3 {
+		return text[:max]
+	}
+	return "..." + text[len(text)-(max-3):]
 }
 
 func gitStatesForRuns(runs []*model.Run, target string) map[string]string {


### PR DESCRIPTION
## Summary
- add branch/worktree columns to `orch ps` table output with abbreviated paths
- surface branch/worktree in `orch monitor` run list and details panel
- keep display formatting helpers aligned across outputs

## Issue
Refs: orch-083