### PR TITLE
feat: Configure worktree directory location with sensible default

### DIFF
--- a/.orch/config.yaml
+++ b/.orch/config.yaml
@@ -1,5 +1,5 @@
 # orch uses itself as the vault - issues live in this repo
 vault: .
 agent: claude
-worktree_root: .git-worktrees
+worktree_dir: .git-worktrees
 base_branch: main

--- a/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
+++ b/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
@@ -146,7 +146,7 @@ Example `.orch/config.yaml`:
 ```yaml
 vault: ~/vault
 agent: claude
-worktree_root: .git-worktrees
+worktree_dir: ~/.orch/worktrees
 base_branch: main
 ```
 

--- a/claude-plugins/orch-toolset/skills/orch-toolset/reference.md
+++ b/claude-plugins/orch-toolset/skills/orch-toolset/reference.md
@@ -165,7 +165,7 @@ orch run orch-055 --agent claude --profile my-profile
 | `--run-id` | Manual run ID (default: YYYYMMDD-HHMMSS) |
 | `--base-branch` | Base branch (default: main) |
 | `--branch` | Custom branch name |
-| `--worktree-root` | Worktree location (default: .git-worktrees) |
+| `--worktree-dir` | Worktree location (default: ~/.orch/worktrees) |
 | `--repo-root` | Explicit git root |
 | `--tmux / --no-tmux` | Enable/disable tmux (default: tmux) |
 | `--tmux-session` | Custom session name |
@@ -175,7 +175,7 @@ orch run orch-055 --agent claude --profile my-profile
 **Default Conventions:**
 - RUN_ID: `YYYYMMDD-HHMMSS`
 - Branch: `issue/<ISSUE_ID>/run-<RUN_ID>`
-- Worktree: `<worktree_root>/<ISSUE_ID>/<SHORT_ID>_<AGENT>_<RUN_ID>`
+- Worktree: `<worktree_dir>/<ISSUE_ID>/<SHORT_ID>_<AGENT>_<RUN_ID>`
 - Tmux session: `run-<ISSUE_ID>-<RUN_ID>`
 
 ### orch continue RUN_REF|ISSUE_ID

--- a/internal/cli/continue.go
+++ b/internal/cli/continue.go
@@ -27,7 +27,7 @@ type continueOptions struct {
 	PromptTemplate string
 	Branch         string
 	IssueID        string
-	WorktreeRoot   string
+	WorktreeDir    string
 	RepoRoot       string
 }
 
