### PR TITLE
Validate worktree names include run short ID

### DIFF
--- a/test/vault/runs/plc124/20231220-100000.md
+++ b/test/vault/runs/plc124/20231220-100000.md
@@ -9,7 +9,7 @@ agent: claude
 
 - 2023-12-20T10:00:00+09:00 | status | queued
 - 2023-12-20T10:00:01+09:00 | status | booting
-- 2023-12-20T10:00:05+09:00 | artifact | worktree | path=.git-worktrees/plc124/20231220-100000
+- 2023-12-20T10:00:05+09:00 | artifact | worktree | path=.git-worktrees/plc124/66c75b_claude_20231220-100000
 - 2023-12-20T10:00:05+09:00 | artifact | branch | name=issue/plc124/run-20231220-100000
 - 2023-12-20T10:00:05+09:00 | artifact | session | name=run-plc124-20231220-100000
 - 2023-12-20T10:00:06+09:00 | status | running

--- a/test/vault/runs/plc125/20231219-140000.md
+++ b/test/vault/runs/plc125/20231219-140000.md
@@ -9,7 +9,7 @@ agent: claude
 
 - 2023-12-19T14:00:00+09:00 | status | queued
 - 2023-12-19T14:00:01+09:00 | status | booting
-- 2023-12-19T14:00:05+09:00 | artifact | worktree | path=.git-worktrees/plc125/20231219-140000
+- 2023-12-19T14:00:05+09:00 | artifact | worktree | path=.git-worktrees/plc125/fb5680_claude_20231219-140000
 - 2023-12-19T14:00:05+09:00 | artifact | branch | name=issue/plc125/run-20231219-140000
 - 2023-12-19T14:00:06+09:00 | status | running
 - 2023-12-19T14:00:10+09:00 | phase | plan


### PR DESCRIPTION
## Summary
- add a dry-run integration assertion for worktree paths using the run short ID prefix
- update sample run fixtures to include short IDs in worktree paths

Refs: orch-063