### PR TITLE
refactor(agent): add DeadStatus method to complete AgentManager unification

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -22,6 +22,9 @@ type AgentManager interface {
 	GetStatus(run *model.Run, output string, state *RunState, outputChanged, hasPrompt bool) model.Status
 	CaptureOutput(run *model.Run) (string, error)
 	DetectPrompt(output string) bool
+	// DeadStatus returns the status to set when the agent is confirmed dead
+	// (i.e., after multiple consecutive failed IsAlive checks)
+	DeadStatus() model.Status
 }
 
 func GetManager(run *model.Run) AgentManager {
@@ -76,6 +79,10 @@ func (m *TmuxManager) GetStatus(run *model.Run, output string, state *RunState, 
 	return ""
 }
 
+func (m *TmuxManager) DeadStatus() model.Status {
+	return model.StatusFailed
+}
+
 type OpenCodeManager struct {
 	Port      int
 	SessionID string
@@ -111,6 +118,10 @@ func (m *OpenCodeManager) GetStatus(run *model.Run, output string, state *RunSta
 		return model.StatusRunning
 	}
 	return ""
+}
+
+func (m *OpenCodeManager) DeadStatus() model.Status {
+	return model.StatusUnknown
 }
 
 func IsWaitingForInput(output string) bool {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -517,3 +517,19 @@ func TestOpenCodeManagerGetStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestTmuxManagerDeadStatus(t *testing.T) {
+	manager := &TmuxManager{SessionName: "test-session"}
+	got := manager.DeadStatus()
+	if got != model.StatusFailed {
+		t.Errorf("TmuxManager.DeadStatus() = %v, want %v", got, model.StatusFailed)
+	}
+}
+
+func TestOpenCodeManagerDeadStatus(t *testing.T) {
+	manager := &OpenCodeManager{Port: 4321, SessionID: "ses_123"}
+	got := manager.DeadStatus()
+	if got != model.StatusUnknown {
+		t.Errorf("OpenCodeManager.DeadStatus() = %v, want %v", got, model.StatusUnknown)
+	}
+}

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -32,12 +32,9 @@ func (d *Daemon) monitorRun(run *model.Run) error {
 			d.logger.Printf("%s#%s: agent not alive (%d/%d checks), waiting", run.IssueID, run.RunID, state.DeadCheckCount, deadChecksBeforeFailed)
 			return nil
 		}
-		if run.Agent == "opencode" {
-			d.logger.Printf("%s#%s: opencode session not found after %d checks, marking unknown", run.IssueID, run.RunID, state.DeadCheckCount)
-			return d.updateStatus(run, model.StatusUnknown)
-		}
-		d.logger.Printf("%s#%s: agent confirmed dead after %d checks, marking failed", run.IssueID, run.RunID, state.DeadCheckCount)
-		return d.updateStatus(run, model.StatusFailed)
+		deadStatus := mgr.DeadStatus()
+		d.logger.Printf("%s#%s: agent confirmed dead after %d checks, marking %s", run.IssueID, run.RunID, state.DeadCheckCount, deadStatus)
+		return d.updateStatus(run, deadStatus)
 	}
 
 	output, err := mgr.CaptureOutput(run)


### PR DESCRIPTION
## Summary

- Add `DeadStatus()` method to the `AgentManager` interface to encapsulate agent-specific logic for determining what status to set when an agent is confirmed dead
- `TmuxManager.DeadStatus()` returns `StatusFailed` (for tmux-based agents: Claude, Codex, Gemini)
- `OpenCodeManager.DeadStatus()` returns `StatusUnknown` (for HTTP-based OpenCode agents)
- Refactor daemon monitor to use `mgr.DeadStatus()` instead of checking `run.Agent` directly

This completes the `AgentManager` interface unification started in #08baceb, removing the last agent-type-specific logic from the daemon.

## Related Issue

orch-104

## Test plan

- [x] Run `go test ./internal/agent/...` - all tests pass including new DeadStatus tests
- [x] Run `go test ./...` - full test suite passes
- [x] Run `go build ./...` - build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)