### PR TITLE
feat(config): add separate config for control agent

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,25 +44,33 @@ type Config struct {
 	Monitor         MonitorConfig    `yaml:"monitor"`
 	OpenCodePresets []OpenCodePreset `yaml:"opencode_presets"`
 	OpenCode        OpenCodeConfig   `yaml:"opencode"`
+	// Control agent settings (for orch monitor 'c' keybinding)
+	// Falls back to Agent/Model/ModelVariant if not set
+	ControlAgent        string `yaml:"control_agent"`
+	ControlModel        string `yaml:"control_model"`
+	ControlModelVariant string `yaml:"control_model_variant"`
 }
 
 type fileConfig struct {
-	Vault             string           `yaml:"vault"`
-	VaultLegacy       string           `yaml:"Vault"`
-	DefaultVault      string           `yaml:"default_vault"`
-	Agent             string           `yaml:"agent"`
-	Model             string           `yaml:"model"`
-	ModelVariant      string           `yaml:"model_variant"`
-	WorktreeDir       string           `yaml:"worktree_dir"`
-	WorktreeDirLegacy string           `yaml:"worktree_root"`
-	BaseBranch        string           `yaml:"base_branch"`
-	PRTargetBranch    string           `yaml:"pr_target_branch"`
-	LogLevel          string           `yaml:"log_level"`
-	PromptTemplate    string           `yaml:"prompt_template"`
-	NoPR              *bool            `yaml:"no_pr"`
-	Monitor           MonitorConfig    `yaml:"monitor"`
-	OpenCodePresets   []OpenCodePreset `yaml:"opencode_presets"`
-	OpenCode          OpenCodeConfig   `yaml:"opencode"`
+	Vault               string           `yaml:"vault"`
+	VaultLegacy         string           `yaml:"Vault"`
+	DefaultVault        string           `yaml:"default_vault"`
+	Agent               string           `yaml:"agent"`
+	Model               string           `yaml:"model"`
+	ModelVariant        string           `yaml:"model_variant"`
+	WorktreeDir         string           `yaml:"worktree_dir"`
+	WorktreeDirLegacy   string           `yaml:"worktree_root"`
+	BaseBranch          string           `yaml:"base_branch"`
+	PRTargetBranch      string           `yaml:"pr_target_branch"`
+	LogLevel            string           `yaml:"log_level"`
+	PromptTemplate      string           `yaml:"prompt_template"`
+	NoPR                *bool            `yaml:"no_pr"`
+	Monitor             MonitorConfig    `yaml:"monitor"`
+	OpenCodePresets     []OpenCodePreset `yaml:"opencode_presets"`
+	OpenCode            OpenCodeConfig   `yaml:"opencode"`
+	ControlAgent        string           `yaml:"control_agent"`
+	ControlModel        string           `yaml:"control_model"`
+	ControlModelVariant string           `yaml:"control_model_variant"`
 }
 
 // configFile is the name of the config file
@@ -242,6 +250,15 @@ func loadFromFile(path string, cfg *Config) error {
 	if fileCfg.OpenCode.DefaultVariant != "" {
 		cfg.OpenCode.DefaultVariant = fileCfg.OpenCode.DefaultVariant
 	}
+	if fileCfg.ControlAgent != "" {
+		cfg.ControlAgent = fileCfg.ControlAgent
+	}
+	if fileCfg.ControlModel != "" {
+		cfg.ControlModel = fileCfg.ControlModel
+	}
+	if fileCfg.ControlModelVariant != "" {
+		cfg.ControlModelVariant = fileCfg.ControlModelVariant
+	}
 
 	return nil
 }
@@ -309,6 +326,15 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("ORCH_OPENCODE_DEFAULT_VARIANT"); v != "" {
 		cfg.OpenCode.DefaultVariant = v
 	}
+	if v := os.Getenv("ORCH_CONTROL_AGENT"); v != "" {
+		cfg.ControlAgent = v
+	}
+	if v := os.Getenv("ORCH_CONTROL_MODEL"); v != "" {
+		cfg.ControlModel = v
+	}
+	if v := os.Getenv("ORCH_CONTROL_MODEL_VARIANT"); v != "" {
+		cfg.ControlModelVariant = v
+	}
 }
 
 // GetOpenCodePreset returns the preset with the given name, or nil if not found.
@@ -319,6 +345,30 @@ func (c *Config) GetOpenCodePreset(name string) *OpenCodePreset {
 		}
 	}
 	return nil
