### PR TITLE
feat(daemon): add query APIs for TUI integration

### DIFF
--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/s22625/orch/internal/agent"
@@ -124,7 +125,7 @@ func (s *SocketServer) handleConnection(conn net.Conn) {
 	var req SendRequest
 	if err := decoder.Decode(&req); err != nil {
 		s.logger.Printf("failed to decode request: %v", err)
-		encoder.Encode(SendResponse{OK: false, Error: "invalid request"})
+		encoder.Encode(SendResponse{OK: false, Error: "invalid_request"})
 		return
 	}
 
@@ -140,7 +141,7 @@ func (s *SocketServer) handleConnection(conn net.Conn) {
 	case "get_issue":
 		s.handleGetIssue(req, encoder)
 	default:
-		encoder.Encode(SendResponse{OK: false, Error: "unknown request type"})
+		encoder.Encode(SendResponse{OK: false, Error: "unknown_type"})
 	}
 }
 
@@ -272,6 +273,10 @@ func (s *SocketServer) handleListIssues(req SendRequest, encoder *json.Encoder) 
 		encoder.Encode(ListIssuesResponse{OK: false, Error: "store_error"})
 		return
 	}
+
+	sort.Slice(issues, func(i, j int) bool {
+		return issues[i].ID < issues[j].ID
+	})
 
 	if len(req.Status) > 0 {
 		statusSet := make(map[string]bool)

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"log"
@@ -651,4 +652,24 @@ func TestCursorEncoding(t *testing.T) {
 			t.Error("expected error for invalid cursor")
 		}
 	})
+
+	t.Run("reject negative offset cursor", func(t *testing.T) {
+		negativeCursor := base64.StdEncoding.EncodeToString([]byte(`{"offset":-1}`))
+		_, err := DecodeCursor(negativeCursor)
+		if err == nil {
+			t.Error("expected error for negative offset cursor")
+		}
+	})
+}
+
+func TestFileURIEmptyPath(t *testing.T) {
+	uri := FileURI("")
+	if uri != "" {
+		t.Errorf("expected empty string for empty path, got %s", uri)
+	}
+
+	uri = FileURI("/path/to/file")
+	if uri != "file:///path/to/file" {
+		t.Errorf("expected file:///path/to/file, got %s", uri)
+	}
 }

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -9,31 +9,6 @@ import (
 	"github.com/s22625/orch/internal/model"
 )
 
-// Request is the common request structure for all daemon API calls
-type Request struct {
-	Type string `json:"type"`
-
-	// For list_runs
-	IssueID string   `json:"issue_id,omitempty"`
-	Status  []string `json:"status,omitempty"`
-	Limit   int      `json:"limit,omitempty"`
-	Cursor  string   `json:"cursor,omitempty"`
-
-	// For get_run
-	RunID string `json:"run_id,omitempty"`
-
-	// For send (existing)
-	Message   string `json:"message,omitempty"`
-	NoEnter   bool   `json:"no_enter,omitempty"`
-	VaultPath string `json:"vault_path,omitempty"`
-}
-
-// Response is the base response structure
-type Response struct {
-	OK    bool   `json:"ok"`
-	Error string `json:"error,omitempty"`
-}
-
 // ListRunsResponse is the response for list_runs
 type ListRunsResponse struct {
 	OK         bool          `json:"ok"`
@@ -149,24 +124,28 @@ func EncodeCursor(offset int) string {
 	return base64.StdEncoding.EncodeToString(data)
 }
 
-// DecodeCursor decodes a pagination cursor
 func DecodeCursor(s string) (int, error) {
 	if s == "" {
 		return 0, nil
 	}
 	data, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
-		return 0, fmt.Errorf("invalid cursor: %w", err)
+		return 0, fmt.Errorf("invalid_cursor")
 	}
 	var c cursor
 	if err := json.Unmarshal(data, &c); err != nil {
-		return 0, fmt.Errorf("invalid cursor: %w", err)
+		return 0, fmt.Errorf("invalid_cursor")
+	}
+	if c.Offset < 0 {
+		return 0, fmt.Errorf("invalid_cursor")
 	}
 	return c.Offset, nil
 }
 
-// FileURI returns a file:// URI for a path
 func FileURI(path string) string {
+	if path == "" {
+		return ""
+	}
 	return "file://" + path
 }
 


### PR DESCRIPTION
## Summary

- Add `list_runs` API with filters (issue_id, status) and cursor-based pagination
- Add `list_issues` API with status filter and cursor-based pagination
- Add `get_run` API to retrieve full run details including all events
- Add `get_issue` API to retrieve full issue details including body and frontmatter
- All responses include `uri` field (file:// path) for local file access

## Changes

- Created `internal/daemon/types.go` with request/response types
- Updated `internal/daemon/socket.go` with new handlers
- Added comprehensive tests for all new APIs

## Testing

- All existing tests pass
- Added tests for:
  - List runs with filtering and pagination
  - List issues with filtering and pagination
  - Get run with events
  - Get issue with body and frontmatter
  - Cursor encoding/decoding
  - Error cases (not_found, invalid_request)

Refs: orch-166