### PR TITLE
feat(orch-monitor): add tmux layout with control agent

### DIFF
--- a/orch-monitor-tui/orch_monitor/__main__.py
+++ b/orch-monitor-tui/orch_monitor/__main__.py
@@ -2,10 +2,74 @@
 
 import argparse
 import os
+import subprocess
 import sys
 from pathlib import Path
 
-from .app import OrchMonitorApp
+from .app import IssuesDashboard, OrchMonitorApp, RunsDashboard
+
+
+SESSION_NAME = "orch-monitor-tui"
+
+
+def get_vault_path(args) -> Path | None:
+    if args.vault:
+        return args.vault
+    vault_env = os.getenv("ORCH_VAULT")
+    if vault_env:
+        return Path(vault_env)
+    return None
+
+
+def launch_tmux_layout(vault_path: Path | None, agent: str = "opencode"):
+    vault_arg = f"--vault {vault_path}" if vault_path else ""
+    vault_env = f"ORCH_VAULT={vault_path}" if vault_path else ""
+
+    existing = subprocess.run(
+        ["tmux", "has-session", "-t", SESSION_NAME],
+        capture_output=True,
+    )
+
+    if existing.returncode == 0:
+        subprocess.run(["tmux", "attach-session", "-t", SESSION_NAME])
+        return
+
+    subprocess.run(
+        [
+            "tmux",
+            "new-session",
+            "-d",
+            "-s",
+            SESSION_NAME,
+            "-x",
+            "180",
+            "-y",
+            "50",
+        ]
+    )
+
+    subprocess.run(["tmux", "split-window", "-h", "-t", SESSION_NAME])
+    subprocess.run(
+        ["tmux", "split-window", "-v", "-t", f"{SESSION_NAME}:0.0", "-p", "70"]
+    )
+
+    runs_cmd = f"{vault_env} python -m orch_monitor --runs {vault_arg}".strip()
+    issues_cmd = f"{vault_env} python -m orch_monitor --issues {vault_arg}".strip()
+    agent_cmd = agent
+
+    subprocess.run(
+        ["tmux", "send-keys", "-t", f"{SESSION_NAME}:0.0", runs_cmd, "Enter"]
+    )
+    subprocess.run(
+        ["tmux", "send-keys", "-t", f"{SESSION_NAME}:0.1", issues_cmd, "Enter"]
+    )
+    subprocess.run(
+        ["tmux", "send-keys", "-t", f"{SESSION_NAME}:0.2", agent_cmd, "Enter"]
+    )
+
+    subprocess.run(["tmux", "select-pane", "-t", f"{SESSION_NAME}:0.2"])
+
+    subprocess.run(["tmux", "attach-session", "-t", SESSION_NAME])
 
 
 def main():
@@ -13,21 +77,35 @@ def main():
     parser.add_argument(
         "--vault",
         type=Path,
-        help="Path to orch vault directory (overrides ORCH_VAULT env var)",
+        help="Path to orch vault directory",
+    )
+    parser.add_argument(
+        "--runs",
+        action="store_true",
+        help="Show runs dashboard only (for tmux pane)",
+    )
+    parser.add_argument(
+        "--issues",
+        action="store_true",
+        help="Show issues dashboard only (for tmux pane)",
+    )
+    parser.add_argument(
+        "--agent",
+        default="opencode",
+        help="Control agent command (default: opencode)",
     )
 
     args = parser.parse_args()
+    vault_path = get_vault_path(args)
 
-    vault_path = None
-    if args.vault:
-        vault_path = args.vault
+    if args.runs:
+        app = RunsDashboard(vault_path=vault_path)
+        app.run()
+    elif args.issues:
+        app = IssuesDashboard(vault_path=vault_path)
+        app.run()
     else:
-        vault_env = os.getenv("ORCH_VAULT")
-        if vault_env:
-            vault_path = Path(vault_env)
-
-    app = OrchMonitorApp(vault_path=vault_path)
-    app.run()
+        launch_tmux_layout(vault_path, args.agent)
 
 
 if __name__ == "__main__":

--- a/orch-monitor-tui/orch_monitor/app.py
+++ b/orch-monitor-tui/orch_monitor/app.py
@@ -7,7 +7,7 @@ from typing import Optional
 from textual import on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Container, Horizontal, Vertical
+from textual.containers import Container, Vertical
 from textual.widgets import Footer, Header, TabbedContent, TabPane
 
 from .config import Config
@@ -16,41 +16,180 @@ from .vault import VaultReader
 from .widgets import DetailPanel, IssueTable, RunTable
 
 
