### PR TITLE
fix(monitor): store model in run metadata at creation time

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -665,6 +665,16 @@ func injectPromptViaHTTP(st interface {
 		"port": fmt.Sprintf("%d", port),
 	}))
 
+	// If no model was explicitly specified, fetch and store the server's configured model
+	if cfg.Model == "" {
+		if fetchedModel, fetchedVariant, err := client.GetAgentModel(ctx); err == nil && fetchedModel != "" {
+			st.AppendEvent(run.Ref(), model.NewArtifactEvent("agent_model", map[string]string{
+				"model":   fetchedModel,
+				"variant": fetchedVariant,
+			}))
+		}
+	}
+
 	// Create a new session in the worktree directory
 	session, err := client.CreateSession(ctx, fmt.Sprintf("%s#%s", run.IssueID, run.RunID), cfg.WorkDir)
 	if err != nil {

--- a/internal/model/run.go
+++ b/internal/model/run.go
@@ -166,6 +166,14 @@ func (r *Run) DeriveState() {
 	if opencodeSession, ok := artifacts["opencode_session"]; ok {
 		r.OpenCodeSessionID = opencodeSession["id"]
 	}
+	if agentModel, ok := artifacts["agent_model"]; ok {
+		if r.Model == "" {
+			r.Model = agentModel["model"]
+		}
+		if r.ModelVariant == "" {
+			r.ModelVariant = agentModel["variant"]
+		}
+	}
 
 	// Derive timestamps
 	if len(r.Events) > 0 {

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -812,18 +812,7 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 			topic = "-"
 		}
 
-		runModel := w.Run.Model
-		runVariant := w.Run.ModelVariant
-		if w.Run.Agent == "opencode" && runModel == "" && w.Run.ServerPort > 0 {
-			client := agent.NewOpenCodeClient(w.Run.ServerPort)
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			if fetchedModel, fetchedVariant, err := client.GetAgentModel(ctx); err == nil && fetchedModel != "" {
-				runModel = fetchedModel
-				runVariant = fetchedVariant
-			}
-			cancel()
-		}
-		agentDisplay := agent.AgentDisplayName(w.Run.Agent, runModel, runVariant)
+		agentDisplay := agent.AgentDisplayName(w.Run.Agent, w.Run.Model, w.Run.ModelVariant)
 
 		// Build PR display string and state
 		prDisplay := "-"


### PR DESCRIPTION
## Summary
- Store opencode model as `agent_model` artifact when run is created
- Parse artifact in run.go to populate `Run.Model`/`Run.ModelVariant`
- Remove dynamic API call from monitor (was causing fluctuating display)

## Problem
Monitor queried the live opencode server API (port 4096) to get the model, but all runs share the same server. Result: all runs showed whatever model the **current** session was using.

## Solution
Capture model once at run creation, store in run metadata. Monitor reads from storage.

## Note
Existing runs won't have this info - only new runs will display correctly.