### PR TITLE
fix(agent): return blocked status for idle opencode sessions (orch-140)

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -186,8 +186,6 @@ func (m *OpenCodeManager) DetectPrompt(output string) bool {
 	return false
 }
 
-const recentActivityThreshold = 30 * time.Second
-
 func (m *OpenCodeManager) GetStatus(run *model.Run, output string, state *RunState, outputChanged, hasPrompt bool) model.Status {
 	if run.Status == model.StatusBooting || run.Status == model.StatusQueued {
 		return model.StatusRunning
@@ -219,11 +217,7 @@ func (m *OpenCodeManager) GetStatus(run *model.Run, output string, state *RunSta
 		return model.StatusRunning
 	}
 
-	if m.hasRecentActivity(ctx, client) {
-		return model.StatusRunning
-	}
-
-	return model.StatusUnknown
+	return model.StatusBlocked
 }
 
 func (m *OpenCodeManager) hasActiveBusyChildren(ctx context.Context, client *OpenCodeClient) bool {
@@ -246,16 +240,6 @@ func (m *OpenCodeManager) hasActiveBusyChildren(ctx context.Context, client *Ope
 	}
 
 	return false
-}
-
-func (m *OpenCodeManager) hasRecentActivity(ctx context.Context, client *OpenCodeClient) bool {
-	session, err := client.GetSession(ctx, m.SessionID, m.Directory)
-	if err != nil {
-		return false
-	}
-
-	timeSinceUpdate := time.Since(session.UpdatedAt())
-	return timeSinceUpdate < recentActivityThreshold
 }
 
 func (m *OpenCodeManager) SendMessage(ctx context.Context, run *model.Run, message string, opts *SendOptions) error {


### PR DESCRIPTION
## Summary

- Fix incorrect status detection for blocked opencode agents that was showing `running` instead of `blocked`
- Remove the flawed `hasRecentActivity` heuristic that caused the bug
- When a session is not in the status map and has no busy children, return `blocked` (idle) status

## Problem

Opencode agents that were blocked (waiting for user input) were incorrectly showing status `running` in `orch ps` and `orch monitor`.

## Root Cause

The `hasRecentActivity` heuristic returned `running` for sessions that had just become idle, as they still had recent activity (within 30 seconds) despite being blocked/waiting for user input.

## Changes

- Removed `hasRecentActivity` method and `recentActivityThreshold` constant from `OpenCodeManager`
- When session is not found in status map and has no busy children, return `blocked` instead of checking recent activity

## Related Issue

Closes orch-140