### PR TITLE
feat(monitor): show issue summary in run details panel

### DIFF
--- a/internal/monitor/dashboard.go
+++ b/internal/monitor/dashboard.go
@@ -755,6 +755,13 @@ func (d *Dashboard) selectedRun() *model.Run {
 	return nil
 }
 
+func (d *Dashboard) selectedRunRow() *RunRow {
+	if d.cursor >= 0 && d.cursor < len(d.runs) {
+		return &d.runs[d.cursor]
+	}
+	return nil
+}
+
 func (d *Dashboard) renderTable(maxRows int) string {
 	if len(d.runs) == 0 {
 		if !d.monitor.RunFilter().IsDefault() {
@@ -883,10 +890,11 @@ func (d *Dashboard) renderDetails(maxLines int) string {
 	if maxLines <= 0 {
 		return ""
 	}
-	run := d.selectedRun()
-	if run == nil {
+	row := d.selectedRunRow()
+	if row == nil || row.Run == nil {
 		return "No run selected."
 	}
+	run := row.Run
 
 	branch := strings.TrimSpace(run.Branch)
 	if branch == "" {
@@ -896,12 +904,18 @@ func (d *Dashboard) renderDetails(maxLines int) string {
 	if worktree == "" {
 		worktree = "-"
 	}
+	summary := strings.TrimSpace(row.IssueSummary)
+	if summary == "" {
+		summary = "-"
+	}
 
 	contentWidth := d.safeWidth()
 	lines := []string{
 		d.styles.Header.Render("DETAILS"),
 	}
 	lines = append(lines, wrapLabelValue("Run: ", run.Ref().String(), contentWidth)...)
+	lines = append(lines, wrapLabelValue("Issue: ", run.IssueID, contentWidth)...)
+	lines = append(lines, wrapLabelValue("Summary: ", summary, contentWidth)...)
 	lines = append(lines, wrapLabelValue("Branch: ", branch, contentWidth)...)
 	lines = append(lines, wrapLabelValue("Worktree: ", worktree, contentWidth)...)
 

--- a/internal/monitor/data.go
+++ b/internal/monitor/data.go
@@ -8,21 +8,22 @@ import (
 
 // RunRow holds display data for a run.
 type RunRow struct {
-	Index       int
-	ShortID     string
-	IssueID     string
-	IssueStatus string
-	Agent       string
-	Status      model.Status
-	Alive       string
-	Branch      string
-	Worktree    string
-	PR          string // PR display string (e.g., "#123" or "-")
-	PRState     string // PR state: open, merged, closed, or empty
-	Merged      string
-	Updated     time.Time
-	Topic       string
-	Run         *model.Run
+	Index        int
+	ShortID      string
+	IssueID      string
+	IssueStatus  string
+	IssueSummary string // Short one-line summary from issue frontmatter
+	Agent        string
+	Status       model.Status
+	Alive        string
+	Branch       string
+	Worktree     string
+	PR           string // PR display string (e.g., "#123" or "-")
+	PRState      string // PR state: open, merged, closed, or empty
+	Merged       string
+	Updated      time.Time
+	Topic        string
+	Run          *model.Run
 }
 
 // IssueRow holds display data for an issue.

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -835,8 +835,9 @@ func (m *Monitor) ensureRunSession(w *RunWindow) error {
 
 func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 	type issueDisplay struct {
-		status string
-		topic  string
+		status  string
+		topic   string
+		summary string
 	}
 
 	var paneCommands map[string][]string
@@ -866,9 +867,14 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 		if topic == "" {
 			topic = "-"
 		}
+		summary := issue.Summary
+		if summary == "" {
+			summary = "-"
+		}
 		issueInfo[w.Run.IssueID] = issueDisplay{
-			status: status,
-			topic:  topic,
+			status:  status,
+			topic:   topic,
+			summary: summary,
 		}
 	}
 
@@ -926,21 +932,22 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 		branch := formatBranchDisplay(w.Run.Branch, runTableBranchWidth)
 		worktree := formatWorktreeDisplay(w.Run.WorktreePath, runTableWorktreeWidth)
 		rows = append(rows, RunRow{
-			Index:       w.Index,
-			ShortID:     shortID,
-			IssueID:     w.Run.IssueID,
-			IssueStatus: issueStatus,
-			Agent:       agentDisplay,
-			Status:      w.Run.Status,
-			Alive:       runAliveLabel(w.Run, paneCommands),
-			Branch:      branch,
-			Worktree:    worktree,
-			PR:          prDisplay,
-			PRState:     prState,
-			Merged:      merged,
-			Updated:     w.Run.UpdatedAt,
-			Topic:       topic,
-			Run:         w.Run,
+			Index:        w.Index,
+			ShortID:      shortID,
+			IssueID:      w.Run.IssueID,
+			IssueStatus:  issueStatus,
+			IssueSummary: info.summary,
+			Agent:        agentDisplay,
+			Status:       w.Run.Status,
+			Alive:        runAliveLabel(w.Run, paneCommands),
+			Branch:       branch,
+			Worktree:     worktree,
+			PR:           prDisplay,
+			PRState:      prState,
+			Merged:       merged,
+			Updated:      w.Run.UpdatedAt,
+			Topic:        topic,
+			Run:          w.Run,
 		})
 	}
 


### PR DESCRIPTION
## Summary
- Display issue summary from frontmatter in the DETAILS panel when a run is selected in orch monitor's ps dashboard
- The summary appears alongside the run reference, issue ID, branch, and worktree information

## Changes
- Added `IssueSummary` field to `RunRow` struct in `data.go`
- Populated summary from issue data during `buildRunRows` in `monitor.go`
- Updated `renderDetails` in `dashboard.go` to display Issue and Summary lines

## Example Output
```
DETAILS
Run: orch-106#20260104-034419
Issue: orch-106
Summary: Add opencode with different model options (claude 4.5 opus, gpt 5.2, gemini 3 pro) to agent selection
Branch: issue/orch-106/run-20260104-034419
Worktree: .git-worktrees/orch-106/...
```

Closes orch-109