### PR TITLE
feat(continue): use opencode --session flag to reuse previous sessions

### DIFF
--- a/internal/monitor/control_session.go
+++ b/internal/monitor/control_session.go
@@ -29,6 +29,10 @@ func LoadControlSession(orchDir string) *ControlSession {
 		return nil
 	}
 
+	if session.SessionID == "" {
+		return nil
+	}
+
 	return &session
 }
 
@@ -36,16 +40,24 @@ func SaveControlSession(orchDir string, session *ControlSession) error {
 	if orchDir == "" {
 		return nil
 	}
+	if session == nil || session.SessionID == "" {
+		return nil
+	}
 
 	if err := os.MkdirAll(orchDir, 0755); err != nil {
 		return err
 	}
 
-	path := filepath.Join(orchDir, controlSessionFile)
 	data, err := json.MarshalIndent(session, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	return os.WriteFile(path, data, 0644)
+	path := filepath.Join(orchDir, controlSessionFile)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+
+	return os.Rename(tmp, path)
 }

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -1137,9 +1137,15 @@ func (m *Monitor) sendPromptViaHTTP(launch agentChatLaunch) {
 
 func (m *Monitor) getOrCreateControlSession(ctx context.Context, client *agent.OpenCodeClient, port int) string {
 	stored := LoadControlSession(m.orchDir)
-	if stored != nil && stored.SessionID != "" && stored.Port == port {
+	if stored != nil && stored.SessionID != "" {
 		session, err := client.GetSession(ctx, stored.SessionID, m.store.VaultPath())
 		if err == nil && session != nil {
+			if stored.Port != port {
+				_ = SaveControlSession(m.orchDir, &ControlSession{
+					SessionID: stored.SessionID,
+					Port:      port,
+				})
+			}
 			return stored.SessionID
 		}
 	}


### PR DESCRIPTION
## Summary

- Add `SessionID` field to `LaunchConfig` for session resumption
- Update `continue` command to handle HTTP-based agents (opencode):
  - Detect and reuse existing opencode servers
  - Pass previous session ID when continuing from a run
  - Create new session when continuing from branch without previous session

## Changes

### `internal/agent/adapter.go`
- Added `SessionID` field to `LaunchConfig` struct

### `internal/cli/continue.go`
- Added `continuePromptViaHTTP()` function to handle opencode session continuation
- Updated `continueFromRun()` and `continueFromBranch()` to detect HTTP-based agents and handle them appropriately
- When continuing from a previous run, reuses the existing opencode session ID
- When continuing from a branch (no previous run), creates a new session

## Testing

- All existing tests pass
- Build succeeds

Closes orch-113