### PR TITLE
feat(monitor): add model/variant config support to chat pane

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	LogLevel       string `yaml:"log_level"`
 	PromptTemplate string `yaml:"prompt_template"` // Path to custom prompt template
 	NoPR           bool   `yaml:"no_pr"`           // Disable PR instructions by default
+	Model          string `yaml:"model"`           // Model in provider/model format (e.g., anthropic/claude-opus-4-5)
+	ModelVariant   string `yaml:"model_variant"`   // Model variant (e.g., "max" for max thinking)
 }
 
 type fileConfig struct {
@@ -31,6 +33,8 @@ type fileConfig struct {
 	LogLevel          string `yaml:"log_level"`
 	PromptTemplate    string `yaml:"prompt_template"`
 	NoPR              *bool  `yaml:"no_pr"`
+	Model             string `yaml:"model"`
+	ModelVariant      string `yaml:"model_variant"`
 }
 
 // configFile is the name of the config file
@@ -192,6 +196,12 @@ func loadFromFile(path string, cfg *Config) error {
 	if fileCfg.NoPR != nil {
 		cfg.NoPR = *fileCfg.NoPR
 	}
+	if fileCfg.Model != "" {
+		cfg.Model = fileCfg.Model
+	}
+	if fileCfg.ModelVariant != "" {
+		cfg.ModelVariant = fileCfg.ModelVariant
+	}
 
 	return nil
 }
@@ -246,6 +256,12 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("ORCH_NO_PR"); v != "" {
 		cfg.NoPR = v == "true" || v == "1" || v == "yes"
+	}
+	if v := os.Getenv("ORCH_MODEL"); v != "" {
+		cfg.Model = v
+	}
+	if v := os.Getenv("ORCH_MODEL_VARIANT"); v != "" {
+		cfg.ModelVariant = v
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `model` and `model_variant` fields to config struct for consistent model configuration
- Update `agentChatLaunch()` to load model/variant from config and pass to `LaunchConfig`
- Add HTTP injection support for opencode with model/variant parameters
- Support `ORCH_MODEL` and `ORCH_MODEL_VARIANT` environment variables

## Changes

1. **Config** (`internal/config/config.go`):
   - Added `Model` and `ModelVariant` fields to `Config` struct
   - Added corresponding YAML fields to `fileConfig`
   - Added environment variable support (`ORCH_MODEL`, `ORCH_MODEL_VARIANT`)

2. **Monitor** (`internal/monitor/monitor.go`):
   - Added `model` and `modelVariant` fields to `agentChatLaunch` struct
   - Updated `agentChatLaunch()` to load model/variant from config
   - Pass model/variant to `LaunchConfig` when launching agents
   - Added `sendAgentChatPromptHTTP()` to handle opencode HTTP injection with model and variant

## Usage

Config file (`.orch/config.yaml`):
```yaml
agent: opencode
model: anthropic/claude-opus-4-5
model_variant: max
```

Fixes: orch-103