### PR TITLE
fix: start new opencode server per worktree

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -292,57 +292,39 @@ func runRun(issueID string, opts *runOptions) error {
 			return exitWithCode(fmt.Errorf("tmux is not available"), ExitTmuxError)
 		}
 
-		// For HTTP-based agents, check if a server is already running (reuse it)
-		// We only need one opencode server - it can handle sessions for any project
-		serverAlreadyRunning := false
+		// TODO(anomalyco/opencode#6413): Share single server once --dir flag works
 		if adapter.PromptInjection() == agent.InjectionHTTP {
-			// Check if any opencode server is already running
-			foundPort := findRunningOpenCodeServer(launchCfg.Port, launchCfg.Port+100)
-			if foundPort > 0 {
-				serverAlreadyRunning = true
-				launchCfg.Port = foundPort
-				fmt.Fprintf(os.Stderr, "reusing existing opencode server on port %d\n", foundPort)
-			} else {
-				// No server running, find a free port
-				freePort := findAvailablePort(launchCfg.Port, launchCfg.Port+100)
-				if freePort == 0 {
-					st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
-					return exitWithCode(fmt.Errorf("no available port found for opencode server"), ExitAgentError)
-				}
-				launchCfg.Port = freePort
-				// Regenerate the agent command with the port
-				agentCmd, err = adapter.LaunchCommand(launchCfg)
-				if err != nil {
-					return exitWithCode(err, ExitAgentError)
-				}
-			}
-		}
-
-		// Only create tmux session if server is not already running
-		if !serverAlreadyRunning {
-			// Build environment variables - merge adapter-specific vars with launch config vars
-			env := launchCfg.Env()
-			if opencodeAdapter, ok := adapter.(*agent.OpenCodeAdapter); ok {
-				env = append(env, opencodeAdapter.Env()...)
-			}
-
-			// Create tmux session
-			err = tmux.NewSession(&tmux.SessionConfig{
-				SessionName: tmuxSession,
-				WorkDir:     worktreeResult.WorktreePath,
-				Command:     agentCmd,
-				Env:         env,
-			})
-			if err != nil {
+			freePort := findAvailablePort(launchCfg.Port, launchCfg.Port+100)
+			if freePort == 0 {
 				st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
-				return exitWithCode(fmt.Errorf("failed to create tmux session: %w", err), ExitTmuxError)
+				return exitWithCode(fmt.Errorf("no available port found for opencode server"), ExitAgentError)
 			}
-
-			// Record session artifact
-			st.AppendEvent(run.Ref(), model.NewArtifactEvent("session", map[string]string{
-				"name": tmuxSession,
-			}))
+			launchCfg.Port = freePort
+			agentCmd, err = adapter.LaunchCommand(launchCfg)
+			if err != nil {
+				return exitWithCode(err, ExitAgentError)
+			}
 		}
+
+		env := launchCfg.Env()
+		if opencodeAdapter, ok := adapter.(*agent.OpenCodeAdapter); ok {
+			env = append(env, opencodeAdapter.Env()...)
+		}
+
+		err = tmux.NewSession(&tmux.SessionConfig{
+			SessionName: tmuxSession,
+			WorkDir:     worktreeResult.WorktreePath,
+			Command:     agentCmd,
+			Env:         env,
+		})
+		if err != nil {
+			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+			return exitWithCode(fmt.Errorf("failed to create tmux session: %w", err), ExitTmuxError)
+		}
+
+		st.AppendEvent(run.Ref(), model.NewArtifactEvent("session", map[string]string{
+			"name": tmuxSession,
+		}))
 
 		// Handle prompt injection based on agent type
 		switch adapter.PromptInjection() {
@@ -370,22 +352,19 @@ func runRun(issueID string, opts *runOptions) error {
 			}
 		}
 
-		// Record window ID only if we created a new tmux session
-		if !serverAlreadyRunning {
-			windowID := ""
-			if windows, err := tmux.ListWindows(tmuxSession); err == nil {
-				for _, window := range windows {
-					if window.Index == 0 {
-						windowID = window.ID
-						break
-					}
+		windowID := ""
+		if windows, err := tmux.ListWindows(tmuxSession); err == nil {
+			for _, window := range windows {
+				if window.Index == 0 {
+					windowID = window.ID
+					break
 				}
 			}
-			if windowID != "" {
-				st.AppendEvent(run.Ref(), model.NewArtifactEvent("window", map[string]string{
-					"id": windowID,
-				}))
-			}
+		}
+		if windowID != "" {
+			st.AppendEvent(run.Ref(), model.NewArtifactEvent("window", map[string]string{
+				"id": windowID,
+			}))
 		}
 	}
 
@@ -657,21 +636,6 @@ func findAvailablePort(start, end int) int {
 		listener, err := net.Listen("tcp", addr)
 		if err == nil {
 			listener.Close()
-			return port
-		}
-	}
-	return 0
-}
-
-// findRunningOpenCodeServer finds a running opencode server in the given port range.
-// Returns the port number if found, 0 if no server is running.
-func findRunningOpenCodeServer(start, end int) int {
-	for port := start; port <= end; port++ {
-		client := agent.NewOpenCodeClient(port)
-		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-		running := client.IsServerRunning(ctx)
-		cancel()
-		if running {
 			return port
 		}
 	}


### PR DESCRIPTION
## Summary

- Start a new opencode server per worktree instead of reusing existing servers
- Workaround for upstream bug where `opencode attach --dir` doesn't work correctly

## Context

Issue: orch-102

The upstream `opencode attach --dir` flag has a bug where the TUI inherits the server's project context instead of respecting the `--dir` flag (anomalyco/opencode#6413). This means if a shared server was started from directory A, attaching with `--dir B` still shows directory A.

## Changes

1. Removed server reuse logic that would check for running opencode servers and reuse them
2. Each `orch run` now always starts its own opencode server in the worktree directory
3. Removed unused `findRunningOpenCodeServer` function
4. Added TODO comment referencing upstream issue for future cleanup

## Trade-off

Multiple servers running (one per active run) instead of one shared server. This is the recommended workaround until the upstream fix is merged.

## Testing

- All existing tests pass
- Build succeeds