### PR TITLE
feat(monitor): add configurable ps columns layout via config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,34 +7,44 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// MonitorConfig holds configuration for the monitor dashboard.
+type MonitorConfig struct {
+	// PSColumns defines which columns to show and in what order.
+	// Available columns: index, id, issue, issue_status, agent, status, alive,
+	// branch, worktree, pr, merged, updated, topic
+	PSColumns []string `yaml:"ps_columns,omitempty"`
+}
+
 // Config holds orch configuration
 type Config struct {
-	Vault          string `yaml:"vault"`
-	Agent          string `yaml:"agent"`
-	Model          string `yaml:"model"`         // Default model (provider/model-id format)
-	ModelVariant   string `yaml:"model_variant"` // Default model variant (e.g., "max")
-	WorktreeDir    string `yaml:"worktree_dir"`
-	BaseBranch     string `yaml:"base_branch"`
-	PRTargetBranch string `yaml:"pr_target_branch"`
-	LogLevel       string `yaml:"log_level"`
-	PromptTemplate string `yaml:"prompt_template"` // Path to custom prompt template
-	NoPR           bool   `yaml:"no_pr"`           // Disable PR instructions by default
+	Vault          string        `yaml:"vault"`
+	Agent          string        `yaml:"agent"`
+	Model          string        `yaml:"model"`         // Default model (provider/model-id format)
+	ModelVariant   string        `yaml:"model_variant"` // Default model variant (e.g., "max")
+	WorktreeDir    string        `yaml:"worktree_dir"`
+	BaseBranch     string        `yaml:"base_branch"`
+	PRTargetBranch string        `yaml:"pr_target_branch"`
+	LogLevel       string        `yaml:"log_level"`
+	PromptTemplate string        `yaml:"prompt_template"` // Path to custom prompt template
+	NoPR           bool          `yaml:"no_pr"`           // Disable PR instructions by default
+	Monitor        MonitorConfig `yaml:"monitor"`
 }
 
 type fileConfig struct {
-	Vault             string `yaml:"vault"`
-	VaultLegacy       string `yaml:"Vault"`
-	DefaultVault      string `yaml:"default_vault"`
-	Agent             string `yaml:"agent"`
-	Model             string `yaml:"model"`
-	ModelVariant      string `yaml:"model_variant"`
-	WorktreeDir       string `yaml:"worktree_dir"`
-	WorktreeDirLegacy string `yaml:"worktree_root"` // Legacy name for backwards compatibility
-	BaseBranch        string `yaml:"base_branch"`
-	PRTargetBranch    string `yaml:"pr_target_branch"`
-	LogLevel          string `yaml:"log_level"`
-	PromptTemplate    string `yaml:"prompt_template"`
-	NoPR              *bool  `yaml:"no_pr"`
+	Vault             string        `yaml:"vault"`
+	VaultLegacy       string        `yaml:"Vault"`
+	DefaultVault      string        `yaml:"default_vault"`
+	Agent             string        `yaml:"agent"`
+	Model             string        `yaml:"model"`
+	ModelVariant      string        `yaml:"model_variant"`
+	WorktreeDir       string        `yaml:"worktree_dir"`
+	WorktreeDirLegacy string        `yaml:"worktree_root"` // Legacy name for backwards compatibility
+	BaseBranch        string        `yaml:"base_branch"`
+	PRTargetBranch    string        `yaml:"pr_target_branch"`
+	LogLevel          string        `yaml:"log_level"`
+	PromptTemplate    string        `yaml:"prompt_template"`
+	NoPR              *bool         `yaml:"no_pr"`
+	Monitor           MonitorConfig `yaml:"monitor"`
 }
 
 // configFile is the name of the config file
@@ -201,6 +211,9 @@ func loadFromFile(path string, cfg *Config) error {
 	}
 	if fileCfg.NoPR != nil {
 		cfg.NoPR = *fileCfg.NoPR
+	}
+	if len(fileCfg.Monitor.PSColumns) > 0 {
+		cfg.Monitor.PSColumns = fileCfg.Monitor.PSColumns
 	}
 
 	return nil

