### PR TITLE
feat(monitor): add 'o' keybinding to open issue file in ps dashboard

### DIFF
--- a/internal/monitor/keymap.go
+++ b/internal/monitor/keymap.go
@@ -8,6 +8,7 @@ type KeyMap struct {
 	Issues      string
 	Chat        string
 	Open        string
+	OpenIssue   string
 	Exec        string
 	Stop        string
 	NewRun      string
@@ -28,6 +29,7 @@ func DefaultKeyMap() KeyMap {
 		Issues:      "i",
 		Chat:        "c",
 		Open:        "enter",
+		OpenIssue:   "o",
 		Exec:        "e",
 		Stop:        "s",
 		NewRun:      "n",
@@ -44,6 +46,6 @@ func DefaultKeyMap() KeyMap {
 
 // HelpLine renders the footer help text.
 func (k KeyMap) HelpLine() string {
-	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] exec  [%s] stop  [%s] new  [%s] resolve  [%s] merge  [%s] refresh  [%s] sort  [%s] filter  [%s] presets  [%s] quit  [%s] help",
-		k.Runs, k.Issues, k.Chat, k.Open, k.Exec, k.Stop, k.NewRun, k.Resolve, k.Merge, k.Refresh, k.Sort, k.Filter, k.QuickFilter, k.Quit, k.Help)
+	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] issue  [%s] exec  [%s] stop  [%s] new  [%s] resolve  [%s] merge  [%s] refresh  [%s] sort  [%s] filter  [%s] presets  [%s] quit  [%s] help",
+		k.Runs, k.Issues, k.Chat, k.Open, k.OpenIssue, k.Exec, k.Stop, k.NewRun, k.Resolve, k.Merge, k.Refresh, k.Sort, k.Filter, k.QuickFilter, k.Quit, k.Help)
 }


### PR DESCRIPTION
## Summary

- Add `o` keybinding to ps (runs) dashboard to open issue file in $EDITOR
- Resolves issue ID from selected run and opens the corresponding issue file
- Uses `tea.ExecProcess` to properly suspend TUI while editor is open
- Falls back to `vim` if `$EDITOR` environment variable is not set
- Displays error message if issue file is not found

Refs: orch-098

## Test plan

- [x] Build project successfully (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [ ] Manual test: Select a run in ps dashboard and press `o` to open issue in editor
- [ ] Verify TUI resumes properly after closing editor
- [ ] Verify error message displays if issue file not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)