### PR TITLE
fix(run): record error artifacts when opencode session creation fails

### DIFF
--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -195,3 +195,9 @@ func NewArtifactEvent(name string, attrs map[string]string) *Event {
 	return NewEvent(EventTypeArtifact, name, attrs)
 }
 
+// NewErrorArtifactEvent creates an error artifact event to persist error messages in run files
+func NewErrorArtifactEvent(errMsg string) *Event {
+	return NewEvent(EventTypeArtifact, "error", map[string]string{
+		"message": errMsg,
+	})
+}


### PR DESCRIPTION
## Summary

- Fixes runs getting stuck in `booting` state when opencode session creation fails
- Records error messages as artifacts so failures are persisted in run files
- Ensures all error paths after `booting` status properly mark runs as `failed`

## Changes

- Add `NewErrorArtifactEvent` helper to model/event.go for persisting error messages
- Add `setRunFailed` helper in run.go that records both error artifact and failed status
- Fix missing status=failed when `LaunchCommand` fails after port selection
- Update all error paths (worktree creation, tmux session, HTTP injection) to use `setRunFailed`

## Issue Reference

Fixes: orch-121 - opencode runs get stuck in booting state when session creation fails silently