### PR TITLE
feat(monitor): enhance control agent init prompt with workflow guidance

### DIFF
--- a/internal/monitor/agent_prompt.go
+++ b/internal/monitor/agent_prompt.go
@@ -34,7 +34,7 @@ You can run orch commands directly via bash to manage issues and runs.
 {{if .GitBranch}}
 - Current branch: {{.GitBranch}}
 {{- end}}
-- Uncommitted changes: {{if .HasUncommittedChanges}}Yes{{else}}No{{end}}
+- Uncommitted changes: {{.UncommittedChanges}}
 {{- if .LastCommitMessage}}
 - Last commit: {{.LastCommitMessage}}
 {{- end}}
@@ -161,9 +161,9 @@ type ControlPromptData struct {
 	Issues         []IssueInfo
 	ActiveRuns     []RunInfo
 
-	GitBranch             string
-	HasUncommittedChanges bool
-	LastCommitMessage     string
+	GitBranch          string
+	UncommittedChanges string
+	LastCommitMessage  string
 
 	DefaultAgent    string
 	AvailableAgents string
@@ -249,8 +249,12 @@ func buildControlAgentPrompt(st store.Store) (string, error) {
 
 	cfg, _ := config.Load()
 	defaultAgent := "opencode"
-	if cfg != nil && cfg.Agent != "" {
-		defaultAgent = cfg.Agent
+	if cfg != nil {
+		if cfg.ControlAgent != "" {
+			defaultAgent = cfg.ControlAgent
+		} else if cfg.Agent != "" {
+			defaultAgent = cfg.Agent
+		}
 	}
 
 	data := ControlPromptData{
@@ -262,9 +266,9 @@ func buildControlAgentPrompt(st store.Store) (string, error) {
 		Issues:         issueInfos,
 		ActiveRuns:     runInfos,
 
-		GitBranch:             getGitBranch(),
-		HasUncommittedChanges: hasUncommittedChanges(),
-		LastCommitMessage:     getLastCommitMessage(),
+		GitBranch:          getGitBranch(cwd),
+		UncommittedChanges: getUncommittedChangesStatus(cwd),
+		LastCommitMessage:  getLastCommitMessage(cwd),
 
 		DefaultAgent:    defaultAgent,
 		AvailableAgents: getAvailableAgents(),
@@ -352,8 +356,8 @@ func detectIssueIDConvention(issues []*model.Issue) (pattern, example, nextID st
 	return
 }
 
-func getGitBranch() string {
-	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+func getGitBranch(workDir string) string {
+	cmd := exec.Command("git", "-C", workDir, "rev-parse", "--abbrev-ref", "HEAD")
 	output, err := cmd.Output()
 	if err != nil {
 		return ""
@@ -361,17 +365,20 @@ func getGitBranch() string {
 	return strings.TrimSpace(string(output))
 }
 
-func hasUncommittedChanges() bool {
-	cmd := exec.Command("git", "status", "--porcelain")
+func getUncommittedChangesStatus(workDir string) string {
+	cmd := exec.Command("git", "-C", workDir, "status", "--porcelain")
 	output, err := cmd.Output()
 	if err != nil {
-		return false
+		return "Unknown"
 	}
-	return len(strings.TrimSpace(string(output))) > 0
+	if len(strings.TrimSpace(string(output))) > 0 {
+		return "Yes"
+	}
+	return "No"
 }
 
-func getLastCommitMessage() string {
-	cmd := exec.Command("git", "log", "-1", "--format=%s")
+func getLastCommitMessage(workDir string) string {
+	cmd := exec.Command("git", "-C", workDir, "log", "-1", "--format=%s")
 	output, err := cmd.Output()
 	if err != nil {
 		return ""
@@ -384,8 +391,10 @@ func getLastCommitMessage() string {
 }
 
 func getAvailableAgents() string {
-	return "opencode, claude, codex, gemini"
+	return "opencode, claude, codex, gemini, custom"
 }
+
+const maxExtraPromptSize = 16 * 1024
 
 func loadExtraPrompt() string {
 	configDir := config.RepoConfigDir()
@@ -393,11 +402,18 @@ func loadExtraPrompt() string {
 		return ""
 	}
 	extraPath := filepath.Join(configDir, "control-prompt-extra.md")
-	data, err := os.ReadFile(extraPath)
+	file, err := os.Open(extraPath)
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(data))
+	defer file.Close()
+
+	data := make([]byte, maxExtraPromptSize)
+	n, err := file.Read(data)
+	if err != nil && n == 0 {
+		return ""
+	}
+	return strings.TrimSpace(string(data[:n]))
 }
 
 // buildFallbackControlPrompt creates a simple prompt when template fails

--- a/internal/monitor/agent_prompt_test.go
+++ b/internal/monitor/agent_prompt_test.go
@@ -1,6 +1,7 @@
 package monitor
 
 import (
+	"os"
 	"testing"
 
 	"github.com/s22625/orch/internal/model"
@@ -148,24 +149,30 @@ func containsSubstring(s, substr string) bool {
 
 func TestGetAvailableAgents(t *testing.T) {
 	agents := getAvailableAgents()
-	if agents != "opencode, claude, codex, gemini" {
-		t.Errorf("getAvailableAgents() = %q, want %q", agents, "opencode, claude, codex, gemini")
+	if agents != "opencode, claude, codex, gemini, custom" {
+		t.Errorf("getAvailableAgents() = %q, want %q", agents, "opencode, claude, codex, gemini, custom")
 	}
 }
 
 func TestGetGitBranch(t *testing.T) {
-	branch := getGitBranch()
+	cwd, _ := os.Getwd()
+	branch := getGitBranch(cwd)
 	if branch == "" {
 		t.Skip("not in a git repository")
 	}
 }
 
-func TestHasUncommittedChanges(t *testing.T) {
-	_ = hasUncommittedChanges()
+func TestGetUncommittedChangesStatus(t *testing.T) {
+	cwd, _ := os.Getwd()
+	status := getUncommittedChangesStatus(cwd)
+	if status != "Yes" && status != "No" && status != "Unknown" {
+		t.Errorf("getUncommittedChangesStatus() = %q, want Yes/No/Unknown", status)
+	}
 }
 
 func TestGetLastCommitMessage(t *testing.T) {
-	msg := getLastCommitMessage()
+	cwd, _ := os.Getwd()
+	msg := getLastCommitMessage(cwd)
 	if msg == "" {
 		t.Skip("no commits in repository")
 	}


### PR DESCRIPTION
## Summary

Enhances the orch-monitor control agent's init prompt (`ORCH_CONTROL_PROMPT.md`) with comprehensive guidance to help users effectively orchestrate agent runs.

## Changes

- **Git Context Section**: Shows current branch, uncommitted changes status, and last commit message
- **Available Agents Section**: Displays default agent and all configured backends
- **Workflow Guidance**: Step-by-step instructions for:
  - Starting new work (create issue → run → monitor)
  - Handling blocked runs (attach → provide input → detach)
  - Continuing work from branches or previous runs
- **Advanced Commands**: Added `orch continue`, `orch attach`, `orch capture` to the command reference
- **Troubleshooting Section**: Common fixes including `orch repair`, daemon logs location, force stop
- **User Customization**: Support for `.orch/control-prompt-extra.md` to append custom instructions

## Files Modified

- `internal/monitor/agent_prompt.go`: Expanded template and added helper functions
- `internal/monitor/agent_prompt_test.go`: Added tests for new functionality

## Testing

- All existing tests pass
- Added new tests for helper functions and template content verification

Closes: orch-186