### PR TITLE
Add ultrathink keyword to Claude agent initial prompt

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -353,7 +353,7 @@ type promptOptions struct {
 
 const (
 	promptFileName        = "ORCH_PROMPT.md"
-	promptFileInstruction = "Please read '" + promptFileName + "' in the current directory and follow the instructions found there."
+	promptFileInstruction = "ultrathink Please read '" + promptFileName + "' in the current directory and follow the instructions found there."
 )
 
 // defaultPromptTemplate is the built-in template for agent prompts

--- a/internal/monitor/agent_prompt.go
+++ b/internal/monitor/agent_prompt.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	controlPromptFileName        = "ORCH_CONTROL_PROMPT.md"
-	controlPromptFileInstruction = "Please read '" + controlPromptFileName + "' in the current directory and follow the instructions found there."
+	controlPromptFileInstruction = "ultrathink Please read '" + controlPromptFileName + "' in the current directory and follow the instructions found there."
 )
 
 // controlPromptTemplate is the template for the control agent prompt


### PR DESCRIPTION
## Summary
- Added `ultrathink` keyword to the direct input prompt passed to Claude agents at startup
- Applied to both the main issue agent (`promptFileInstruction`) and the control agent (`controlPromptFileInstruction`)
- This enables extended thinking mode for Claude agent runs

## Changes Made
- `internal/cli/run.go`: Modified `promptFileInstruction` constant to prefix the instruction with `ultrathink`
- `internal/monitor/agent_prompt.go`: Modified `controlPromptFileInstruction` constant for consistency

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Build succeeds (`go build ./...`)

References issue: orch-085

🤖 Generated with [Claude Code](https://claude.com/claude-code)