### PR TITLE
feat(orch-core): add comprehensive serialization tests for core model types

### DIFF
--- a/orch-core/src/models/event.rs
+++ b/orch-core/src/models/event.rs
@@ -305,4 +305,116 @@ mod tests {
         let line = event.to_line();
         assert!(line.contains("| status | running"));
     }
+
+    #[test]
+    fn test_event_type_json_serialization() {
+        let types = [
+            EventType::Status,
+            EventType::Phase,
+            EventType::Artifact,
+            EventType::Test,
+            EventType::Note,
+        ];
+        
+        for event_type in types {
+            let json = serde_json::to_string(&event_type).unwrap();
+            let deserialized: EventType = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, event_type);
+        }
+    }
+
+    #[test]
+    fn test_event_type_yaml_serialization() {
+        let types = [
+            EventType::Status,
+            EventType::Phase,
+            EventType::Artifact,
+            EventType::Test,
+            EventType::Note,
+        ];
+        
+        for event_type in types {
+            let yaml = serde_yaml::to_string(&event_type).unwrap();
+            let deserialized: EventType = serde_yaml::from_str(&yaml).unwrap();
+            assert_eq!(deserialized, event_type);
+        }
+    }
+
+    #[test]
+    fn test_event_json_serialization() {
+        let mut attrs = HashMap::new();
+        attrs.insert("path".to_string(), "/tmp/worktree".to_string());
+        let event = Event::artifact("worktree", attrs);
+
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("worktree"));
+        assert!(json.contains("artifact"));
+
+        let deserialized: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.event_type, EventType::Artifact);
+        assert_eq!(deserialized.name, "worktree");
+        assert_eq!(deserialized.attrs.get("path"), Some(&"/tmp/worktree".to_string()));
+    }
+
+    #[test]
+    fn test_event_yaml_serialization() {
+        let event = Event::status(Status::Running);
+
+        let yaml = serde_yaml::to_string(&event).unwrap();
+        assert!(yaml.contains("running"));
+
+        let deserialized: Event = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(deserialized.event_type, EventType::Status);
+        assert_eq!(deserialized.name, "running");
+    }
+
+    #[test]
+    fn test_event_type_from_str() {
+        assert_eq!(EventType::from_str("status").unwrap(), EventType::Status);
+        assert_eq!(EventType::from_str("phase").unwrap(), EventType::Phase);
+        assert_eq!(EventType::from_str("artifact").unwrap(), EventType::Artifact);
+        assert_eq!(EventType::from_str("test").unwrap(), EventType::Test);
+        assert_eq!(EventType::from_str("note").unwrap(), EventType::Note);
+        assert!(EventType::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn test_event_type_display() {
+        assert_eq!(EventType::Status.to_string(), "status");
+        assert_eq!(EventType::Phase.to_string(), "phase");
+        assert_eq!(EventType::Artifact.to_string(), "artifact");
+        assert_eq!(EventType::Test.to_string(), "test");
+        assert_eq!(EventType::Note.to_string(), "note");
+    }
+
+    #[test]
+    fn test_event_type_value() {
+        assert_eq!(EventType::Status.value(), "status");
+        assert_eq!(EventType::Phase.value(), "phase");
+        assert_eq!(EventType::Artifact.value(), "artifact");
+        assert_eq!(EventType::Test.value(), "test");
+        assert_eq!(EventType::Note.value(), "note");
+    }
+
+    #[test]
+    fn test_event_error_creation() {
+        let event = Event::error("something went wrong");
+        assert_eq!(event.event_type, EventType::Artifact);
+        assert_eq!(event.name, "error");
+        assert_eq!(event.attrs.get("message"), Some(&"something went wrong".to_string()));
+    }
+
+    #[test]
+    fn test_event_phase_creation() {
+        let event = Event::phase(Phase::Implement);
+        assert_eq!(event.event_type, EventType::Phase);
+        assert_eq!(event.name, "implement");
+    }
+
+    #[test]
+    fn test_parse_event_invalid_format() {
+        assert!(Event::parse("invalid line").is_none());
+        assert!(Event::parse("not starting with dash").is_none());
+        assert!(Event::parse("").is_none());
+    }
 }

--- a/orch-core/src/models/issue.rs
+++ b/orch-core/src/models/issue.rs
@@ -241,4 +241,82 @@ mod tests {
         assert_eq!(issue.id, "my-issue");
         assert_eq!(issue.status, IssueStatus::Open);
     }
+
+    #[test]
+    fn test_issue_status_json_serialization() {
+        let statuses = [IssueStatus::Open, IssueStatus::Resolved, IssueStatus::Closed];
+        
+        for status in statuses {
+            let json = serde_json::to_string(&status).unwrap();
+            let deserialized: IssueStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, status);
+        }
+    }
+
+    #[test]
+    fn test_issue_status_yaml_serialization() {
+        let statuses = [IssueStatus::Open, IssueStatus::Resolved, IssueStatus::Closed];
+        
+        for status in statuses {
+            let yaml = serde_yaml::to_string(&status).unwrap();
+            let deserialized: IssueStatus = serde_yaml::from_str(&yaml).unwrap();
+            assert_eq!(deserialized, status);
+        }
+    }
+
+    #[test]
+    fn test_issue_json_serialization() {
+        let mut issue = Issue::new("test-issue");
+        issue.title = "Test Title".to_string();
+        issue.summary = "A brief summary".to_string();
+        issue.status = IssueStatus::Open;
+
+        let json = serde_json::to_string(&issue).unwrap();
+        assert!(json.contains("test-issue"));
+        assert!(json.contains("Test Title"));
+
+        let deserialized: Issue = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.id, "test-issue");
+        assert_eq!(deserialized.title, "Test Title");
+        assert_eq!(deserialized.status, IssueStatus::Open);
+    }
+
+    #[test]
+    fn test_issue_yaml_serialization() {
+        let mut issue = Issue::new("yaml-issue");
+        issue.title = "YAML Test".to_string();
+        issue.body = "Issue body content".to_string();
+
+        let yaml = serde_yaml::to_string(&issue).unwrap();
+        assert!(yaml.contains("yaml-issue"));
+        assert!(yaml.contains("YAML Test"));
+
+        let deserialized: Issue = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(deserialized.id, "yaml-issue");
+        assert_eq!(deserialized.title, "YAML Test");
+        assert_eq!(deserialized.body, "Issue body content");
+    }
+
+    #[test]
+    fn test_issue_status_display() {
+        assert_eq!(IssueStatus::Open.to_string(), "open");
+        assert_eq!(IssueStatus::Resolved.to_string(), "resolved");
+        assert_eq!(IssueStatus::Closed.to_string(), "closed");
+    }
+
+    #[test]
+    fn test_issue_status_value() {
+        assert_eq!(IssueStatus::Open.value(), "open");
+        assert_eq!(IssueStatus::Resolved.value(), "resolved");
+        assert_eq!(IssueStatus::Closed.value(), "closed");
+    }
+
+    #[test]
+    fn test_is_valid_status() {
+        assert!(Issue::is_valid_status("open"));
+        assert!(Issue::is_valid_status("resolved"));
+        assert!(Issue::is_valid_status("closed"));
+        assert!(!Issue::is_valid_status("invalid"));
+        assert!(!Issue::is_valid_status(""));
+    }
 }