-class OrchMonitorApp(App):
-    """Orch monitor TUI application."""
+COMMON_CSS = """
+Screen {
+    layout: vertical;
+}
 
-    CSS = """
-    Screen {
-        layout: vertical;
-    }
-    
-    #main-container {
-        height: 1fr;
-    }
-    
+#main-container {
+    height: 1fr;
+}
+
+DataTable {
+    height: 1fr;
+}
+
+#detail-container {
+    height: 40%;
+    border-top: solid $accent;
+}
+
+#detail-content {
+    padding: 1;
+    height: 1fr;
+    overflow-y: auto;
+}
+"""
+
+
+class RunsDashboard(App):
+    """Runs-only dashboard for tmux pane."""
+
+    CSS = COMMON_CSS
+
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("r", "refresh", "Refresh"),
+        Binding("enter", "attach", "Attach"),
+        Binding("s", "stop", "Stop"),
+    ]
+
+    def __init__(self, vault_path: Optional[Path] = None):
+        super().__init__()
+        if vault_path:
+            self.config = Config.from_vault(vault_path)
+        else:
+            self.config = Config.load()
+        self.vault = VaultReader(self.config.vault_path)
+        self.runs: list[Run] = []
+        self.selected_run: Optional[Run] = None
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=False)
+        with Container(id="main-container"):
+            yield RunTable(id="runs-table")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.refresh_data()
+
+    def action_refresh(self) -> None:
+        self.refresh_data()
+
+    def refresh_data(self) -> None:
+        from datetime import datetime
+
+        self.runs = self.vault.list_runs()
+        self.runs.sort(
+            key=lambda r: r.updated_at or r.started_at or datetime.min, reverse=True
+        )
+        run_table = self.query_one("#runs-table", RunTable)
+        run_table.populate(self.runs)
+
+    @on(RunTable.RowSelected)
+    def on_run_selected(self, event: RunTable.RowSelected) -> None:
+        run_ref = event.row_key.value
+        if not run_ref:
+            return
+        issue_id, run_id = run_ref.split("#")
+        self.selected_run = self.vault.get_run(issue_id, run_id)
+
+    def action_attach(self) -> None:
+        if not self.selected_run or not self.selected_run.tmux_session:
+            return
+        self.exit()
+        subprocess.run(["tmux", "attach-session", "-t", self.selected_run.tmux_session])
+
+    def action_stop(self) -> None:
+        if not self.selected_run:
+            return
+        try:
+            subprocess.run(
+                [
+                    "orch",
+                    "--vault",
+                    str(self.config.vault_path),
+                    "stop",
+                    self.selected_run.ref(),
+                ],
+                check=True,
+            )
+            self.refresh_data()
+        except subprocess.CalledProcessError:
+            pass
+
+
+class IssuesDashboard(App):
+    """Issues-only dashboard for tmux pane."""
+
+    CSS = COMMON_CSS
+
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("r", "refresh", "Refresh"),
+        Binding("enter", "new_run", "New Run"),
+    ]
+
+    def __init__(self, vault_path: Optional[Path] = None):
+        super().__init__()
+        if vault_path:
+            self.config = Config.from_vault(vault_path)
+        else:
+            self.config = Config.load()
+        self.vault = VaultReader(self.config.vault_path)
+        self.issues: list[Issue] = []
+        self.selected_issue: Optional[Issue] = None
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=False)
+        with Container(id="main-container"):
+            yield IssueTable(id="issues-table")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.refresh_data()
+
+    def action_refresh(self) -> None:
+        self.refresh_data()
+
+    def refresh_data(self) -> None:
+        self.issues = self.vault.list_issues()
+        self.issues.sort(key=lambda i: i.id)
+        issue_table = self.query_one("#issues-table", IssueTable)
+        issue_table.populate(self.issues)
+
+    @on(IssueTable.RowSelected)
+    def on_issue_selected(self, event: IssueTable.RowSelected) -> None:
+        issue_id = event.row_key.value
+        if issue_id:
+            self.selected_issue = self.vault.get_issue(issue_id)
+
+    def action_new_run(self) -> None:
+        if not self.selected_issue:
+            return
+        self.exit()
+        subprocess.run(
+            [
+                "orch",
+                "--vault",
+                str(self.config.vault_path),
+                "run",
+                self.selected_issue.id,
+            ]
+        )
+
+
+class OrchMonitorApp(App):
+    """Orch monitor TUI application (tabbed view)."""
+
+    CSS = (
+        COMMON_CSS
+        + """
     #tables-container {
         height: 60%;
     }
