### PR TITLE
Fix false positive merged status for branches with no commits ahead

### DIFF
--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -642,44 +642,49 @@ func gitStatesForRuns(runs []*model.Run, target string) map[string]string {
 
 	states := make(map[string]string)
 	branchToRun := make(map[string]*model.Run)
-	var unmergedBranches []string
+	var allBranches []string
 
 	for _, r := range runs {
 		if r.Branch == "" {
 			continue
 		}
 
-		if merged[r.Branch] {
-			branchHead := git.GetBranchHead(repoRoot, r.Branch)
-			if branchHead != "" && branchHead == targetHead {
-				states[r.RunID] = "clean"
-			} else {
-				states[r.RunID] = "merged"
-			}
-			continue
-		}
-
 		branchToRun[r.Branch] = r
-		unmergedBranches = append(unmergedBranches, r.Branch)
+		allBranches = append(allBranches, r.Branch)
 	}
 
-	if len(unmergedBranches) == 0 {
+	if len(allBranches) == 0 {
 		return states
 	}
 
-	aheadCounts := git.GetBranchesAheadCounts(repoRoot, targetRef, unmergedBranches)
+	aheadCounts := git.GetBranchesAheadCounts(repoRoot, targetRef, allBranches)
 
 	var branchesWithChanges []string
 	for branch, r := range branchToRun {
 		ahead, ok := aheadCounts[branch]
 		if !ok {
+			if merged[branch] {
+				branchHead := git.GetBranchHead(repoRoot, branch)
+				if branchHead != "" && branchHead == targetHead {
+					states[r.RunID] = "clean"
+				} else {
+					states[r.RunID] = "merged"
+				}
+			}
 			continue
 		}
+
 		if ahead == 0 {
 			states[r.RunID] = "clean"
-		} else {
-			branchesWithChanges = append(branchesWithChanges, branch)
+			continue
 		}
+
+		if merged[branch] {
+			states[r.RunID] = "merged"
+			continue
+		}
+
+		branchesWithChanges = append(branchesWithChanges, branch)
 	}
 
 	if len(branchesWithChanges) == 0 {


### PR DESCRIPTION
## Summary

- Fixed `orch ps` MERGED column showing incorrect "merged" status for branches with no commits ahead
- Now checks commit ahead count before merged status to properly identify clean branches

## Changes

Modified `internal/cli/ps.go` `gitStatesForRuns()` function:
- Get ahead counts for ALL branches (not just unmerged)
- Check `ahead == 0` first → "clean" (no changes made)
- Only then check merged status → "merged" (has commits that were merged)
- Preserves existing conflict/dirty detection for branches with changes

## Example

Before:
```
Branch: issue/orch-137/run-20260105-023041
Commits ahead: 0
Git merged: yes (all commits reachable from main)
Branch HEAD: d1db6c7 != Main HEAD: afd1aa0
Result: MERGED = "merged" ❌
```

After:
```
Branch: issue/orch-137/run-20260105-023041
Commits ahead: 0
Result: MERGED = "clean" ✅
```

## Testing

- All existing tests pass
- Verified fix addresses the root cause identified in orch-142

Fixes #142