### PR TITLE
Fix skill installation to use ~/.claude/skills/ symlink

### DIFF
--- a/claude-plugins/orch-toolset/README.md
+++ b/claude-plugins/orch-toolset/README.md
@@ -1,10 +1,10 @@
-# Orch Toolset - Claude Code Skill Plugin
+# Orch Toolset - Claude Code Skill
 
 Agent Skills for Claude Code that teach the orch CLI workflow: issue management, run orchestration, monitoring, and multi-agent coordination.
 
 ## Overview
 
-This plugin provides Claude Code with comprehensive knowledge about using the **orch** orchestrator CLI to:
+This skill provides Claude Code with comprehensive knowledge about using the **orch** orchestrator CLI to:
 
 - Create and manage issues
 - Start, stop, and monitor LLM agent runs
@@ -14,43 +14,39 @@ This plugin provides Claude Code with comprehensive knowledge about using the **
 
 ## Installation
 
-### Option 1: Add as Local Marketplace (Recommended)
+### Option 1: Symlink (Recommended)
 
-Add the plugin as a local marketplace in your Claude Code settings (`~/.claude/settings.json`):
+Create a symlink from the orch repo to your Claude Code skills directory:
 
-```json
-{
-  "enabledPlugins": {
-    "orch-toolset@orch-toolset-marketplace": true
-  },
-  "extraKnownMarketplaces": {
-    "orch-toolset-marketplace": {
-      "source": {
-        "source": "directory",
-        "path": "/absolute/path/to/orch/claude-plugins/orch-toolset"
-      }
-    }
-  }
-}
+```bash
+ln -s /path/to/orch/claude-plugins/orch-toolset/skills/orch-toolset ~/.claude/skills/orch-toolset
 ```
 
-Replace `/absolute/path/to/orch` with your actual orch repository path.
+### Option 2: Copy
 
-### Option 2: Load Per-Session
+Copy the skill directory:
 
-Load the plugin for a single session:
+```bash
+cp -r /path/to/orch/claude-plugins/orch-toolset/skills/orch-toolset ~/.claude/skills/
+```
+
+### Option 3: Load as Plugin (Per-Session)
+
+Load the entire plugin for a single session:
 
 ```bash
 claude --plugin-dir /path/to/orch/claude-plugins/orch-toolset
 ```
 
-### Option 3: GitHub Marketplace (Future)
+## Verification
 
-After publishing to a public GitHub marketplace:
+After installation, verify the skill is in place:
 
 ```bash
-claude plugin install proboscis/orch-toolset
+ls ~/.claude/skills/orch-toolset/SKILL.md
 ```
+
+Then **restart Claude Code** for the skill to be loaded.
 
 ## Usage
 
@@ -62,38 +58,22 @@ Skills are model-invoked - Claude will automatically use this skill when you ask
 - "How do I run tests in an agent's worktree?"
 - "What commands can I use to check on blocked runs?"
 
-### Slash Commands
-
-- `/install` - Install this plugin to your Claude Code settings (when loaded temporarily)
-
-## Plugin Contents
+## Skill Contents
 
 ```
 orch-toolset/
-├── .claude-plugin/
-│   ├── plugin.json           # Plugin metadata
-│   └── marketplace.json      # Local marketplace definition
-├── skills/
-│   ├── orch-toolset/
-│   │   ├── SKILL.md          # Core orchestration guidance
-│   │   └── reference.md      # Detailed command reference
-│   └── install-orch-plugin/
-│       └── SKILL.md          # Installation helper skill
-├── commands/
-│   └── install.md            # /install command
-└── README.md                 # This file
+├── SKILL.md          # Core orchestration guidance
+└── reference.md      # Detailed command reference
 ```
 
-### Skills
+### SKILL.md
 
-**orch-toolset**: Main skill covering:
+Main skill file covering:
 - Core workflow and design philosophy
 - Command categories (issues, runs, monitoring, communication)
 - Run lifecycle states
 - Best practices for multi-run orchestration
 - Control agent workflow
-
-**install-orch-plugin**: Helper skill for installing the plugin to user settings.
 
 ### reference.md
 
@@ -148,3 +128,8 @@ MIT
 ## Contributing
 
 Issues and PRs welcome at https://github.com/proboscis/orch
+
+## Sources
+
+- [Agent Skills - Claude Code Docs](https://code.claude.com/docs/en/skills)
+- [How to create custom Skills | Claude Help Center](https://support.claude.com/en/articles/12512198-how-to-create-custom-skills)

--- a/claude-plugins/orch-toolset/commands/install.md
+++ b/claude-plugins/orch-toolset/commands/install.md
@@ -1,53 +1,36 @@
 ---
 name: install
-description: Install the orch-toolset plugin to Claude Code settings
-allowed-tools: Read, Write, Edit, Bash, Glob
+description: Install the orch-toolset skill to ~/.claude/skills/
+allowed-tools: Bash
 ---
 
-# Install Orch-Toolset Plugin
+# Install Orch-Toolset Skill
 
-Install this plugin to the user's Claude Code settings so it's available in all sessions.
+Install this skill to the user's Claude Code skills directory so it's available in all sessions.
 
 ## Instructions
 
-1. **Find the orch repository path**:
-   - Check if we're currently in the orch repo by looking for `claude-plugins/orch-toolset`
-   - Search common locations: `~/repos/orch`, `~/orch`, or use `which orch` to find it
-   - Ask the user if the path cannot be determined
+1. **Find the orch repository path** by checking current directory or asking user
 
-2. **Get the absolute plugin path**:
+2. **Create symlink** to `~/.claude/skills/orch-toolset`:
    ```bash
