### PR TITLE
refactor(git): extract GetBranchMergeStates as shared function

### DIFF
--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -628,72 +628,26 @@ func colorAlive(info agentAliveInfo) string {
 }
 
 func gitStatesForRuns(runs []*model.Run, target string) map[string]string {
-	repoRoot, err := git.FindRepoRoot("")
-	if err != nil {
-		return nil
-	}
-
-	targetRef, merged, err := git.MergedBranchesForTarget(repoRoot, target)
-	if err != nil {
-		return nil
-	}
-
-	targetHead := git.GetBranchHead(repoRoot, targetRef)
-
-	states := make(map[string]string)
-	branchToRun := make(map[string]*model.Run)
-	var unmergedBranches []string
+	branchToRunID := make(map[string]string)
+	var branches []string
 
 	for _, r := range runs {
 		if r.Branch == "" {
 			continue
 		}
-
-		if merged[r.Branch] {
-			branchHead := git.GetBranchHead(repoRoot, r.Branch)
-			if branchHead != "" && branchHead == targetHead {
-				states[r.RunID] = "clean"
-			} else {
-				states[r.RunID] = "merged"
-			}
-			continue
-		}
-
-		branchToRun[r.Branch] = r
-		unmergedBranches = append(unmergedBranches, r.Branch)
+		branchToRunID[r.Branch] = r.RunID
+		branches = append(branches, r.Branch)
 	}
 
-	if len(unmergedBranches) == 0 {
-		return states
+	branchStates := git.GetBranchMergeStates("", target, branches)
+	if branchStates == nil {
+		return nil
 	}
 
-	aheadCounts := git.GetBranchesAheadCounts(repoRoot, targetRef, unmergedBranches)
-
-	var branchesWithChanges []string
-	for branch, r := range branchToRun {
-		ahead, ok := aheadCounts[branch]
-		if !ok {
-			continue
-		}
-		if ahead == 0 {
-			states[r.RunID] = "clean"
-		} else {
-			branchesWithChanges = append(branchesWithChanges, branch)
-		}
-	}
-
-	if len(branchesWithChanges) == 0 {
-		return states
-	}
-
-	conflicts := git.CheckMergeConflicts(repoRoot, targetRef, branchesWithChanges)
-
-	for _, branch := range branchesWithChanges {
-		r := branchToRun[branch]
-		if conflicts[branch] {
-			states[r.RunID] = "conflict"
-		} else {
-			states[r.RunID] = "dirty"
+	states := make(map[string]string)
+	for branch, runID := range branchToRunID {
+		if state, ok := branchStates[branch]; ok {
+			states[runID] = state
 		}
 	}
 

--- a/internal/git/merge.go
+++ b/internal/git/merge.go
@@ -142,6 +142,90 @@ func checkMergeConflictLegacy(repoRoot, branch, target string) (bool, error) {
 	return hasMergeTreeConflict(string(output)), nil
 }
 
+const (
+	MergeStateClean    = "clean"
+	MergeStateDirty    = "dirty"
+	MergeStateMerged   = "merged"
+	MergeStateConflict = "conflict"
+)
+
+func GetBranchMergeStates(repoRoot, target string, branches []string) map[string]string {
+	if len(branches) == 0 {
+		return nil
+	}
+
+	if repoRoot == "" {
+		var err error
+		repoRoot, err = FindRepoRoot("")
+		if err != nil {
+			return nil
+		}
+	}
+
+	targetRef, merged, err := MergedBranchesForTarget(repoRoot, target)
+	if err != nil {
+		return nil
+	}
+
+	targetHead := GetBranchHead(repoRoot, targetRef)
+
+	states := make(map[string]string)
+	var unmergedBranches []string
+
+	for _, branch := range branches {
+		if branch == "" {
+			continue
+		}
+
+		if merged[branch] {
+			branchHead := GetBranchHead(repoRoot, branch)
+			if branchHead != "" && branchHead == targetHead {
+				states[branch] = MergeStateClean
+			} else {
+				states[branch] = MergeStateMerged
+			}
+			continue
+		}
+
+		unmergedBranches = append(unmergedBranches, branch)
+	}
+
+	if len(unmergedBranches) == 0 {
+		return states
+	}
+
+	aheadCounts := GetBranchesAheadCounts(repoRoot, targetRef, unmergedBranches)
+
+	var branchesWithChanges []string
+	for _, branch := range unmergedBranches {
+		ahead, ok := aheadCounts[branch]
+		if !ok {
+			continue
+		}
+		if ahead == 0 {
+			states[branch] = MergeStateClean
+		} else {
+			branchesWithChanges = append(branchesWithChanges, branch)
+		}
+	}
+
+	if len(branchesWithChanges) == 0 {
+		return states
+	}
+
+	conflicts := CheckMergeConflicts(repoRoot, targetRef, branchesWithChanges)
+
+	for _, branch := range branchesWithChanges {
+		if conflicts[branch] {
+			states[branch] = MergeStateConflict
+		} else {
+			states[branch] = MergeStateDirty
+		}
+	}
+
+	return states
+}
+
 func CheckMergeConflicts(repoRoot, target string, branches []string) map[string]bool {
 	if len(branches) == 0 {
 		return nil

--- a/internal/monitor/ps_helpers.go
+++ b/internal/monitor/ps_helpers.go
@@ -124,74 +124,26 @@ func truncateLeading(text string, max int) string {
 }
 
 func gitStatesForRuns(runs []*model.Run, target string) map[string]string {
-	repoRoot, err := git.FindRepoRoot("")
-	if err != nil {
-		return nil
-	}
-
-	targetRef, merged, err := git.MergedBranchesForTarget(repoRoot, target)
-	if err != nil {
-		return nil
-	}
-
-	targetHead := git.GetBranchHead(repoRoot, targetRef)
-
-	states := make(map[string]string)
-	branchToRun := make(map[string]*model.Run)
-	var unmergedBranches []string
+	branchToRunID := make(map[string]string)
+	var branches []string
 
 	for _, r := range runs {
 		if r == nil || r.Branch == "" {
 			continue
 		}
-
-		if merged[r.Branch] {
-			// Branch is in merged set, but check if it's just a new branch with no commits
-			// (branch HEAD == target HEAD means no new commits, so it's "clean" not "merged")
-			branchHead := git.GetBranchHead(repoRoot, r.Branch)
-			if branchHead != "" && branchHead == targetHead {
-				states[r.RunID] = "clean"
-			} else {
-				states[r.RunID] = "merged"
-			}
-			continue
-		}
-
-		branchToRun[r.Branch] = r
-		unmergedBranches = append(unmergedBranches, r.Branch)
+		branchToRunID[r.Branch] = r.RunID
+		branches = append(branches, r.Branch)
 	}
 
-	if len(unmergedBranches) == 0 {
-		return states
+	branchStates := git.GetBranchMergeStates("", target, branches)
+	if branchStates == nil {
+		return nil
 	}
 
-	aheadCounts := git.GetBranchesAheadCounts(repoRoot, targetRef, unmergedBranches)
-
-	var branchesWithChanges []string
-	for branch, r := range branchToRun {
-		ahead, ok := aheadCounts[branch]
-		if !ok {
-			continue
-		}
-		if ahead == 0 {
-			states[r.RunID] = "clean"
-		} else {
-			branchesWithChanges = append(branchesWithChanges, branch)
-		}
-	}
-
-	if len(branchesWithChanges) == 0 {
-		return states
-	}
-
-	conflicts := git.CheckMergeConflicts(repoRoot, targetRef, branchesWithChanges)
-
-	for _, branch := range branchesWithChanges {
-		r := branchToRun[branch]
-		if conflicts[branch] {
-			states[r.RunID] = "conflict"
-		} else {
-			states[r.RunID] = "dirty"
+	states := make(map[string]string)
+	for branch, runID := range branchToRunID {
+		if state, ok := branchStates[branch]; ok {
+			states[runID] = state
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Extract duplicate merge state detection logic into shared `git.GetBranchMergeStates()` function
- Both `orch ps` CLI and `orch monitor` dashboard now use the same implementation
- Add typed constants for merge states

## Changes

- **internal/git/merge.go**: Added `GetBranchMergeStates()` function and merge state constants
- **internal/cli/ps.go**: Simplified `gitStatesForRuns()` to use shared function
- **internal/monitor/ps_helpers.go**: Simplified `gitStatesForRuns()` to use shared function

## Why

The previous PR (#185) fixed the merge status bug in `ps_helpers.go`, but there was duplicate logic in `cli/ps.go`. This refactoring ensures both code paths share the same implementation, preventing future divergence.

## Testing

- All existing tests pass
- Build compiles successfully

Follow-up to: #185
Related: orch-147