### PR TITLE
feat(monitor): add keybinding to view PR diff in terminal

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,19 +16,21 @@ type Config struct {
 	LogLevel       string `yaml:"log_level"`
 	PromptTemplate string `yaml:"prompt_template"` // Path to custom prompt template
 	NoPR           bool   `yaml:"no_pr"`           // Disable PR instructions by default
+	PRViewer       string `yaml:"pr_viewer"`       // Preferred PR diff viewer: octo, gh-diff, pager
 }
 
 type fileConfig struct {
-	Vault           string `yaml:"vault"`
-	VaultLegacy     string `yaml:"Vault"`
-	DefaultVault    string `yaml:"default_vault"`
-	Agent           string `yaml:"agent"`
-	WorktreeDir     string `yaml:"worktree_dir"`
+	Vault             string `yaml:"vault"`
+	VaultLegacy       string `yaml:"Vault"`
+	DefaultVault      string `yaml:"default_vault"`
+	Agent             string `yaml:"agent"`
+	WorktreeDir       string `yaml:"worktree_dir"`
 	WorktreeDirLegacy string `yaml:"worktree_root"` // Legacy name for backwards compatibility
-	BaseBranch      string `yaml:"base_branch"`
-	LogLevel        string `yaml:"log_level"`
-	PromptTemplate  string `yaml:"prompt_template"`
-	NoPR            *bool  `yaml:"no_pr"`
+	BaseBranch        string `yaml:"base_branch"`
+	LogLevel          string `yaml:"log_level"`
+	PromptTemplate    string `yaml:"prompt_template"`
+	NoPR              *bool  `yaml:"no_pr"`
+	PRViewer          string `yaml:"pr_viewer"`
 }
 
 // configFile is the name of the config file
@@ -187,6 +189,9 @@ func loadFromFile(path string, cfg *Config) error {
 	if fileCfg.NoPR != nil {
 		cfg.NoPR = *fileCfg.NoPR
 	}
+	if fileCfg.PRViewer != "" {
+		cfg.PRViewer = fileCfg.PRViewer
+	}
 
 	return nil
 }
@@ -238,6 +243,9 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("ORCH_NO_PR"); v != "" {
 		cfg.NoPR = v == "true" || v == "1" || v == "yes"
+	}
+	if v := os.Getenv("ORCH_PR_VIEWER"); v != "" {
+		cfg.PRViewer = v
 	}
 }
 

--- a/internal/monitor/keymap.go
+++ b/internal/monitor/keymap.go
@@ -9,6 +9,7 @@ type KeyMap struct {
 	Chat        string
 	Open        string
 	Exec        string
+	Diff        string
 	Stop        string
 	NewRun      string
 	Resolve     string
@@ -29,6 +30,7 @@ func DefaultKeyMap() KeyMap {
 		Chat:        "c",
 		Open:        "enter",
 		Exec:        "e",
+		Diff:        "d",
 		Stop:        "s",
 		NewRun:      "n",
 		Resolve:     "R",
@@ -44,6 +46,6 @@ func DefaultKeyMap() KeyMap {
 
 // HelpLine renders the footer help text.
 func (k KeyMap) HelpLine() string {
-	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] exec  [%s] stop  [%s] new  [%s] resolve  [%s] merge  [%s] refresh  [%s] sort  [%s] filter  [%s] presets  [%s] quit  [%s] help",
-		k.Runs, k.Issues, k.Chat, k.Open, k.Exec, k.Stop, k.NewRun, k.Resolve, k.Merge, k.Refresh, k.Sort, k.Filter, k.QuickFilter, k.Quit, k.Help)
+	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] exec  [%s] diff  [%s] stop  [%s] new  [%s] resolve  [%s] merge  [%s] refresh  [%s] sort  [%s] filter  [%s] presets  [%s] quit  [%s] help",
+		k.Runs, k.Issues, k.Chat, k.Open, k.Exec, k.Diff, k.Stop, k.NewRun, k.Resolve, k.Merge, k.Refresh, k.Sort, k.Filter, k.QuickFilter, k.Quit, k.Help)
 }


### PR DESCRIPTION
## Summary

- Add `d` keybinding to runs dashboard that opens PR diff in terminal viewer
- Implement intelligent fallback chain: octo.nvim → $EDITOR → $PAGER/less
- Add optional `pr_viewer` config option (octo, gh-diff, pager)
- Show appropriate error message when run has no PR

Closes: orch-097

## Configuration (optional)

```yaml
# .orch/config.yaml
monitor:
  pr_viewer: octo  # or "gh-diff", "pager"
```

Or via environment variable: `ORCH_PR_VIEWER=gh-diff`

## Test plan

- [ ] Press `d` on a run with PR → opens diff viewer
- [ ] Press `d` on a run without PR → shows error message
- [ ] Press `d` on a run without branch → shows error message
- [ ] Configure `pr_viewer: pager` → uses pager fallback directly
- [ ] With nvim installed → tries octo.nvim first
- [ ] Without nvim but with $EDITOR → uses editor with diff syntax
- [ ] Without nvim or $EDITOR → falls back to pager

🤖 Generated with [Claude Code](https://claude.com/claude-code)