### PR TITLE
fix(send): add double Enter for codex agent message submission

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -55,7 +55,8 @@ func GetManager(run *model.Run) AgentManager {
 			RunRef:    run.Ref().String(),
 		}
 	}
-	return &TmuxManager{SessionName: getSessionName(run)}
+	agentType, _ := ParseAgentType(run.Agent)
+	return &TmuxManager{SessionName: getSessionName(run), AgentType: agentType}
 }
 
 func getSessionName(run *model.Run) string {
@@ -67,6 +68,7 @@ func getSessionName(run *model.Run) string {
 
 type TmuxManager struct {
 	SessionName string
+	AgentType   AgentType
 }
 
 func (m *TmuxManager) IsAlive(run *model.Run) bool {
@@ -110,6 +112,11 @@ func (m *TmuxManager) SendMessage(ctx context.Context, run *model.Run, message s
 
 	if opts != nil && opts.NoEnter {
 		return tmux.SendKeysLiteral(m.SessionName, message)
+	}
+
+	// Codex CLI requires double Enter to submit input
+	if m.AgentType == AgentCodex {
+		return tmux.SendKeysDoubleEnter(m.SessionName, message)
 	}
 	return tmux.SendKeys(m.SessionName, message)
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -88,6 +88,16 @@ func SendKeys(session, keys string) error {
 	return SendText(session, enterKey)
 }
 
+func SendKeysDoubleEnter(session, keys string) error {
+	if err := SendKeysLiteral(session, keys); err != nil {
+		return err
+	}
+	if err := SendText(session, enterKey); err != nil {
+		return err
+	}
+	return SendText(session, enterKey)
+}
+
 // SendKeysLiteral sends keys to a tmux session without pressing Enter
 // Uses -l flag to send keys literally (without interpreting special keys)
 func SendKeysLiteral(session, keys string) error {


### PR DESCRIPTION
## Summary

- Add `AgentType` field to `TmuxManager` to enable agent-specific message handling
- Add `SendKeysDoubleEnter()` function in tmux package for sending text with double Enter
- Use double Enter for codex agents in `TmuxManager.SendMessage()` since codex CLI requires it to submit input

## Related Issue

Fixes: orch-141

## Changes

1. **internal/agent/manager.go**:
   - Added `AgentType` field to `TmuxManager` struct
   - Updated `GetManager()` to parse and pass agent type to `TmuxManager`
   - Modified `SendMessage()` to use `SendKeysDoubleEnter` for codex agents

2. **internal/tmux/tmux.go**:
   - Added `SendKeysDoubleEnter()` function that sends text followed by two Enter keypresses