-   PLUGIN_PATH="$(cd /path/to/orch/claude-plugins/orch-toolset && pwd)"
+   ln -sf /path/to/orch/claude-plugins/orch-toolset/skills/orch-toolset ~/.claude/skills/orch-toolset
    ```
 
-3. **Check user's Claude Code settings** at `~/.claude/settings.json`:
-   - If file doesn't exist, create it with the plugin
-   - If file exists, read it and check if plugin is already installed
-   - If not installed, add to the `plugins` array
+3. **Verify installation**:
+   ```bash
+   ls -la ~/.claude/skills/orch-toolset
+   ```
 
-4. **Update the settings file**:
-   - Preserve all existing settings
-   - Add the absolute plugin path to `plugins` array
-   - Handle case where `plugins` key doesn't exist
-
-5. **Report success** and tell user to restart Claude Code
-
-## Settings File Format
-
-```json
-{
-  "plugins": [
-    "/absolute/path/to/orch/claude-plugins/orch-toolset"
-  ]
-}
-```
-
-## Error Handling
-
-- If orch repo not found: Ask user for the path
-- If plugin already installed: Inform user, no changes needed
-- If settings file has invalid JSON: Report error, don't overwrite
+4. **Report success** and tell user to restart Claude Code
 
 ## Execute Now
 
-Find the orch repository and install the plugin to `~/.claude/settings.json`.
+Create a symlink from the orch repo's skill to ~/.claude/skills/orch-toolset.
+
+The orch repo is likely at one of:
+- Current working directory or parent
+- ~/repos/orch
+- The directory containing the currently loaded plugin
+
+After creating the symlink, verify it points to a directory containing SKILL.md.

--- a/claude-plugins/orch-toolset/skills/install-orch-plugin/SKILL.md
+++ b/claude-plugins/orch-toolset/skills/install-orch-plugin/SKILL.md
@@ -1,92 +1,57 @@
 ---
-name: install-orch-plugin
+name: install-orch-skill
 description: |
-  Install the orch-toolset plugin to user's Claude Code settings.
-  Use when the user asks to "install orch plugin", "add orch skill", "setup orch for claude", or wants to make the orch toolset available in Claude Code.
-allowed-tools: Read, Write, Bash, Glob
+  Install the orch-toolset skill to ~/.claude/skills/ by creating a symlink.
+  Use when user asks to "install orch skill", "add orch skill to claude", "setup orch skill", or wants to make orch-toolset available permanently.
+allowed-tools: Bash
 ---
 
-# Install Orch Plugin
+# Install Orch Skill
 
-This skill installs the orch-toolset Claude Code plugin to the user's settings.
+This skill installs the orch-toolset skill to `~/.claude/skills/` by creating a symlink.
 
-## Installation Process
+## Installation Steps
 
-1. **Find the orch repository** - Locate where orch is installed
-2. **Verify plugin exists** - Check that `claude-plugins/orch-toolset` exists
-3. **Update Claude Code settings** - Add the plugin path to settings
-
-## Steps to Execute
-
-### Step 1: Find the orch repository
-
-Look for the orch repository. Common locations:
-- Current working directory or parent
-- `~/repos/orch`
-- Check if `orch` command is available and trace its location
+Execute these commands:
 
 ```bash
