### PR TITLE
feat(daemon): detect opencode agent status via /session/status API

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -120,9 +120,13 @@ func (m *OpenCodeManager) GetStatus(run *model.Run, output string, state *RunSta
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	sessionStatus, err := client.GetSingleSessionStatus(ctx, m.SessionID, m.Directory)
+	sessionStatus, found, err := client.GetSingleSessionStatus(ctx, m.SessionID, m.Directory)
 	if err != nil {
 		return ""
+	}
+
+	if !found {
+		return model.StatusBlocked
 	}
 
 	switch sessionStatus {
@@ -130,6 +134,8 @@ func (m *OpenCodeManager) GetStatus(run *model.Run, output string, state *RunSta
 		return model.StatusRunning
 	case SessionStatusIdle:
 		return model.StatusBlocked
+	case SessionStatusRetry:
+		return model.StatusBlockedAPI
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Summary

- Add `GetSessionStatus` and `GetSingleSessionStatus` methods to `OpenCodeClient` to query the `/session/status` API endpoint
- Update `OpenCodeManager.GetStatus()` to detect agent state via the API and map to orch statuses:
  - `busy` → `running` (agent actively working)
  - `idle` → `blocked` (agent waiting for input)
- Add comprehensive tests for the new functionality

## Status Mapping

| OpenCode Session Status | orch Status |
|------------------------|-------------|
| `busy` | `running` |
| `idle` | `blocked` |

## Testing

All existing tests pass, plus new tests added for:
- `TestGetSessionStatus` - verifies the API client correctly parses session status
- `TestGetSingleSessionStatus` - verifies single session lookup
- `TestOpenCodeManagerGetStatusFromAPI` - verifies the manager correctly maps API status to orch status

Resolves: orch-111