### PR TITLE
fix(agent): make IsAlive check consistent with GetStatus for opencode agents

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -130,12 +130,9 @@ func (m *OpenCodeManager) IsAlive(run *model.Run) bool {
 		return false
 	}
 
-	sessions, err := client.GetSessionIDs(ctx)
-	if err != nil {
-		return false
-	}
-
-	return sessions[m.SessionID]
+	return m.sessionExists(ctx, client) ||
+		m.hasActiveBusyChildren(ctx, client) ||
+		m.hasRecentActivity(ctx, client)
 }
 
 func (m *OpenCodeManager) CaptureOutput(run *model.Run) (string, error) {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/s22625/orch/internal/model"
 )
@@ -778,4 +779,124 @@ func findSubstringIndex(s, substr string) int {
 		}
 	}
 	return -1
+}
+
+func TestOpenCodeManagerIsAliveServerNotRunning(t *testing.T) {
+	manager := &OpenCodeManager{Port: 59999, SessionID: "ses_test"}
+	run := &model.Run{Agent: "opencode"}
+
+	got := manager.IsAlive(run)
+	if got != false {
+		t.Errorf("IsAlive() with no server = %v, want false", got)
+	}
+}
+
+func TestOpenCodeManagerIsAliveSessionExists(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/global/health":
+			json.NewEncoder(w).Encode(HealthResponse{Healthy: true})
+		case "/session":
+			json.NewEncoder(w).Encode([]Session{{ID: "ses_test123"}})
+		}
+	}))
+	defer server.Close()
+
+	port := extractPort(server.URL)
+	manager := &OpenCodeManager{Port: port, SessionID: "ses_test123"}
+	run := &model.Run{Agent: "opencode"}
+
+	got := manager.IsAlive(run)
+	if got != true {
+		t.Errorf("IsAlive() with existing session = %v, want true", got)
+	}
+}
+
+func TestOpenCodeManagerIsAliveBusyChildren(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/global/health":
+			json.NewEncoder(w).Encode(HealthResponse{Healthy: true})
+		case "/session":
+			json.NewEncoder(w).Encode([]Session{})
+		case "/session/status":
+			json.NewEncoder(w).Encode(map[string]SessionStatus{
+				"ses_child": SessionStatusBusy,
+			})
+		case "/session/ses_child":
+			json.NewEncoder(w).Encode(Session{ID: "ses_child", ParentID: "ses_parent"})
+		}
+	}))
+	defer server.Close()
+
+	port := extractPort(server.URL)
+	manager := &OpenCodeManager{Port: port, SessionID: "ses_parent"}
+	run := &model.Run{Agent: "opencode"}
+
+	got := manager.IsAlive(run)
+	if got != true {
+		t.Errorf("IsAlive() with busy children = %v, want true", got)
+	}
+}
+
+func TestOpenCodeManagerIsAliveRecentActivity(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/global/health":
+			json.NewEncoder(w).Encode(HealthResponse{Healthy: true})
+		case "/session":
+			json.NewEncoder(w).Encode([]Session{})
+		case "/session/status":
+			json.NewEncoder(w).Encode(map[string]SessionStatus{})
+		case "/session/ses_active":
+			now := time.Now().UnixMilli()
+			json.NewEncoder(w).Encode(Session{
+				ID:   "ses_active",
+				Time: SessionTimeMillis{Updated: now},
+			})
+		}
+	}))
+	defer server.Close()
+
+	port := extractPort(server.URL)
+	manager := &OpenCodeManager{Port: port, SessionID: "ses_active"}
+	run := &model.Run{Agent: "opencode"}
+
+	got := manager.IsAlive(run)
+	if got != true {
+		t.Errorf("IsAlive() with recent activity = %v, want true", got)
+	}
+}
+
+func TestOpenCodeManagerIsAliveNoActivity(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/global/health":
+			json.NewEncoder(w).Encode(HealthResponse{Healthy: true})
+		case "/session":
+			json.NewEncoder(w).Encode([]Session{})
+		case "/session/status":
+			json.NewEncoder(w).Encode(map[string]SessionStatus{})
+		case "/session/ses_stale":
+			staleTime := time.Now().Add(-time.Hour).UnixMilli()
+			json.NewEncoder(w).Encode(Session{
+				ID:   "ses_stale",
+				Time: SessionTimeMillis{Updated: staleTime},
+			})
+		}
+	}))
+	defer server.Close()
+
+	port := extractPort(server.URL)
+	manager := &OpenCodeManager{Port: port, SessionID: "ses_stale"}
+	run := &model.Run{Agent: "opencode"}
+
+	got := manager.IsAlive(run)
+	if got != false {
+		t.Errorf("IsAlive() with no activity = %v, want false", got)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes the ALIVE column in `orch ps` showing `no` for running opencode agents while STATUS shows `running`.

- Updated `OpenCodeManager.IsAlive()` to use the same comprehensive checks as `GetStatus()`
- Added tests for the new IsAlive behavior covering all scenarios

## Issue

Resolves: orch-137

## Root Cause

The `IsAlive()` method only checked if the session ID exists in the session list. This is insufficient because:

1. **Background tasks**: When an agent spawns child sessions, the parent session may not appear in the session list while children are busy
2. **Status API limitation**: The status API may not reflect busy state even when there's recent activity on the session

## Changes

**internal/agent/manager.go**
- Updated `IsAlive()` to check session existence OR busy children OR recent activity (same logic as `GetStatus()`)

**internal/agent/manager_test.go**
- Added 5 new tests covering all scenarios:
  - Server not running → false
  - Session exists → true
  - Session has busy children → true
  - Session has recent activity → true
  - No activity → false

## Testing

All tests pass:
```
go test ./... 
ok      github.com/s22625/orch/internal/agent   0.238s
ok      github.com/s22625/orch/internal/cli     4.081s
...
```