@@ -74,7 +74,7 @@ Use --branch with an issue ID to continue from an untracked branch.`,
 	cmd.Flags().StringVar(&opts.PromptTemplate, "prompt-template", "", "Custom prompt template file")
 	cmd.Flags().StringVar(&opts.Branch, "branch", "", "Existing branch to continue from")
 	cmd.Flags().StringVar(&opts.IssueID, "issue", "", "Issue ID (required with --branch when no RUN_REF)")
-	cmd.Flags().StringVar(&opts.WorktreeRoot, "worktree-root", ".git-worktrees", "Root directory for worktrees")
+	cmd.Flags().StringVar(&opts.WorktreeDir, "worktree-dir", "", "Directory for worktrees (default: ~/.orch/worktrees)")
 	cmd.Flags().StringVar(&opts.RepoRoot, "repo-root", "", "Git repository root (default: auto-detect)")
 
 	return cmd
@@ -338,7 +338,7 @@ func continueFromBranch(st store.Store, refStr string, opts *continueOptions) er
 		agentName = "claude"
 	}
 
-	worktreePath, err := resolveWorktreeForBranch(repoRoot, branch, opts.WorktreeRoot, issueID, runID, agentName)
+	worktreePath, err := resolveWorktreeForBranch(repoRoot, branch, opts.WorktreeDir, issueID, runID, agentName)
 	if err != nil {
 		return exitWithCode(err, ExitWorktreeError)
 	}
@@ -517,6 +517,17 @@ func applyPromptConfigDefaultsForContinue(opts *continueOptions) error {
 		opts.NoPR = cfg.NoPR
 	}
 
+	// WorktreeDir: use config value if flag not provided, fallback to "~/.orch/worktrees"
+	if opts.WorktreeDir == "" {
+		if cfg.WorktreeDir != "" {
+			opts.WorktreeDir = cfg.WorktreeDir
+		} else {
+			// Default to ~/.orch/worktrees (outside repo, keeps repo clean)
+			home, _ := os.UserHomeDir()
+			opts.WorktreeDir = filepath.Join(home, ".orch", "worktrees")
+		}
+	}
+
 	return nil
 }
 
@@ -547,7 +558,7 @@ func normalizeBranchName(branch string) string {
 	return strings.TrimPrefix(branch, "refs/heads/")
 }
 
-func resolveWorktreeForBranch(repoRoot, branch, worktreeRoot, issueID, runID, agent string) (string, error) {
+func resolveWorktreeForBranch(repoRoot, branch, worktreeDir, issueID, runID, agent string) (string, error) {
 	matches, err := git.FindWorktreesByBranch(repoRoot, branch)
 	if err != nil {
 		return "", fmt.Errorf("failed to list worktrees: %w", err)
@@ -584,12 +595,12 @@ func resolveWorktreeForBranch(repoRoot, branch, worktreeRoot, issueID, runID, ag
 	}
 
 	result, err := git.CreateWorktreeFromBranch(&git.WorktreeConfig{
-		RepoRoot:     repoRoot,
-		WorktreeRoot: worktreeRoot,
-		IssueID:      issueID,
-		RunID:        runID,
-		Agent:        agent,
-		Branch:       branch,
+		RepoRoot:    repoRoot,
+		WorktreeDir: worktreeDir,
+		IssueID:     issueID,
+		RunID:       runID,
+		Agent:       agent,
+		Branch:      branch,
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create worktree: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,7 +75,7 @@ func TestParentConfigPrecedence(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("ORCH_VAULT", "/env")
 	t.Setenv("ORCH_AGENT", "gemini")
-	t.Setenv("ORCH_WORKTREE_ROOT", "/env-worktrees")
+	t.Setenv("ORCH_WORKTREE_DIR", "/env-worktrees")
 
 	repo := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repo, ".orch"), 0755); err != nil {
@@ -108,8 +108,8 @@ func TestParentConfigPrecedence(t *testing.T) {
 	if cfg.Vault != "/parent" || cfg.Agent != "claude" {
 		t.Fatalf("unexpected parent config: %+v", cfg)
 	}
-	if cfg.WorktreeRoot != "/env-worktrees" {
-		t.Fatalf("unexpected env worktree_root: %q", cfg.WorktreeRoot)
+	if cfg.WorktreeDir != "/env-worktrees" {
+		t.Fatalf("unexpected env worktree_dir: %q", cfg.WorktreeDir)
 	}
 
 	if err := os.MkdirAll(filepath.Join(child, ".orch"), 0755); err != nil {
@@ -126,8 +126,8 @@ func TestParentConfigPrecedence(t *testing.T) {
 	if cfgLocal.Vault != "/local" || cfgLocal.Agent != "claude" {
 		t.Fatalf("unexpected local config: %+v", cfgLocal)
 	}
-	if cfgLocal.WorktreeRoot != "/env-worktrees" {
-		t.Fatalf("unexpected env worktree_root (local): %q", cfgLocal.WorktreeRoot)
+	if cfgLocal.WorktreeDir != "/env-worktrees" {
+		t.Fatalf("unexpected env worktree_dir (local): %q", cfgLocal.WorktreeDir)
 	}
 }
 
@@ -299,7 +299,7 @@ func TestRelativeVaultPathResolution(t *testing.T) {
 	// Clear environment variables that could interfere
 	t.Setenv("ORCH_VAULT", "")
 	t.Setenv("ORCH_AGENT", "")
-	t.Setenv("ORCH_WORKTREE_ROOT", "")
+	t.Setenv("ORCH_WORKTREE_DIR", "")
 	t.Setenv("ORCH_PROMPT_TEMPLATE", "")
 
 	// Create a temp home directory to avoid loading user's global config
@@ -355,7 +355,7 @@ func TestRelativePathFromSubdirectory(t *testing.T) {
 	// Clear environment variables
 	t.Setenv("ORCH_VAULT", "")
 	t.Setenv("ORCH_AGENT", "")
-	t.Setenv("ORCH_WORKTREE_ROOT", "")
+	t.Setenv("ORCH_WORKTREE_DIR", "")
 
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -372,7 +372,7 @@ func TestRelativePathFromSubdirectory(t *testing.T) {
 		t.Fatalf("mkdir subdir: %v", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(repo, ".orch", "config.yaml"), []byte("vault: ./VAULT\nworktree_root: .git-worktrees\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(repo, ".orch", "config.yaml"), []byte("vault: ./VAULT\nworktree_dir: .git-worktrees\n"), 0644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -407,14 +407,14 @@ func TestRelativePathFromSubdirectory(t *testing.T) {
 		t.Fatalf("vault not resolved relative to repo root: got %q, want %q", gotVault, expectedVault)
 	}
 
-	// WorktreeRoot directory doesn't exist, so we can't use EvalSymlinks
+	// WorktreeDir directory doesn't exist, so we can't use EvalSymlinks
 	// But we need to handle the /private symlink on macOS
 	// The easiest way is to check if the path ends correctly
 	expectedSuffix := ".git-worktrees"
-	if !filepath.IsAbs(cfg.WorktreeRoot) {
-		t.Fatalf("worktree_root should be absolute: got %q", cfg.WorktreeRoot)
+	if !filepath.IsAbs(cfg.WorktreeDir) {
+		t.Fatalf("worktree_dir should be absolute: got %q", cfg.WorktreeDir)
 	}
-	if filepath.Base(cfg.WorktreeRoot) != expectedSuffix {
-		t.Fatalf("worktree_root should end with %q: got %q", expectedSuffix, cfg.WorktreeRoot)
+	if filepath.Base(cfg.WorktreeDir) != expectedSuffix {
+		t.Fatalf("worktree_dir should end with %q: got %q", expectedSuffix, cfg.WorktreeDir)
 	}
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -15,7 +15,7 @@ var execCommand = exec.Command
 // WorktreeConfig holds configuration for worktree creation
 type WorktreeConfig struct {
 	RepoRoot     string
-	WorktreeRoot string
+	WorktreeDir  string
 	IssueID      string
 	RunID        string
 	Agent        string
@@ -40,7 +40,7 @@ type WorktreeInfo struct {
 func normalizeWorktreePath(cfg *WorktreeConfig) error {
 	if cfg.WorktreePath == "" {
 		worktreeName := model.GenerateWorktreeName(cfg.IssueID, cfg.RunID, cfg.Agent)
-		cfg.WorktreePath = filepath.Join(cfg.WorktreeRoot, cfg.IssueID, worktreeName)
+		cfg.WorktreePath = filepath.Join(cfg.WorktreeDir, cfg.IssueID, worktreeName)
 	}
 
 	if filepath.IsAbs(cfg.WorktreePath) {

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -74,7 +74,7 @@ func TestCreateWorktree(t *testing.T) {
 
 	result, err := CreateWorktree(&WorktreeConfig{
 		RepoRoot:     repo,
-		WorktreeRoot: worktreeRoot,
+		WorktreeDir: worktreeRoot,
 		IssueID:      "issue",
 		RunID:        "run",
 		Agent:        "claude",
@@ -137,7 +137,7 @@ func TestCreateWorktreeRelativeRootUsesRepoRoot(t *testing.T) {
 
 	result, err := CreateWorktree(&WorktreeConfig{
 		RepoRoot:     repo,
-		WorktreeRoot: ".git-worktrees",
+		WorktreeDir: ".git-worktrees",
 		IssueID:      "issue",
 		RunID:        "run",
 		Agent:        "claude",
@@ -185,7 +185,7 @@ func TestCreateWorktreeFromBranch(t *testing.T) {
 	worktreeRoot := filepath.Join(repo, ".git-worktrees")
 	result, err := CreateWorktreeFromBranch(&WorktreeConfig{
 		RepoRoot:     repo,
-		WorktreeRoot: worktreeRoot,
+		WorktreeDir: worktreeRoot,
 		IssueID:      "issue",
 		RunID:        "run",
 		Agent:        "claude",
@@ -216,7 +216,7 @@ func TestListWorktreeInfos(t *testing.T) {
 	worktreeRoot := filepath.Join(repo, ".git-worktrees")
 	result, err := CreateWorktree(&WorktreeConfig{
 		RepoRoot:     repo,
-		WorktreeRoot: worktreeRoot,
+		WorktreeDir: worktreeRoot,
 		IssueID:      "issue",
 		RunID:        "run",
 		Agent:        "claude",
@@ -243,7 +243,7 @@ func TestFindWorktreesByBranch(t *testing.T) {
 	worktreeRoot := filepath.Join(repo, ".git-worktrees")
 	result, err := CreateWorktree(&WorktreeConfig{
 		RepoRoot:     repo,
-		WorktreeRoot: worktreeRoot,
+		WorktreeDir: worktreeRoot,
 		IssueID:      "issue",
 		RunID:        "run",
 		Agent:        "claude",

--- a/specs/03-commands.md
+++ b/specs/03-commands.md
@@ -41,7 +41,7 @@
 | `--agent-cmd` | custom時の起動コマンド |
 | `--base-branch main` | デフォルトmain |
 | `--branch` | 省略時は規約生成 |
-| `--worktree-root` | 例: .git-worktrees |
+| `--worktree-dir` | ワークツリーディレクトリ（デフォルト: ~/.orch/worktrees） |
 | `--repo-root` | git rootを明示（省略時は探索） |
 | `--tmux / --no-tmux` | デフォルトtmux |
 | `--tmux-session` | 省略時は規約生成 |
@@ -51,7 +51,7 @@
 
 - RUN_ID = `YYYYMMDD-HHMMSS`
 - branch = `issue/<ISSUE_ID>/run-<RUN_ID>`
-- worktree_path = `<worktree_root>/<ISSUE_ID>/<RUN_SHORT>_<AGENT>_<RUN_ID>`（RUN_SHORT = 6桁hex）
+- worktree_path = `<worktree_dir>/<ISSUE_ID>/<RUN_SHORT>_<AGENT>_<RUN_ID>`（RUN_SHORT = 6桁hex）
 - tmux_session = `run-<ISSUE_ID>-<RUN_ID>`
 
 ### 副作用
@@ -80,7 +80,7 @@
 | `--no-pr` | PR作成指示を省略 |
 | `--branch` | 既存branchから継続する場合に指定 |
 | `--issue` | `--branch` 使用時のissue ID（引数がISSUE_IDなら省略可） |
-| `--worktree-root` | worktree配置先（デフォルト: `.git-worktrees`） |
+| `--worktree-dir` | worktree配置先（デフォルト: `~/.orch/worktrees`） |
 | `--repo-root` | git rootを明示（省略時は探索） |
 
 ### 挙動

--- a/specs/07-config.md
+++ b/specs/07-config.md
@@ -35,8 +35,8 @@ vault: .
 # default agent
 agent: claude
 
-# worktree settings
-worktree_root: .git-worktrees
+# worktree directory (default: ~/.orch/worktrees)
+worktree_dir: ~/.orch/worktrees
 
 # base branch for new runs
 base_branch: main

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -491,7 +491,7 @@ func TestRunWithTmux(t *testing.T) {
 		"--run-id", runID,
 		"--agent", "custom",
 		"--agent-cmd", "echo 'test'; sleep 1",
-		"--worktree-root", filepath.Join(testRepo, ".git-worktrees"),
+		"--worktree-dir", filepath.Join(testRepo, ".git-worktrees"),
 		"--repo-root", testRepo,
 		"--json",
 	)


### PR DESCRIPTION
## Summary

- Add configurable worktree directory location with sensible default (`~/.orch/worktrees/`)
- Rename `worktree_root` to `worktree_dir` in config and CLI (with backwards compatibility)
- Support both absolute and relative paths for worktree directory

### Changes

- **Config**: `worktree_dir` replaces `worktree_root` (legacy key still supported)
- **CLI**: `--worktree-dir` flag for `orch run` and `orch continue`
- **Default**: Changed from `.git-worktrees` (inside repo) to `~/.orch/worktrees/` (outside repo)
- **Path handling**: Absolute paths used directly; relative paths joined with repo root

### Priority order

1. CLI option `--worktree-dir` (highest)
2. Config file `worktree_dir` setting
3. Default `~/.orch/worktrees/`

### Benefits

- Keeps the repository directory clean
- Allows placing worktrees on faster storage
- Centralizes worktrees across multiple orch-managed repos
- Easier cleanup of old worktrees

## Test plan

- [x] Unit tests updated and passing
- [x] Integration tests updated
- [x] Documentation updated (specs, config examples, plugin reference)
- [x] Binary builds successfully
- [x] Help text shows new default

Fixes: orch-090

🤖 Generated with [Claude Code](https://claude.com/claude-code)