### PR TITLE
feat: add configurable default agent/model and model discovery

### DIFF
--- a/internal/cli/continue.go
+++ b/internal/cli/continue.go
@@ -335,10 +335,7 @@ func continueFromBranch(st store.Store, refStr string, opts *continueOptions) er
 		tmuxSession = model.GenerateTmuxSession(issueID, runID)
 	}
 
-	agentName := opts.Agent
-	if agentName == "" {
-		agentName = "claude"
-	}
+	agentName := opts.Agent // Already set via applyPromptConfigDefaultsForContinue
 
 	worktreePath, err := resolveWorktreeForBranch(repoRoot, branch, opts.WorktreeDir, issueID, runID, agentName)
 	if err != nil {
@@ -510,6 +507,15 @@ func applyPromptConfigDefaultsForContinue(opts *continueOptions) error {
 	cfg, err := config.Load()
 	if err != nil {
 		return err
+	}
+
+	// Agent: use config value if flag not provided, fallback to "claude"
+	if opts.Agent == "" {
+		if cfg.Agent != "" {
+			opts.Agent = cfg.Agent
+		} else {
+			opts.Agent = "claude"
+		}
 	}
 
 	if opts.PromptTemplate == "" && cfg.PromptTemplate != "" {

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -1,0 +1,217 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/s22625/orch/internal/agent"
+	"github.com/spf13/cobra"
+)
+
+type modelsOptions struct {
+	Agent string
+	Port  int
+}
+
+func newModelsCmd() *cobra.Command {
+	opts := &modelsOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "models",
+		Short: "List available models and variants",
+		Long: `List available models and their thinking variants for opencode.
+
+This command queries a running opencode server for available models.
+If no server is running, it will report that.
+
+Example output:
+  Provider: anthropic
+    claude-opus-4-5
+      variants: default, high, max
+    claude-sonnet-4-5
+      variants: default, high, max
+
+Use with --json for machine-readable output.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runModels(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Agent, "agent", "a", "opencode", "Agent type (only opencode currently supported)")
+	cmd.Flags().IntVar(&opts.Port, "port", 4096, "OpenCode server port")
+
+	return cmd
+}
+
+// modelInfo represents a model with its variants for output
+type modelInfo struct {
+	Provider string   `json:"provider"`
+	Model    string   `json:"model"`
+	Name     string   `json:"name,omitempty"`
+	Variants []string `json:"variants,omitempty"`
+}
+
+type modelsResult struct {
+	OK       bool        `json:"ok"`
+	Agent    string      `json:"agent"`
+	Models   []modelInfo `json:"models,omitempty"`
+	Error    string      `json:"error,omitempty"`
+	Fallback bool        `json:"fallback,omitempty"` // True if showing hardcoded defaults
+}
+
+func runModels(opts *modelsOptions) error {
+	if opts.Agent != "opencode" {
+		return fmt.Errorf("models command currently only supports opencode agent")
+	}
+
+	result := &modelsResult{
+		OK:    true,
+		Agent: opts.Agent,
+	}
+
+	// Try to connect to a running opencode server
+	client := agent.NewOpenCodeClient(opts.Port)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Check for running server in port range
+	serverPort := findRunningOpenCodeServer(opts.Port, opts.Port+100)
+	if serverPort == 0 {
+		// No server running - show fallback defaults
+		result.Models = getDefaultModels()
+		result.Fallback = true
+		return outputModelsResult(result)
+	}
+
+	// Use the found port
+	client = agent.NewOpenCodeClient(serverPort)
+	providers, err := client.GetProviders(ctx)
+	if err != nil {
+		// Server running but can't get providers - show fallback
+		result.Models = getDefaultModels()
+		result.Fallback = true
+		return outputModelsResult(result)
+	}
+
+	// Convert providers to model info
+	models := []modelInfo{}
+	for _, provider := range providers.All {
+		for _, m := range provider.Models {
+			info := modelInfo{
+				Provider: provider.ID,
+				Model:    m.ID,
+				Name:     m.Name,
+				Variants: m.Variants,
+			}
+			models = append(models, info)
+		}
+	}
+
+	// Sort by provider then model
+	sort.Slice(models, func(i, j int) bool {
+		if models[i].Provider != models[j].Provider {
+			return models[i].Provider < models[j].Provider
+		}
+		return models[i].Model < models[j].Model
+	})
+
+	result.Models = models
+	return outputModelsResult(result)
+}
+
+func outputModelsResult(result *modelsResult) error {
+	if globalOpts.JSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	if !result.OK {
+		return fmt.Errorf("%s", result.Error)
+	}
+
+	if result.Fallback {
+		fmt.Println("Note: No opencode server running. Showing default models.")
+		fmt.Println("Start a server with 'opencode serve' for live model discovery.")
+		fmt.Println()
+	}
+
+	// Group by provider for display
+	providerModels := make(map[string][]modelInfo)
+	for _, m := range result.Models {
+		providerModels[m.Provider] = append(providerModels[m.Provider], m)
+	}
+
+	// Sort provider names
+	providers := make([]string, 0, len(providerModels))
+	for p := range providerModels {
+		providers = append(providers, p)
+	}
+	sort.Strings(providers)
+
+	for _, provider := range providers {
+		fmt.Printf("Provider: %s\n", provider)
+		for _, m := range providerModels[provider] {
+			// Display model ID
+			fmt.Printf("  %s/%s\n", provider, m.Model)
+			// Display variants if any
+			if len(m.Variants) > 0 {
+				fmt.Printf("    variants: %s\n", strings.Join(m.Variants, ", "))
+			}
+		}
+		fmt.Println()
+	}
+
+	return nil
+}
+
+// getDefaultModels returns hardcoded default models when no server is available
+func getDefaultModels() []modelInfo {
+	return []modelInfo{
+		{
+			Provider: "anthropic",
+			Model:    "claude-opus-4-5",
+			Variants: []string{"default", "high", "max"},
+		},
+		{
+			Provider: "anthropic",
+			Model:    "claude-sonnet-4-5",
+			Variants: []string{"default", "high", "max"},
+		},
+		{
+			Provider: "anthropic",
+			Model:    "claude-haiku-4-5",
+			Variants: []string{"default", "high", "max"},
+		},
+		{
+			Provider: "openai",
+			Model:    "gpt-4o",
+			Variants: []string{},
+		},
+		{
+			Provider: "openai",
+			Model:    "o1-preview",
+			Variants: []string{},
+		},
+		{
+			Provider: "openai",
+			Model:    "o1-mini",
+			Variants: []string{},
+		},
+		{
+			Provider: "google",
+			Model:    "gemini-2.5-pro",
+			Variants: []string{"low", "high", "max"},
+		},
+		{
+			Provider: "google",
+			Model:    "gemini-2.5-flash",
+			Variants: []string{"low", "high", "max"},
+		},
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -44,6 +44,7 @@ var noDaemonCommands = map[string]bool{
 	"delete":     true,
 	"help":       true,
 	"completion": true,
+	"models":     true,
 }
 
 // rootCmd represents the base command
@@ -93,6 +94,7 @@ func init() {
 	rootCmd.AddCommand(newSendCmd())
 	rootCmd.AddCommand(newCaptureCmd())
 	rootCmd.AddCommand(newCaptureAllCmd())
+	rootCmd.AddCommand(newModelsCmd())
 }
 
 // Execute runs the root command

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -580,6 +580,16 @@ func applyPromptConfigDefaults(opts *runOptions) error {
 		opts.NoPR = cfg.NoPR
 	}
 
+	// Model: use config value if flag not provided (for opencode agent)
+	if opts.Model == "" && cfg.Model != "" {
+		opts.Model = cfg.Model
+	}
+
+	// ModelVariant: use config value if flag not provided
+	if opts.ModelVariant == "" && cfg.ModelVariant != "" {
+		opts.ModelVariant = cfg.ModelVariant
+	}
+
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 type Config struct {
 	Vault          string `yaml:"vault"`
 	Agent          string `yaml:"agent"`
+	Model          string `yaml:"model"`         // Default model in provider/model format (e.g., anthropic/claude-opus-4-5)
+	ModelVariant   string `yaml:"model_variant"` // Default model variant (e.g., "max" for extended thinking)
 	WorktreeDir    string `yaml:"worktree_dir"`
 	BaseBranch     string `yaml:"base_branch"`
 	PRTargetBranch string `yaml:"pr_target_branch"`
@@ -24,6 +26,8 @@ type fileConfig struct {
 	VaultLegacy       string `yaml:"Vault"`
 	DefaultVault      string `yaml:"default_vault"`
 	Agent             string `yaml:"agent"`
+	Model             string `yaml:"model"`         // Default model in provider/model format
+	ModelVariant      string `yaml:"model_variant"` // Default model variant (e.g., "max")
 	WorktreeDir       string `yaml:"worktree_dir"`
 	WorktreeDirLegacy string `yaml:"worktree_root"` // Legacy name for backwards compatibility
 	BaseBranch        string `yaml:"base_branch"`
@@ -170,6 +174,12 @@ func loadFromFile(path string, cfg *Config) error {
 	if fileCfg.Agent != "" {
 		cfg.Agent = fileCfg.Agent
 	}
+	if fileCfg.Model != "" {
+		cfg.Model = fileCfg.Model
+	}
+	if fileCfg.ModelVariant != "" {
+		cfg.ModelVariant = fileCfg.ModelVariant
+	}
 	worktreeDir := fileCfg.WorktreeDir
 	if worktreeDir == "" {
 		worktreeDir = fileCfg.WorktreeDirLegacy // Support legacy worktree_root
@@ -226,6 +236,12 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("ORCH_AGENT"); v != "" {
 		cfg.Agent = v
+	}
+	if v := os.Getenv("ORCH_MODEL"); v != "" {
+		cfg.Model = v
+	}
+	if v := os.Getenv("ORCH_MODEL_VARIANT"); v != "" {
+		cfg.ModelVariant = v
 	}
 	if v := os.Getenv("ORCH_WORKTREE_DIR"); v != "" {
 		cfg.WorktreeDir = v


### PR DESCRIPTION
## Summary

- Add `model` and `model_variant` config fields for setting default OpenCode model preferences
- Add `orch models` command for discovering available models from OpenCode server
- Apply config defaults for agent in run and continue commands

## Changes

### Config (`internal/config/config.go`)
- Added `Model` field for default model in `provider/model` format (e.g., `anthropic/claude-opus-4-5`)
- Added `ModelVariant` field for default thinking variant (e.g., `max`)
- Support `ORCH_MODEL` and `ORCH_MODEL_VARIANT` environment variables

### Model Discovery (`internal/cli/models.go`)
- New `orch models` command that queries OpenCode server for available models
- Shows providers, models, and available thinking variants
- Falls back to hardcoded defaults when no server is running
- Supports `--json` for machine-readable output

### Commands
- `orch run` now reads `model` and `model_variant` from config
- `orch continue` now reads `agent` from config with proper fallback

### Example Config

```yaml
# .orch/config.yaml
agent: opencode
model: anthropic/claude-opus-4-5
model_variant: max
```

### Example Output

```
$ orch models
Provider: anthropic
  anthropic/claude-opus-4-5
    variants: default, high, max
  anthropic/claude-sonnet-4-5
    variants: default, high, max

Provider: openai
  openai/gpt-4o
```

Refs: orch-101