+}
+
+// GetControlAgent returns the control agent, falling back to Agent if not set.
+func (c *Config) GetControlAgent() string {
+	if c.ControlAgent != "" {
+		return c.ControlAgent
+	}
+	return c.Agent
+}
+
+// GetControlModel returns the control model, falling back to Model if not set.
+func (c *Config) GetControlModel() string {
+	if c.ControlModel != "" {
+		return c.ControlModel
+	}
+	return c.Model
+}
+
+// GetControlModelVariant returns the control model variant, falling back to ModelVariant if not set.
+func (c *Config) GetControlModelVariant() string {
+	if c.ControlModelVariant != "" {
+		return c.ControlModelVariant
+	}
+	return c.ModelVariant
 }
 
 // ExpandPath expands ~ and makes path absolute relative to base

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -995,10 +995,10 @@ func (m *Monitor) agentChatLaunch() agentChatLaunch {
 	cfg, cfgErr := config.Load()
 	if cfgErr == nil {
 		if agentName == "" {
-			agentName = cfg.Agent
+			agentName = cfg.GetControlAgent()
 		}
-		modelName = cfg.Model
-		modelVariant = cfg.ModelVariant
+		modelName = cfg.GetControlModel()
+		modelVariant = cfg.GetControlModelVariant()
 	}
 	if agentName == "" {
 		agentName = "opencode"

--- a/specs/07-config.md
+++ b/specs/07-config.md
@@ -32,8 +32,12 @@ vault: ~/vault
 # または同じvault内にissueを置く場合
 vault: .
 
-# default agent
+# default agent for runs
 agent: claude
+
+# default model/variant for runs
+model: sonnet
+model_variant: default
 
 # worktree directory (default: ~/.orch/worktrees)
 worktree_dir: ~/.orch/worktrees
@@ -43,6 +47,12 @@ base_branch: main
 
 # default PR target branch
 pr_target_branch: main
+
+# control agent settings (for orch monitor 'c' keybinding)
+# falls back to agent/model/model_variant if not set
+control_agent: opencode
+control_model: opus
+control_model_variant: default
 ```
 
 ### 自動検出
@@ -78,5 +88,10 @@ log_level: info
 | `ORCH_VAULT` | Vault path |
 | `ORCH_BACKEND` | Backend type (file/github/linear) |
 | `ORCH_AGENT` | Default agent |
+| `ORCH_MODEL` | Default model |
+| `ORCH_MODEL_VARIANT` | Default model variant |
 | `ORCH_LOG_LEVEL` | Log level |
 | `ORCH_PR_TARGET_BRANCH` | Default PR target branch |
+| `ORCH_CONTROL_AGENT` | Control agent (falls back to ORCH_AGENT) |
+| `ORCH_CONTROL_MODEL` | Control model (falls back to ORCH_MODEL) |
+| `ORCH_CONTROL_MODEL_VARIANT` | Control model variant (falls back to ORCH_MODEL_VARIANT) |


### PR DESCRIPTION
## Summary

Adds dedicated control agent configuration in `.orch/config.yaml` to allow different agent settings for run agents vs. control agents (used by `orch monitor` 'c' keybinding).

- Add `control_agent`, `control_model`, `control_model_variant` fields to config schema
- Update `orch monitor` control agent spawning to use these settings
- Fall back to run agent defaults (`agent`/`model`/`model_variant`) if control-specific config is not set

## Changes

- `internal/config/config.go`: Add new config fields, fileConfig fields, environment variable support, and helper methods (`GetControlAgent()`, `GetControlModel()`, `GetControlModelVariant()`)
- `internal/monitor/monitor.go`: Update `agentChatLaunch()` to use control agent config
- `internal/config/config_test.go`: Add tests for new config fields and fallback behavior
- `specs/07-config.md`: Document new config options and environment variables

## Example Usage

```yaml
# Existing run defaults
agent: opencode
model: sonnet
model_variant: default

# New: Control agent defaults (optional, falls back to run defaults)
control_agent: opencode
control_model: opus
control_model_variant: high
```

## Environment Variables

- `ORCH_CONTROL_AGENT` - Control agent (falls back to `ORCH_AGENT`)
- `ORCH_CONTROL_MODEL` - Control model (falls back to `ORCH_MODEL`)
- `ORCH_CONTROL_MODEL_VARIANT` - Control model variant (falls back to `ORCH_MODEL_VARIANT`)

Closes: orch-132