### PR TITLE
Include base_branch in agent initial prompt for PR target

### DIFF
--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -26,6 +26,19 @@ func TestBuildAgentPromptDefault(t *testing.T) {
 	}
 }
 
+func TestBuildAgentPromptWithBaseBranch(t *testing.T) {
+	issue := &model.Issue{
+		ID:    "orch-1",
+		Title: "Title",
+		Body:  "Body text",
+	}
+
+	prompt := buildAgentPrompt(issue, &promptOptions{BaseBranch: "develop"})
+	if !strings.Contains(prompt, "create a pull request targeting `develop`") {
+		t.Fatalf("prompt missing base branch in PR instructions: %q", prompt)
+	}
+}
+
 func TestBuildAgentPromptNoPR(t *testing.T) {
 	issue := &model.Issue{ID: "orch-2", Body: "Body"}
 	prompt := buildAgentPrompt(issue, &promptOptions{NoPR: true})


### PR DESCRIPTION
## Summary
- Add `BaseBranch` to the agent's initial prompt so it knows which branch to target when creating PRs
- The prompt now includes `create a pull request targeting \`{base_branch}\`` instruction
- This complements orch-086 which added base_branch support for worktree creation

## Changes
- Add `BaseBranch` field to `promptOptions` struct
- Pass `BaseBranch` when creating `promptOpts` in `runRun`
- Add `BaseBranch` to template data in `executeTemplate`
- Update `defaultPromptTemplate` to include target branch
- Update `buildSimplePrompt` to include base branch info
- Add test for `BaseBranch` in prompt

## Test plan
- [x] All existing tests pass
- [x] New test `TestBuildAgentPromptWithBaseBranch` verifies the feature
- [x] Manual verification: generated prompt now includes target branch

Fixes: orch-087

🤖 Generated with [Claude Code](https://claude.com/claude-code)