### PR TITLE
feat(config): add separate control agent configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,25 +44,34 @@ type Config struct {
 	Monitor         MonitorConfig    `yaml:"monitor"`
 	OpenCodePresets []OpenCodePreset `yaml:"opencode_presets"`
 	OpenCode        OpenCodeConfig   `yaml:"opencode"`
+
+	// Control agent settings (for orch monitor 'c' keybinding)
+	// Falls back to run agent defaults if not set
+	ControlAgent        string `yaml:"control_agent"`
+	ControlModel        string `yaml:"control_model"`
+	ControlModelVariant string `yaml:"control_model_variant"`
 }
 
 type fileConfig struct {
-	Vault             string           `yaml:"vault"`
-	VaultLegacy       string           `yaml:"Vault"`
-	DefaultVault      string           `yaml:"default_vault"`
-	Agent             string           `yaml:"agent"`
-	Model             string           `yaml:"model"`
-	ModelVariant      string           `yaml:"model_variant"`
-	WorktreeDir       string           `yaml:"worktree_dir"`
-	WorktreeDirLegacy string           `yaml:"worktree_root"`
-	BaseBranch        string           `yaml:"base_branch"`
-	PRTargetBranch    string           `yaml:"pr_target_branch"`
-	LogLevel          string           `yaml:"log_level"`
-	PromptTemplate    string           `yaml:"prompt_template"`
-	NoPR              *bool            `yaml:"no_pr"`
-	Monitor           MonitorConfig    `yaml:"monitor"`
-	OpenCodePresets   []OpenCodePreset `yaml:"opencode_presets"`
-	OpenCode          OpenCodeConfig   `yaml:"opencode"`
+	Vault               string           `yaml:"vault"`
+	VaultLegacy         string           `yaml:"Vault"`
+	DefaultVault        string           `yaml:"default_vault"`
+	Agent               string           `yaml:"agent"`
+	Model               string           `yaml:"model"`
+	ModelVariant        string           `yaml:"model_variant"`
+	WorktreeDir         string           `yaml:"worktree_dir"`
+	WorktreeDirLegacy   string           `yaml:"worktree_root"`
+	BaseBranch          string           `yaml:"base_branch"`
+	PRTargetBranch      string           `yaml:"pr_target_branch"`
+	LogLevel            string           `yaml:"log_level"`
+	PromptTemplate      string           `yaml:"prompt_template"`
+	NoPR                *bool            `yaml:"no_pr"`
+	Monitor             MonitorConfig    `yaml:"monitor"`
+	OpenCodePresets     []OpenCodePreset `yaml:"opencode_presets"`
+	OpenCode            OpenCodeConfig   `yaml:"opencode"`
+	ControlAgent        string           `yaml:"control_agent"`
+	ControlModel        string           `yaml:"control_model"`
+	ControlModelVariant string           `yaml:"control_model_variant"`
 }
 
 // configFile is the name of the config file
@@ -242,6 +251,15 @@ func loadFromFile(path string, cfg *Config) error {
 	if fileCfg.OpenCode.DefaultVariant != "" {
 		cfg.OpenCode.DefaultVariant = fileCfg.OpenCode.DefaultVariant
 	}
+	if fileCfg.ControlAgent != "" {
+		cfg.ControlAgent = fileCfg.ControlAgent
+	}
+	if fileCfg.ControlModel != "" {
+		cfg.ControlModel = fileCfg.ControlModel
+	}
+	if fileCfg.ControlModelVariant != "" {
+		cfg.ControlModelVariant = fileCfg.ControlModelVariant
+	}
 
 	return nil
 }
@@ -308,6 +326,15 @@ func applyEnv(cfg *Config) {
 	}
 	if v := os.Getenv("ORCH_OPENCODE_DEFAULT_VARIANT"); v != "" {
 		cfg.OpenCode.DefaultVariant = v
+	}
+	if v := os.Getenv("ORCH_CONTROL_AGENT"); v != "" {
+		cfg.ControlAgent = v
+	}
+	if v := os.Getenv("ORCH_CONTROL_MODEL"); v != "" {
+		cfg.ControlModel = v
+	}
+	if v := os.Getenv("ORCH_CONTROL_MODEL_VARIANT"); v != "" {
+		cfg.ControlModelVariant = v
 	}
 }
 

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -995,10 +995,19 @@ func (m *Monitor) agentChatLaunch() agentChatLaunch {
 	cfg, cfgErr := config.Load()
 	if cfgErr == nil {
 		if agentName == "" {
-			agentName = cfg.Agent
+			agentName = cfg.ControlAgent
+			if agentName == "" {
+				agentName = cfg.Agent
+			}
 		}
-		modelName = cfg.Model
-		modelVariant = cfg.ModelVariant
+		modelName = cfg.ControlModel
+		if modelName == "" {
+			modelName = cfg.Model
+		}
+		modelVariant = cfg.ControlModelVariant
+		if modelVariant == "" {
+			modelVariant = cfg.ModelVariant
+		}
 	}
 	if agentName == "" {
 		agentName = "opencode"

--- a/specs/07-config.md
+++ b/specs/07-config.md
@@ -32,8 +32,12 @@ vault: ~/vault
 # または同じvault内にissueを置く場合
 vault: .
 
-# default agent
+# default agent for runs
 agent: claude
+
+# default model/variant for runs
+model: sonnet
+model_variant: default
 
 # worktree directory (default: ~/.orch/worktrees)
 worktree_dir: ~/.orch/worktrees
@@ -43,6 +47,12 @@ base_branch: main
 
 # default PR target branch
 pr_target_branch: main
+
+# control agent settings (for orch monitor 'c' keybinding)
+# falls back to run agent defaults if not set
+control_agent: opencode
+control_model: opus
+control_model_variant: default
 ```
 
 ### 自動検出
@@ -77,6 +87,11 @@ log_level: info
 |------|------|
 | `ORCH_VAULT` | Vault path |
 | `ORCH_BACKEND` | Backend type (file/github/linear) |
-| `ORCH_AGENT` | Default agent |
+| `ORCH_AGENT` | Default agent for runs |
+| `ORCH_MODEL` | Default model for runs |
+| `ORCH_MODEL_VARIANT` | Default model variant for runs |
 | `ORCH_LOG_LEVEL` | Log level |
 | `ORCH_PR_TARGET_BRANCH` | Default PR target branch |
+| `ORCH_CONTROL_AGENT` | Control agent (falls back to ORCH_AGENT) |
+| `ORCH_CONTROL_MODEL` | Control agent model (falls back to ORCH_MODEL) |
+| `ORCH_CONTROL_MODEL_VARIANT` | Control agent model variant (falls back to ORCH_MODEL_VARIANT) |


### PR DESCRIPTION
## Summary

- Add `control_agent`, `control_model`, `control_model_variant` config options for the orch monitor control agent ('c' keybinding)
- Control agent settings fall back to run agent defaults if not set
- Add environment variable support (`ORCH_CONTROL_AGENT`, `ORCH_CONTROL_MODEL`, `ORCH_CONTROL_MODEL_VARIANT`)

## Changes

- `internal/config/config.go`: Add new config fields, YAML parsing, and env var handling
- `internal/monitor/monitor.go`: Update `agentChatLaunch()` to prefer control-specific settings with fallback
- `specs/07-config.md`: Document new configuration options

## Usage

```yaml
# .orch/config.yaml

# Run agent defaults
agent: opencode
model: sonnet
model_variant: default

# Control agent settings (optional - falls back to run defaults)
control_agent: opencode
control_model: opus
control_model_variant: default
```

Closes orch-132