### PR TITLE
feat(monitor): open issue file with $EDITOR when pressing Enter

### DIFF
--- a/internal/monitor/issue_keymap.go
+++ b/internal/monitor/issue_keymap.go
@@ -7,6 +7,7 @@ type IssueKeyMap struct {
 	Runs        string
 	Issues      string
 	Chat        string
+	EditIssue   string
 	OpenRun     string
 	StartRun    string
 	ContinueRun string
@@ -24,7 +25,8 @@ func DefaultIssueKeyMap() IssueKeyMap {
 		Runs:        "g",
 		Issues:      "i",
 		Chat:        "c",
-		OpenRun:     "enter",
+		EditIssue:   "enter",
+		OpenRun:     "O",
 		StartRun:    "r",
 		ContinueRun: "C",
 		Open:        "o",
@@ -38,6 +40,6 @@ func DefaultIssueKeyMap() IssueKeyMap {
 
 // HelpLine renders the footer help text.
 func (k IssueKeyMap) HelpLine() string {
-	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open run  [%s] start run  [%s] continue  [%s] open  [%s] resolve  [%s] filter  [%s] sort  [%s] quit  [%s] help",
-		k.Runs, k.Issues, k.Chat, k.OpenRun, k.StartRun, k.ContinueRun, k.Open, k.Resolve, k.Filter, k.Sort, k.Quit, k.Help)
+	return fmt.Sprintf("[%s] edit  [%s] runs  [%s] issues  [%s] chat  [%s] open run  [%s] start run  [%s] continue  [%s] open  [%s] resolve  [%s] filter  [%s] sort  [%s] quit  [%s] help",
+		k.EditIssue, k.Runs, k.Issues, k.Chat, k.OpenRun, k.StartRun, k.ContinueRun, k.Open, k.Resolve, k.Filter, k.Sort, k.Quit, k.Help)
 }


### PR DESCRIPTION
## Summary

- Adds Enter key binding to open the selected issue file in `$EDITOR`
- Suspends the TUI while the editor is open
- Automatically refreshes the issue list after the editor closes (in case the user modified the issue)
- Remaps "Open Run" from Enter to `O` (capital O) to avoid key conflict

## Key Changes

- `internal/monitor/issue_keymap.go`: Added `EditIssue` key binding to Enter, moved `OpenRun` to `O`
- `internal/monitor/issues_dashboard.go`: Added `editIssueInEditorCmd()` using `tea.ExecProcess` to properly suspend the TUI

## Behavior

1. User presses Enter on a selected issue
2. TUI is suspended and `$EDITOR` (or vim fallback) opens the issue file
3. After editor closes, TUI resumes and issue list refreshes

Resolves: orch-091

## Test plan

- [x] Build succeeds (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [ ] Manual test: Press Enter on issue → opens in editor → returns to dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)