### PR TITLE
Rust: Add agent alive detection to orch-core

### DIFF
--- a/orch-core/Cargo.toml
+++ b/orch-core/Cargo.toml
@@ -53,6 +53,9 @@ nix = { version = "0.29", features = ["signal", "process"] }
 # Process execution
 which = "7.0"
 
+# HTTP client for OpenCode health checks
+reqwest = { version = "0.11", features = ["blocking", "json"] }
+
 [dev-dependencies]
 tempfile = "3.14"
 

--- a/orch-core/src/agent/alive.rs
+++ b/orch-core/src/agent/alive.rs
@@ -1,0 +1,271 @@
+//! Agent alive detection functionality.
+//!
+//! This module provides functions to detect if agents are alive by checking:
+//! - Tmux session existence and active processes
+//! - OpenCode HTTP health endpoints
+//! - Batch operations for efficient checking of multiple runs
+
+use std::collections::{HashMap, HashSet};
+use std::process::Command;
+use std::time::{Duration, SystemTime};
+
+use crate::agent::opencode;
+use crate::models::Run;
+use crate::tmux;
+
+/// Status of whether an agent is alive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AliveStatus {
+    /// Agent is alive and running
+    Alive,
+    /// Agent is not alive
+    Dead,
+    /// Unable to determine status
+    Unknown,
+}
+
+impl std::fmt::Display for AliveStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Alive => write!(f, "yes"),
+            Self::Dead => write!(f, "no"),
+            Self::Unknown => write!(f, "?"),
+        }
+    }
+}
+
+/// Cache for tmux session data to enable efficient batch operations.
+pub struct TmuxCache {
+    sessions: HashSet<String>,
+    pane_commands: HashMap<String, Vec<String>>,
+    last_refreshed: SystemTime,
+    ttl: Duration,
+}
+
+impl TmuxCache {
+    /// Create a new tmux cache with default TTL of 5 seconds.
+    pub fn new() -> Self {
+        Self {
+            sessions: HashSet::new(),
+            pane_commands: HashMap::new(),
+            last_refreshed: SystemTime::UNIX_EPOCH,
+            ttl: Duration::from_secs(5),
+        }
+    }
+
+    /// Check if the cache is stale and needs refreshing.
+    pub fn is_stale(&self) -> bool {
+        SystemTime::now()
+            .duration_since(self.last_refreshed)
+            .map(|d| d > self.ttl)
+            .unwrap_or(true)
+    }
+
+    /// Refresh the cache with current tmux state.
+    pub fn refresh(&mut self) {
+        if let Ok(sessions) = tmux::list_sessions() {
+            self.sessions = sessions.into_iter().collect();
+        }
+
+        if let Ok(commands) = list_pane_commands() {
+            self.pane_commands = commands;
+        }
+
+        self.last_refreshed = SystemTime::now();
+    }
+
+    /// Get cached session existence.
+    pub fn has_session(&mut self, session: &str) -> Option<bool> {
+        if self.is_stale() {
+            self.refresh();
+        }
+        Some(self.sessions.contains(session))
+    }
+
+    /// Get cached pane commands for a session.
+    pub fn get_pane_commands(&mut self, session: &str) -> Option<&Vec<String>> {
+        if self.is_stale() {
+            self.refresh();
+        }
+        self.pane_commands.get(session)
+    }
+}
+
+impl Default for TmuxCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Check if a tmux session is alive (exists and has active processes).
+pub fn is_tmux_session_alive(session: &str) -> bool {
+    if !tmux::session_exists(session) {
+        return false;
+    }
+
+    if let Ok(commands) = list_pane_commands() {
+        if let Some(session_commands) = commands.get(session) {
+            return has_non_shell_command(session_commands);
+        }
+    }
+
+    true
+}
+
+/// Get the PID of a tmux session's pane.
+pub fn get_tmux_session_pid(session: &str) -> Option<u32> {
+    let output = Command::new("tmux")
+        .args(["list-panes", "-t", session, "-F", "#{pane_pid}"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout.lines().next()?.trim().parse().ok()
+}
+
+/// List all pane commands grouped by session name.
+pub fn list_pane_commands() -> Result<HashMap<String, Vec<String>>, std::io::Error> {
+    let output = Command::new("tmux")
+        .args([
+            "list-panes",
+            "-a",
+            "-F",
+            "#{session_name}\t#{pane_current_command}",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        if String::from_utf8_lossy(&output.stderr).contains("no server running") {
+            return Ok(HashMap::new());
+        }
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "tmux command failed",
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut commands: HashMap<String, Vec<String>> = HashMap::new();
+
+    for line in stdout.lines() {
+        if let Some((session, command)) = line.split_once('\t') {
+            let session = session.trim();
+            let command = command.trim();
+            if !session.is_empty() {
+                commands
+                    .entry(session.to_string())
+                    .or_default()
+                    .push(command.to_string());
+            }
+        }
+    }
+
+    Ok(commands)
+}
+
+/// Check if any command in the list is not a shell command.
+fn has_non_shell_command(commands: &[String]) -> bool {
+    const SHELL_COMMANDS: &[&str] = &[
+        "bash",
+        "zsh",
+        "sh",
+        "fish",
+        "ksh",
+        "tcsh",
+        "dash",
+        "pwsh",
+        "powershell",
+        "cmd",
+        "cmd.exe",
+        "nu",
+        "elvish",
+    ];
+
+    for command in commands {
+        let command = command.trim().to_lowercase();
+        if !command.is_empty() && !SHELL_COMMANDS.contains(&command.as_str()) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Check if a run is alive using cached data for batch operations.
+pub fn is_run_alive_cached(run: &Run, cache: &mut TmuxCache) -> AliveStatus {
+    if run.agent == "opencode" {
+        if run.server_port > 0 && !run.opencode_session_id.is_empty() {
+            let alive = opencode::is_opencode_session_alive(
+                run.server_port,
+                &run.opencode_session_id,
+            );
+            return if alive {
+                AliveStatus::Alive
+            } else {
+                AliveStatus::Dead
+            };
+        }
+        return AliveStatus::Unknown;
+    }
+
+    let session = if !run.tmux_session.is_empty() {
+        &run.tmux_session
+    } else {
+        return AliveStatus::Unknown;
+    };
+
+    match cache.has_session(session) {
+        Some(false) => return AliveStatus::Dead,
+        Some(true) => {
+            if let Some(commands) = cache.get_pane_commands(session) {
+                if has_non_shell_command(commands) {
+                    return AliveStatus::Alive;
+                }
+                return AliveStatus::Dead;
+            }
+            AliveStatus::Alive
+        }
+        None => AliveStatus::Unknown,
+    }
+}
+
+/// Check alive status for multiple runs in batch (efficient for large lists).
+pub fn check_alive_batch(runs: &[Run]) -> HashMap<String, AliveStatus> {
+    let mut cache = TmuxCache::new();
+    let mut result = HashMap::new();
+
+    cache.refresh();
+
+    for run in runs {
+        let run_ref = format!("{}#{}", run.issue_id, run.run_id);
+        let status = is_run_alive_cached(run, &mut cache);
+        result.insert(run_ref, status);
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_has_non_shell_command() {
+        assert!(!has_non_shell_command(&[]));
+        assert!(!has_non_shell_command(&["bash".to_string()]));
+        assert!(!has_non_shell_command(&["zsh".to_string(), "sh".to_string()]));
+        assert!(has_non_shell_command(&["claude".to_string()]));
+        assert!(has_non_shell_command(&["bash".to_string(), "codex".to_string()]));
+    }
+
+    #[test]
+    fn test_alive_status_display() {
+        assert_eq!(AliveStatus::Alive.to_string(), "yes");
+        assert_eq!(AliveStatus::Dead.to_string(), "no");
+        assert_eq!(AliveStatus::Unknown.to_string(), "?");
+    }
+}

--- a/orch-core/src/agent/mod.rs
+++ b/orch-core/src/agent/mod.rs
@@ -6,6 +6,9 @@
 
 use thiserror::Error;
 
+pub mod alive;
+pub mod opencode;
+
 #[derive(Error, Debug)]
 pub enum AgentError {
     #[error("agent not found: {0}")]

--- a/orch-core/src/agent/opencode.rs
+++ b/orch-core/src/agent/opencode.rs
@@ -1,0 +1,132 @@
+//! OpenCode HTTP health check functionality.
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+use super::AgentError;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenCodeSession {
+    pub session_id: String,
+    pub status: String,
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct HealthResponse {
+    healthy: bool,
+    #[serde(default)]
+    version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SessionInfo {
+    #[serde(rename = "id")]
+    session_id: String,
+    #[serde(default)]
+    title: String,
+}
+
+pub fn check_opencode_health(
+    port: i32,
+    session_id: &str,
+) -> Result<OpenCodeSession, AgentError> {
+    let url = format!("http://127.0.0.1:{}/session/{}", port, session_id);
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(DEFAULT_TIMEOUT)
+        .build()
+        .map_err(|e| AgentError::HealthCheckFailed(e.to_string()))?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .map_err(|e| AgentError::HealthCheckFailed(e.to_string()))?;
+
+    if !response.status().is_success() {
+        return Err(AgentError::HealthCheckFailed(format!(
+            "HTTP {}",
+            response.status()
+        )));
+    }
+
+    let session: SessionInfo = response
+        .json()
+        .map_err(|e| AgentError::HealthCheckFailed(e.to_string()))?;
+
+    Ok(OpenCodeSession {
+        session_id: session.session_id,
+        status: "running".to_string(),
+        model: None,
+    })
+}
+
+pub fn list_opencode_sessions(port: i32) -> Result<Vec<OpenCodeSession>, AgentError> {
+    let url = format!("http://127.0.0.1:{}/session", port);
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(DEFAULT_TIMEOUT)
+        .build()
+        .map_err(|e| AgentError::HealthCheckFailed(e.to_string()))?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .map_err(|e| AgentError::HealthCheckFailed(e.to_string()))?;
+
+    if !response.status().is_success() {
+        return Err(AgentError::HealthCheckFailed(format!(
+            "HTTP {}",
+            response.status()
+        )));
+    }
+
+    let sessions: Vec<SessionInfo> = response
+        .json()
+        .map_err(|e| AgentError::HealthCheckFailed(e.to_string()))?;
+
+    Ok(sessions
+        .into_iter()
+        .map(|s| OpenCodeSession {
+            session_id: s.session_id,
+            status: "running".to_string(),
+            model: None,
+        })
+        .collect())
+}
+
+pub fn is_opencode_server_alive(port: i32) -> bool {
+    let url = format!("http://127.0.0.1:{}/global/health", port);
+
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(DEFAULT_TIMEOUT)
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+
+    match client.get(&url).send() {
+        Ok(response) => {
+            if !response.status().is_success() {
+                return false;
+            }
+
+            match response.json::<HealthResponse>() {
+                Ok(health) => health.healthy,
+                Err(_) => false,
+            }
+        }
+        Err(_) => false,
+    }
+}
+
+pub fn is_opencode_session_alive(port: i32, session_id: &str) -> bool {
+    if !is_opencode_server_alive(port) {
+        return false;
+    }
+
+    check_opencode_health(port, session_id).is_ok()
+}

--- a/orch-core/src/cli/ps.rs
+++ b/orch-core/src/cli/ps.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use clap::Args;
 use std::path::Path;
 
+use crate::agent::alive::{check_alive_batch, AliveStatus};
 use crate::models::Status;
 use crate::store::{FileStore, ListRunsFilter, Store};
 
@@ -64,41 +65,47 @@ impl PsCommand {
         let runs = store.list_runs(&filter)
             .context("failed to list runs")?;
 
+        let alive_map = check_alive_batch(&runs);
+
         if json {
             println!("{}", serde_json::to_string_pretty(&runs)
                 .context("failed to serialize runs")?);
         } else if tsv {
-            // TSV format for fzf
             for run in &runs {
+                let run_ref = format!("{}#{}", run.issue_id, run.run_id);
+                let alive = alive_map.get(&run_ref).unwrap_or(&AliveStatus::Unknown);
                 println!(
-                    "{}\t{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}\t{}",
                     run.short_id(),
                     run.issue_id,
                     run.run_id,
                     run.status,
-                    run.agent
+                    run.agent,
+                    alive
                 );
             }
         } else {
-            // Human-readable format
             if runs.is_empty() {
                 println!("No runs found.");
             } else {
                 println!(
-                    "{:<6} {:<15} {:<17} {:<10} {:<8} {:<10}",
-                    "ID", "ISSUE", "RUN", "STATUS", "ELAPSED", "AGENT"
+                    "{:<6} {:<15} {:<17} {:<10} {:<8} {:<10} {:<6}",
+                    "ID", "ISSUE", "RUN", "STATUS", "ELAPSED", "AGENT", "ALIVE"
                 );
-                println!("{}", "-".repeat(70));
+                println!("{}", "-".repeat(77));
 
                 for run in &runs {
+                    let run_ref = format!("{}#{}", run.issue_id, run.run_id);
+                    let alive = alive_map.get(&run_ref).unwrap_or(&AliveStatus::Unknown);
                     println!(
-                        "{:<6} {:<15} {:<17} {:<10} {:<8} {:<10}",
+                        "{:<6} {:<15} {:<17} {:<10} {:<8} {:<10} {:<6}",
                         run.short_id(),
                         truncate(&run.issue_id, 15),
                         truncate(&run.run_id, 17),
                         run.status,
                         run.elapsed_time(),
-                        truncate(&run.agent, 10)
+                        truncate(&run.agent, 10),
+                        alive
                     );
                 }
             }


### PR DESCRIPTION
## Summary
- Implements agent alive detection for orch-core to achieve feature parity with Go implementation
- Adds ALIVE column to `orch ps` output showing whether agents are actually running

## Changes Made
- Created `orch-core/src/agent/alive.rs` with tmux session detection
  - Checks if tmux session exists
  - Detects non-shell commands running in panes
  - Supports batch operations with caching for performance
- Created `orch-core/src/agent/opencode.rs` with HTTP health check
  - Checks OpenCode server health endpoint
  - Validates session existence via HTTP API
- Updated `orch-core/src/cli/ps.rs` to show ALIVE column (yes/no/?)
  - Uses batch operations for efficient checking of multiple runs
- Added reqwest dependency for HTTP client functionality

## Testing
- All existing tests pass
- Build succeeds with no errors
- Batch operation completes efficiently as required

## References
- Issue: orch-155
- Go reference: internal/agent/manager.go, internal/agent/opencode.go