### PR TITLE
feat(notify): add 'orch notify test' command to test Slack integration

### DIFF
--- a/internal/cli/notify.go
+++ b/internal/cli/notify.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/s22625/orch/internal/config"
+	"github.com/s22625/orch/internal/notify"
+	"github.com/spf13/cobra"
+)
+
+type notifyTestOptions struct {
+	Message string
+}
+
+func newNotifyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "notify",
+		Short: "Notification management commands",
+	}
+
+	cmd.AddCommand(newNotifyTestCmd())
+
+	return cmd
+}
+
+func newNotifyTestCmd() *cobra.Command {
+	opts := &notifyTestOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Send a test notification to verify Slack configuration",
+		Long: `Send a test notification to verify Slack is configured correctly.
+
+Uses configuration from .orch/config.yaml or ~/.config/orch/config.yaml.
+
+Examples:
+  orch notify test
+  orch notify test --message "Custom test message"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runNotifyTest(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Message, "message", "m", "", "Custom test message")
+
+	return cmd
+}
+
+func runNotifyTest(opts *notifyTestOptions) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if !cfg.Slack.IsConfigured() {
+		return fmt.Errorf("Slack not configured. Add slack config to .orch/config.yaml")
+	}
+
+	notifier := notify.NewSlackNotifier(&cfg.Slack)
+
+	channelName, err := notifier.SendTest(opts.Message)
+	if err != nil {
+		return fmt.Errorf("Slack API error: %w", err)
+	}
+
+	fmt.Printf("Slack notification sent successfully to %s\n", channelName)
+	return nil
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -45,6 +45,7 @@ var noDaemonCommands = map[string]bool{
 	"help":       true,
 	"completion": true,
 	"models":     true,
+	"notify":     true,
 }
 
 // rootCmd represents the base command
@@ -96,6 +97,7 @@ func init() {
 	rootCmd.AddCommand(newCaptureCmd())
 	rootCmd.AddCommand(newCaptureAllCmd())
 	rootCmd.AddCommand(newModelsCmd())
+	rootCmd.AddCommand(newNotifyCmd())
 }
 
 // Execute runs the root command

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -198,3 +198,37 @@ func statusDescription(status model.Status) string {
 		return string(status)
 	}
 }
+
+// SendTest sends a test notification to verify Slack is configured correctly.
+// Returns the channel name used (for success messages).
+func (s *SlackNotifier) SendTest(message string) (string, error) {
+	if message == "" {
+		message = ":white_check_mark: orch Slack integration test successful!"
+	}
+
+	msg := SlackMessage{
+		Text:        message,
+		UnfurlLinks: false,
+	}
+
+	var channelName string
+	if s.config.BotToken != "" && s.config.Channel != "" {
+		msg.Channel = s.config.Channel
+		channelName = s.config.Channel
+		if err := s.sendBotMessage(msg); err != nil {
+			return "", err
+		}
+	} else {
+		channelName = "webhook"
+		if err := s.sendWebhookMessage(msg); err != nil {
+			return "", err
+		}
+	}
+
+	return channelName, nil
+}
+
+// IsConfigured returns whether the notifier is properly configured.
+func (s *SlackNotifier) IsConfigured() bool {
+	return s.config.IsConfigured()
+}


### PR DESCRIPTION
## Summary

- Add `orch notify test` command to send test notifications to verify Slack configuration
- Support custom messages via `--message` flag
- Reports success/failure with appropriate error messages

## Usage

```bash
# Send test notification using config
orch notify test

# With custom message
orch notify test --message "Custom test message"
```

## Files Changed

- New: `internal/cli/notify.go` - notify command with test subcommand
- Modified: `internal/cli/root.go` - register notify command
- Modified: `internal/notify/slack.go` - add SendTest() method

Closes orch-150