### PR TITLE
fix(monitor): increase details panel height for issue summary

### DIFF
--- a/internal/monitor/constants.go
+++ b/internal/monitor/constants.go
@@ -7,5 +7,5 @@ const (
 	defaultCaptureLines    = 200
 	runTableBranchWidth    = 8
 	runTableWorktreeWidth  = 16
-	runDetailsMaxLines     = 4
+	runDetailsMaxLines     = 7
 )


### PR DESCRIPTION
## Summary
The DETAILS panel in orch monitor was limited to 4 lines, which caused the new Issue and Summary fields to be truncated.

## Fix
Increase `runDetailsMaxLines` from 4 to 7 to accommodate:
1. DETAILS header
2. Run
3. Issue
4. Summary
5. Branch
6. Worktree
7. Buffer for text wrapping

Follow-up to #134 (orch-109)