### PR TITLE
feat(orch-core): add agent alive detection for orch ps

### DIFF
--- a/orch-core/Cargo.toml
+++ b/orch-core/Cargo.toml
@@ -53,6 +53,9 @@ nix = { version = "0.29", features = ["signal", "process"] }
 # Process execution
 which = "7.0"
 
+# HTTP client (for OpenCode API)
+ureq = { version = "2.10", features = ["json"] }
+
 [dev-dependencies]
 tempfile = "3.14"
 

--- a/orch-core/src/agent/alive.rs
+++ b/orch-core/src/agent/alive.rs
@@ -1,0 +1,243 @@
+use std::collections::{HashMap, HashSet};
+use std::process::Command;
+use std::sync::{RwLock, OnceLock};
+use std::time::{Duration, Instant};
+
+use crate::models::Run;
+
+static TMUX_CACHE: OnceLock<RwLock<TmuxCache>> = OnceLock::new();
+const CACHE_TTL: Duration = Duration::from_secs(5);
+
+static SHELL_COMMANDS: OnceLock<HashSet<&'static str>> = OnceLock::new();
+
+fn shell_commands() -> &'static HashSet<&'static str> {
+    SHELL_COMMANDS.get_or_init(|| {
+        [
+            "bash", "zsh", "sh", "fish", "ksh", "tcsh", 
+            "dash", "pwsh", "powershell", "cmd", "cmd.exe", "nu", "elvish",
+        ].into_iter().collect()
+    })
+}
+
+struct TmuxCache {
+    sessions: HashMap<String, bool>,
+    pane_commands: HashMap<String, Vec<String>>,
+    last_refreshed: Instant,
+}
+
+impl TmuxCache {
+    fn new() -> Self {
+        Self {
+            sessions: HashMap::new(),
+            pane_commands: HashMap::new(),
+            last_refreshed: Instant::now() - CACHE_TTL - Duration::from_secs(1),
+        }
+    }
+
+    fn is_stale(&self) -> bool {
+        self.last_refreshed.elapsed() >= CACHE_TTL
+    }
+}
+
+fn get_tmux_cache() -> &'static RwLock<TmuxCache> {
+    TMUX_CACHE.get_or_init(|| RwLock::new(TmuxCache::new()))
+}
+
+pub fn refresh_tmux_cache() {
+    let cache = get_tmux_cache();
+    let mut cache_guard = cache.write().unwrap();
+
+    if let Ok(sessions) = list_all_sessions() {
+        cache_guard.sessions = sessions.into_iter().map(|s| (s, true)).collect();
+    }
+
+    if let Ok(pane_commands) = list_pane_commands() {
+        cache_guard.pane_commands = pane_commands;
+    }
+
+    cache_guard.last_refreshed = Instant::now();
+}
+
+pub fn invalidate_tmux_cache() {
+    let cache = get_tmux_cache();
+    let mut cache_guard = cache.write().unwrap();
+    cache_guard.last_refreshed = Instant::now() - CACHE_TTL - Duration::from_secs(1);
+}
+
+fn ensure_cache_fresh() {
+    let cache = get_tmux_cache();
+    let needs_refresh = {
+        let cache_guard = cache.read().unwrap();
+        cache_guard.is_stale()
+    };
+
+    if needs_refresh {
+        refresh_tmux_cache();
+    }
+}
+
+pub fn is_tmux_session_alive(session: &str) -> bool {
+    ensure_cache_fresh();
+    
+    let cache = get_tmux_cache();
+    let cache_guard = cache.read().unwrap();
+
+    if !cache_guard.sessions.contains_key(session) {
+        return false;
+    }
+
+    if let Some(commands) = cache_guard.pane_commands.get(session) {
+        return commands.iter().any(|cmd| !is_shell_command(cmd));
+    }
+
+    true
+}
+
+pub fn get_tmux_session_pid(session: &str) -> Option<u32> {
+    let output = Command::new("tmux")
+        .args(["list-panes", "-t", session, "-F", "#{pane_pid}"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .and_then(|line| line.trim().parse().ok())
+}
+
+fn list_all_sessions() -> Result<Vec<String>, std::io::Error> {
+    let output = Command::new("tmux")
+        .args(["list-sessions", "-F", "#{session_name}"])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("no server running") {
+            return Ok(Vec::new());
+        }
+        return Ok(Vec::new());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect())
+}
+
+fn list_pane_commands() -> Result<HashMap<String, Vec<String>>, std::io::Error> {
+    let output = Command::new("tmux")
+        .args(["list-panes", "-a", "-F", "#{session_name}\t#{pane_current_command}"])
+        .output()?;
+
+    if !output.status.success() {
+        return Ok(HashMap::new());
+    }
+
+    let mut commands: HashMap<String, Vec<String>> = HashMap::new();
+
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        if let Some((session, command)) = line.split_once('\t') {
+            let session = session.trim();
+            let command = command.trim();
+            if !session.is_empty() {
+                commands.entry(session.to_string())
+                    .or_default()
+                    .push(command.to_string());
+            }
+        }
+    }
+
+    Ok(commands)
+}
+
+fn is_shell_command(command: &str) -> bool {
+    let command = command.to_lowercase();
+    let command = command.trim();
+    if command.is_empty() {
+        return true;
+    }
+    shell_commands().contains(command)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AliveStatus {
+    Alive,
+    Dead,
+    Unknown,
+}
+
+impl std::fmt::Display for AliveStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AliveStatus::Alive => write!(f, "yes"),
+            AliveStatus::Dead => write!(f, "no"),
+            AliveStatus::Unknown => write!(f, "?"),
+        }
+    }
+}
+
+pub fn check_alive_batch(runs: &[Run]) -> HashMap<String, AliveStatus> {
+    ensure_cache_fresh();
+    
+    let mut results = HashMap::new();
+
+    let opencode_runs: Vec<&Run> = runs.iter()
+        .filter(|r| r.agent.to_lowercase() == "opencode")
+        .collect();
+
+    let tmux_runs: Vec<&Run> = runs.iter()
+        .filter(|r| r.agent.to_lowercase() != "opencode")
+        .collect();
+
+    for run in tmux_runs {
+        let ref_key = format!("{}#{}", run.issue_id, run.run_id);
+        let session_name = if !run.tmux_session.is_empty() {
+            run.tmux_session.clone()
+        } else {
+            crate::models::run::generate_tmux_session(&run.issue_id, &run.run_id)
+        };
+
+        let status = if is_tmux_session_alive(&session_name) {
+            AliveStatus::Alive
+        } else {
+            AliveStatus::Dead
+        };
+
+        results.insert(ref_key, status);
+    }
+
+    if !opencode_runs.is_empty() {
+        let opencode_statuses = super::opencode::check_opencode_batch(&opencode_runs);
+        results.extend(opencode_statuses);
+    }
+
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_shell_command() {
+        assert!(is_shell_command("bash"));
+        assert!(is_shell_command("zsh"));
+        assert!(is_shell_command("ZSH"));
+        assert!(is_shell_command("  bash  "));
+        assert!(!is_shell_command("claude"));
+        assert!(!is_shell_command("opencode"));
+        assert!(!is_shell_command("python"));
+    }
+
+    #[test]
+    fn test_alive_status_display() {
+        assert_eq!(format!("{}", AliveStatus::Alive), "yes");
+        assert_eq!(format!("{}", AliveStatus::Dead), "no");
+        assert_eq!(format!("{}", AliveStatus::Unknown), "?");
+    }
+}