-    
-    #detail-container {
-        height: 40%;
-        border-top: solid $accent;
-    }
-    
-    DataTable {
-        height: 1fr;
-    }
-    
-    #detail-content {
-        padding: 1;
-        height: 1fr;
-        overflow-y: auto;
-    }
-    
-    .hidden {
-        display: none;
-    }
     """
+    )
 
     BINDINGS = [
         Binding("q", "quit", "Quit"),
@@ -94,15 +233,12 @@ class OrchMonitorApp(App):
         yield Footer()
 
     def on_mount(self) -> None:
-        """Load data when app mounts."""
         self.refresh_data()
 
     def action_refresh(self) -> None:
-        """Refresh data from vault."""
         self.refresh_data()
 
     def refresh_data(self) -> None:
-        """Reload data from vault."""
         from datetime import datetime
 
         self.runs = self.vault.list_runs()
@@ -120,7 +256,6 @@ class OrchMonitorApp(App):
         issue_table.populate(self.issues)
 
     def action_switch_focus(self) -> None:
-        """Switch focus between runs and issues tabs."""
         tabbed = self.query_one(TabbedContent)
         if tabbed.active == "runs-pane":
             tabbed.active = "issues-pane"
@@ -131,7 +266,6 @@ class OrchMonitorApp(App):
 
     @on(RunTable.RowSelected)
     def on_run_selected(self, event: RunTable.RowSelected) -> None:
-        """Handle run selection."""
         run_ref = event.row_key.value
         if not run_ref:
             return
@@ -145,7 +279,6 @@ class OrchMonitorApp(App):
 
     @on(IssueTable.RowSelected)
     def on_issue_selected(self, event: IssueTable.RowSelected) -> None:
-        """Handle issue selection."""
         issue_id = event.row_key.value
         if not issue_id:
             return
@@ -157,7 +290,6 @@ class OrchMonitorApp(App):
             self.show_issue_detail(issue)
 
     def show_run_detail(self, run: Run) -> None:
-        """Display run details in detail panel."""
         detail_panel = self.query_one("#detail-panel", DetailPanel)
 
         content_lines = [
@@ -184,7 +316,6 @@ class OrchMonitorApp(App):
         )
 
     def show_issue_detail(self, issue: Issue) -> None:
-        """Display issue details in detail panel."""
         detail_panel = self.query_one("#detail-panel", DetailPanel)
 
         content_lines = [
@@ -200,7 +331,6 @@ class OrchMonitorApp(App):
         detail_panel.update_content("\n".join(content_lines), f"Issue: {issue.id}")
 
     def action_attach(self) -> None:
-        """Attach to selected run's tmux session."""
         if not self.selected_run or not self.selected_run.tmux_session:
             return
 
@@ -208,7 +338,6 @@ class OrchMonitorApp(App):
         subprocess.run(["tmux", "attach-session", "-t", self.selected_run.tmux_session])
 
     def action_stop(self) -> None:
-        """Stop selected run."""
         if not self.selected_run:
             return
 
@@ -228,7 +357,6 @@ class OrchMonitorApp(App):
             pass
 
     def action_new_run(self) -> None:
-        """Create a new run for selected issue."""
         if not self.selected_issue:
             return
 
@@ -244,7 +372,6 @@ class OrchMonitorApp(App):
         )
 
     def action_select(self) -> None:
-        """Handle enter key on selected item."""
         if self.current_focus == "runs" and self.selected_run:
             self.action_attach()
         elif self.current_focus == "issues" and self.selected_issue:


### PR DESCRIPTION
## Summary

Adds tmux-based layout for orch-monitor with separate panes for runs, issues, and a control agent.

## Layout

```
┌─────────────────┬─────────────────┐
│     Runs        │     Issues      │
├─────────────────┴─────────────────┤
│         Control Agent             │
│           (opencode)              │
└───────────────────────────────────┘
```

## Changes

- Add `RunsDashboard` - standalone runs-only view for tmux pane
- Add `IssuesDashboard` - standalone issues-only view for tmux pane
- Add tmux launcher that creates 3-pane session
- Support `--runs` and `--issues` flags for pane modes
- Support `--agent` flag to customize control agent (default: opencode)
- Handle reattach to existing `orch-monitor-tui` session

## Usage

```bash
# Launch full layout (creates tmux session)
orch-monitor

# Or with custom control agent
orch-monitor --agent claude

# Individual pane modes (used internally)
orch-monitor --runs
orch-monitor --issues
```