--- a/orch-core/src/models/run.rs
+++ b/orch-core/src/models/run.rs
@@ -593,4 +593,104 @@ mod tests {
         let branch = generate_branch_name("my-issue", "20240115-103000");
         assert_eq!(branch, "issue/my-issue/run-20240115-103000");
     }
+
+    #[test]
+    fn test_run_ref_json_serialization() {
+        let run_ref = RunRef {
+            issue_id: "test-issue".to_string(),
+            run_id: "20240115-103000".to_string(),
+        };
+
+        let json = serde_json::to_string(&run_ref).unwrap();
+        assert!(json.contains("test-issue"));
+        assert!(json.contains("20240115-103000"));
+
+        let deserialized: RunRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.issue_id, "test-issue");
+        assert_eq!(deserialized.run_id, "20240115-103000");
+    }
+
+    #[test]
+    fn test_run_ref_yaml_serialization() {
+        let run_ref = RunRef {
+            issue_id: "yaml-issue".to_string(),
+            run_id: "20240120-120000".to_string(),
+        };
+
+        let yaml = serde_yaml::to_string(&run_ref).unwrap();
+        assert!(yaml.contains("yaml-issue"));
+        assert!(yaml.contains("20240120-120000"));
+
+        let deserialized: RunRef = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(deserialized.issue_id, "yaml-issue");
+        assert_eq!(deserialized.run_id, "20240120-120000");
+    }
+
+    #[test]
+    fn test_run_json_serialization() {
+        let run = Run::new("test-issue", "20240115-103000");
+
+        let json = serde_json::to_string(&run).unwrap();
+        assert!(json.contains("test-issue"));
+        assert!(json.contains("20240115-103000"));
+
+        let deserialized: Run = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.issue_id, "test-issue");
+        assert_eq!(deserialized.run_id, "20240115-103000");
+        assert_eq!(deserialized.status, Status::Queued);
+    }
+
+    #[test]
+    fn test_run_yaml_serialization() {
+        let mut run = Run::new("yaml-issue", "20240120-120000");
+        run.agent = "claude".to_string();
+        run.branch = "feature/test".to_string();
+
+        let yaml = serde_yaml::to_string(&run).unwrap();
+        assert!(yaml.contains("yaml-issue"));
+        assert!(yaml.contains("claude"));
+
+        let deserialized: Run = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(deserialized.issue_id, "yaml-issue");
+        assert_eq!(deserialized.agent, "claude");
+        assert_eq!(deserialized.branch, "feature/test");
+    }
+
+    #[test]
+    fn test_run_ref_display() {
+        let ref1 = RunRef {
+            issue_id: "my-issue".to_string(),
+            run_id: "20240115-103000".to_string(),
+        };
+        assert_eq!(ref1.to_string(), "my-issue#20240115-103000");
+
+        let ref2 = RunRef {
+            issue_id: "my-issue".to_string(),
+            run_id: "".to_string(),
+        };
+        assert_eq!(ref2.to_string(), "my-issue");
+    }
+
+    #[test]
+    fn test_run_ref_parse_empty_error() {
+        let result = RunRef::parse("");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "empty run reference");
+    }
+
+    #[test]
+    fn test_generate_worktree_name() {
+        let name = generate_worktree_name("my-issue", "20240115-103000", "claude");
+        assert!(name.contains("claude"));
+        assert!(name.contains("20240115-103000"));
+
+        let name_empty = generate_worktree_name("my-issue", "20240115-103000", "");
+        assert!(name_empty.contains("unknown"));
+    }
+
+    #[test]
+    fn test_generate_tmux_session() {
+        let session = generate_tmux_session("my-issue", "20240115-103000");
+        assert_eq!(session, "run-my-issue-20240115-103000");
+    }
 }

