### PR TITLE
feat(ps,monitor): add start time column to run displays

### DIFF
--- a/internal/monitor/columns.go
+++ b/internal/monitor/columns.go
@@ -23,6 +23,7 @@ const (
 	ColWorktree    ColumnID = "worktree"
 	ColPR          ColumnID = "pr"
 	ColMerged      ColumnID = "merged"
+	ColStarted     ColumnID = "started"
 	ColUpdated     ColumnID = "updated"
 	ColTopic       ColumnID = "topic"
 )
@@ -46,6 +47,7 @@ var columnRegistry = map[ColumnID]ColumnDef{
 	ColWorktree:    {ID: ColWorktree, Header: "WORKTREE", Width: runTableWorktreeWidth},
 	ColPR:          {ID: ColPR, Header: "PR", Width: 6},
 	ColMerged:      {ID: ColMerged, Header: "MERGED", Width: 8},
+	ColStarted:     {ID: ColStarted, Header: "STARTED", Width: 7},
 	ColUpdated:     {ID: ColUpdated, Header: "UPDATED", Width: 7},
 	ColTopic:       {ID: ColTopic, Header: "TOPIC", Width: 6, Flexible: true},
 }
@@ -62,6 +64,7 @@ var defaultColumns = []ColumnID{
 	ColWorktree,
 	ColPR,
 	ColMerged,
+	ColStarted,
 	ColUpdated,
 	ColTopic,
 }
@@ -119,6 +122,8 @@ func GetColumnValue(col ColumnID, row *RunRow, now time.Time) string {
 		return row.PR
 	case ColMerged:
 		return row.Merged
+	case ColStarted:
+		return formatRelativeTime(row.Started, now)
 	case ColUpdated:
 		return formatRelativeTime(row.Updated, now)
 	case ColTopic:

--- a/internal/monitor/data.go
+++ b/internal/monitor/data.go
@@ -18,9 +18,10 @@ type RunRow struct {
 	Alive        string
 	Branch       string
 	Worktree     string
-	PR           string // PR display string (e.g., "#123" or "-")
-	PRState      string // PR state: open, merged, closed, or empty
+	PR           string
+	PRState      string
 	Merged       string
+	Started      time.Time
 	Updated      time.Time
 	Topic        string
 	Run          *model.Run

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -850,6 +850,7 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 			PR:           prDisplay,
 			PRState:      prState,
 			Merged:       merged,
+			Started:      w.Run.StartedAt,
 			Updated:      w.Run.UpdatedAt,
 			Topic:        topic,
 			Run:          w.Run,


### PR DESCRIPTION
## Summary

- Add STARTED column showing when each run's agent was started
- Display elapsed time in relative format (e.g., "5m ago") matching existing UPDATED column
- Add to both `orch ps` table/TSV output and monitor dashboard ps panel

## Changes

- **internal/cli/ps.go**: Add STARTED column to table output, add started_at to TSV output
- **internal/monitor/dashboard.go**: Add STARTED column to dashboard table rendering
- **internal/monitor/data.go**: Add Started field to RunRow struct
- **internal/monitor/monitor.go**: Populate Started field from run StartedAt

## Related Issue

orch-122