### PR TITLE
feat(cli): add --preset flag to orch run with backend-agnostic preset config

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -38,6 +38,7 @@ type runOptions struct {
 	PRTargetBranch string
 	Model          string
 	ModelVariant   string
+	Preset         string
 	Verbose        bool
 }
 
@@ -80,6 +81,7 @@ Debug output can be enabled with --verbose, --log-level debug, or ORCH_DEBUG=1.`
 	cmd.Flags().StringVar(&opts.PromptTemplate, "prompt-template", "", "Custom prompt template file")
 	cmd.Flags().StringVar(&opts.Model, "model", "", "Model for opencode (provider/model format, e.g., anthropic/claude-opus-4-5)")
 	cmd.Flags().StringVar(&opts.ModelVariant, "model-variant", "", "Model variant (e.g., 'max' for max thinking)")
+	cmd.Flags().StringVar(&opts.Preset, "preset", "", "Use a named preset from config (e.g., 'opus:high', 'gpt5.2-codex:xhigh')")
 	cmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Enable debug output for troubleshooting")
 
 	return cmd
@@ -563,6 +565,28 @@ func applyPromptConfigDefaults(opts *runOptions) error {
 	cfg, err := config.Load()
 	if err != nil {
 		return err
+	}
+
+	if opts.Preset != "" {
+		presetOpts := cfg.ResolvePreset(opts.Preset)
+		if presetOpts == nil {
+			return fmt.Errorf("preset not found: %s", opts.Preset)
+		}
+		if opts.Agent == "" {
+			opts.Agent = presetOpts.Agent
+		}
+		if opts.Model == "" {
+			opts.Model = presetOpts.Model
+		}
+		if opts.ModelVariant == "" {
+			opts.ModelVariant = presetOpts.ModelVariant
+		}
+		if opts.AgentProfile == "" {
+			opts.AgentProfile = presetOpts.Profile
+		}
+		if opts.AgentCmd == "" {
+			opts.AgentCmd = presetOpts.Command
+		}
 	}
 
 	// Apply config defaults for core run options

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,10 +17,38 @@ type MonitorConfig struct {
 
 // OpenCodePreset defines a configurable opencode model+variant preset.
 // These presets appear in the monitor agent selection as "opencode:<name>".
+// Deprecated: Use Preset with Backend="opencode" instead.
 type OpenCodePreset struct {
 	Name    string `yaml:"name"`    // Display name (e.g., "opus:high")
 	Model   string `yaml:"model"`   // Model identifier (e.g., "anthropic/claude-opus-4-5")
 	Variant string `yaml:"variant"` // Model variant (e.g., "high", "max")
+}
+
+// Preset defines a backend-agnostic preset configuration.
+// Presets allow configuring agent+model combinations with memorable names.
+type Preset struct {
+	Name    string `yaml:"name"`              // Display name (e.g., "opus:high", "codex:default")
+	Backend string `yaml:"backend,omitempty"` // Agent backend (claude, codex, gemini, opencode, custom)
+	// OpenCode-specific options
+	Model   string `yaml:"model,omitempty"`   // Model in provider/model format (e.g., "anthropic/claude-opus-4-5")
+	Variant string `yaml:"variant,omitempty"` // Model variant (e.g., "high", "max", "xhigh")
+	// Claude-specific options
+	Profile string `yaml:"profile,omitempty"` // Claude profile name
+	// Codex-specific options
+	// (Model field is reused for codex model specification)
+	// Gemini-specific options
+	// (Model field is reused for gemini model specification)
+	// Custom agent options
+	Command string `yaml:"command,omitempty"` // Custom agent command
+}
+
+// PresetOptions contains the resolved options from a preset.
+type PresetOptions struct {
+	Agent        string
+	Model        string
+	ModelVariant string
+	Profile      string
+	Command      string
 }
 
 // OpenCodeConfig holds default configuration for the opencode agent.
@@ -42,7 +70,8 @@ type Config struct {
 	PromptTemplate  string           `yaml:"prompt_template"`
 	NoPR            bool             `yaml:"no_pr"`
 	Monitor         MonitorConfig    `yaml:"monitor"`
-	OpenCodePresets []OpenCodePreset `yaml:"opencode_presets"`
+	Presets         []Preset         `yaml:"presets"`
+	OpenCodePresets []OpenCodePreset `yaml:"opencode_presets"` // Deprecated: use Presets
 	OpenCode        OpenCodeConfig   `yaml:"opencode"`
 
 	// Control agent settings (for orch monitor 'c' keybinding)
@@ -67,6 +96,7 @@ type fileConfig struct {
 	PromptTemplate      string           `yaml:"prompt_template"`
 	NoPR                *bool            `yaml:"no_pr"`
 	Monitor             MonitorConfig    `yaml:"monitor"`
+	Presets             []Preset         `yaml:"presets"`
 	OpenCodePresets     []OpenCodePreset `yaml:"opencode_presets"`
 	OpenCode            OpenCodeConfig   `yaml:"opencode"`
 	ControlAgent        string           `yaml:"control_agent"`
@@ -242,6 +272,9 @@ func loadFromFile(path string, cfg *Config) error {
 	if len(fileCfg.Monitor.PSColumns) > 0 {
 		cfg.Monitor.PSColumns = fileCfg.Monitor.PSColumns
 	}
+	if len(fileCfg.Presets) > 0 {
+		cfg.Presets = fileCfg.Presets
+	}
 	if len(fileCfg.OpenCodePresets) > 0 {
 		cfg.OpenCodePresets = fileCfg.OpenCodePresets
 	}
@@ -339,6 +372,7 @@ func applyEnv(cfg *Config) {
 }
 
 // GetOpenCodePreset returns the preset with the given name, or nil if not found.
+// Deprecated: Use GetPreset instead.
 func (c *Config) GetOpenCodePreset(name string) *OpenCodePreset {
 	for i := range c.OpenCodePresets {
 		if c.OpenCodePresets[i].Name == name {
@@ -346,6 +380,74 @@ func (c *Config) GetOpenCodePreset(name string) *OpenCodePreset {
 		}
 	}
 	return nil
+}
+
+// GetPreset returns the preset with the given name, or nil if not found.
+// It first searches the new Presets field, then falls back to OpenCodePresets
+// for backward compatibility.
+func (c *Config) GetPreset(name string) *Preset {
+	for i := range c.Presets {
+		if c.Presets[i].Name == name {
+			return &c.Presets[i]
+		}
+	}
+	for i := range c.OpenCodePresets {
+		if c.OpenCodePresets[i].Name == name {
+			return &Preset{
+				Name:    c.OpenCodePresets[i].Name,
+				Backend: "opencode",
+				Model:   c.OpenCodePresets[i].Model,
+				Variant: c.OpenCodePresets[i].Variant,
+			}
+		}
+	}
+	return nil
+}
+
+// ResolvePreset resolves a preset name to run options.
+// Returns nil if the preset is not found.
+func (c *Config) ResolvePreset(name string) *PresetOptions {
+	preset := c.GetPreset(name)
+	if preset == nil {
+		return nil
+	}
+
+	backend := preset.Backend
+	if backend == "" {
+		backend = "opencode"
+	}
+
+	return &PresetOptions{
+		Agent:        backend,
+		Model:        preset.Model,
+		ModelVariant: preset.Variant,
+		Profile:      preset.Profile,
+		Command:      preset.Command,
+	}
+}
+
+// GetAllPresets returns all presets, merging both new Presets and legacy OpenCodePresets.
+// This is useful for UI display in the monitor.
+func (c *Config) GetAllPresets() []Preset {
+	result := make([]Preset, 0, len(c.Presets)+len(c.OpenCodePresets))
+	result = append(result, c.Presets...)
+
+	seen := make(map[string]bool, len(c.Presets))
+	for _, p := range c.Presets {
+		seen[p.Name] = true
+	}
+
+	for _, ocp := range c.OpenCodePresets {
+		if !seen[ocp.Name] {
+			result = append(result, Preset{
+				Name:    ocp.Name,
+				Backend: "opencode",
+				Model:   ocp.Model,
+				Variant: ocp.Variant,
+			})
+		}
+	}
+	return result
 }
 
 // ExpandPath expands ~ and makes path absolute relative to base

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -492,3 +492,198 @@ func TestRelativePathFromSubdirectory(t *testing.T) {
 		t.Fatalf("worktree_dir should end with %q: got %q", expectedSuffix, cfg.WorktreeDir)
 	}
 }
+
+func TestPresets(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ORCH_VAULT", "")
+	t.Setenv("ORCH_AGENT", "")
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".orch"), 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	configContent := `vault: /repo
+presets:
+  - name: opus:high
+    backend: opencode
+    model: anthropic/claude-opus-4-5
+    variant: high
+  - name: gpt5.2-codex:xhigh
+    backend: opencode
+    model: openai/gpt-5.2-codex
+    variant: xhigh
+  - name: codex:default
+    backend: codex
+    model: gpt-5.2-codex
+  - name: claude:fast
+    backend: claude
+    profile: fast-profile
+`
+	if err := os.WriteFile(filepath.Join(repo, ".orch", "config.yaml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("write repo config: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+
+	if len(cfg.Presets) != 4 {
+		t.Fatalf("Presets length = %d, want 4", len(cfg.Presets))
+	}
+
+	preset := cfg.GetPreset("opus:high")
+	if preset == nil {
+		t.Fatalf("GetPreset(opus:high) returned nil")
+	}
+	if preset.Backend != "opencode" || preset.Model != "anthropic/claude-opus-4-5" || preset.Variant != "high" {
+		t.Fatalf("unexpected preset: %+v", preset)
+	}
+
+	opts := cfg.ResolvePreset("claude:fast")
+	if opts == nil {
+		t.Fatalf("ResolvePreset(claude:fast) returned nil")
+	}
+	if opts.Agent != "claude" || opts.Profile != "fast-profile" {
+		t.Fatalf("unexpected resolved preset: %+v", opts)
+	}
+
+	missingOpts := cfg.ResolvePreset("nonexistent")
+	if missingOpts != nil {
+		t.Fatalf("ResolvePreset(nonexistent) should return nil")
+	}
+}
+
+func TestLegacyOpenCodePresetsBackwardCompat(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ORCH_VAULT", "")
+	t.Setenv("ORCH_AGENT", "")
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".orch"), 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	configContent := `vault: /repo
+opencode_presets:
+  - name: opus:high
+    model: anthropic/claude-opus-4-5
+    variant: high
+  - name: sonnet:max
+    model: anthropic/claude-sonnet-4-5
+    variant: max
+`
+	if err := os.WriteFile(filepath.Join(repo, ".orch", "config.yaml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("write repo config: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+
+	if len(cfg.OpenCodePresets) != 2 {
+		t.Fatalf("OpenCodePresets length = %d, want 2", len(cfg.OpenCodePresets))
+	}
+
+	preset := cfg.GetPreset("opus:high")
+	if preset == nil {
+		t.Fatalf("GetPreset(opus:high) returned nil for legacy preset")
+	}
+	if preset.Backend != "opencode" || preset.Model != "anthropic/claude-opus-4-5" || preset.Variant != "high" {
+		t.Fatalf("unexpected legacy preset converted: %+v", preset)
+	}
+
+	opts := cfg.ResolvePreset("sonnet:max")
+	if opts == nil {
+		t.Fatalf("ResolvePreset(sonnet:max) returned nil for legacy preset")
+	}
+	if opts.Agent != "opencode" || opts.Model != "anthropic/claude-sonnet-4-5" || opts.ModelVariant != "max" {
+		t.Fatalf("unexpected resolved legacy preset: %+v", opts)
+	}
+
+	allPresets := cfg.GetAllPresets()
+	if len(allPresets) != 2 {
+		t.Fatalf("GetAllPresets length = %d, want 2", len(allPresets))
+	}
+}
+
+func TestMixedPresetsAndLegacy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ORCH_VAULT", "")
+	t.Setenv("ORCH_AGENT", "")
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".orch"), 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	configContent := `vault: /repo
+presets:
+  - name: gpt5:xhigh
+    backend: opencode
+    model: openai/gpt-5.2-codex
+    variant: xhigh
+opencode_presets:
+  - name: opus:high
+    model: anthropic/claude-opus-4-5
+    variant: high
+`
+	if err := os.WriteFile(filepath.Join(repo, ".orch", "config.yaml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("write repo config: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+
+	allPresets := cfg.GetAllPresets()
+	if len(allPresets) != 2 {
+		t.Fatalf("GetAllPresets length = %d, want 2", len(allPresets))
+	}
+
+	gpt5 := cfg.GetPreset("gpt5:xhigh")
+	if gpt5 == nil || gpt5.Model != "openai/gpt-5.2-codex" {
+		t.Fatalf("GetPreset(gpt5:xhigh) failed: %+v", gpt5)
+	}
+
+	opus := cfg.GetPreset("opus:high")
+	if opus == nil || opus.Model != "anthropic/claude-opus-4-5" {
+		t.Fatalf("GetPreset(opus:high) failed: %+v", opus)
+	}
+}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -58,23 +58,23 @@ type Options struct {
 
 // Monitor manages tmux windows and dashboard state.
 type Monitor struct {
-	session         string
-	runFilter       RunFilter
-	runSort         SortKey
-	issueSort       SortKey
-	store           store.Store
-	orchPath        string
-	globalFlags     []string
-	agent           string
-	attach          bool
-	forceNew        bool
-	runs            []*RunWindow
-	dashboard       *Dashboard
-	showResolved    bool
-	showClosed      bool
-	uiSettings      *UISettings
-	orchDir         string
-	opencodePresets []config.OpenCodePreset
+	session      string
+	runFilter    RunFilter
+	runSort      SortKey
+	issueSort    SortKey
+	store        store.Store
+	orchPath     string
+	globalFlags  []string
+	agent        string
+	attach       bool
+	forceNew     bool
+	runs         []*RunWindow
+	dashboard    *Dashboard
+	showResolved bool
+	showClosed   bool
+	uiSettings   *UISettings
+	orchDir      string
+	presets      []config.Preset
 }
 
 // RunWindow links a run to a dashboard index.
@@ -104,26 +104,26 @@ func New(st store.Store, opts Options) *Monitor {
 		uiSettings = DefaultUISettings()
 	}
 	orchDir := GetOrchDir(st.VaultPath())
-	var presets []config.OpenCodePreset
+	var presets []config.Preset
 	if cfg, err := config.Load(); err == nil {
-		presets = cfg.OpenCodePresets
+		presets = cfg.GetAllPresets()
 	}
 	return &Monitor{
-		session:         session,
-		runFilter:       newRunFilter(opts),
-		runSort:         runSort,
-		issueSort:       issueSort,
-		store:           st,
-		orchPath:        orchPath,
-		globalFlags:     opts.GlobalFlags,
-		agent:           opts.Agent,
-		attach:          opts.Attach,
-		forceNew:        opts.ForceNew,
-		showResolved:    opts.ShowResolved,
-		showClosed:      opts.ShowClosed,
-		uiSettings:      uiSettings,
-		orchDir:         orchDir,
-		opencodePresets: presets,
+		session:      session,
+		runFilter:    newRunFilter(opts),
+		runSort:      runSort,
+		issueSort:    issueSort,
+		store:        st,
+		orchPath:     orchPath,
+		globalFlags:  opts.GlobalFlags,
+		agent:        opts.Agent,
+		attach:       opts.Attach,
+		forceNew:     opts.ForceNew,
+		showResolved: opts.ShowResolved,
+		showClosed:   opts.ShowClosed,
+		uiSettings:   uiSettings,
+		orchDir:      orchDir,
+		presets:      presets,
 	}
 }
 
@@ -426,9 +426,15 @@ func (m *Monitor) parseAgentPreset(agentType string) (agentName, model, variant 
 	agentName = agentType[:idx]
 	presetName := agentType[idx+1:]
 
-	for _, preset := range m.opencodePresets {
+	for _, preset := range m.presets {
 		if preset.Name == presetName {
-			return agentName, preset.Model, preset.Variant
+			backend := preset.Backend
+			if backend == "" {
+				backend = "opencode"
+			}
+			if backend == agentName {
+				return agentName, preset.Model, preset.Variant
+			}
 		}
 	}
 
@@ -456,8 +462,12 @@ func (m *Monitor) GetAvailableAgents() []string {
 		}
 		if adapter.IsAvailable() {
 			available = append(available, agentName)
-			if aType == agent.AgentOpenCode {
-				for _, preset := range m.opencodePresets {
+			for _, preset := range m.presets {
+				backend := preset.Backend
+				if backend == "" {
+					backend = "opencode"
+				}
+				if backend == agentName {
 					available = append(available, agentName+":"+preset.Name)
 				}
 			}

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -195,11 +195,11 @@ func TestExtractAgentName(t *testing.T) {
 }
 
 func TestParseAgentPreset(t *testing.T) {
-	presets := []config.OpenCodePreset{
-		{Name: "opus:high", Model: "anthropic/claude-opus-4-5", Variant: "high"},
-		{Name: "gpt5.2", Model: "openai/gpt-5.2", Variant: ""},
+	presets := []config.Preset{
+		{Name: "opus:high", Backend: "opencode", Model: "anthropic/claude-opus-4-5", Variant: "high"},
+		{Name: "gpt5.2", Backend: "opencode", Model: "openai/gpt-5.2", Variant: ""},
 	}
-	m := &Monitor{opencodePresets: presets}
+	m := &Monitor{presets: presets}
 
 	tests := []struct {
 		input       string


### PR DESCRIPTION
## Summary

- Add `--preset` flag to `orch run` command for using named presets from config
- Refactor preset system to support all backends (claude, codex, gemini, opencode, custom), not just opencode
- Maintain backward compatibility with legacy `opencode_presets` config key

## Changes

### Config Structure

**New backend-agnostic format:**
```yaml
presets:
  - name: opus:high
    backend: opencode
    model: anthropic/claude-opus-4-5
    variant: high
  - name: codex:default
    backend: codex
    model: gpt-5.2-codex
  - name: claude:fast
    backend: claude
    profile: fast-profile
```

**Legacy format still works (backward compat):**
```yaml
opencode_presets:
  - name: opus:high
    model: anthropic/claude-opus-4-5
    variant: high
```

### CLI Usage

```bash
# Use a preset
orch run issue-123 --preset opus:high

# Override preset options with explicit flags
orch run issue-123 --preset opus:high --model-variant xhigh
```

### Files Changed

- `internal/config/config.go`: Add `Preset` struct, `GetPreset`, `ResolvePreset`, `GetAllPresets` functions
- `internal/cli/run.go`: Add `--preset` flag and preset resolution in config defaults
- `internal/monitor/monitor.go`: Update to use new `presets` format with backward compat
- `internal/config/config_test.go`: Add tests for preset resolution and backward compatibility
- `internal/monitor/monitor_test.go`: Update test to use new Preset type

## Testing

All tests pass:
```
go test ./...
```

Closes: orch-133