### PR TITLE
feat(cli): add --preset flag to orch run with backend-agnostic preset configuration

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -38,6 +38,7 @@ type runOptions struct {
 	PRTargetBranch string
 	Model          string
 	ModelVariant   string
+	Preset         string
 	Verbose        bool
 }
 
@@ -80,6 +81,7 @@ Debug output can be enabled with --verbose, --log-level debug, or ORCH_DEBUG=1.`
 	cmd.Flags().StringVar(&opts.PromptTemplate, "prompt-template", "", "Custom prompt template file")
 	cmd.Flags().StringVar(&opts.Model, "model", "", "Model for opencode (provider/model format, e.g., anthropic/claude-opus-4-5)")
 	cmd.Flags().StringVar(&opts.ModelVariant, "model-variant", "", "Model variant (e.g., 'max' for max thinking)")
+	cmd.Flags().StringVar(&opts.Preset, "preset", "", "Named preset from config (e.g., 'opus:high', 'gpt5.2-codex:xhigh')")
 	cmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Enable debug output for troubleshooting")
 
 	return cmd
@@ -204,9 +206,11 @@ func runRun(issueID string, opts *runOptions) error {
 		return nil
 	}
 
-	// Create run document
 	metadata := map[string]string{
 		"agent": opts.Agent,
+	}
+	if opts.Preset != "" {
+		metadata["preset"] = opts.Preset
 	}
 	if opts.Model != "" {
 		metadata["model"] = opts.Model
@@ -557,16 +561,35 @@ func buildSimplePrompt(issue *model.Issue, opts *promptOptions) string {
 	return prompt
 }
 
-// applyPromptConfigDefaults applies config file defaults for prompt options
-// Command-line flags take precedence over config values
 func applyPromptConfigDefaults(opts *runOptions) error {
 	cfg, err := config.Load()
 	if err != nil {
 		return err
 	}
 
-	// Apply config defaults for core run options
-	// Only apply if command-line flag wasn't explicitly set (empty string = not set)
+	agentExplicit := opts.Agent != ""
+	modelExplicit := opts.Model != ""
+	variantExplicit := opts.ModelVariant != ""
+	profileExplicit := opts.AgentProfile != ""
+
+	if opts.Preset != "" {
+		preset := cfg.GetPreset(opts.Preset)
+		if preset == nil {
+			return fmt.Errorf("preset not found: %s", opts.Preset)
+		}
+		if !agentExplicit {
+			opts.Agent = preset.EffectiveBackend()
+		}
+		if !modelExplicit && preset.Model != "" {
+			opts.Model = preset.Model
+		}
+		if !variantExplicit && preset.Variant != "" {
+			opts.ModelVariant = preset.Variant
+		}
+		if !profileExplicit && preset.Profile != "" {
+			opts.AgentProfile = preset.Profile
+		}
+	}
 
 	// BaseBranch: use config value if flag not provided, fallback to "main"
 	if opts.BaseBranch == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"gopkg.in/yaml.v3"
 )
@@ -17,10 +19,29 @@ type MonitorConfig struct {
 
 // OpenCodePreset defines a configurable opencode model+variant preset.
 // These presets appear in the monitor agent selection as "opencode:<name>".
+// Deprecated: Use Preset with Backend="opencode" instead.
 type OpenCodePreset struct {
 	Name    string `yaml:"name"`    // Display name (e.g., "opus:high")
 	Model   string `yaml:"model"`   // Model identifier (e.g., "anthropic/claude-opus-4-5")
 	Variant string `yaml:"variant"` // Model variant (e.g., "high", "max")
+}
+
+// Preset defines a backend-agnostic preset configuration.
+// Presets can be used with --preset flag in orch run or via monitor agent selection.
+type Preset struct {
+	Name    string `yaml:"name"`              // Display name (e.g., "opus:high", "gpt5.2-codex:xhigh")
+	Backend string `yaml:"backend,omitempty"` // Backend type: opencode, claude, codex, gemini (default: opencode)
+	Model   string `yaml:"model,omitempty"`   // Model identifier (backend-specific)
+	Variant string `yaml:"variant,omitempty"` // Model variant (e.g., "high", "max", "xhigh")
+	Profile string `yaml:"profile,omitempty"` // Agent profile (e.g., for claude --profile)
+}
+
+// EffectiveBackend returns the backend for this preset, defaulting to "opencode" if not set.
+func (p *Preset) EffectiveBackend() string {
+	if p.Backend == "" {
+		return "opencode"
+	}
+	return p.Backend
 }
 
 // OpenCodeConfig holds default configuration for the opencode agent.
@@ -42,7 +63,8 @@ type Config struct {
 	PromptTemplate  string           `yaml:"prompt_template"`
 	NoPR            bool             `yaml:"no_pr"`
 	Monitor         MonitorConfig    `yaml:"monitor"`
-	OpenCodePresets []OpenCodePreset `yaml:"opencode_presets"`
+	Presets         []Preset         `yaml:"presets"`
+	OpenCodePresets []OpenCodePreset `yaml:"opencode_presets"` // Deprecated: use Presets instead
 	OpenCode        OpenCodeConfig   `yaml:"opencode"`
 
 	// Control agent settings (for orch monitor 'c' keybinding)
@@ -67,6 +89,7 @@ type fileConfig struct {
 	PromptTemplate      string           `yaml:"prompt_template"`
 	NoPR                *bool            `yaml:"no_pr"`
 	Monitor             MonitorConfig    `yaml:"monitor"`
+	Presets             []Preset         `yaml:"presets"`
 	OpenCodePresets     []OpenCodePreset `yaml:"opencode_presets"`
 	OpenCode            OpenCodeConfig   `yaml:"opencode"`
 	ControlAgent        string           `yaml:"control_agent"`
@@ -242,6 +265,9 @@ func loadFromFile(path string, cfg *Config) error {
 	if len(fileCfg.Monitor.PSColumns) > 0 {
 		cfg.Monitor.PSColumns = fileCfg.Monitor.PSColumns
 	}
+	if len(fileCfg.Presets) > 0 {
+		cfg.Presets = fileCfg.Presets
+	}
 	if len(fileCfg.OpenCodePresets) > 0 {
 		cfg.OpenCodePresets = fileCfg.OpenCodePresets
 	}
@@ -339,6 +365,7 @@ func applyEnv(cfg *Config) {
 }
 
 // GetOpenCodePreset returns the preset with the given name, or nil if not found.
+// Deprecated: Use GetPreset instead.
 func (c *Config) GetOpenCodePreset(name string) *OpenCodePreset {
 	for i := range c.OpenCodePresets {
 		if c.OpenCodePresets[i].Name == name {
@@ -346,6 +373,92 @@ func (c *Config) GetOpenCodePreset(name string) *OpenCodePreset {
 		}
 	}
 	return nil
+}
+
+// GetPreset returns the preset with the given name, searching both
+// new-style Presets and legacy OpenCodePresets (with backward compatibility).
+func (c *Config) GetPreset(name string) *Preset {
+	for i := range c.Presets {
+		if c.Presets[i].Name == name {
+			return &c.Presets[i]
+		}
+	}
+	for i := range c.OpenCodePresets {
+		if c.OpenCodePresets[i].Name == name {
+			return &Preset{
+				Name:    c.OpenCodePresets[i].Name,
+				Backend: "opencode",
+				Model:   c.OpenCodePresets[i].Model,
+				Variant: c.OpenCodePresets[i].Variant,
+			}
+		}
+	}
+	return nil
+}
+
+// GetAllPresets returns all presets, merging new-style Presets with
+// legacy OpenCodePresets (converted to Preset format). Results are sorted by name.
+func (c *Config) GetAllPresets() []Preset {
+	presetMap := make(map[string]Preset)
+	for _, p := range c.Presets {
+		presetMap[p.Name] = p
+	}
+	for _, p := range c.OpenCodePresets {
+		if _, exists := presetMap[p.Name]; !exists {
+			presetMap[p.Name] = Preset{
+				Name:    p.Name,
+				Backend: "opencode",
+				Model:   p.Model,
+				Variant: p.Variant,
+			}
+		}
+	}
+	result := make([]Preset, 0, len(presetMap))
+	for _, p := range presetMap {
+		result = append(result, p)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+// GetPresetsForBackend returns all presets for a specific backend.
+func (c *Config) GetPresetsForBackend(backend string) []Preset {
+	var result []Preset
+	for _, p := range c.GetAllPresets() {
+		if p.EffectiveBackend() == backend {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+var validBackends = map[string]bool{
+	"opencode": true,
+	"claude":   true,
+	"codex":    true,
+	"gemini":   true,
+	"custom":   true,
+}
+
+// ValidatePresets checks all presets for valid backends and configuration.
+func (c *Config) ValidatePresets() []string {
+	var warnings []string
+	for _, p := range c.Presets {
+		if p.Name == "" {
+			warnings = append(warnings, "preset has empty name")
+			continue
+		}
+		backend := p.EffectiveBackend()
+		if !validBackends[backend] {
+			warnings = append(warnings, fmt.Sprintf("preset %q has invalid backend %q", p.Name, backend))
+		}
+	}
+	if len(c.OpenCodePresets) > 0 && len(c.Presets) == 0 {
+		warnings = append(warnings, "opencode_presets is deprecated, migrate to presets with backend field")
+	}
+	return warnings
 }
 
 // ExpandPath expands ~ and makes path absolute relative to base

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -58,23 +58,23 @@ type Options struct {
 
 // Monitor manages tmux windows and dashboard state.
 type Monitor struct {
-	session         string
-	runFilter       RunFilter
-	runSort         SortKey
-	issueSort       SortKey
-	store           store.Store
-	orchPath        string
-	globalFlags     []string
-	agent           string
-	attach          bool
-	forceNew        bool
-	runs            []*RunWindow
-	dashboard       *Dashboard
-	showResolved    bool
-	showClosed      bool
-	uiSettings      *UISettings
-	orchDir         string
-	opencodePresets []config.OpenCodePreset
+	session      string
+	runFilter    RunFilter
+	runSort      SortKey
+	issueSort    SortKey
+	store        store.Store
+	orchPath     string
+	globalFlags  []string
+	agent        string
+	attach       bool
+	forceNew     bool
+	runs         []*RunWindow
+	dashboard    *Dashboard
+	showResolved bool
+	showClosed   bool
+	uiSettings   *UISettings
+	orchDir      string
+	presets      []config.Preset
 }
 
 // RunWindow links a run to a dashboard index.
@@ -104,26 +104,26 @@ func New(st store.Store, opts Options) *Monitor {
 		uiSettings = DefaultUISettings()
 	}
 	orchDir := GetOrchDir(st.VaultPath())
-	var presets []config.OpenCodePreset
+	var presets []config.Preset
 	if cfg, err := config.Load(); err == nil {
-		presets = cfg.OpenCodePresets
+		presets = cfg.GetAllPresets()
 	}
 	return &Monitor{
-		session:         session,
-		runFilter:       newRunFilter(opts),
-		runSort:         runSort,
-		issueSort:       issueSort,
-		store:           st,
-		orchPath:        orchPath,
-		globalFlags:     opts.GlobalFlags,
-		agent:           opts.Agent,
-		attach:          opts.Attach,
-		forceNew:        opts.ForceNew,
-		showResolved:    opts.ShowResolved,
-		showClosed:      opts.ShowClosed,
-		uiSettings:      uiSettings,
-		orchDir:         orchDir,
-		opencodePresets: presets,
+		session:      session,
+		runFilter:    newRunFilter(opts),
+		runSort:      runSort,
+		issueSort:    issueSort,
+		store:        st,
+		orchPath:     orchPath,
+		globalFlags:  opts.GlobalFlags,
+		agent:        opts.Agent,
+		attach:       opts.Attach,
+		forceNew:     opts.ForceNew,
+		showResolved: opts.ShowResolved,
+		showClosed:   opts.ShowClosed,
+		uiSettings:   uiSettings,
+		orchDir:      orchDir,
+		presets:      presets,
 	}
 }
 
@@ -388,13 +388,16 @@ func (m *Monitor) StartRun(issueID string, agentType string) (string, error) {
 	args := append([]string{}, m.globalFlags...)
 	args = append(args, "run", issueID)
 	if agentType != "" {
-		agentName, model, variant := m.parseAgentPreset(agentType)
+		agentName, model, variant, profile := m.parseAgentPreset(agentType)
 		args = append(args, "--agent", agentName)
 		if model != "" {
 			args = append(args, "--model", model)
 		}
 		if variant != "" {
 			args = append(args, "--model-variant", variant)
+		}
+		if profile != "" {
+			args = append(args, "--profile", profile)
 		}
 	}
 
@@ -417,22 +420,22 @@ func (m *Monitor) StartRun(issueID string, agentType string) (string, error) {
 	return output, nil
 }
 
-func (m *Monitor) parseAgentPreset(agentType string) (agentName, model, variant string) {
+func (m *Monitor) parseAgentPreset(agentType string) (agentName, model, variant, profile string) {
 	idx := strings.Index(agentType, ":")
 	if idx == -1 {
-		return agentType, "", ""
+		return agentType, "", "", ""
 	}
 
 	agentName = agentType[:idx]
 	presetName := agentType[idx+1:]
 
-	for _, preset := range m.opencodePresets {
-		if preset.Name == presetName {
-			return agentName, preset.Model, preset.Variant
+	for _, preset := range m.presets {
+		if preset.Name == presetName && preset.EffectiveBackend() == agentName {
+			return agentName, preset.Model, preset.Variant, preset.Profile
 		}
 	}
 
-	return agentName, "", presetName
+	return agentName, "", presetName, ""
 }
 
 func (m *Monitor) GetAvailableAgents() []string {
@@ -456,8 +459,8 @@ func (m *Monitor) GetAvailableAgents() []string {
 		}
 		if adapter.IsAvailable() {
 			available = append(available, agentName)
-			if aType == agent.AgentOpenCode {
-				for _, preset := range m.opencodePresets {
+			for _, preset := range m.presets {
+				if preset.EffectiveBackend() == agentName {
 					available = append(available, agentName+":"+preset.Name)
 				}
 			}
@@ -585,13 +588,16 @@ func (m *Monitor) ContinueRun(issueID, branch, agentType, prompt string) (string
 	args := append([]string{}, m.globalFlags...)
 	args = append(args, "continue", "--issue", issueID, "--branch", branch)
 	if agentType != "" {
-		agentName, model, variant := m.parseAgentPreset(agentType)
+		agentName, model, variant, profile := m.parseAgentPreset(agentType)
 		args = append(args, "--agent", agentName)
 		if model != "" {
 			args = append(args, "--model", model)
 		}
 		if variant != "" {
 			args = append(args, "--model-variant", variant)
+		}
+		if profile != "" {
+			args = append(args, "--profile", profile)
 		}
 	}
 

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -195,28 +195,31 @@ func TestExtractAgentName(t *testing.T) {
 }
 
 func TestParseAgentPreset(t *testing.T) {
-	presets := []config.OpenCodePreset{
-		{Name: "opus:high", Model: "anthropic/claude-opus-4-5", Variant: "high"},
-		{Name: "gpt5.2", Model: "openai/gpt-5.2", Variant: ""},
+	presets := []config.Preset{
+		{Name: "opus:high", Backend: "opencode", Model: "anthropic/claude-opus-4-5", Variant: "high"},
+		{Name: "gpt5.2", Backend: "opencode", Model: "openai/gpt-5.2", Variant: ""},
+		{Name: "dev", Backend: "claude", Profile: "developer"},
 	}
-	m := &Monitor{opencodePresets: presets}
+	m := &Monitor{presets: presets}
 
 	tests := []struct {
 		input       string
 		wantAgent   string
 		wantModel   string
 		wantVariant string
+		wantProfile string
 	}{
-		{"opencode", "opencode", "", ""},
-		{"opencode:opus:high", "opencode", "anthropic/claude-opus-4-5", "high"},
-		{"opencode:gpt5.2", "opencode", "openai/gpt-5.2", ""},
-		{"opencode:unknown", "opencode", "", "unknown"},
-		{"claude", "claude", "", ""},
+		{"opencode", "opencode", "", "", ""},
+		{"opencode:opus:high", "opencode", "anthropic/claude-opus-4-5", "high", ""},
+		{"opencode:gpt5.2", "opencode", "openai/gpt-5.2", "", ""},
+		{"opencode:unknown", "opencode", "", "unknown", ""},
+		{"claude", "claude", "", "", ""},
+		{"claude:dev", "claude", "", "", "developer"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			agent, model, variant := m.parseAgentPreset(tt.input)
+			agent, model, variant, profile := m.parseAgentPreset(tt.input)
 			if agent != tt.wantAgent {
 				t.Errorf("parseAgentPreset(%q) agent = %q, want %q", tt.input, agent, tt.wantAgent)
 			}
@@ -225,6 +228,9 @@ func TestParseAgentPreset(t *testing.T) {
 			}
 			if variant != tt.wantVariant {
 				t.Errorf("parseAgentPreset(%q) variant = %q, want %q", tt.input, variant, tt.wantVariant)
+			}
+			if profile != tt.wantProfile {
+				t.Errorf("parseAgentPreset(%q) profile = %q, want %q", tt.input, profile, tt.wantProfile)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Add `--preset` flag to `orch run` for using named presets from config
- Refactor preset system to support all backends (not just opencode)
- Maintain backward compatibility with existing `opencode_presets` config

## Changes

### New `--preset` Flag
```bash
# Instead of:
orch run issue-123 --agent opencode --model openai/gpt-5.2-codex --model-variant xhigh

# Now you can use:
orch run issue-123 --preset gpt5.2-codex:xhigh
```

### New Config Format
```yaml
presets:
  - name: opus:high
    backend: opencode
    model: anthropic/claude-opus-4-5
    variant: high
  
  - name: gpt5.2-codex:xhigh
    backend: opencode
    model: openai/gpt-5.2-codex
    variant: xhigh
  
  - name: claude:default
    backend: claude
    profile: default
```

### Files Changed
- `internal/config/config.go`: Add `Preset` type, `GetPreset()`, `GetAllPresets()`, `GetPresetsForBackend()`, `ValidatePresets()` 
- `internal/cli/run.go`: Add `--preset` flag and preset resolution in `applyPromptConfigDefaults()`
- `internal/monitor/monitor.go`: Update to use new `presets` field with backward compatibility
- `internal/monitor/monitor_test.go`: Update test to use new `Preset` type

### Backward Compatibility
- Existing `opencode_presets` config continues to work (deprecated)
- `ValidatePresets()` returns warning when using deprecated format

Refs: orch-133