### PR TITLE
feat(monitor): add configurable agent presets with favorites

### DIFF
--- a/internal/monitor/settings.go
+++ b/internal/monitor/settings.go
@@ -9,10 +9,11 @@ import (
 
 // UISettings holds persistent UI settings for the monitor.
 type UISettings struct {
-	RunSort      SortKey `yaml:"run_sort,omitempty"`
-	IssueSort    SortKey `yaml:"issue_sort,omitempty"`
-	ShowResolved bool    `yaml:"show_resolved"`
-	ShowClosed   bool    `yaml:"show_closed"`
+	RunSort        SortKey  `yaml:"run_sort,omitempty"`
+	IssueSort      SortKey  `yaml:"issue_sort,omitempty"`
+	ShowResolved   bool     `yaml:"show_resolved"`
+	ShowClosed     bool     `yaml:"show_closed"`
+	FavoriteAgents []string `yaml:"favorite_agents,omitempty"`
 }
 
 const uiSettingsFile = "monitor-settings.yaml"


### PR DESCRIPTION
## Summary

- Add `AgentPreset` type to config for defining named agent configurations
- Support configuring presets in `config.yaml` with model, variant, and favorite settings
- Add `f` key to toggle favorites in agent selection UI
- Show favorites first (marked with `*`) in agent selection list
- Persist favorites in `monitor-settings.yaml`

## Config Example

```yaml
agent_presets:
  - name: "oc:opus4.5-max"
    agent: opencode
    model: anthropic/claude-opus-4-5
    variant: max
    favorite: true
    
  - name: "oc:sonnet4.5-max"
    agent: opencode
    model: anthropic/claude-sonnet-4-5
    variant: max
```

## UI Changes

Agent selection now shows:
```
  [1] * oc:opus4.5-max      <- favorites first, marked with *
  [2] * oc:sonnet4.5-max
  [3]   claude
  [4]   opencode
  ...

[Enter/1-9] select  [f] toggle favorite  [Esc] back
```

## Files Changed

- `internal/config/config.go` - Add AgentPreset struct and parsing
- `internal/monitor/monitor.go` - Add GetAgentOptions(), preset lookup, favorite management
- `internal/monitor/issues_dashboard.go` - UI for favorites and agent display
- `internal/monitor/settings.go` - Add FavoriteAgents field

## Issue

Closes: orch-106