--- a/internal/monitor/columns.go
+++ b/internal/monitor/columns.go
@@ -1,0 +1,155 @@
+package monitor
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/s22625/orch/internal/agent"
+	"github.com/s22625/orch/internal/config"
+)
+
+type ColumnID string
+
+const (
+	ColIndex       ColumnID = "index"
+	ColID          ColumnID = "id"
+	ColIssue       ColumnID = "issue"
+	ColIssueStatus ColumnID = "issue_status"
+	ColAgent       ColumnID = "agent"
+	ColStatus      ColumnID = "status"
+	ColAlive       ColumnID = "alive"
+	ColBranch      ColumnID = "branch"
+	ColWorktree    ColumnID = "worktree"
+	ColPR          ColumnID = "pr"
+	ColMerged      ColumnID = "merged"
+	ColUpdated     ColumnID = "updated"
+	ColTopic       ColumnID = "topic"
+)
+
+type ColumnDef struct {
+	ID       ColumnID
+	Header   string
+	Width    int
+	Flexible bool
+}
+
+var columnRegistry = map[ColumnID]ColumnDef{
+	ColIndex:       {ID: ColIndex, Header: "#", Width: 2},
+	ColID:          {ID: ColID, Header: "ID", Width: 6},
+	ColIssue:       {ID: ColIssue, Header: "ISSUE", Width: 14},
+	ColIssueStatus: {ID: ColIssueStatus, Header: "ISSUE-ST", Width: 8},
+	ColAgent:       {ID: ColAgent, Header: "AGENT", Width: agent.MaxAgentDisplayWidth},
+	ColStatus:      {ID: ColStatus, Header: "STATUS", Width: 10},
+	ColAlive:       {ID: ColAlive, Header: "ALIVE", Width: 5},
+	ColBranch:      {ID: ColBranch, Header: "BRANCH", Width: runTableBranchWidth},
+	ColWorktree:    {ID: ColWorktree, Header: "WORKTREE", Width: runTableWorktreeWidth},
+	ColPR:          {ID: ColPR, Header: "PR", Width: 6},
+	ColMerged:      {ID: ColMerged, Header: "MERGED", Width: 8},
+	ColUpdated:     {ID: ColUpdated, Header: "UPDATED", Width: 7},
+	ColTopic:       {ID: ColTopic, Header: "TOPIC", Width: 6, Flexible: true},
+}
+
+var defaultColumns = []ColumnID{
+	ColIndex,
+	ColID,
+	ColIssue,
+	ColIssueStatus,
+	ColAgent,
+	ColStatus,
+	ColAlive,
+	ColBranch,
+	ColWorktree,
+	ColPR,
+	ColMerged,
+	ColUpdated,
+	ColTopic,
+}
+
+func GetColumnDef(id ColumnID) (ColumnDef, bool) {
+	def, ok := columnRegistry[id]
+	return def, ok
+}
+
+func DefaultColumns() []ColumnID {
+	return defaultColumns
+}
+
+func LoadColumns(cfg *config.Config) []ColumnID {
+	if cfg == nil || len(cfg.Monitor.PSColumns) == 0 {
+		return defaultColumns
+	}
+	cols := make([]ColumnID, 0, len(cfg.Monitor.PSColumns))
+	for _, name := range cfg.Monitor.PSColumns {
+		id := ColumnID(name)
+		if _, ok := columnRegistry[id]; ok {
+			cols = append(cols, id)
+		}
+	}
+	if len(cols) == 0 {
+		return defaultColumns
+	}
+	return cols
+}
+
+func GetColumnValue(col ColumnID, row *RunRow, now time.Time) string {
+	if row == nil {
+		return "-"
+	}
+	switch col {
+	case ColIndex:
+		return fmt.Sprintf("%d", row.Index)
+	case ColID:
+		return row.ShortID
+	case ColIssue:
+		return row.IssueID
+	case ColIssueStatus:
+		return row.IssueStatus
+	case ColAgent:
+		return row.Agent
+	case ColStatus:
+		return string(row.Status)
+	case ColAlive:
+		return row.Alive
+	case ColBranch:
+		return row.Branch
+	case ColWorktree:
+		return row.Worktree
+	case ColPR:
+		return row.PR
+	case ColMerged:
+		return row.Merged
+	case ColUpdated:
+		return formatRelativeTime(row.Updated, now)
+	case ColTopic:
+		return row.Topic
+	default:
+		return "-"
+	}
+}
+
+func GetColumnStyle(col ColumnID, row *RunRow, styles *Styles, isHeader bool) lipgloss.Style {
+	if isHeader {
+		return styles.Header
+	}
+	if row == nil {
+		return styles.Text
+	}
+	switch col {
+	case ColStatus:
+		if style, ok := styles.Status[row.Status]; ok {
+			return style
+		}
+	case ColAlive:
+		if style, ok := styles.Alive[row.Alive]; ok {
+			return style
+		}
+	case ColPR:
+		if row.PRState != "" {
+			if style, ok := styles.PRState[row.PRState]; ok {
+				return style
+			}
+		}
+	}
+	return styles.Text
+}


### PR DESCRIPTION
## Summary

- Add `monitor.ps_columns` configuration option to `.orch/config.yaml`
- Allow users to configure which columns to show and their order in the ps panel
- Use sensible defaults (all columns) when no config is specified

## Changes

- **internal/config/config.go**: Add `MonitorConfig` struct with `PSColumns` field
- **internal/monitor/columns.go**: New file with column definitions, registry, and rendering helpers
- **internal/monitor/dashboard.go**: Refactor table rendering to use configurable columns

## Example Config

```yaml
monitor:
  ps_columns:
    - id
    - issue
    - agent
    - status
    - pr
    - updated
```

## Available Columns

`index`, `id`, `issue`, `issue_status`, `agent`, `status`, `alive`, `branch`, `worktree`, `pr`, `merged`, `updated`, `topic`

## Testing

- All existing tests pass
- Build succeeds

Resolves: orch-124