### PR TITLE
feat(daemon): route opencode sends through daemon for async message delivery

### DIFF
--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -1,0 +1,218 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/s22625/orch/internal/agent"
+	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/store"
+)
+
+const (
+	socketFile = "daemon.sock"
+)
+
+func SocketFilePath(vaultPath string) string {
+	return filepath.Join(OrchDir(vaultPath), socketFile)
+}
+
+type SendRequest struct {
+	Type      string `json:"type"`
+	IssueID   string `json:"issue_id"`
+	RunID     string `json:"run_id"`
+	Message   string `json:"message"`
+	NoEnter   bool   `json:"no_enter,omitempty"`
+	VaultPath string `json:"vault_path"`
+}
+
+type SendResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+type SocketServer struct {
+	vaultPath string
+	store     store.Store
+	listener  net.Listener
+	logger    Logger
+	stopCh    chan struct{}
+}
+
+type Logger interface {
+	Printf(format string, v ...interface{})
+}
+
+func NewSocketServer(vaultPath string, st store.Store, logger Logger) *SocketServer {
+	return &SocketServer{
+		vaultPath: vaultPath,
+		store:     st,
+		logger:    logger,
+		stopCh:    make(chan struct{}),
+	}
+}
+
+func (s *SocketServer) Start() error {
+	socketPath := SocketFilePath(s.vaultPath)
+
+	os.Remove(socketPath)
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("failed to listen on socket: %w", err)
+	}
+	s.listener = listener
+
+	if err := os.Chmod(socketPath, 0660); err != nil {
+		s.logger.Printf("warning: failed to chmod socket: %v", err)
+	}
+
+	s.logger.Printf("socket server listening on %s", socketPath)
+
+	go s.acceptLoop()
+
+	return nil
+}
+
+func (s *SocketServer) Stop() {
+	close(s.stopCh)
+	if s.listener != nil {
+		s.listener.Close()
+	}
+	os.Remove(SocketFilePath(s.vaultPath))
+}
+
+func (s *SocketServer) acceptLoop() {
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		default:
+		}
+
+		conn, err := s.listener.Accept()
+		if err != nil {
+			select {
+			case <-s.stopCh:
+				return
+			default:
+				s.logger.Printf("accept error: %v", err)
+				continue
+			}
+		}
+
+		go s.handleConnection(conn)
+	}
+}
+
+func (s *SocketServer) handleConnection(conn net.Conn) {
+	defer conn.Close()
+
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+
+	decoder := json.NewDecoder(conn)
+	encoder := json.NewEncoder(conn)
+
+	var req SendRequest
+	if err := decoder.Decode(&req); err != nil {
+		s.logger.Printf("failed to decode request: %v", err)
+		encoder.Encode(SendResponse{OK: false, Error: "invalid request"})
+		return
+	}
+
+	switch req.Type {
+	case "send":
+		s.handleSend(req, encoder)
+	default:
+		encoder.Encode(SendResponse{OK: false, Error: "unknown request type"})
+	}
+}
+
+func (s *SocketServer) handleSend(req SendRequest, encoder *json.Encoder) {
+	encoder.Encode(SendResponse{OK: true})
+	go s.processSend(req)
+}
+
+func (s *SocketServer) processSend(req SendRequest) {
+	s.logger.Printf("processing send for %s#%s", req.IssueID, req.RunID)
+
+	ref := &model.RunRef{IssueID: req.IssueID, RunID: req.RunID}
+	run, err := s.store.GetRun(ref)
+	if err != nil {
+		s.logger.Printf("failed to get run %s#%s: %v", req.IssueID, req.RunID, err)
+		return
+	}
+
+	if run.Agent != string(agent.AgentOpenCode) {
+		s.logger.Printf("run %s#%s is not opencode agent, skipping", req.IssueID, req.RunID)
+		return
+	}
+
+	if run.ServerPort <= 0 || run.OpenCodeSessionID == "" {
+		s.logger.Printf("run %s#%s missing server config (port=%d, session=%s)",
+			req.IssueID, req.RunID, run.ServerPort, run.OpenCodeSessionID)
+		return
+	}
+
+	client := agent.NewOpenCodeClient(run.ServerPort)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	err = client.SendMessagePrompt(ctx, run.OpenCodeSessionID, req.Message, run.WorktreePath)
+	if err != nil {
+		s.logger.Printf("failed to send message to %s#%s: %v", req.IssueID, req.RunID, err)
+		return
+	}
+
+	s.logger.Printf("message sent successfully to %s#%s", req.IssueID, req.RunID)
+}
+
+func SendViaDaemon(vaultPath string, run *model.Run, message string, noEnter bool) error {
+	socketPath := SocketFilePath(vaultPath)
+
+	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("failed to connect to daemon: %w", err)
+	}
+	defer conn.Close()
+
+	conn.SetDeadline(time.Now().Add(10 * time.Second))
+
+	req := SendRequest{
+		Type:      "send",
+		IssueID:   run.IssueID,
+		RunID:     run.RunID,
+		Message:   message,
+		NoEnter:   noEnter,
+		VaultPath: vaultPath,
+	}
+
+	encoder := json.NewEncoder(conn)
+	if err := encoder.Encode(req); err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+
+	decoder := json.NewDecoder(conn)
+	var resp SendResponse
+	if err := decoder.Decode(&resp); err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if !resp.OK {
+		return fmt.Errorf("daemon error: %s", resp.Error)
+	}
+
+	return nil
+}
+
+func IsDaemonSocketAvailable(vaultPath string) bool {
+	socketPath := SocketFilePath(vaultPath)
+	_, err := os.Stat(socketPath)
+	return err == nil
+}

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -1,0 +1,182 @@
+package daemon
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/store"
+)
+
+type mockStore struct {
+	runs map[string]*model.Run
+}
+
+func (m *mockStore) ResolveIssue(issueID string) (*model.Issue, error) {
+	return nil, nil
+}
+
+func (m *mockStore) ListIssues() ([]*model.Issue, error) {
+	return nil, nil
+}
+
+func (m *mockStore) SetIssueStatus(issueID string, status model.IssueStatus) error {
+	return nil
+}
+
+func (m *mockStore) CreateRun(issueID, runID string, metadata map[string]string) (*model.Run, error) {
+	return nil, nil
+}
+
+func (m *mockStore) AppendEvent(ref *model.RunRef, event *model.Event) error {
+	return nil
+}
+
+func (m *mockStore) ListRuns(filter *store.ListRunsFilter) ([]*model.Run, error) {
+	return nil, nil
+}
+
+func (m *mockStore) GetRun(ref *model.RunRef) (*model.Run, error) {
+	key := ref.IssueID + "#" + ref.RunID
+	if run, ok := m.runs[key]; ok {
+		return run, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func (m *mockStore) GetRunByShortID(shortID string) (*model.Run, error) {
+	return nil, nil
+}
+
+func (m *mockStore) GetLatestRun(issueID string) (*model.Run, error) {
+	return nil, nil
+}
+
+func (m *mockStore) VaultPath() string {
+	return ""
+}
+
+func TestSocketFilePath(t *testing.T) {
+	path := SocketFilePath("/vault")
+	expected := filepath.Join("/vault", ".orch", "daemon.sock")
+	if path != expected {
+		t.Errorf("expected %s, got %s", expected, path)
+	}
+}
+
+func TestSocketServerStartStop(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("/tmp", "orch-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	orchDir := filepath.Join(tmpDir, ".orch")
+	if err := os.MkdirAll(orchDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	st := &mockStore{runs: make(map[string]*model.Run)}
+	logger := log.New(io.Discard, "", 0)
+
+	server := NewSocketServer(tmpDir, st, logger)
+	if err := server.Start(); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+
+	socketPath := SocketFilePath(tmpDir)
+	if _, err := os.Stat(socketPath); err != nil {
+		t.Errorf("socket file not created: %v", err)
+	}
+
+	server.Stop()
+
+	if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+		t.Error("socket file not cleaned up")
+	}
+}
+
+func TestSocketServerSendRequest(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("/tmp", "orch-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	orchDir := filepath.Join(tmpDir, ".orch")
+	if err := os.MkdirAll(orchDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	st := &mockStore{
+		runs: map[string]*model.Run{
+			"issue#run": {
+				IssueID:           "issue",
+				RunID:             "run",
+				Agent:             "claude",
+				ServerPort:        4096,
+				OpenCodeSessionID: "session",
+			},
+		},
+	}
+	logger := log.New(io.Discard, "", 0)
+
+	server := NewSocketServer(tmpDir, st, logger)
+	if err := server.Start(); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	defer server.Stop()
+
+	conn, err := net.DialTimeout("unix", SocketFilePath(tmpDir), 5*time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	req := SendRequest{
+		Type:    "send",
+		IssueID: "issue",
+		RunID:   "run",
+		Message: "test message",
+	}
+
+	encoder := json.NewEncoder(conn)
+	if err := encoder.Encode(req); err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+
+	decoder := json.NewDecoder(conn)
+	var resp SendResponse
+	if err := decoder.Decode(&resp); err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+
+	if !resp.OK {
+		t.Errorf("expected OK=true, got error: %s", resp.Error)
+	}
+}
+
+func TestIsDaemonSocketAvailable(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if IsDaemonSocketAvailable(tmpDir) {
+		t.Error("expected socket not available initially")
+	}
+
+	orchDir := filepath.Join(tmpDir, ".orch")
+	os.MkdirAll(orchDir, 0755)
+
+	socketPath := SocketFilePath(tmpDir)
+	f, _ := os.Create(socketPath)
+	f.Close()
+
+	if !IsDaemonSocketAvailable(tmpDir) {
+		t.Error("expected socket available after creation")
+	}
+}


### PR DESCRIPTION
## Summary

Routes `orch send` for opencode agents through the daemon's Unix socket IPC to avoid CLI timeout issues.

- Add Unix socket server to daemon at `.orch/daemon.sock` for IPC
- CLI detects opencode agents and routes via daemon when socket is available
- Daemon processes message asynchronously with 10-minute timeout, returning immediately to CLI
- Falls back to direct API call if daemon socket unavailable

## Changes

- `internal/daemon/socket.go`: New Unix socket server and client for IPC
- `internal/daemon/socket_test.go`: Comprehensive tests for socket functionality
- `internal/daemon/daemon.go`: Integrate socket server into daemon lifecycle
- `internal/cli/send.go`: Route opencode sends through daemon when available

## Testing

- All existing tests pass
- Added new tests for socket server start/stop, request handling, and availability check

## Related

Fixes orch-126