### PR TITLE
fix(ps): show clean instead of merged for fresh branches at target HEAD

### DIFF
--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -638,6 +638,8 @@ func gitStatesForRuns(runs []*model.Run, target string) map[string]string {
 		return nil
 	}
 
+	targetHead := git.GetBranchHead(repoRoot, targetRef)
+
 	states := make(map[string]string)
 	branchToRun := make(map[string]*model.Run)
 	var unmergedBranches []string
@@ -648,7 +650,12 @@ func gitStatesForRuns(runs []*model.Run, target string) map[string]string {
 		}
 
 		if merged[r.Branch] {
-			states[r.RunID] = "merged"
+			branchHead := git.GetBranchHead(repoRoot, r.Branch)
+			if branchHead != "" && branchHead == targetHead {
+				states[r.RunID] = "clean"
+			} else {
+				states[r.RunID] = "merged"
+			}
 			continue
 		}
 

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -115,3 +115,33 @@ func GetBranchesAheadCounts(repoRoot, target string, branches []string) map[stri
 	wg.Wait()
 	return results
 }
+
+// GetBranchHead returns the commit SHA that a branch points to.
+// Returns empty string if the branch doesn't exist or on error.
+func GetBranchHead(repoRoot, branch string) string {
+	if branch == "" {
+		return ""
+	}
+	if repoRoot == "" {
+		var err error
+		repoRoot, err = FindRepoRoot("")
+		if err != nil {
+			return ""
+		}
+	}
+
+	cmd := exec.Command(
+		"git",
+		"-C", repoRoot,
+		"rev-parse",
+		"--verify",
+		"--quiet",
+		branch,
+	)
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(string(output))
+}


### PR DESCRIPTION
## Summary

- Fresh branches at the same commit as main were incorrectly shown as `merged` in `orch ps` MERGED column
- Now compares branch HEAD to target HEAD first - if identical, shows `clean` instead of `merged`
- Adds `GetBranchHead` helper to `internal/git/branch.go`

## Issue

Fixes orch-136

## Root Cause

`git branch --merged target` returns branches where all commits are reachable from target. For a fresh branch at the same commit as main, all commits (just the base commit) ARE reachable from main, so it was incorrectly marked as "merged".

## Solution

Before marking as "merged", check if the branch HEAD equals the target HEAD. If they're the same commit, it's a fresh branch - mark as `clean` instead.

## Testing

- `go build ./...` - builds successfully
- `go test ./...` - all tests pass