### PR TITLE
Print CLI errors before exit

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -466,7 +466,9 @@ func exitWithCode(err error, code int) error {
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		enc.Encode(result)
+		_ = enc.Encode(result)
+	} else {
+		fmt.Fprintln(os.Stderr, err)
 	}
 	os.Exit(code)
 	return err


### PR DESCRIPTION
## Summary
- Print non-JSON CLI errors to stderr before exiting so orch continue reports failures.

## Issue
- orch-082