### PR TITLE
fix(store): sync file after appending events for immediate visibility

### DIFF
--- a/internal/store/file/file.go
+++ b/internal/store/file/file.go
@@ -431,6 +431,11 @@ func (s *FileStore) AppendEvent(ref *model.RunRef, event *model.Event) error {
 		return fmt.Errorf("failed to append event: %w", err)
 	}
 
+	// Sync ensures daemon writes are immediately visible to monitor (fixes orch-127)
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("failed to sync run file: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Add `f.Sync()` call in `AppendEvent` to ensure daemon status writes are immediately visible to other processes

## Problem

When a user interacts with an agent via attached TUI (e.g., sends a message after agent is blocked), the `orch monitor` dashboard continued to show the old "blocked" status. The status only updated after running `orch ps` separately.

## Root Cause

The daemon correctly detects status changes via the opencode API and writes status events to run files. However, without calling `Sync()` after writing, the OS may buffer the write data, causing other processes (like the monitor TUI) to not see the updated status until the buffer is eventually flushed.

## Solution

Add `f.Sync()` after writing events to ensure the data is immediately flushed to disk and visible to all processes reading the file.

## Testing

- All existing tests pass
- `go test ./...` passes

Fixes: orch-127