### PR TITLE
feat: add configurable initial prompt template per backend

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -20,26 +20,27 @@ import (
 )
 
 type runOptions struct {
-	New            bool
-	Reuse          bool
-	RunID          string
-	Agent          string
-	AgentCmd       string
-	AgentProfile   string
-	BaseBranch     string
-	Branch         string
-	WorktreeDir    string
-	RepoRoot       string
-	Tmux           bool
-	TmuxSession    string
-	DryRun         bool
-	NoPR           bool
-	PromptTemplate string
-	PRTargetBranch string
-	Model          string
-	ModelVariant   string
-	Preset         string
-	Verbose        bool
+	New                   bool
+	Reuse                 bool
+	RunID                 string
+	Agent                 string
+	AgentCmd              string
+	AgentProfile          string
+	BaseBranch            string
+	Branch                string
+	WorktreeDir           string
+	RepoRoot              string
+	Tmux                  bool
+	TmuxSession           string
+	DryRun                bool
+	NoPR                  bool
+	PromptTemplate        string
+	InitialPromptTemplate string
+	PRTargetBranch        string
+	Model                 string
+	ModelVariant          string
+	Preset                string
+	Verbose               bool
 }
 
 func newRunCmd() *cobra.Command {
@@ -178,6 +179,7 @@ func runRun(issueID string, opts *runOptions) error {
 		// Build the command that would be run (for display purposes)
 		agentType, _ := agent.ParseAgentType(opts.Agent)
 		adapter, _ := agent.GetAdapter(agentType)
+		dryRunPrompt := renderInitialPrompt(opts.InitialPromptTemplate, issue)
 		launchCfg := &agent.LaunchConfig{
 			Type:      agentType,
 			CustomCmd: opts.AgentCmd,
@@ -186,7 +188,7 @@ func runRun(issueID string, opts *runOptions) error {
 			RunID:     runID,
 			VaultPath: "",
 			Branch:    branch,
-			Prompt:    promptFileInstruction,
+			Prompt:    dryRunPrompt,
 			Profile:   opts.AgentProfile,
 		}
 		agentCmd, _ := adapter.LaunchCommand(launchCfg)
@@ -285,6 +287,9 @@ func runRun(issueID string, opts *runOptions) error {
 	if err := os.WriteFile(promptPath, []byte(agentPrompt), 0644); err != nil {
 		return exitWithCode(fmt.Errorf("failed to write prompt file: %w", err), ExitInternalError)
 	}
+
+	initialPrompt := renderInitialPrompt(opts.InitialPromptTemplate, issue)
+
 	launchCfg := &agent.LaunchConfig{
 		Type:         agentType,
 		CustomCmd:    opts.AgentCmd,
@@ -294,9 +299,9 @@ func runRun(issueID string, opts *runOptions) error {
 		RunPath:      run.Path,
 		VaultPath:    st.VaultPath(),
 		Branch:       worktreeResult.Branch,
-		Prompt:       promptFileInstruction,
+		Prompt:       initialPrompt,
 		Profile:      opts.AgentProfile,
-		Port:         4096, // Default port for HTTP-based agents (e.g., opencode)
+		Port:         4096,
 		Model:        opts.Model,
 		ModelVariant: opts.ModelVariant,
 	}
@@ -453,6 +458,21 @@ const (
 	promptFileInstruction = "ultrathink Please read '" + promptFileName + "' in the current directory and follow the instructions found there."
 	defaultPRTargetBranch = "main"
 )
+
+// renderInitialPrompt renders the initial prompt template with issue variables.
+// Template variables: {{issue}} (full content), {{issue_id}}, {{issue_title}}
+// Returns promptFileInstruction if no template is provided.
+func renderInitialPrompt(tmplStr string, issue *model.Issue) string {
+	if tmplStr == "" {
+		return promptFileInstruction
+	}
+
+	result := tmplStr
+	result = strings.ReplaceAll(result, "{{issue}}", issue.Body)
+	result = strings.ReplaceAll(result, "{{issue_id}}", issue.ID)
+	result = strings.ReplaceAll(result, "{{issue_title}}", issue.Title)
+	return result
+}
 
 const defaultPromptTemplate = `## Context
 
@@ -654,6 +674,10 @@ func applyPromptConfigDefaults(opts *runOptions) error {
 		if opts.ModelVariant == "" && cfg.OpenCode.DefaultVariant != "" {
 			opts.ModelVariant = cfg.OpenCode.DefaultVariant
 		}
+	}
+
+	if opts.InitialPromptTemplate == "" {
+		opts.InitialPromptTemplate = cfg.GetPromptTemplate(opts.Agent)
 	}
 
 	return nil

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -556,3 +556,62 @@ func TestApplyDefaultPresetNotFound(t *testing.T) {
 		t.Errorf("error = %q, want to contain 'preset not found'", err.Error())
 	}
 }
+
+func TestRenderInitialPrompt(t *testing.T) {
+	issue := &model.Issue{
+		ID:    "orch-123",
+		Title: "Add feature X",
+		Body:  "Full issue content here",
+	}
+
+	t.Run("empty template returns default instruction", func(t *testing.T) {
+		result := renderInitialPrompt("", issue)
+		if result != promptFileInstruction {
+			t.Errorf("got %q, want %q", result, promptFileInstruction)
+		}
+	})
+
+	t.Run("replaces {{issue}} placeholder", func(t *testing.T) {
+		tmpl := "ultrathink Work on this:\n\n{{issue}}"
+		result := renderInitialPrompt(tmpl, issue)
+		expected := "ultrathink Work on this:\n\nFull issue content here"
+		if result != expected {
+			t.Errorf("got %q, want %q", result, expected)
+		}
+	})
+
+	t.Run("replaces {{issue_id}} placeholder", func(t *testing.T) {
+		tmpl := "Working on issue {{issue_id}}"
+		result := renderInitialPrompt(tmpl, issue)
+		expected := "Working on issue orch-123"
+		if result != expected {
+			t.Errorf("got %q, want %q", result, expected)
+		}
+	})
+
+	t.Run("replaces {{issue_title}} placeholder", func(t *testing.T) {
+		tmpl := "Task: {{issue_title}}"
+		result := renderInitialPrompt(tmpl, issue)
+		expected := "Task: Add feature X"
+		if result != expected {
+			t.Errorf("got %q, want %q", result, expected)
+		}
+	})
+
+	t.Run("replaces all placeholders", func(t *testing.T) {
+		tmpl := "Issue {{issue_id}}: {{issue_title}}\n\n{{issue}}"
+		result := renderInitialPrompt(tmpl, issue)
+		expected := "Issue orch-123: Add feature X\n\nFull issue content here"
+		if result != expected {
+			t.Errorf("got %q, want %q", result, expected)
+		}
+	})
+
+	t.Run("preserves template without placeholders", func(t *testing.T) {
+		tmpl := "ultrathink Please read 'ORCH_PROMPT.md'"
+		result := renderInitialPrompt(tmpl, issue)
+		if result != tmpl {
+			t.Errorf("got %q, want %q", result, tmpl)
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,22 @@ func (p *Preset) EffectiveBackend() string {
 type OpenCodeConfig struct {
 	DefaultModel   string `yaml:"default_model,omitempty"`
 	DefaultVariant string `yaml:"default_variant,omitempty"`
+	PromptTemplate string `yaml:"prompt_template,omitempty"`
+}
+
+// ClaudeConfig holds default configuration for the claude agent.
+type ClaudeConfig struct {
+	PromptTemplate string `yaml:"prompt_template,omitempty"`
+}
+
+// CodexConfig holds default configuration for the codex agent.
+type CodexConfig struct {
+	PromptTemplate string `yaml:"prompt_template,omitempty"`
+}
+
+// GeminiConfig holds default configuration for the gemini agent.
+type GeminiConfig struct {
+	PromptTemplate string `yaml:"prompt_template,omitempty"`
 }
 
 // SlackConfig holds configuration for Slack notifications.
@@ -94,6 +110,9 @@ type Config struct {
 	Presets         []Preset         `yaml:"presets"`
 	OpenCodePresets []OpenCodePreset `yaml:"opencode_presets"` // Deprecated: use Presets instead
 	OpenCode        OpenCodeConfig   `yaml:"opencode"`
+	Claude          ClaudeConfig     `yaml:"claude"`
+	Codex           CodexConfig      `yaml:"codex"`
+	Gemini          GeminiConfig     `yaml:"gemini"`
 	DefaultPreset   string           `yaml:"default_preset"` // Default preset to use when no --preset flag is provided
 	Slack           SlackConfig      `yaml:"slack"`
 
@@ -122,6 +141,9 @@ type fileConfig struct {
 	Presets             []Preset         `yaml:"presets"`
 	OpenCodePresets     []OpenCodePreset `yaml:"opencode_presets"`
 	OpenCode            OpenCodeConfig   `yaml:"opencode"`
+	Claude              ClaudeConfig     `yaml:"claude"`
+	Codex               CodexConfig      `yaml:"codex"`
+	Gemini              GeminiConfig     `yaml:"gemini"`
 	DefaultPreset       string           `yaml:"default_preset"`
 	Slack               *SlackConfig     `yaml:"slack"`
 	ControlAgent        string           `yaml:"control_agent"`
@@ -308,6 +330,18 @@ func loadFromFile(path string, cfg *Config) error {
 	}
 	if fileCfg.OpenCode.DefaultVariant != "" {
 		cfg.OpenCode.DefaultVariant = fileCfg.OpenCode.DefaultVariant
+	}
+	if fileCfg.OpenCode.PromptTemplate != "" {
+		cfg.OpenCode.PromptTemplate = fileCfg.OpenCode.PromptTemplate
+	}
+	if fileCfg.Claude.PromptTemplate != "" {
+		cfg.Claude.PromptTemplate = fileCfg.Claude.PromptTemplate
+	}
+	if fileCfg.Codex.PromptTemplate != "" {
+		cfg.Codex.PromptTemplate = fileCfg.Codex.PromptTemplate
+	}
+	if fileCfg.Gemini.PromptTemplate != "" {
+		cfg.Gemini.PromptTemplate = fileCfg.Gemini.PromptTemplate
 	}
 	if fileCfg.DefaultPreset != "" {
 		cfg.DefaultPreset = fileCfg.DefaultPreset
@@ -512,6 +546,23 @@ func (c *Config) ValidatePresets() []string {
 		warnings = append(warnings, "opencode_presets is deprecated, migrate to presets with backend field")
 	}
 	return warnings
+}
+
+// GetPromptTemplate returns the initial prompt template for the given agent.
+// This template is used for the initial prompt sent to the agent (not the ORCH_PROMPT.md content).
+// Returns empty string if no template is configured.
+func (c *Config) GetPromptTemplate(agent string) string {
+	switch agent {
+	case "opencode":
+		return c.OpenCode.PromptTemplate
+	case "claude":
+		return c.Claude.PromptTemplate
+	case "codex":
+		return c.Codex.PromptTemplate
+	case "gemini":
+		return c.Gemini.PromptTemplate
+	}
+	return ""
 }
 
 // ExpandPath expands ~ and makes path absolute relative to base

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -916,3 +916,110 @@ func TestDefaultPresetEnv(t *testing.T) {
 		t.Errorf("DefaultPreset = %q, want sonnet:max", cfg.DefaultPreset)
 	}
 }
+
+func TestGetPromptTemplate(t *testing.T) {
+	cfg := &Config{
+		OpenCode: OpenCodeConfig{
+			DefaultModel:   "model",
+			PromptTemplate: "opencode template",
+		},
+		Claude: ClaudeConfig{
+			PromptTemplate: "claude template",
+		},
+		Codex: CodexConfig{
+			PromptTemplate: "codex template",
+		},
+		Gemini: GeminiConfig{
+			PromptTemplate: "gemini template",
+		},
+	}
+
+	tests := []struct {
+		agent string
+		want  string
+	}{
+		{"opencode", "opencode template"},
+		{"claude", "claude template"},
+		{"codex", "codex template"},
+		{"gemini", "gemini template"},
+		{"custom", ""},
+		{"unknown", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.agent, func(t *testing.T) {
+			got := cfg.GetPromptTemplate(tt.agent)
+			if got != tt.want {
+				t.Errorf("GetPromptTemplate(%q) = %q, want %q", tt.agent, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPromptTemplateEmpty(t *testing.T) {
+	cfg := &Config{}
+
+	got := cfg.GetPromptTemplate("opencode")
+	if got != "" {
+		t.Errorf("GetPromptTemplate returned %q, want empty string", got)
+	}
+}
+
+func TestLoadPromptTemplateFromConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ORCH_VAULT", "")
+	t.Setenv("ORCH_AGENT", "")
+	t.Setenv("ORCH_PROMPT_TEMPLATE", "")
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".orch"), 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+
+	configContent := `vault: /repo
+opencode:
+  prompt_template: "ultrawork {{issue}}"
+claude:
+  prompt_template: "ultrathink {{issue}}"
+codex:
+  prompt_template: "think step by step\n{{issue}}"
+gemini:
+  prompt_template: "{{issue}}"
+`
+	if err := os.WriteFile(filepath.Join(repo, ".orch", "config.yaml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("write repo config: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+
+	if cfg.GetPromptTemplate("opencode") != "ultrawork {{issue}}" {
+		t.Errorf("opencode prompt_template = %q", cfg.GetPromptTemplate("opencode"))
+	}
+	if cfg.GetPromptTemplate("claude") != "ultrathink {{issue}}" {
+		t.Errorf("claude prompt_template = %q", cfg.GetPromptTemplate("claude"))
+	}
+	if cfg.GetPromptTemplate("codex") != "think step by step\n{{issue}}" {
+		t.Errorf("codex prompt_template = %q", cfg.GetPromptTemplate("codex"))
+	}
+	if cfg.GetPromptTemplate("gemini") != "{{issue}}" {
+		t.Errorf("gemini prompt_template = %q", cfg.GetPromptTemplate("gemini"))
+	}
+	if cfg.GetPromptTemplate("custom") != "" {
+		t.Errorf("custom (no template) should be empty, got %q", cfg.GetPromptTemplate("custom"))
+	}
+}


### PR DESCRIPTION
## Summary

- Add per-backend `prompt_template` configuration for customizing the initial prompt sent to agents (opencode, claude, codex, gemini)
- Support template variables: `{{issue}}`, `{{issue_id}}`, `{{issue_title}}`
- Falls back to default `promptFileInstruction` when no template is configured

## Configuration Example

```yaml
opencode:
  prompt_template: |
    ultrawork Please read 'ORCH_PROMPT.md'...
    {{issue}}

claude:
  prompt_template: |
    ultrathink Be thorough.
    {{issue}}

codex:
  prompt_template: |
    Think step by step.
    {{issue}}

gemini:
  prompt_template: "{{issue}}"
```

## Changes

- `internal/config/config.go`: Added `PromptTemplate` field to per-backend configs (OpenCodeConfig, ClaudeConfig, CodexConfig, GeminiConfig) and `GetPromptTemplate()` method
- `internal/cli/run.go`: Added `renderInitialPrompt()` function to process template variables and integrated it into the run flow
- Added comprehensive tests for the new functionality

Fixes: orch-149