--- a/orch-core/src/models/status.rs
+++ b/orch-core/src/models/status.rs
@@ -214,4 +214,171 @@ mod tests {
         assert_eq!(Phase::from_str("implement").unwrap(), Phase::Implement);
         assert!(Phase::from_str("invalid").is_err());
     }
+
+    #[test]
+    fn test_status_json_serialization() {
+        let statuses = [
+            Status::Queued,
+            Status::Booting,
+            Status::Running,
+            Status::Blocked,
+            Status::BlockedApi,
+            Status::PrOpen,
+            Status::Done,
+            Status::Failed,
+            Status::Canceled,
+            Status::Unknown,
+        ];
+        
+        for status in statuses {
+            let json = serde_json::to_string(&status).unwrap();
+            let deserialized: Status = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, status);
+        }
+    }
+
+    #[test]
+    fn test_status_yaml_serialization() {
+        let statuses = [
+            Status::Queued,
+            Status::Booting,
+            Status::Running,
+            Status::Blocked,
+            Status::BlockedApi,
+            Status::PrOpen,
+            Status::Done,
+            Status::Failed,
+            Status::Canceled,
+            Status::Unknown,
+        ];
+        
+        for status in statuses {
+            let yaml = serde_yaml::to_string(&status).unwrap();
+            let deserialized: Status = serde_yaml::from_str(&yaml).unwrap();
+            assert_eq!(deserialized, status);
+        }
+    }
+
+    #[test]
+    fn test_phase_json_serialization() {
+        let phases = [
+            Phase::Plan,
+            Phase::Implement,
+            Phase::Test,
+            Phase::Pr,
+            Phase::Review,
+        ];
+        
+        for phase in phases {
+            let json = serde_json::to_string(&phase).unwrap();
+            let deserialized: Phase = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, phase);
+        }
+    }
+
+    #[test]
+    fn test_phase_yaml_serialization() {
+        let phases = [
+            Phase::Plan,
+            Phase::Implement,
+            Phase::Test,
+            Phase::Pr,
+            Phase::Review,
+        ];
+        
+        for phase in phases {
+            let yaml = serde_yaml::to_string(&phase).unwrap();
+            let deserialized: Phase = serde_yaml::from_str(&yaml).unwrap();
+            assert_eq!(deserialized, phase);
+        }
+    }
+
+    #[test]
+    fn test_status_display() {
+        assert_eq!(Status::Queued.to_string(), "queued");
+        assert_eq!(Status::Booting.to_string(), "booting");
+        assert_eq!(Status::Running.to_string(), "running");
+        assert_eq!(Status::Blocked.to_string(), "blocked");
+        assert_eq!(Status::BlockedApi.to_string(), "blocked_api");
+        assert_eq!(Status::PrOpen.to_string(), "pr_open");
+        assert_eq!(Status::Done.to_string(), "done");
+        assert_eq!(Status::Failed.to_string(), "failed");
+        assert_eq!(Status::Canceled.to_string(), "canceled");
+        assert_eq!(Status::Unknown.to_string(), "unknown");
+    }
+
+    #[test]
+    fn test_status_value() {
+        assert_eq!(Status::Queued.value(), "queued");
+        assert_eq!(Status::Booting.value(), "booting");
+        assert_eq!(Status::Running.value(), "running");
+        assert_eq!(Status::Blocked.value(), "blocked");
+        assert_eq!(Status::BlockedApi.value(), "blocked_api");
+        assert_eq!(Status::PrOpen.value(), "pr_open");
+        assert_eq!(Status::Done.value(), "done");
+        assert_eq!(Status::Failed.value(), "failed");
+        assert_eq!(Status::Canceled.value(), "canceled");
+        assert_eq!(Status::Unknown.value(), "unknown");
+    }
+
+    #[test]
+    fn test_status_is_active() {
+        assert!(Status::Queued.is_active());
+        assert!(Status::Booting.is_active());
+        assert!(Status::Running.is_active());
+        assert!(Status::Blocked.is_active());
+        assert!(Status::BlockedApi.is_active());
+        assert!(Status::PrOpen.is_active());
+        assert!(Status::Unknown.is_active());
+        assert!(!Status::Done.is_active());
+        assert!(!Status::Failed.is_active());
+        assert!(!Status::Canceled.is_active());
+    }
+
+    #[test]
+    fn test_phase_display() {
+        assert_eq!(Phase::Plan.to_string(), "plan");
+        assert_eq!(Phase::Implement.to_string(), "implement");
+        assert_eq!(Phase::Test.to_string(), "test");
+        assert_eq!(Phase::Pr.to_string(), "pr");
+        assert_eq!(Phase::Review.to_string(), "review");
+    }
+
+    #[test]
+    fn test_phase_value() {
+        assert_eq!(Phase::Plan.value(), "plan");
+        assert_eq!(Phase::Implement.value(), "implement");
+        assert_eq!(Phase::Test.value(), "test");
+        assert_eq!(Phase::Pr.value(), "pr");
+        assert_eq!(Phase::Review.value(), "review");
+    }
+
+    #[test]
+    fn test_status_default() {
+        let status = Status::default();
+        assert_eq!(status, Status::Queued);
+    }
+
+    #[test]
+    fn test_status_from_str_all_values() {
+        assert_eq!(Status::from_str("queued").unwrap(), Status::Queued);
+        assert_eq!(Status::from_str("booting").unwrap(), Status::Booting);
+        assert_eq!(Status::from_str("running").unwrap(), Status::Running);
+        assert_eq!(Status::from_str("blocked").unwrap(), Status::Blocked);
+        assert_eq!(Status::from_str("blocked_api").unwrap(), Status::BlockedApi);
+        assert_eq!(Status::from_str("pr_open").unwrap(), Status::PrOpen);
+        assert_eq!(Status::from_str("done").unwrap(), Status::Done);
+        assert_eq!(Status::from_str("failed").unwrap(), Status::Failed);
+        assert_eq!(Status::from_str("canceled").unwrap(), Status::Canceled);
+        assert_eq!(Status::from_str("unknown").unwrap(), Status::Unknown);
+    }
+
+    #[test]
+    fn test_phase_from_str_all_values() {
+        assert_eq!(Phase::from_str("plan").unwrap(), Phase::Plan);
+        assert_eq!(Phase::from_str("implement").unwrap(), Phase::Implement);
+        assert_eq!(Phase::from_str("test").unwrap(), Phase::Test);
+        assert_eq!(Phase::from_str("pr").unwrap(), Phase::Pr);
+        assert_eq!(Phase::from_str("review").unwrap(), Phase::Review);
+    }
 }


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for JSON and YAML serialization/deserialization for all core model types
- Tests verify roundtrip serialization for: RunRef, Run, Issue, IssueStatus, Event, EventType, Status, Phase
- Add tests for helper functions: generate_worktree_name, generate_tmux_session, is_valid_status
- All 71 tests pass

## Details

This PR addresses the acceptance criteria from orch-171:

**All model types ported with serde derive** - Already implemented:
- `Run` and `RunRef` in `run.rs`
- `Issue` and `IssueStatus` in `issue.rs`
- `Event` and `EventType` in `event.rs`
- `Status` and `Phase` in `status.rs`

**Unit tests for serialization/deserialization** - Added in this PR:
- JSON roundtrip tests for all types
- YAML roundtrip tests for all types
- Display trait tests
- FromStr parsing tests
- Edge case tests (empty strings, all enum variants)

**Markdown parsing for issue/run files** - Already implemented in `store/file.rs`:
- `parse_issue_file` for issues
- `load_run` for runs with event parsing

**RunRef parsing ("issue#run" format)** - Already implemented with tests

## Test Results

```
running 71 tests
...
test result: ok. 71 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Refs: orch-171