-# Check if orch is in PATH and find its location
-which orch 2>/dev/null || echo "orch not in PATH"
+# 1. Find the orch repository (check common locations)
+ORCH_REPO=""
+if [ -d "$HOME/repos/orch/claude-plugins/orch-toolset/skills/orch-toolset" ]; then
+  ORCH_REPO="$HOME/repos/orch"
+elif [ -d "./claude-plugins/orch-toolset/skills/orch-toolset" ]; then
+  ORCH_REPO="$(pwd)"
+elif [ -d "../claude-plugins/orch-toolset/skills/orch-toolset" ]; then
+  ORCH_REPO="$(cd .. && pwd)"
+fi
 
-# Or find by searching common locations
-ls -d ~/repos/orch 2>/dev/null || ls -d ~/orch 2>/dev/null || echo "Check current directory"
+# 2. Create ~/.claude/skills/ if it doesn't exist
+mkdir -p ~/.claude/skills
+
+# 3. Create symlink (use -sf to overwrite if exists)
+ln -sf "$ORCH_REPO/claude-plugins/orch-toolset/skills/orch-toolset" ~/.claude/skills/orch-toolset
+
+# 4. Verify
+ls -la ~/.claude/skills/orch-toolset/SKILL.md
 ```
 
-### Step 2: Verify plugin directory exists
+## What This Does
 
-```bash
-# Replace ORCH_PATH with actual path
-ls -la ORCH_PATH/claude-plugins/orch-toolset/.claude-plugin/plugin.json
-```
-
-### Step 3: Update Claude Code settings
-
-The plugin can be added to either:
-- **User settings**: `~/.claude/settings.json` (applies to all projects)
-- **Project settings**: `.claude/settings.json` (applies to current project only)
-
-Read the existing settings file, add the plugin path to the `plugins` array, and write back.
-
-Example settings structure:
-```json
-{
-  "plugins": [
-    "/absolute/path/to/orch/claude-plugins/orch-toolset"
-  ]
-}
-```
-
-### Step 4: Verify installation
-
-After updating settings, inform the user to restart Claude Code for changes to take effect.
-
-## Important Notes
-
-- Always use **absolute paths** for plugin directories
-- Create the settings file if it doesn't exist
-- Preserve existing settings when adding the plugin
-- Don't add duplicate entries if plugin is already installed
-
-## Example Installation Flow
-
-```bash
-# 1. Find orch path (example)
-ORCH_PATH="$HOME/repos/orch"
-
-# 2. Verify plugin exists
-test -f "$ORCH_PATH/claude-plugins/orch-toolset/.claude-plugin/plugin.json" && echo "Plugin found"
-
-# 3. Get absolute path
-PLUGIN_PATH="$(cd "$ORCH_PATH/claude-plugins/orch-toolset" && pwd)"
-
-# 4. Add to settings (user level)
-# Read ~/.claude/settings.json, add PLUGIN_PATH to plugins array, write back
-```
+1. Locates the orch repository
+2. Creates `~/.claude/skills/` directory if needed
+3. Creates a symlink: `~/.claude/skills/orch-toolset` -> `<orch-repo>/claude-plugins/orch-toolset/skills/orch-toolset`
+4. Verifies the symlink points to valid SKILL.md
 
 ## After Installation
 
 Tell the user:
-1. Restart Claude Code (or start a new session)
-2. The orch-toolset skill will be automatically available
-3. Ask questions like "How do I start a new run?" to verify it works
+1. **Restart Claude Code** for the skill to be loaded
+2. The orch-toolset skill will then be available in all sessions
+3. Test by asking: "How do I start a new run with orch?"
+
+## If Orch Repo Not Found
+
+Ask the user for the path to their orch repository, then run:
+```bash
+ln -sf /path/to/orch/claude-plugins/orch-toolset/skills/orch-toolset ~/.claude/skills/orch-toolset
+```


### PR DESCRIPTION
## Summary

Fix the orch-toolset skill installation to use the correct `~/.claude/skills/` approach instead of marketplace configuration.

## Changes

- Update `/install` command to create symlink to `~/.claude/skills/`
- Update `install-orch-skill` to properly locate orch repo and create symlink
- Simplify README with correct installation instructions

## Correct Installation

Skills are installed by symlinking to `~/.claude/skills/<skill-name>`:

```bash
ln -s /path/to/orch/claude-plugins/orch-toolset/skills/orch-toolset ~/.claude/skills/orch-toolset
```

## Test plan

- [ ] Verify symlink installation works
- [ ] Verify skill loads after restart

Related: orch-055

🤖 Generated with [Claude Code](https://claude.com/claude-code)