### PR TITLE
fix(daemon): verify daemon is running before checking socket availability

### DIFF
--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/s22625/orch/internal/agent"
@@ -42,6 +43,7 @@ type SocketServer struct {
 	listener  net.Listener
 	logger    Logger
 	stopCh    chan struct{}
+	stopOnce  sync.Once
 }
 
 type Logger interface {
@@ -80,11 +82,13 @@ func (s *SocketServer) Start() error {
 }
 
 func (s *SocketServer) Stop() {
-	close(s.stopCh)
-	if s.listener != nil {
-		s.listener.Close()
-	}
-	os.Remove(SocketFilePath(s.vaultPath))
+	s.stopOnce.Do(func() {
+		close(s.stopCh)
+		if s.listener != nil {
+			s.listener.Close()
+		}
+		os.Remove(SocketFilePath(s.vaultPath))
+	})
 }
 
 func (s *SocketServer) acceptLoop() {

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -212,6 +212,9 @@ func SendViaDaemon(vaultPath string, run *model.Run, message string, noEnter boo
 }
 
 func IsDaemonSocketAvailable(vaultPath string) bool {
+	if !IsRunning(vaultPath) {
+		return false
+	}
 	socketPath := SocketFilePath(vaultPath)
 	_, err := os.Stat(socketPath)
 	return err == nil

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -176,7 +176,30 @@ func TestIsDaemonSocketAvailable(t *testing.T) {
 	f, _ := os.Create(socketPath)
 	f.Close()
 
+	if IsDaemonSocketAvailable(tmpDir) {
+		t.Error("expected socket not available without running daemon")
+	}
+}
+
+func TestIsDaemonSocketAvailableWithDaemon(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("/tmp", "orch-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	orchDir := filepath.Join(tmpDir, ".orch")
+	os.MkdirAll(orchDir, 0755)
+
+	if err := WritePID(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	socketPath := SocketFilePath(tmpDir)
+	f, _ := os.Create(socketPath)
+	f.Close()
+
 	if !IsDaemonSocketAvailable(tmpDir) {
-		t.Error("expected socket available after creation")
+		t.Error("expected socket available with running daemon and socket file")
 	}
 }

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -100,6 +100,8 @@ func TestSocketServerStartStop(t *testing.T) {
 	if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
 		t.Error("socket file not cleaned up")
 	}
+
+	server.Stop()
 }
 
 func TestSocketServerSendRequest(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a bug in `IsDaemonSocketAvailable` where it only checked if the socket file exists, but didn't verify the daemon was actually running.

## Problem

The previous implementation could return `true` even when:
- Socket file remains from a crashed daemon
- Daemon process has exited but socket file wasn't cleaned up

This would cause `orch send` to try connecting to a dead socket and fail.

## Solution

Now checks `IsRunning()` (via PID file and process check) before checking socket file existence.

## Changes

- `internal/daemon/socket.go`: Add `IsRunning()` check to `IsDaemonSocketAvailable()`
- `internal/daemon/socket_test.go`: Update tests to reflect new behavior

## Related

Follow-up fix for orch-126