### PR TITLE
feat(config): add opencode default model/variant configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,12 @@ type OpenCodePreset struct {
 	Variant string `yaml:"variant"` // Model variant (e.g., "high", "max")
 }
 
+// OpenCodeConfig holds default configuration for the opencode agent.
+type OpenCodeConfig struct {
+	DefaultModel   string `yaml:"default_model,omitempty"`
+	DefaultVariant string `yaml:"default_variant,omitempty"`
+}
+
 // Config holds orch configuration
 type Config struct {
 	Vault           string           `yaml:"vault"`
@@ -37,6 +43,7 @@ type Config struct {
 	NoPR            bool             `yaml:"no_pr"`
 	Monitor         MonitorConfig    `yaml:"monitor"`
 	OpenCodePresets []OpenCodePreset `yaml:"opencode_presets"`
+	OpenCode        OpenCodeConfig   `yaml:"opencode"`
 }
 
 type fileConfig struct {
@@ -55,6 +62,7 @@ type fileConfig struct {
 	NoPR              *bool            `yaml:"no_pr"`
 	Monitor           MonitorConfig    `yaml:"monitor"`
 	OpenCodePresets   []OpenCodePreset `yaml:"opencode_presets"`
+	OpenCode          OpenCodeConfig   `yaml:"opencode"`
 }
 
 // configFile is the name of the config file
@@ -228,6 +236,12 @@ func loadFromFile(path string, cfg *Config) error {
 	if len(fileCfg.OpenCodePresets) > 0 {
 		cfg.OpenCodePresets = fileCfg.OpenCodePresets
 	}
+	if fileCfg.OpenCode.DefaultModel != "" {
+		cfg.OpenCode.DefaultModel = fileCfg.OpenCode.DefaultModel
+	}
+	if fileCfg.OpenCode.DefaultVariant != "" {
+		cfg.OpenCode.DefaultVariant = fileCfg.OpenCode.DefaultVariant
+	}
 
 	return nil
 }
@@ -288,6 +302,12 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("ORCH_NO_PR"); v != "" {
 		cfg.NoPR = v == "true" || v == "1" || v == "yes"
+	}
+	if v := os.Getenv("ORCH_OPENCODE_DEFAULT_MODEL"); v != "" {
+		cfg.OpenCode.DefaultModel = v
+	}
+	if v := os.Getenv("ORCH_OPENCODE_DEFAULT_VARIANT"); v != "" {
+		cfg.OpenCode.DefaultVariant = v
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `OpenCodeConfig` struct with `default_model` and `default_variant` fields
- Configure via `opencode.default_model` and `opencode.default_variant` in config.yaml
- Environment variable support: `ORCH_OPENCODE_DEFAULT_MODEL`, `ORCH_OPENCODE_DEFAULT_VARIANT`
- Always log `agent_model` artifact when model is explicitly specified (not just when fetched from API)

## Configuration Example

```yaml
opencode:
  default_model: anthropic/claude-sonnet-4-5
  default_variant: max
```

## Changes

- `internal/config/config.go`: Add OpenCodeConfig struct and parsing
- `internal/cli/run.go`: Apply opencode-specific defaults, always log agent_model artifact
- `internal/config/config_test.go`: Add tests for new config parsing

Resolves: orch-129