--- a/orch-core/src/agent/mod.rs
+++ b/orch-core/src/agent/mod.rs
@@ -1,10 +1,10 @@
-//! Agent adapters for different LLM CLIs.
-//!
-//! This module provides adapters for launching and interacting with
-//! different LLM agents (claude, codex, gemini, opencode).
-//! This will be fully implemented in Phase 2/3.
+pub mod alive;
+pub mod opencode;
 
 use thiserror::Error;
+
+pub use alive::{AliveStatus, check_alive_batch, is_tmux_session_alive, refresh_tmux_cache, invalidate_tmux_cache};
+pub use opencode::{OpenCodeClient, OpenCodeSession, OpenCodeError, check_opencode_health, list_opencode_sessions};
 
 #[derive(Error, Debug)]
 pub enum AgentError {

--- a/orch-core/src/agent/opencode.rs
+++ b/orch-core/src/agent/opencode.rs
@@ -1,0 +1,392 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::models::Run;
+use super::alive::AliveStatus;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenCodeSession {
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub directory: String,
+    #[serde(default, rename = "parentID")]
+    pub parent_id: String,
+    #[serde(default)]
+    pub time: SessionTime,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionTime {
+    pub created: i64,
+    pub updated: i64,
+}
+
+impl OpenCodeSession {
+    pub fn updated_at(&self) -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::from_timestamp_millis(self.time.updated)
+            .unwrap_or_else(chrono::Utc::now)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthResponse {
+    pub healthy: bool,
+    #[serde(default)]
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionStatus {
+    Idle,
+    Busy,
+    Retry,
+}
+
+impl std::fmt::Display for SessionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionStatus::Idle => write!(f, "idle"),
+            SessionStatus::Busy => write!(f, "busy"),
+            SessionStatus::Retry => write!(f, "retry"),
+        }
+    }
+}
+
+pub struct OpenCodeClient {
+    base_url: String,
+    port: i32,
+    timeout: Duration,
+}
+
+impl OpenCodeClient {
+    pub fn new(port: i32) -> Self {
+        Self {
+            base_url: format!("http://127.0.0.1:{}", port),
+            port,
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn port(&self) -> i32 {
+        self.port
+    }
+
+    pub fn is_server_running(&self) -> bool {
+        self.health().map(|h| h.healthy).unwrap_or(false)
+    }
+
+    pub fn health(&self) -> Result<HealthResponse, OpenCodeError> {
+        let url = format!("{}/global/health", self.base_url);
+        
+        let response = ureq::get(&url)
+            .timeout(self.timeout)
+            .call()
+            .map_err(|e| OpenCodeError::Request(e.to_string()))?;
+
+        let health: HealthResponse = response.into_json()
+            .map_err(|e| OpenCodeError::Parse(e.to_string()))?;
+
+        Ok(health)
+    }
+
+    pub fn get_sessions(&self, directory: Option<&str>) -> Result<Vec<OpenCodeSession>, OpenCodeError> {
+        let url = format!("{}/session", self.base_url);
+        
+        let mut request = ureq::get(&url).timeout(self.timeout);
+        
+        if let Some(dir) = directory {
+            request = request.set("X-OpenCode-Directory", dir);
+        }
+
+        let response = request.call()
+            .map_err(|e| OpenCodeError::Request(e.to_string()))?;
+
+        let sessions: Vec<OpenCodeSession> = response.into_json()
+            .map_err(|e| OpenCodeError::Parse(e.to_string()))?;
+
+        Ok(sessions)
+    }
+
+    pub fn get_session(&self, session_id: &str, directory: Option<&str>) -> Result<OpenCodeSession, OpenCodeError> {
+        let url = format!("{}/session/{}", self.base_url, session_id);
+        
+        let mut request = ureq::get(&url).timeout(self.timeout);
+        
+        if let Some(dir) = directory {
+            request = request.set("X-OpenCode-Directory", dir);
+        }
+
+        let response = request.call()
+            .map_err(|e| {
+                if e.to_string().contains("404") {
+                    OpenCodeError::SessionNotFound(session_id.to_string())
+                } else {
+                    OpenCodeError::Request(e.to_string())
+                }
+            })?;
+
+        let session: OpenCodeSession = response.into_json()
+            .map_err(|e| OpenCodeError::Parse(e.to_string()))?;
+
+        Ok(session)
+    }
+
+    pub fn get_session_status(&self, directory: Option<&str>) -> Result<HashMap<String, SessionStatus>, OpenCodeError> {
+        let url = format!("{}/session/status", self.base_url);
+        
+        let mut request = ureq::get(&url).timeout(self.timeout);
+        
+        if let Some(dir) = directory {
+            request = request.set("X-OpenCode-Directory", dir);
+        }
+
+        let response = request.call()
+            .map_err(|e| OpenCodeError::Request(e.to_string()))?;
+
+        let body = response.into_string()
+            .map_err(|e| OpenCodeError::Parse(e.to_string()))?;
+
+        parse_session_status_response(&body)
+    }
+
+    pub fn get_single_session_status(&self, session_id: &str, directory: Option<&str>) -> Result<(SessionStatus, bool), OpenCodeError> {
+        let status_map = self.get_session_status(directory)?;
+        
+        if let Some(&status) = status_map.get(session_id) {
+            Ok((status, true))
+        } else {
+            Ok((SessionStatus::Idle, false))
+        }
+    }
+}
+
+fn parse_session_status_response(body: &str) -> Result<HashMap<String, SessionStatus>, OpenCodeError> {
+    if let Ok(string_map) = serde_json::from_str::<HashMap<String, String>>(body) {
+        let result: HashMap<String, SessionStatus> = string_map
+            .into_iter()
+            .filter_map(|(k, v)| {
+                let status = match v.as_str() {
+                    "idle" => SessionStatus::Idle,
+                    "busy" => SessionStatus::Busy,
+                    "retry" => SessionStatus::Retry,
+                    _ => return None,
+                };
+                Some((k, status))
+            })
+            .collect();
+        return Ok(result);
+    }
+
+    #[derive(Deserialize)]
+    struct StatusObject {
+        #[serde(rename = "type")]
+        status_type: String,
+    }
+
+    if let Ok(object_map) = serde_json::from_str::<HashMap<String, StatusObject>>(body) {
+        let result: HashMap<String, SessionStatus> = object_map
+            .into_iter()
+            .filter_map(|(k, v)| {
+                let status = match v.status_type.as_str() {
+                    "idle" => SessionStatus::Idle,
+                    "busy" => SessionStatus::Busy,
+                    "retry" => SessionStatus::Retry,
+                    _ => return None,
+                };
+                Some((k, status))
+            })
+            .collect();
+        return Ok(result);
+    }
+
+    Err(OpenCodeError::Parse(format!("unable to parse session status response: {}", body)))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum OpenCodeError {
+    #[error("request failed: {0}")]
+    Request(String),
+    
+    #[error("failed to parse response: {0}")]
+    Parse(String),
+    
+    #[error("session not found: {0}")]
+    SessionNotFound(String),
+    
+    #[error("server not running on port {0}")]
+    ServerNotRunning(i32),
+}
+
+pub fn check_opencode_health(port: i32, session_id: &str, directory: Option<&str>) -> Result<AliveStatus, OpenCodeError> {
+    let client = OpenCodeClient::new(port);
+
+    if !client.is_server_running() {
+        return Ok(AliveStatus::Dead);
+    }
+
+    let status_map = client.get_session_status(directory)?;
+
+    if let Some(&status) = status_map.get(session_id) {
+        return match status {
+            SessionStatus::Busy => Ok(AliveStatus::Alive),
+            SessionStatus::Idle => Ok(AliveStatus::Alive),
+            SessionStatus::Retry => Ok(AliveStatus::Alive),
+        };
+    }
+
+    if has_active_busy_children(&client, session_id, directory)? {
+        return Ok(AliveStatus::Alive);
+    }
+
+    if has_recent_activity(&client, session_id, directory)? {
+        return Ok(AliveStatus::Alive);
+    }
+
+    if status_map.contains_key(session_id) {
+        return Ok(AliveStatus::Alive);
+    }
+
+    Ok(AliveStatus::Dead)
+}
+
+fn has_active_busy_children(client: &OpenCodeClient, parent_session_id: &str, directory: Option<&str>) -> Result<bool, OpenCodeError> {
+    let status_map = client.get_session_status(directory)?;
+
+    for (session_id, status) in &status_map {
+        if *status != SessionStatus::Busy {
+            continue;
+        }
+        
+        if let Ok(session) = client.get_session(session_id, directory) {
+            if session.parent_id == parent_session_id {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+fn has_recent_activity(client: &OpenCodeClient, session_id: &str, directory: Option<&str>) -> Result<bool, OpenCodeError> {
+    const RECENT_ACTIVITY_THRESHOLD: chrono::Duration = chrono::Duration::seconds(30);
+
+    let session = client.get_session(session_id, directory)?;
+    let time_since_update = chrono::Utc::now() - session.updated_at();
+
+    Ok(time_since_update < RECENT_ACTIVITY_THRESHOLD)
+}
+
+pub fn list_opencode_sessions(port: i32) -> Result<Vec<OpenCodeSession>, OpenCodeError> {
+    let client = OpenCodeClient::new(port);
+    
+    if !client.is_server_running() {
+        return Err(OpenCodeError::ServerNotRunning(port));
+    }
+    
+    client.get_sessions(None)
+}
+
+pub fn check_opencode_batch(runs: &[&Run]) -> HashMap<String, AliveStatus> {
+    let mut results = HashMap::new();
+    let mut ports_checked: HashMap<i32, (bool, Option<HashMap<String, SessionStatus>>)> = HashMap::new();
+
+    for run in runs {
+        let ref_key = format!("{}#{}", run.issue_id, run.run_id);
+
+        if run.server_port <= 0 {
+            results.insert(ref_key, AliveStatus::Unknown);
+            continue;
+        }
+
+        let port = run.server_port;
+
+        let (server_running, status_map) = ports_checked
+            .entry(port)
+            .or_insert_with(|| {
+                let client = OpenCodeClient::new(port);
+                let running = client.is_server_running();
+                let status = if running {
+                    let directory = if run.worktree_path.is_empty() { 
+                        None 
+                    } else { 
+                        Some(run.worktree_path.as_str()) 
+                    };
+                    client.get_session_status(directory).ok()
+                } else {
+                    None
+                };
+                (running, status)
+            });
+
+        if !*server_running {
+            results.insert(ref_key, AliveStatus::Dead);
+            continue;
+        }
+
+        if run.opencode_session_id.is_empty() {
+            results.insert(ref_key, AliveStatus::Unknown);
+            continue;
+        }
+
+        let status = if let Some(ref map) = status_map {
+            if map.contains_key(&run.opencode_session_id) {
+                AliveStatus::Alive
+            } else {
+                AliveStatus::Dead
+            }
+        } else {
+            AliveStatus::Unknown
+        };
+
+        results.insert(ref_key, status);
+    }
+
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_session_status_string_format() {
+        let body = r#"{"ses_abc123": "busy", "ses_def456": "idle"}"#;
+        let result = parse_session_status_response(body).unwrap();
+        
+        assert_eq!(result.get("ses_abc123"), Some(&SessionStatus::Busy));
+        assert_eq!(result.get("ses_def456"), Some(&SessionStatus::Idle));
+    }
+
+    #[test]
+    fn test_parse_session_status_object_format() {
+        let body = r#"{"ses_abc123": {"type": "busy"}, "ses_def456": {"type": "idle"}}"#;
+        let result = parse_session_status_response(body).unwrap();
+        
+        assert_eq!(result.get("ses_abc123"), Some(&SessionStatus::Busy));
+        assert_eq!(result.get("ses_def456"), Some(&SessionStatus::Idle));
+    }
+
+    #[test]
+    fn test_session_status_display() {
+        assert_eq!(format!("{}", SessionStatus::Idle), "idle");
+        assert_eq!(format!("{}", SessionStatus::Busy), "busy");
+        assert_eq!(format!("{}", SessionStatus::Retry), "retry");
+    }
+
+    #[test]
+    fn test_opencode_client_new() {
+        let client = OpenCodeClient::new(4096);
+        assert_eq!(client.port(), 4096);
+    }
+}

--- a/orch-core/src/cli/ps.rs
+++ b/orch-core/src/cli/ps.rs
@@ -1,9 +1,8 @@
-//! ps command - list runs
-
 use anyhow::{Context, Result};
 use clap::Args;
 use std::path::Path;
 
+use crate::agent::{check_alive_batch, AliveStatus};
 use crate::models::Status;
 use crate::store::{FileStore, ListRunsFilter, Store};
 
@@ -64,39 +63,64 @@ impl PsCommand {
         let runs = store.list_runs(&filter)
             .context("failed to list runs")?;
 
+        let alive_statuses = check_alive_batch(&runs);
+
         if json {
-            println!("{}", serde_json::to_string_pretty(&runs)
+            #[derive(serde::Serialize)]
+            struct RunWithAlive<'a> {
+                #[serde(flatten)]
+                run: &'a crate::models::Run,
+                alive: String,
+            }
+
+            let runs_with_alive: Vec<RunWithAlive> = runs.iter()
+                .map(|run| {
+                    let ref_key = format!("{}#{}", run.issue_id, run.run_id);
+                    let alive = alive_statuses.get(&ref_key)
+                        .unwrap_or(&AliveStatus::Unknown)
+                        .to_string();
+                    RunWithAlive { run, alive }
+                })
+                .collect();
+
+            println!("{}", serde_json::to_string_pretty(&runs_with_alive)
                 .context("failed to serialize runs")?);
         } else if tsv {
-            // TSV format for fzf
             for run in &runs {
+                let ref_key = format!("{}#{}", run.issue_id, run.run_id);
+                let alive = alive_statuses.get(&ref_key)
+                    .unwrap_or(&AliveStatus::Unknown);
                 println!(
-                    "{}\t{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}\t{}",
                     run.short_id(),
                     run.issue_id,
                     run.run_id,
                     run.status,
-                    run.agent
+                    run.agent,
+                    alive
                 );
             }
         } else {
-            // Human-readable format
             if runs.is_empty() {
                 println!("No runs found.");
             } else {
                 println!(
-                    "{:<6} {:<15} {:<17} {:<10} {:<8} {:<10}",
-                    "ID", "ISSUE", "RUN", "STATUS", "ELAPSED", "AGENT"
+                    "{:<6} {:<15} {:<17} {:<10} {:<5} {:<8} {:<10}",
+                    "ID", "ISSUE", "RUN", "STATUS", "ALIVE", "ELAPSED", "AGENT"
                 );
-                println!("{}", "-".repeat(70));
+                println!("{}", "-".repeat(77));
 
                 for run in &runs {
+                    let ref_key = format!("{}#{}", run.issue_id, run.run_id);
+                    let alive = alive_statuses.get(&ref_key)
+                        .unwrap_or(&AliveStatus::Unknown);
                     println!(
-                        "{:<6} {:<15} {:<17} {:<10} {:<8} {:<10}",
+                        "{:<6} {:<15} {:<17} {:<10} {:<5} {:<8} {:<10}",
                         run.short_id(),
                         truncate(&run.issue_id, 15),
                         truncate(&run.run_id, 17),
                         run.status,
+                        alive,
                         run.elapsed_time(),
                         truncate(&run.agent, 10)
                     );


### PR DESCRIPTION
## Summary

- Add agent alive detection to Rust orch-core for feature parity with Go implementation
- `orch ps` now shows ALIVE column (yes/no/?) for each run
- Tmux-based agents (claude, codex, gemini) detect session existence and non-shell commands
- OpenCode agents check HTTP health endpoint via API

## Changes

- **orch-core/src/agent/alive.rs**: New module for tmux session detection
  - `is_tmux_session_alive()` checks if session exists with non-shell command running
  - `check_alive_batch()` performs batch checking for performance
  - Uses a 5-second TTL cache to minimize tmux calls

- **orch-core/src/agent/opencode.rs**: New module for OpenCode API integration
  - `OpenCodeClient` struct with health check, session status, and batch operations
  - `check_opencode_batch()` for efficient batch status checking
  - Supports both string and object session status response formats

- **orch-core/src/cli/ps.rs**: Integrated alive detection into ps output
  - Adds ALIVE column showing yes/no/? status
  - JSON and TSV output formats include alive field

## Testing

All 34 tests pass including new tests for:
- Shell command detection
- Session status parsing (string and object formats)
- AliveStatus display formatting

Closes: orch-155