### PR TITLE
Add marketplace.json and install command for orch-toolset plugin

### DIFF
--- a/claude-plugins/orch-toolset/.claude-plugin/marketplace.json
+++ b/claude-plugins/orch-toolset/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "orch-toolset-marketplace",
+  "owner": {
+    "name": "Orch Maintainers"
+  },
+  "plugins": [
+    {
+      "name": "orch-toolset",
+      "source": ".",
+      "description": "Agent Skills for using the orch CLI to orchestrate LLM agent runs, manage issues, monitor agents, and coordinate multi-agent workflows",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/claude-plugins/orch-toolset/README.md
+++ b/claude-plugins/orch-toolset/README.md
@@ -14,32 +14,43 @@ This plugin provides Claude Code with comprehensive knowledge about using the **
 
 ## Installation
 
-### Option 1: Local Development
+### Option 1: Add as Local Marketplace (Recommended)
 
-Load the plugin directly while testing:
+Add the plugin as a local marketplace in your Claude Code settings (`~/.claude/settings.json`):
+
+```json
+{
+  "enabledPlugins": {
+    "orch-toolset@orch-toolset-marketplace": true
+  },
+  "extraKnownMarketplaces": {
+    "orch-toolset-marketplace": {
+      "source": {
+        "source": "directory",
+        "path": "/absolute/path/to/orch/claude-plugins/orch-toolset"
+      }
+    }
+  }
+}
+```
+
+Replace `/absolute/path/to/orch` with your actual orch repository path.
+
+### Option 2: Load Per-Session
+
+Load the plugin for a single session:
 
 ```bash
 claude --plugin-dir /path/to/orch/claude-plugins/orch-toolset
 ```
 
-### Option 2: From GitHub Repository
+### Option 3: GitHub Marketplace (Future)
 
-If you have the orch repository cloned:
-
-```bash
-claude --plugin-dir ./claude-plugins/orch-toolset
-```
-
-### Option 3: Marketplace Install
-
-After publishing to a Claude Code marketplace:
+After publishing to a public GitHub marketplace:
 
 ```bash
-claude plugin install orch-toolset@<marketplace>
+claude plugin install proboscis/orch-toolset
 ```
-
-For marketplace setup and publishing guidelines, see:
-https://code.claude.com/docs/en/plugin-marketplaces
 
 ## Usage
 
@@ -51,27 +62,38 @@ Skills are model-invoked - Claude will automatically use this skill when you ask
 - "How do I run tests in an agent's worktree?"
 - "What commands can I use to check on blocked runs?"
 
+### Slash Commands
+
+- `/install` - Install this plugin to your Claude Code settings (when loaded temporarily)
+
 ## Plugin Contents
 
 ```
 orch-toolset/
 ├── .claude-plugin/
-│   └── plugin.json           # Plugin metadata
+│   ├── plugin.json           # Plugin metadata
+│   └── marketplace.json      # Local marketplace definition
 ├── skills/
-│   └── orch-toolset/
-│       ├── SKILL.md          # Core orchestration guidance
-│       └── reference.md      # Detailed command reference
+│   ├── orch-toolset/
+│   │   ├── SKILL.md          # Core orchestration guidance
+│   │   └── reference.md      # Detailed command reference
+│   └── install-orch-plugin/
+│       └── SKILL.md          # Installation helper skill
+├── commands/
+│   └── install.md            # /install command
 └── README.md                 # This file
 ```
 
-### SKILL.md
+### Skills
 
-Main skill file covering:
+**orch-toolset**: Main skill covering:
 - Core workflow and design philosophy
 - Command categories (issues, runs, monitoring, communication)
 - Run lifecycle states
 - Best practices for multi-run orchestration
 - Control agent workflow
+
+**install-orch-plugin**: Helper skill for installing the plugin to user settings.
 
 ### reference.md
 

--- a/claude-plugins/orch-toolset/commands/install.md
+++ b/claude-plugins/orch-toolset/commands/install.md
@@ -1,0 +1,53 @@
+---
+name: install
+description: Install the orch-toolset plugin to Claude Code settings
+allowed-tools: Read, Write, Edit, Bash, Glob
+---
+
+# Install Orch-Toolset Plugin
+
+Install this plugin to the user's Claude Code settings so it's available in all sessions.
+
+## Instructions
+
+1. **Find the orch repository path**:
+   - Check if we're currently in the orch repo by looking for `claude-plugins/orch-toolset`
+   - Search common locations: `~/repos/orch`, `~/orch`, or use `which orch` to find it
+   - Ask the user if the path cannot be determined
+
+2. **Get the absolute plugin path**:
+   ```bash
+   PLUGIN_PATH="$(cd /path/to/orch/claude-plugins/orch-toolset && pwd)"
+   ```
+
+3. **Check user's Claude Code settings** at `~/.claude/settings.json`:
+   - If file doesn't exist, create it with the plugin
+   - If file exists, read it and check if plugin is already installed
+   - If not installed, add to the `plugins` array
+
+4. **Update the settings file**:
+   - Preserve all existing settings
+   - Add the absolute plugin path to `plugins` array
+   - Handle case where `plugins` key doesn't exist
+
+5. **Report success** and tell user to restart Claude Code
+
+## Settings File Format
+
+```json
+{
+  "plugins": [
+    "/absolute/path/to/orch/claude-plugins/orch-toolset"
+  ]
+}
+```
+
+## Error Handling
+
+- If orch repo not found: Ask user for the path
+- If plugin already installed: Inform user, no changes needed
+- If settings file has invalid JSON: Report error, don't overwrite
+
+## Execute Now
+
+Find the orch repository and install the plugin to `~/.claude/settings.json`.

--- a/claude-plugins/orch-toolset/skills/install-orch-plugin/SKILL.md
+++ b/claude-plugins/orch-toolset/skills/install-orch-plugin/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: install-orch-plugin
+description: |
+  Install the orch-toolset plugin to user's Claude Code settings.
+  Use when the user asks to "install orch plugin", "add orch skill", "setup orch for claude", or wants to make the orch toolset available in Claude Code.
+allowed-tools: Read, Write, Bash, Glob
+---
+
+# Install Orch Plugin
+
+This skill installs the orch-toolset Claude Code plugin to the user's settings.
+
+## Installation Process
+
+1. **Find the orch repository** - Locate where orch is installed
+2. **Verify plugin exists** - Check that `claude-plugins/orch-toolset` exists
+3. **Update Claude Code settings** - Add the plugin path to settings
+
+## Steps to Execute
+
+### Step 1: Find the orch repository
+
+Look for the orch repository. Common locations:
+- Current working directory or parent
+- `~/repos/orch`
+- Check if `orch` command is available and trace its location
+
+```bash
+# Check if orch is in PATH and find its location
+which orch 2>/dev/null || echo "orch not in PATH"
+
+# Or find by searching common locations
+ls -d ~/repos/orch 2>/dev/null || ls -d ~/orch 2>/dev/null || echo "Check current directory"
+```
+
+### Step 2: Verify plugin directory exists
+
+```bash
+# Replace ORCH_PATH with actual path
+ls -la ORCH_PATH/claude-plugins/orch-toolset/.claude-plugin/plugin.json
+```
+
+### Step 3: Update Claude Code settings
+
+The plugin can be added to either:
+- **User settings**: `~/.claude/settings.json` (applies to all projects)
+- **Project settings**: `.claude/settings.json` (applies to current project only)
+
+Read the existing settings file, add the plugin path to the `plugins` array, and write back.
+
+Example settings structure:
+```json
+{
+  "plugins": [
+    "/absolute/path/to/orch/claude-plugins/orch-toolset"
+  ]
+}
+```
+
+### Step 4: Verify installation
+
+After updating settings, inform the user to restart Claude Code for changes to take effect.
+
+## Important Notes
+
+- Always use **absolute paths** for plugin directories
+- Create the settings file if it doesn't exist
+- Preserve existing settings when adding the plugin
+- Don't add duplicate entries if plugin is already installed
+
+## Example Installation Flow
+
+```bash
+# 1. Find orch path (example)
+ORCH_PATH="$HOME/repos/orch"
+
+# 2. Verify plugin exists
+test -f "$ORCH_PATH/claude-plugins/orch-toolset/.claude-plugin/plugin.json" && echo "Plugin found"
+
+# 3. Get absolute path
+PLUGIN_PATH="$(cd "$ORCH_PATH/claude-plugins/orch-toolset" && pwd)"
+
+# 4. Add to settings (user level)
+# Read ~/.claude/settings.json, add PLUGIN_PATH to plugins array, write back
+```
+
+## After Installation
+
+Tell the user:
+1. Restart Claude Code (or start a new session)
+2. The orch-toolset skill will be automatically available
+3. Ask questions like "How do I start a new run?" to verify it works


### PR DESCRIPTION
## Summary

Follow-up to #102. Adds marketplace support and installation tooling for the orch-toolset Claude Code plugin.

- Add `marketplace.json` for local marketplace registration
- Add `/install` slash command to install plugin to user settings
- Add `install-orch-plugin` skill for installation guidance
- Update README with correct marketplace-based installation instructions

## Installation

The plugin can now be installed by adding to `~/.claude/settings.json`:

```json
{
  "enabledPlugins": {
    "orch-toolset@orch-toolset-marketplace": true
  },
  "extraKnownMarketplaces": {
    "orch-toolset-marketplace": {
      "source": {
        "source": "directory",
        "path": "/path/to/orch/claude-plugins/orch-toolset"
      }
    }
  }
}
```

## Test plan

- [ ] Verify marketplace.json is valid JSON
- [ ] Verify plugin loads correctly with marketplace config
- [ ] Test /install command works when plugin is loaded

Related: orch-055

🤖 Generated with [Claude Code](https://claude.com/claude-code)