### PR TITLE
fix(monitor): include unknown status in default filter

### DIFF
--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -1134,6 +1134,7 @@ func defaultStatuses() []model.Status {
 		model.StatusBooting,
 		model.StatusQueued,
 		model.StatusPROpen,
+		model.StatusUnknown,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Added `unknown` status to the default status filter in `orch monitor`
- Runs with `unknown` status now appear by default in the ps dashboard

## Issue

Fixes orch-138

## Problem

When runs have `unknown` status, they were not shown by default in `orch monitor` ps dashboard. Users had to manually enable the `unknown` filter to see them, which was problematic because `unknown` often indicates runs that need attention (e.g., status detection issues, agent not responding properly).

## Changes

- Modified `defaultStatuses()` in `internal/monitor/monitor.go` to include `model.StatusUnknown`
- The `defaultStatusSet()` function in `run_filter.go` automatically inherits this change since it calls `defaultStatuses()`

## Testing

- All existing tests pass
- Build succeeds