### PR TITLE
fix(agent): return blocked instead of unknown for opencode double-escape stop

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -223,7 +223,9 @@ func (m *OpenCodeManager) GetStatus(run *model.Run, output string, state *RunSta
 		return model.StatusRunning
 	}
 
-	return model.StatusUnknown
+	// Session not actively processing - treat as blocked (waiting for user input)
+	// This handles the double-escape (Esc Esc) case where the user stopped the agent
+	return model.StatusBlocked
 }
 
 func (m *OpenCodeManager) hasActiveBusyChildren(ctx context.Context, client *OpenCodeClient) bool {


### PR DESCRIPTION
## Summary

- Return `blocked` status instead of `unknown` when opencode session is stopped via double-escape (Esc Esc)
- Fixes existing test `TestOpenCodeManagerGetStatusMissingSession` which expected `blocked` behavior
- Improves user experience by correctly indicating that user action is needed (`orch attach` to resume)

## Issue

orch-139

## Changes

When `OpenCodeManager.GetStatus()` cannot determine the session status from the API (session not in status map, no busy children, no recent activity), it now returns `blocked` instead of `unknown`.

This is the correct behavior because:
1. The session exists but is not actively processing
2. The user pressed Esc Esc to pause the agent
3. User action is needed to resume (via `orch attach`)

## Testing

- All existing tests pass including `TestOpenCodeManagerGetStatusMissingSession`
- Build succeeds