### PR TITLE
feat(monitor): add configurable opencode model+variant presets

### DIFF
--- a/internal/monitor/run_attacher.go
+++ b/internal/monitor/run_attacher.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/s22625/orch/internal/agent"
 	"github.com/s22625/orch/internal/model"
@@ -14,11 +15,18 @@ type RunAttacher interface {
 }
 
 func GetRunAttacher(agentType string) RunAttacher {
-	baseAgent, _ := parseAgentVariant(agentType)
+	baseAgent := extractAgentName(agentType)
 	if baseAgent == string(agent.AgentOpenCode) {
 		return &OpenCodeRunAttacher{}
 	}
 	return &TmuxRunAttacher{}
+}
+
+func extractAgentName(agentType string) string {
+	if idx := strings.Index(agentType, ":"); idx != -1 {
+		return agentType[:idx]
+	}
+	return agentType
 }
 
 type TmuxRunAttacher struct{}


### PR DESCRIPTION
## Summary

- Add `opencode_presets` config option to `.orch/config.yaml` for defining custom model+variant combinations
- Presets appear in monitor `[r]` agent selection menu as `opencode:<preset-name>`
- When selected, passes `--model` and `--model-variant` flags to `orch run`/`orch continue`

## Example Configuration

```yaml
opencode_presets:
  - name: opus:high
    model: anthropic/claude-opus-4-5
    variant: high
  - name: opus:max
    model: anthropic/claude-opus-4-5
    variant: max
  - name: gpt5.2
    model: openai/gpt-5.2
  - name: gemini3-pro:high
    model: google/gemini-3-pro
    variant: high
```

## Changes

- `internal/config/config.go`: Add `OpenCodePreset` struct and `OpenCodePresets` field
- `internal/monitor/monitor.go`: Load presets from config, update `GetAvailableAgents()` and `StartRun()`/`ContinueRun()` 
- `internal/monitor/run_attacher.go`: Extract agent name helper for attacher logic
- `internal/monitor/monitor_test.go`: Add tests for new preset parsing

Closes: orch-131