### PR TITLE
fix(monitor): fetch opencode model from API when not stored in run

### DIFF
--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -811,7 +811,19 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 		if topic == "" {
 			topic = "-"
 		}
-		agentDisplay := agent.AgentDisplayName(w.Run.Agent, w.Run.Model, w.Run.ModelVariant)
+
+		runModel := w.Run.Model
+		runVariant := w.Run.ModelVariant
+		if w.Run.Agent == "opencode" && runModel == "" && w.Run.ServerPort > 0 {
+			client := agent.NewOpenCodeClient(w.Run.ServerPort)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			if fetchedModel, fetchedVariant, err := client.GetAgentModel(ctx); err == nil && fetchedModel != "" {
+				runModel = fetchedModel
+				runVariant = fetchedVariant
+			}
+			cancel()
+		}
+		agentDisplay := agent.AgentDisplayName(w.Run.Agent, runModel, runVariant)
 
 		// Build PR display string and state
 		prDisplay := "-"


### PR DESCRIPTION
## Summary

- Add `GetAgentModel` method to OpenCodeClient to fetch model from `/config` API
- Update monitor to query opencode server for model when run metadata is missing it

## Problem

When an opencode run is created without `--model` flag, the model info is not stored in the run frontmatter. This causes the agent column to show just `oc` instead of the full `oc:opus4.5`.

## Solution

Query the opencode server's `/config` endpoint to get the configured agent model when:
- Agent is `opencode`
- Model is empty in run metadata
- ServerPort is available (server is running)

This allows displaying the correct model even for runs created before model tracking was added.

## Testing

- Tested with running opencode server - correctly shows `oc:opus4.5` instead of `oc`
- All existing tests pass