### PR TITLE
fix(agent): detect double-escape stop as blocked instead of unknown

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -223,6 +223,10 @@ func (m *OpenCodeManager) GetStatus(run *model.Run, output string, state *RunSta
 		return model.StatusRunning
 	}
 
+	if m.sessionExists(ctx, client) {
+		return model.StatusBlocked
+	}
+
 	return model.StatusUnknown
 }
 
@@ -256,6 +260,15 @@ func (m *OpenCodeManager) hasRecentActivity(ctx context.Context, client *OpenCod
 
 	timeSinceUpdate := time.Since(session.UpdatedAt())
 	return timeSinceUpdate < recentActivityThreshold
+}
+
+// sessionExists distinguishes "session doesn't exist" (unknown) from "session idle" (blocked)
+func (m *OpenCodeManager) sessionExists(ctx context.Context, client *OpenCodeClient) bool {
+	sessions, err := client.GetSessionIDs(ctx)
+	if err != nil {
+		return false
+	}
+	return sessions[m.SessionID]
 }
 
 func (m *OpenCodeManager) SendMessage(ctx context.Context, run *model.Run, message string, opts *SendOptions) error {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -560,11 +560,37 @@ func TestOpenCodeManagerGetStatusFromAPI(t *testing.T) {
 	}
 }
 
-func TestOpenCodeManagerGetStatusMissingSession(t *testing.T) {
+func TestOpenCodeManagerGetStatusSessionExistsButNotInStatusMap(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/session/status" {
-			w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/session/status":
 			json.NewEncoder(w).Encode(map[string]SessionStatus{})
+		case "/session":
+			json.NewEncoder(w).Encode([]Session{{ID: "ses_idle"}})
+		}
+	}))
+	defer server.Close()
+
+	port := extractPort(server.URL)
+	manager := &OpenCodeManager{Port: port, SessionID: "ses_idle", Directory: "/test"}
+
+	run := &model.Run{Status: model.StatusRunning}
+	state := &RunState{}
+	got := manager.GetStatus(run, "", state, false, false)
+	if got != model.StatusBlocked {
+		t.Errorf("GetStatus() for session not in status map but exists = %v, want %v", got, model.StatusBlocked)
+	}
+}
+
+func TestOpenCodeManagerGetStatusSessionDoesNotExist(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/session/status":
+			json.NewEncoder(w).Encode(map[string]SessionStatus{})
+		case "/session":
+			json.NewEncoder(w).Encode([]Session{})
 		}
 	}))
 	defer server.Close()
@@ -575,8 +601,8 @@ func TestOpenCodeManagerGetStatusMissingSession(t *testing.T) {
 	run := &model.Run{Status: model.StatusRunning}
 	state := &RunState{}
 	got := manager.GetStatus(run, "", state, false, false)
-	if got != model.StatusBlocked {
-		t.Errorf("GetStatus() for missing session = %v, want %v", got, model.StatusBlocked)
+	if got != model.StatusUnknown {
+		t.Errorf("GetStatus() for non-existent session = %v, want %v", got, model.StatusUnknown)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes opencode sessions paused via Esc Esc being detected as `unknown` instead of `blocked`
- Adds `sessionExists()` helper to check if session is in the session list
- Updates `GetStatus()` to return `blocked` when session exists but isn't in the status map

## Problem

When a user stops an opencode session by pressing double-escape (Esc Esc), `orch monitor` and `orch ps` showed status as `unknown` instead of `blocked`. This was confusing because:
- `unknown` suggests something is wrong
- The agent is actually just waiting for the user to continue
- Users need to know they should `orch attach` to resume

## Solution

Before returning `unknown` from `GetStatus()`, verify if the session exists in the session list:
- Session exists but not in status map → `blocked` (user paused with Esc Esc)
- Session does not exist → `unknown` (session truly gone)

## Testing

- Added `TestOpenCodeManagerGetStatusSessionExistsButNotInStatusMap` - verifies blocked is returned
- Added `TestOpenCodeManagerGetStatusSessionDoesNotExist` - verifies unknown is returned
- All tests pass

Fixes: orch-139