### PR TITLE
feat(daemon): Daemon-first CLI architecture (orch-169)

### DIFF
--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/s22625/orch/internal/daemon"
 	"github.com/s22625/orch/internal/model"
 	"github.com/spf13/cobra"
 )
@@ -65,22 +66,6 @@ func runIssueCreate(issueID string, opts *issueCreateOptions) error {
 		return err
 	}
 
-	issuesDir, err := resolveIssuesDir(vaultPath)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(issuesDir, 0755); err != nil {
-		return fmt.Errorf("failed to create issues directory: %w", err)
-	}
-
-	issuePath := filepath.Join(issuesDir, issueID+".md")
-
-	// Check if issue already exists
-	if _, err := os.Stat(issuePath); err == nil {
-		return fmt.Errorf("issue already exists: %s", issueID)
-	}
-
-	// If no title provided, prompt for it
 	title := opts.Title
 	if title == "" && !opts.Edit {
 		fmt.Print("Title: ")
@@ -92,7 +77,52 @@ func runIssueCreate(issueID string, opts *issueCreateOptions) error {
 		title = issueID
 	}
 
-	// Build issue content
+	client := daemon.NewClient(vaultPath)
+
+	if client.IsAvailable() && !opts.Edit {
+		resp, err := client.CreateIssue(issueID, title, opts.Summary, opts.Body)
+		if err == nil {
+			if globalOpts.JSON {
+				output := struct {
+					OK      bool   `json:"ok"`
+					IssueID string `json:"issue_id"`
+					Path    string `json:"path"`
+				}{
+					OK:      true,
+					IssueID: resp.IssueID,
+					Path:    resp.Path,
+				}
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(output)
+			}
+
+			if !globalOpts.Quiet {
+				fmt.Printf("Created issue: %s\n", issueID)
+				fmt.Printf("  Path: %s\n", resp.Path)
+			}
+			return nil
+		}
+
+		if err.Error() == "daemon error: issue_exists" {
+			return fmt.Errorf("issue already exists: %s", issueID)
+		}
+	}
+
+	issuesDir, err := resolveIssuesDir(vaultPath)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(issuesDir, 0755); err != nil {
+		return fmt.Errorf("failed to create issues directory: %w", err)
+	}
+
+	issuePath := filepath.Join(issuesDir, issueID+".md")
+
+	if _, err := os.Stat(issuePath); err == nil {
+		return fmt.Errorf("issue already exists: %s", issueID)
+	}
+
 	var sb strings.Builder
 	sb.WriteString("---\n")
 	sb.WriteString("type: issue\n")
@@ -210,13 +240,43 @@ func runIssueList() error {
 		return err
 	}
 
-	issues, err := st.ListIssues()
-	if err != nil {
-		return err
+	vaultPath := st.VaultPath()
+	client := daemon.NewClient(vaultPath)
+
+	var issues []*model.Issue
+	var allRuns []*model.Run
+
+	if client.IsAvailable() {
+		issuesResp, issuesErr := client.ListIssues(nil, 0, "")
+		runsResp, runsErr := client.ListRuns("", nil, 0, "")
+
+		if issuesErr == nil && runsErr == nil {
+			issues = make([]*model.Issue, len(issuesResp.Issues))
+			for i, summary := range issuesResp.Issues {
+				issues[i] = daemon.IssueSummaryToModel(summary)
+			}
+
+			allRuns = make([]*model.Run, len(runsResp.Runs))
+			for i, summary := range runsResp.Runs {
+				run, convErr := daemon.SummaryToRun(summary)
+				if convErr != nil {
+					issues = nil
+					allRuns = nil
+					break
+				}
+				allRuns[i] = run
+			}
+		}
 	}
 
-	// Get all runs to match with issues
-	allRuns, _ := st.ListRuns(nil)
+	if issues == nil || allRuns == nil {
+		issues, err = st.ListIssues()
+		if err != nil {
+			return err
+		}
+		allRuns, _ = st.ListRuns(nil)
+	}
+
 	runsByIssue := make(map[string][]*model.Run)
 	for _, run := range allRuns {
 		runsByIssue[run.IssueID] = append(runsByIssue[run.IssueID], run)

--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -76,28 +76,61 @@ func runPs(opts *psOptions) error {
 		return err
 	}
 
-	// Build filter
+	vaultPath := st.VaultPath()
+	client := daemon.NewClient(vaultPath)
+
 	requestedLimit := opts.Limit
-	filter := &store.ListRunsFilter{
-		IssueID: opts.Issue,
-		Limit:   opts.Limit,
-		Since:   opts.Since,
-	}
-	if len(opts.IssueStatus) > 0 {
-		filter.Limit = 0
-	}
+	var runs []*model.Run
+	usedDaemon := false
 
-	if len(opts.Status) > 0 {
-		for _, s := range opts.Status {
-			filter.Status = append(filter.Status, model.Status(s))
+	if client.IsAvailable() && !opts.NoGit && !opts.NoAlive {
+		statusStrings := make([]string, len(opts.Status))
+		for i, s := range opts.Status {
+			statusStrings[i] = string(s)
 		}
-	} else if !opts.All {
-		filter.Limit = 0
+
+		limit := opts.Limit
+		if len(opts.IssueStatus) > 0 || (len(opts.Status) == 0 && !opts.All) {
+			limit = 0
+		}
+
+		resp, err := client.ListRuns(opts.Issue, statusStrings, limit, "")
+		if err == nil {
+			usedDaemon = true
+			runs = make([]*model.Run, len(resp.Runs))
+			for i, summary := range resp.Runs {
+				run, convErr := daemon.SummaryToRun(summary)
+				if convErr != nil {
+					usedDaemon = false
+					break
+				}
+				runs[i] = run
+			}
+		}
 	}
 
-	runs, err := st.ListRuns(filter)
-	if err != nil {
-		return err
+	if !usedDaemon {
+		filter := &store.ListRunsFilter{
+			IssueID: opts.Issue,
+			Limit:   opts.Limit,
+			Since:   opts.Since,
+		}
+		if len(opts.IssueStatus) > 0 {
+			filter.Limit = 0
+		}
+
+		if len(opts.Status) > 0 {
+			for _, s := range opts.Status {
+				filter.Status = append(filter.Status, model.Status(s))
+			}
+		} else if !opts.All {
+			filter.Limit = 0
+		}
+
+		runs, err = st.ListRuns(filter)
+		if err != nil {
+			return err
+		}
 	}
 
 	issueStatusFilter := make(map[string]bool)

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/s22625/orch/internal/daemon"
 	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/store"
 	"github.com/spf13/cobra"
@@ -41,6 +42,28 @@ func runResolve(issueID string, opts *resolveOptions) error {
 		return err
 	}
 
+	client := daemon.NewClient(st.VaultPath())
+
+	if client.IsAvailable() {
+		err := client.ResolveIssue(issueID, opts.Force)
+		if err == nil {
+			if !globalOpts.Quiet {
+				fmt.Printf("resolved: %s\n", issueID)
+			}
+			return nil
+		}
+
+		if err.Error() == "daemon error: not_found" {
+			fmt.Fprintf(os.Stderr, "issue not found: %s\n", issueID)
+			os.Exit(ExitRunNotFound)
+			return err
+		}
+
+		if err.Error() == "daemon error: no_completed_runs" {
+			return fmt.Errorf("issue %s has no completed runs; use --force to resolve anyway", issueID)
+		}
+	}
+
 	issue, err := st.ResolveIssue(issueID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "issue not found: %s\n", issueID)
@@ -55,7 +78,6 @@ func runResolve(issueID string, opts *resolveOptions) error {
 		return nil
 	}
 
-	// Check if there are any completed runs (done or pr_open) unless --force is used
 	if !opts.Force {
 		filter := store.ListRunsFilter{IssueID: issueID}
 		runs, err := st.ListRuns(&filter)

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/s22625/orch/internal/daemon"
 	"github.com/s22625/orch/internal/model"
 	"github.com/spf13/cobra"
 )
@@ -42,11 +43,28 @@ func runShow(refStr string, opts *showOptions) error {
 		return err
 	}
 
-	// Resolve by short ID or run ref
-	run, err := resolveRun(st, refStr)
-	if err != nil {
-		os.Exit(ExitRunNotFound)
-		return err
+	var run *model.Run
+	client := daemon.NewClient(st.VaultPath())
+
+	if client.IsAvailable() {
+		ref, parseErr := model.ParseRunRef(refStr)
+		if parseErr == nil {
+			resp, apiErr := client.GetRun(ref.IssueID, ref.RunID)
+			if apiErr == nil && resp.Run != nil {
+				run, err = daemon.FullToRun(resp.Run)
+				if err != nil {
+					run = nil
+				}
+			}
+		}
+	}
+
+	if run == nil {
+		run, err = resolveRun(st, refStr)
+		if err != nil {
+			os.Exit(ExitRunNotFound)
+			return err
+		}
 	}
 
 	if globalOpts.JSON {

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/s22625/orch/internal/daemon"
 	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/store"
 	"github.com/s22625/orch/internal/tmux"
@@ -87,6 +88,24 @@ func runStop(refStr string, opts *stopOptions) error {
 }
 
 func stopIssueRuns(st store.Store, issueID string, opts *stopOptions) error {
+	client := daemon.NewClient(st.VaultPath())
+
+	if client.IsAvailable() {
+		resp, err := client.StopRun(issueID, "", false, opts.Force)
+		if err == nil {
+			if !globalOpts.Quiet {
+				if resp.Stopped == 0 {
+					fmt.Printf("No active runs for issue: %s\n", issueID)
+				} else if resp.Stopped == 1 {
+					fmt.Printf("stopped: %s\n", issueID)
+				} else {
+					fmt.Printf("stopped %d runs for %s\n", resp.Stopped, issueID)
+				}
+			}
+			return nil
+		}
+	}
+
 	runs, err := st.ListRuns(&store.ListRunsFilter{
 		IssueID: issueID,
 		Status:  []model.Status{model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusBlockedAPI, model.StatusQueued},
@@ -122,6 +141,22 @@ func runStopAll(opts *stopOptions) error {
 	st, err := getStore()
 	if err != nil {
 		return err
+	}
+
+	client := daemon.NewClient(st.VaultPath())
+
+	if client.IsAvailable() {
+		resp, err := client.StopRun("", "", true, opts.Force)
+		if err == nil {
+			if !globalOpts.Quiet {
+				if resp.Stopped == 0 {
+					fmt.Println("No running runs to stop")
+				} else {
+					fmt.Printf("Stopped %d run(s)\n", resp.Stopped)
+				}
+			}
+			return nil
+		}
 	}
 
 	runs, err := st.ListRuns(&store.ListRunsFilter{

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -1,0 +1,222 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"time"
+)
+
+// Client is a client for communicating with the daemon
+type Client struct {
+	vaultPath string
+}
+
+// NewClient creates a new daemon client
+func NewClient(vaultPath string) *Client {
+	return &Client{vaultPath: vaultPath}
+}
+
+// IsAvailable checks if the daemon is available
+func (c *Client) IsAvailable() bool {
+	return IsDaemonSocketAvailable(c.vaultPath)
+}
+
+// ListRuns calls the daemon's list_runs API
+func (c *Client) ListRuns(issueID string, status []string, limit int, cursor string) (*ListRunsResponse, error) {
+	req := SendRequest{
+		Type:      "list_runs",
+		IssueID:   issueID,
+		Status:    status,
+		Limit:     limit,
+		Cursor:    cursor,
+		VaultPath: c.vaultPath,
+	}
+
+	var resp ListRunsResponse
+	if err := c.call(&req, &resp); err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("daemon error: %s", resp.Error)
+	}
+
+	return &resp, nil
+}
+
+// ListIssues calls the daemon's list_issues API
+func (c *Client) ListIssues(status []string, limit int, cursor string) (*ListIssuesResponse, error) {
+	req := SendRequest{
+		Type:      "list_issues",
+		Status:    status,
+		Limit:     limit,
+		Cursor:    cursor,
+		VaultPath: c.vaultPath,
+	}
+
+	var resp ListIssuesResponse
+	if err := c.call(&req, &resp); err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("daemon error: %s", resp.Error)
+	}
+
+	return &resp, nil
+}
+
+// GetRun calls the daemon's get_run API
+func (c *Client) GetRun(issueID, runID string) (*GetRunResponse, error) {
+	req := SendRequest{
+		Type:      "get_run",
+		IssueID:   issueID,
+		RunID:     runID,
+		VaultPath: c.vaultPath,
+	}
+
+	var resp GetRunResponse
+	if err := c.call(&req, &resp); err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("daemon error: %s", resp.Error)
+	}
+
+	return &resp, nil
+}
+
+// GetIssue calls the daemon's get_issue API
+func (c *Client) GetIssue(issueID string) (*GetIssueResponse, error) {
+	req := SendRequest{
+		Type:      "get_issue",
+		IssueID:   issueID,
+		VaultPath: c.vaultPath,
+	}
+
+	var resp GetIssueResponse
+	if err := c.call(&req, &resp); err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("daemon error: %s", resp.Error)
+	}
+
+	return &resp, nil
+}
+
+// StopRun calls the daemon's stop_run API
+func (c *Client) StopRun(issueID, runID string, all, force bool) (*StopRunResponse, error) {
+	req := SendRequest{
+		Type:      "stop_run",
+		IssueID:   issueID,
+		RunID:     runID,
+		All:       all,
+		Force:     force,
+		VaultPath: c.vaultPath,
+	}
+
+	var resp StopRunResponse
+	if err := c.call(&req, &resp); err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("daemon error: %s", resp.Error)
+	}
+
+	return &resp, nil
+}
+
+// ResolveIssue calls the daemon's resolve_issue API
+func (c *Client) ResolveIssue(issueID string, force bool) error {
+	req := SendRequest{
+		Type:      "resolve_issue",
+		IssueID:   issueID,
+		Force:     force,
+		VaultPath: c.vaultPath,
+	}
+
+	var resp ResolveIssueResponse
+	if err := c.call(&req, &resp); err != nil {
+		return err
+	}
+
+	if !resp.OK {
+		return fmt.Errorf("daemon error: %s", resp.Error)
+	}
+
+	return nil
+}
+
+// CreateIssue calls the daemon's create_issue API
+func (c *Client) CreateIssue(issueID, title, summary, body string) (*CreateIssueResponse, error) {
+	req := SendRequest{
+		Type:      "create_issue",
+		IssueID:   issueID,
+		Title:     title,
+		Summary:   summary,
+		Body:      body,
+		VaultPath: c.vaultPath,
+	}
+
+	var resp CreateIssueResponse
+	if err := c.call(&req, &resp); err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("daemon error: %s", resp.Error)
+	}
+
+	return &resp, nil
+}
+
+// GetAttachInfo calls the daemon's attach_info API
+func (c *Client) GetAttachInfo(issueID, runID string) (*AttachInfoResponse, error) {
+	req := SendRequest{
+		Type:      "attach_info",
+		IssueID:   issueID,
+		RunID:     runID,
+		VaultPath: c.vaultPath,
+	}
+
+	var resp AttachInfoResponse
+	if err := c.call(&req, &resp); err != nil {
+		return nil, err
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("daemon error: %s", resp.Error)
+	}
+
+	return &resp, nil
+}
+
+// call makes a request to the daemon
+func (c *Client) call(req *SendRequest, resp interface{}) error {
+	socketPath := SocketFilePath(c.vaultPath)
+
+	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("failed to connect to daemon: %w", err)
+	}
+	defer conn.Close()
+
+	conn.SetDeadline(time.Now().Add(10 * time.Second))
+
+	encoder := json.NewEncoder(conn)
+	if err := encoder.Encode(req); err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+
+	decoder := json.NewDecoder(conn)
+	if err := decoder.Decode(resp); err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	return nil
+}

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -8,11 +8,13 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/s22625/orch/internal/agent"
 	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/store"
+	"github.com/s22625/orch/internal/tmux"
 )
 
 const (
@@ -33,6 +35,11 @@ type SendRequest struct {
 	Status    []string `json:"status,omitempty"`
 	Limit     int      `json:"limit,omitempty"`
 	Cursor    string   `json:"cursor,omitempty"`
+	All       bool     `json:"all,omitempty"`
+	Force     bool     `json:"force,omitempty"`
+	Title     string   `json:"title,omitempty"`
+	Summary   string   `json:"summary,omitempty"`
+	Body      string   `json:"body,omitempty"`
 }
 
 type SendResponse struct {
@@ -140,6 +147,14 @@ func (s *SocketServer) handleConnection(conn net.Conn) {
 		s.handleGetRun(req, encoder)
 	case "get_issue":
 		s.handleGetIssue(req, encoder)
+	case "stop_run":
+		s.handleStopRun(req, encoder)
+	case "resolve_issue":
+		s.handleResolveIssue(req, encoder)
+	case "create_issue":
+		s.handleCreateIssue(req, encoder)
+	case "attach_info":
+		s.handleAttachInfo(req, encoder)
 	default:
 		encoder.Encode(SendResponse{OK: false, Error: "unknown_type"})
 	}
@@ -359,6 +374,265 @@ func (s *SocketServer) handleGetIssue(req SendRequest, encoder *json.Encoder) {
 		OK:    true,
 		Issue: IssueToFull(issue),
 	})
+}
+
+func (s *SocketServer) handleStopRun(req SendRequest, encoder *json.Encoder) {
+	if req.All {
+		runs, err := s.store.ListRuns(&store.ListRunsFilter{
+			Status: []model.Status{model.StatusRunning, model.StatusBooting},
+		})
+		if err != nil {
+			encoder.Encode(StopRunResponse{OK: false, Error: "store_error"})
+			return
+		}
+
+		stopped := 0
+		for _, run := range runs {
+			if s.stopSingleRun(run) {
+				stopped++
+			}
+		}
+
+		encoder.Encode(StopRunResponse{OK: true, Stopped: stopped})
+		return
+	}
+
+	if req.IssueID == "" {
+		encoder.Encode(StopRunResponse{OK: false, Error: "invalid_request: issue_id required"})
+		return
+	}
+
+	if req.RunID == "" {
+		runs, err := s.store.ListRuns(&store.ListRunsFilter{
+			IssueID: req.IssueID,
+			Status:  []model.Status{model.StatusRunning, model.StatusBooting, model.StatusBlocked, model.StatusBlockedAPI, model.StatusQueued},
+		})
+		if err != nil {
+			encoder.Encode(StopRunResponse{OK: false, Error: "store_error"})
+			return
+		}
+
+		stopped := 0
+		for _, run := range runs {
+			if s.stopSingleRun(run) {
+				stopped++
+			}
+		}
+
+		encoder.Encode(StopRunResponse{OK: true, Stopped: stopped})
+		return
+	}
+
+	ref := &model.RunRef{IssueID: req.IssueID, RunID: req.RunID}
+	run, err := s.store.GetRun(ref)
+	if err != nil {
+		encoder.Encode(StopRunResponse{OK: false, Error: "not_found"})
+		return
+	}
+
+	if s.stopSingleRun(run) {
+		encoder.Encode(StopRunResponse{OK: true, Stopped: 1})
+	} else {
+		encoder.Encode(StopRunResponse{OK: true, Stopped: 0})
+	}
+}
+
+func (s *SocketServer) stopSingleRun(run *model.Run) bool {
+	if run.Status == model.StatusDone || run.Status == model.StatusFailed || run.Status == model.StatusCanceled {
+		return false
+	}
+
+	sessionName := run.TmuxSession
+	if sessionName == "" {
+		sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
+	}
+
+	if hasSession(sessionName) {
+		if err := killSession(sessionName); err != nil {
+			s.logger.Printf("warning: failed to kill session %s: %v", sessionName, err)
+		}
+	}
+
+	ref := &model.RunRef{IssueID: run.IssueID, RunID: run.RunID}
+	event := &model.Event{
+		Timestamp: time.Now(),
+		Type:      "status",
+		Name:      string(model.StatusCanceled),
+	}
+
+	if err := s.store.AppendEvent(ref, event); err != nil {
+		s.logger.Printf("failed to append canceled event: %v", err)
+		return false
+	}
+
+	return true
+}
+
+func (s *SocketServer) handleResolveIssue(req SendRequest, encoder *json.Encoder) {
+	if req.IssueID == "" {
+		encoder.Encode(ResolveIssueResponse{OK: false, Error: "invalid_request: issue_id required"})
+		return
+	}
+
+	issue, err := s.store.ResolveIssue(req.IssueID)
+	if err != nil {
+		encoder.Encode(ResolveIssueResponse{OK: false, Error: "not_found"})
+		return
+	}
+
+	if issue.Status == model.IssueStatusResolved {
+		encoder.Encode(ResolveIssueResponse{OK: true})
+		return
+	}
+
+	if !req.Force {
+		filter := store.ListRunsFilter{IssueID: req.IssueID}
+		runs, err := s.store.ListRuns(&filter)
+		if err != nil {
+			encoder.Encode(ResolveIssueResponse{OK: false, Error: "store_error"})
+			return
+		}
+
+		hasCompletedRun := false
+		for _, run := range runs {
+			if run.Status == model.StatusDone || run.Status == model.StatusPROpen {
+				hasCompletedRun = true
+				break
+			}
+		}
+
+		if !hasCompletedRun {
+			encoder.Encode(ResolveIssueResponse{OK: false, Error: "no_completed_runs"})
+			return
+		}
+	}
+
+	if err := s.store.SetIssueStatus(req.IssueID, model.IssueStatusResolved); err != nil {
+		encoder.Encode(ResolveIssueResponse{OK: false, Error: "store_error"})
+		return
+	}
+
+	encoder.Encode(ResolveIssueResponse{OK: true})
+}
+
+func (s *SocketServer) handleCreateIssue(req SendRequest, encoder *json.Encoder) {
+	if req.IssueID == "" {
+		encoder.Encode(CreateIssueResponse{OK: false, Error: "invalid_request: issue_id required"})
+		return
+	}
+
+	issuesDir := resolveIssuesDir(s.vaultPath)
+	if err := os.MkdirAll(issuesDir, 0755); err != nil {
+		encoder.Encode(CreateIssueResponse{OK: false, Error: "failed_to_create_dir"})
+		return
+	}
+
+	issuePath := filepath.Join(issuesDir, req.IssueID+".md")
+
+	if _, err := os.Stat(issuePath); err == nil {
+		encoder.Encode(CreateIssueResponse{OK: false, Error: "issue_exists"})
+		return
+	}
+
+	title := req.Title
+	if title == "" {
+		title = req.IssueID
+	}
+
+	var sb strings.Builder
+	sb.WriteString("---\n")
+	sb.WriteString("type: issue\n")
+	sb.WriteString(fmt.Sprintf("id: %s\n", req.IssueID))
+	sb.WriteString(fmt.Sprintf("title: %s\n", title))
+	if req.Summary != "" {
+		sb.WriteString(fmt.Sprintf("summary: %s\n", req.Summary))
+	}
+	sb.WriteString("status: open\n")
+	sb.WriteString("---\n\n")
+	sb.WriteString(fmt.Sprintf("# %s\n\n", title))
+
+	if req.Body != "" {
+		sb.WriteString(req.Body)
+		sb.WriteString("\n")
+	}
+
+	if err := os.WriteFile(issuePath, []byte(sb.String()), 0644); err != nil {
+		encoder.Encode(CreateIssueResponse{OK: false, Error: "write_failed"})
+		return
+	}
+
+	encoder.Encode(CreateIssueResponse{
+		OK:      true,
+		IssueID: req.IssueID,
+		Path:    issuePath,
+	})
+}
+
+func (s *SocketServer) handleAttachInfo(req SendRequest, encoder *json.Encoder) {
+	if req.IssueID == "" {
+		encoder.Encode(AttachInfoResponse{OK: false, Error: "invalid_request: issue_id required"})
+		return
+	}
+
+	ref := &model.RunRef{IssueID: req.IssueID, RunID: req.RunID}
+	run, err := s.store.GetRun(ref)
+	if err != nil {
+		encoder.Encode(AttachInfoResponse{OK: false, Error: "not_found"})
+		return
+	}
+
+	sessionName := run.TmuxSession
+	if sessionName == "" {
+		sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
+	}
+
+	sessionExists := hasSession(sessionName)
+	canAutoCreate := !sessionExists && run.WorktreePath != ""
+
+	encoder.Encode(AttachInfoResponse{
+		OK:            true,
+		Agent:         run.Agent,
+		TmuxSession:   sessionName,
+		ServerPort:    run.ServerPort,
+		SessionID:     run.OpenCodeSessionID,
+		WorktreePath:  run.WorktreePath,
+		SessionExists: sessionExists,
+		CanAutoCreate: canAutoCreate,
+	})
+}
+
+func resolveIssuesDir(vaultPath string) string {
+	if strings.EqualFold(filepath.Base(vaultPath), "issues") {
+		return vaultPath
+	}
+
+	issuesDir := filepath.Join(vaultPath, "issues")
+	if dirExists(issuesDir) {
+		return issuesDir
+	}
+
+	issuesDir = filepath.Join(vaultPath, "Issues")
+	if dirExists(issuesDir) {
+		return issuesDir
+	}
+
+	return filepath.Join(vaultPath, "issues")
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
+func hasSession(name string) bool {
+	return tmux.HasSession(name)
+}
+
+func killSession(name string) error {
+	return tmux.KillSession(name)
 }
 
 func SendViaDaemon(vaultPath string, run *model.Run, message string, noEnter bool) error {

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/s22625/orch/internal/model"
@@ -236,4 +237,152 @@ func formatTime(t time.Time) string {
 		return ""
 	}
 	return t.Format(time.RFC3339)
+}
+
+// SummaryToRun converts a RunSummary to a model.Run for display purposes
+func SummaryToRun(summary *RunSummary) (*model.Run, error) {
+	startedAt, err := time.Parse(time.RFC3339, summary.StartedAt)
+	if err != nil {
+		return nil, fmt.Errorf("invalid started_at: %w", err)
+	}
+	updatedAt, err := time.Parse(time.RFC3339, summary.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("invalid updated_at: %w", err)
+	}
+
+	return &model.Run{
+		IssueID:      summary.IssueID,
+		RunID:        summary.RunID,
+		Status:       model.Status(summary.Status),
+		Phase:        model.Phase(summary.Phase),
+		Agent:        summary.Agent,
+		Model:        summary.Model,
+		Branch:       summary.Branch,
+		WorktreePath: summary.WorktreePath,
+		TmuxSession:  summary.TmuxSession,
+		PRUrl:        summary.PRUrl,
+		StartedAt:    startedAt,
+		UpdatedAt:    updatedAt,
+		Events:       []*model.Event{},
+	}, nil
+}
+
+// IssueSummaryToModel converts an IssueSummary to a model.Issue
+func IssueSummaryToModel(summary *IssueSummary) *model.Issue {
+	return &model.Issue{
+		ID:      summary.ID,
+		Title:   summary.Title,
+		Topic:   summary.Topic,
+		Summary: summary.Summary,
+		Status:  model.IssueStatus(summary.Status),
+		Path:    extractPathFromURI(summary.URI),
+	}
+}
+
+func extractPathFromURI(uri string) string {
+	if strings.HasPrefix(uri, "file://") {
+		return strings.TrimPrefix(uri, "file://")
+	}
+	return uri
+}
+
+type StopRunRequest struct {
+	IssueID string `json:"issue_id"`
+	RunID   string `json:"run_id"`
+	All     bool   `json:"all,omitempty"`
+	Force   bool   `json:"force,omitempty"`
+}
+
+type StopRunResponse struct {
+	OK      bool   `json:"ok"`
+	Error   string `json:"error,omitempty"`
+	Stopped int    `json:"stopped,omitempty"`
+}
+
+type ResolveIssueRequest struct {
+	IssueID string `json:"issue_id"`
+	Force   bool   `json:"force,omitempty"`
+}
+
+type ResolveIssueResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+type CreateIssueRequest struct {
+	IssueID string `json:"issue_id"`
+	Title   string `json:"title"`
+	Summary string `json:"summary,omitempty"`
+	Body    string `json:"body,omitempty"`
+}
+
+type CreateIssueResponse struct {
+	OK      bool   `json:"ok"`
+	Error   string `json:"error,omitempty"`
+	IssueID string `json:"issue_id,omitempty"`
+	Path    string `json:"path,omitempty"`
+}
+
+type AttachInfoRequest struct {
+	IssueID string `json:"issue_id"`
+	RunID   string `json:"run_id"`
+}
+
+type AttachInfoResponse struct {
+	OK            bool   `json:"ok"`
+	Error         string `json:"error,omitempty"`
+	Agent         string `json:"agent,omitempty"`
+	TmuxSession   string `json:"tmux_session,omitempty"`
+	ServerPort    int    `json:"server_port,omitempty"`
+	SessionID     string `json:"session_id,omitempty"`
+	WorktreePath  string `json:"worktree_path,omitempty"`
+	SessionExists bool   `json:"session_exists"`
+	CanAutoCreate bool   `json:"can_auto_create"`
+}
+
+// FullToRun converts a RunFull to a model.Run
+func FullToRun(full *RunFull) (*model.Run, error) {
+	startedAt, err := time.Parse(time.RFC3339, full.StartedAt)
+	if err != nil {
+		return nil, fmt.Errorf("invalid started_at: %w", err)
+	}
+	updatedAt, err := time.Parse(time.RFC3339, full.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("invalid updated_at: %w", err)
+	}
+
+	events := make([]*model.Event, len(full.Events))
+	for i, e := range full.Events {
+		ts, err := time.Parse(time.RFC3339, e.Timestamp)
+		if err != nil {
+			return nil, fmt.Errorf("invalid event timestamp: %w", err)
+		}
+		events[i] = &model.Event{
+			Timestamp: ts,
+			Type:      model.EventType(e.Type),
+			Name:      e.Name,
+			Attrs:     e.Attrs,
+		}
+	}
+
+	return &model.Run{
+		IssueID:           full.IssueID,
+		RunID:             full.RunID,
+		Path:              extractPathFromURI(full.URI),
+		Status:            model.Status(full.Status),
+		Phase:             model.Phase(full.Phase),
+		Agent:             full.Agent,
+		Model:             full.Model,
+		ModelVariant:      full.ModelVariant,
+		Branch:            full.Branch,
+		WorktreePath:      full.WorktreePath,
+		TmuxSession:       full.TmuxSession,
+		PRUrl:             full.PRUrl,
+		ServerPort:        full.ServerPort,
+		OpenCodeSessionID: full.OpenCodeSessionID,
+		ContinuedFrom:     full.ContinuedFrom,
+		StartedAt:         startedAt,
+		UpdatedAt:         updatedAt,
+		Events:            events,
+	}, nil
 }


### PR DESCRIPTION
## Summary

Implements daemon-first CLI architecture where all orch commands route through daemon APIs.

## Changes Made

### Phase 2: Read Commands via Daemon
- **ps**: Uses daemon `list_runs` API with fallback to store
- **issue list**: Uses daemon `list_issues` API with fallback to store  
- **show**: Uses daemon `get_run` API with fallback to store

### Phase 3: Write Commands via Daemon
- **stop**: Uses daemon `stop_run` API with fallback to store
- **resolve**: Uses daemon `resolve_issue` API with fallback to store
- **issue create**: Uses daemon `create_issue` API with fallback to file operations

### Infrastructure
- Created `internal/daemon/client.go` with unified daemon client interface
- Added daemon handlers for new APIs: `stop_run`, `resolve_issue`, `create_issue`, `attach_info`
- Extended daemon request/response types to support new operations
- Added conversion helpers: `SummaryToRun`, `FullToRun`, `IssueSummaryToModel`

## Benefits

- **Consistency**: All clients get same data from centralized daemon
- **Performance**: Daemon can cache expensive operations (future enhancement)
- **Simplicity**: CLI is thin, business logic centralized in daemon
- **Graceful Degradation**: All commands fall back to direct access when daemon unavailable

## Testing

- ✅ All existing tests pass
- ✅ Build succeeds
- ✅ Backward compatible - commands work with and without daemon

## Related Issues

Closes orch-169
Depends on orch-166 (Daemon Query APIs)