### PR TITLE
feat(monitor): add P keybinding to open PR in browser

### DIFF
--- a/internal/monitor/keymap.go
+++ b/internal/monitor/keymap.go
@@ -13,6 +13,7 @@ type KeyMap struct {
 	NewRun      string
 	Resolve     string
 	Merge       string
+	OpenPR      string
 	Refresh     string
 	Sort        string
 	Filter      string
@@ -33,6 +34,7 @@ func DefaultKeyMap() KeyMap {
 		NewRun:      "n",
 		Resolve:     "R",
 		Merge:       "M",
+		OpenPR:      "P",
 		Refresh:     "r",
 		Sort:        "S",
 		Filter:      "f",
@@ -44,6 +46,6 @@ func DefaultKeyMap() KeyMap {
 
 // HelpLine renders the footer help text.
 func (k KeyMap) HelpLine() string {
-	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] exec  [%s] stop  [%s] new  [%s] resolve  [%s] merge  [%s] refresh  [%s] sort  [%s] filter  [%s] presets  [%s] quit  [%s] help",
-		k.Runs, k.Issues, k.Chat, k.Open, k.Exec, k.Stop, k.NewRun, k.Resolve, k.Merge, k.Refresh, k.Sort, k.Filter, k.QuickFilter, k.Quit, k.Help)
+	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] exec  [%s] stop  [%s] new  [%s] resolve  [%s] merge  [%s] pr  [%s] refresh  [%s] sort  [%s] filter  [%s] presets  [%s] quit  [%s] help",
+		k.Runs, k.Issues, k.Chat, k.Open, k.Exec, k.Stop, k.NewRun, k.Resolve, k.Merge, k.OpenPR, k.Refresh, k.Sort, k.Filter, k.QuickFilter, k.Quit, k.Help)
 }


### PR DESCRIPTION
## Summary

- Add `P` keybinding to the orch monitor ps dashboard that opens the associated PR in the default web browser
- Uses OS-native browser opener (open on macOS, xdg-open on Linux, cmd/start on Windows)
- Shows appropriate error message if no PR is associated with the selected run

## Changes

- `internal/monitor/keymap.go`: Add `OpenPR` field to KeyMap struct with default value `P`
- `internal/monitor/dashboard.go`: 
  - Add handler case for `P` keybinding in `handleDashboardKey`
  - Add `openPRCmd` function that validates PR URL and opens browser
  - Add `openURL` utility function for cross-platform browser opening
  - Update help text to document the new keybinding

## Test plan

- [x] Build succeeds (`go build ./...`)
- [x] All existing tests pass (`go test ./...`)
- [ ] Manual: Run `orch monitor ps`, select a run with an associated PR, press `P` - browser opens PR page
- [ ] Manual: Select a run without a PR, press `P` - shows "no PR associated with this run" message

## References

Closes: orch-096

🤖 Generated with [Claude Code](https://claude.com/claude-code)