### PR TITLE
feat(monitor): add ability to kill tmux session with confirmation

### DIFF
--- a/internal/monitor/dashboard.go
+++ b/internal/monitor/dashboard.go
@@ -26,11 +26,17 @@ const (
 	modeStopSelectRun
 	modeNewSelectIssue
 	modeDashboardFilter
+	modeKillConfirm
 	modeHelp
 )
 
 type stopState struct {
 	runs []RunRow
+}
+
+type killState struct {
+	run         *model.Run
+	tmuxSession string
 }
 
 type newRunState struct {
@@ -70,6 +76,7 @@ type Dashboard struct {
 	issue   issueState
 
 	stop   stopState
+	kill   killState
 	newRun newRunState
 	filter runFilterState
 
@@ -243,6 +250,8 @@ func (d *Dashboard) View() string {
 		return d.styles.Box.Render(d.viewNewRun())
 	case modeDashboardFilter:
 		return d.styles.Box.Render(d.viewFilter())
+	case modeKillConfirm:
+		return d.styles.Box.Render(d.viewKillConfirm())
 	case modeHelp:
 		return d.styles.Box.Render(d.viewHelp())
 	default:
@@ -264,6 +273,8 @@ func (d *Dashboard) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return d.handleNewRunKey(msg)
 	case modeDashboardFilter:
 		return d.handleFilterKey(msg)
+	case modeKillConfirm:
+		return d.handleKillKey(msg)
 	case modeHelp:
 		return d.handleHelpKey(msg)
 	default:
@@ -295,6 +306,8 @@ func (d *Dashboard) handleDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return d, d.refreshCmd()
 	case "s":
 		return d.enterStopMode()
+	case d.keymap.KillSession:
+		return d.enterKillMode()
 	case "n":
 		return d.enterNewRunMode()
 	case d.keymap.Filter, "/":
@@ -455,6 +468,60 @@ func (d *Dashboard) enterStopMode() (tea.Model, tea.Cmd) {
 	d.stop = stopState{runs: runs}
 	d.mode = modeStopSelectRun
 	return d, nil
+}
+
+func (d *Dashboard) enterKillMode() (tea.Model, tea.Cmd) {
+	run := d.selectedRun()
+	if run == nil {
+		d.message = "no run selected"
+		return d, nil
+	}
+	sessionName := run.TmuxSession
+	if sessionName == "" {
+		sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
+	}
+	d.kill = killState{
+		run:         run,
+		tmuxSession: sessionName,
+	}
+	d.mode = modeKillConfirm
+	return d, nil
+}
+
+func (d *Dashboard) handleKillKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "n":
+		d.mode = modeDashboard
+		return d, nil
+	case "q":
+		return d.quit()
+	case "y", "Y":
+		cmd := d.killSessionCmd(d.kill.run, d.kill.tmuxSession)
+		d.mode = modeDashboard
+		return d, cmd
+	}
+	return d, nil
+}
+
+func (d *Dashboard) killSessionCmd(run *model.Run, sessionName string) tea.Cmd {
+	return func() tea.Msg {
+		if run == nil {
+			return errMsg{err: fmt.Errorf("run not found")}
+		}
+		sessionExisted := tmux.HasSession(sessionName)
+		if sessionExisted {
+			if err := tmux.KillSession(sessionName); err != nil {
+				return errMsg{err: fmt.Errorf("failed to kill session: %w", err)}
+			}
+		}
+		if err := d.monitor.StopRun(run); err != nil {
+			return errMsg{err: fmt.Errorf("failed to stop run: %w", err)}
+		}
+		if sessionExisted {
+			return infoMsg{text: fmt.Sprintf("killed session %s", sessionName)}
+		}
+		return infoMsg{text: fmt.Sprintf("session already dead; run %s marked canceled", run.Ref().String())}
+	}
 }
 
 func (d *Dashboard) enterNewRunMode() (tea.Model, tea.Cmd) {
@@ -729,6 +796,27 @@ func (d *Dashboard) viewStopRuns() string {
 	return strings.Join(lines, "\n")
 }
 
+func (d *Dashboard) viewKillConfirm() string {
+	run := d.kill.run
+	if run == nil {
+		return "No run selected."
+	}
+	lines := []string{
+		d.styles.Title.Render("KILL TMUX SESSION"),
+		"",
+		fmt.Sprintf("Run: %s#%s", run.IssueID, run.RunID),
+		fmt.Sprintf("Session: %s", d.kill.tmuxSession),
+		"",
+		"This will:",
+		"  • Kill the tmux session",
+		"  • Mark the run as canceled",
+		"  • Stop any running agent",
+		"",
+		"[Y] Yes, kill    [N] No, cancel",
+	}
+	return strings.Join(lines, "\n")
+}
+
 func (d *Dashboard) viewNewRun() string {
 	lines := []string{
 		d.styles.Title.Render("NEW RUN"),
@@ -772,6 +860,7 @@ func (d *Dashboard) viewHelp() string {
 		"  I          Open issue file in nvim",
 		"  e          Execute shell in run's worktree",
 		"  s          Stop run (select from active runs)",
+		"  X          Kill tmux session (forceful, with confirmation)",
 		"  n          New run (select issue to start)",
 		"  R          Resolve run and mark issue as resolved",
 		"  M          Request merge for run",

--- a/internal/monitor/keymap.go
+++ b/internal/monitor/keymap.go
@@ -11,6 +11,7 @@ type KeyMap struct {
 	EditIssue   string
 	Exec        string
 	Stop        string
+	KillSession string
 	NewRun      string
 	Resolve     string
 	Merge       string
@@ -32,6 +33,7 @@ func DefaultKeyMap() KeyMap {
 		EditIssue:   "I",
 		Exec:        "e",
 		Stop:        "s",
+		KillSession: "X",
 		NewRun:      "n",
 		Resolve:     "R",
 		Merge:       "M",
@@ -46,6 +48,6 @@ func DefaultKeyMap() KeyMap {
 
 // HelpLine renders the footer help text.
 func (k KeyMap) HelpLine() string {
-	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] issue  [%s] exec  [%s] stop  [%s] new  [%s] resolve  [%s] merge  [%s] refresh  [%s] sort  [%s] filter  [%s] presets  [%s] quit  [%s] help",
-		k.Runs, k.Issues, k.Chat, k.Open, k.EditIssue, k.Exec, k.Stop, k.NewRun, k.Resolve, k.Merge, k.Refresh, k.Sort, k.Filter, k.QuickFilter, k.Quit, k.Help)
+	return fmt.Sprintf("[%s] runs  [%s] issues  [%s] chat  [%s] open  [%s] issue  [%s] exec  [%s] stop  [%s] kill  [%s] new  [%s] resolve  [%s] merge  [%s] refresh  [%s] sort  [%s] filter  [%s] presets  [%s] quit  [%s] help",
+		k.Runs, k.Issues, k.Chat, k.Open, k.EditIssue, k.Exec, k.Stop, k.KillSession, k.NewRun, k.Resolve, k.Merge, k.Refresh, k.Sort, k.Filter, k.QuickFilter, k.Quit, k.Help)
 }

--- a/orch-monitor-tui/orch_monitor/app.py
+++ b/orch-monitor-tui/orch_monitor/app.py
@@ -45,6 +45,91 @@ TIME_RANGES = [
 ]
 
 
+class KillConfirmScreen(ModalScreen[bool]):
+    """Confirmation dialog for killing tmux session."""
+
+    CSS = """
+    KillConfirmScreen {
+        align: center middle;
+    }
+
+    #kill-dialog {
+        width: 50;
+        height: auto;
+        padding: 1 2;
+        background: $surface;
+        border: thick $error;
+    }
+
+    #kill-title {
+        text-align: center;
+        width: 100%;
+        padding-bottom: 1;
+        color: $error;
+    }
+
+    #kill-details {
+        height: auto;
+        padding: 1;
+    }
+
+    #kill-consequences {
+        height: auto;
+        padding: 1;
+        color: $warning;
+    }
+
+    #kill-buttons {
+        height: 3;
+        align: center middle;
+        padding-top: 1;
+    }
+
+    #kill-buttons Button {
+        margin: 0 1;
+    }
+    """
+
+    BINDINGS = [
+        Binding("y", "confirm", "Yes, kill"),
+        Binding("n", "cancel", "No, cancel"),
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, run: Run):
+        super().__init__()
+        self.run = run
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="kill-dialog"):
+            yield Label("Kill tmux session?", id="kill-title")
+            with Vertical(id="kill-details"):
+                yield Static(f"Run: {self.run.ref()}")
+                yield Static(f"Session: {self.run.tmux_session or 'N/A'}")
+            with Vertical(id="kill-consequences"):
+                yield Static("This will:")
+                yield Static("  • Kill the tmux session")
+                yield Static("  • Mark the run as canceled")
+                yield Static("  • Stop any running agent")
+            with Horizontal(id="kill-buttons"):
+                yield Button("Yes, kill", variant="error", id="confirm-btn")
+                yield Button("No, cancel", id="cancel-btn")
+
+    @on(Button.Pressed, "#confirm-btn")
+    def confirm(self) -> None:
+        self.dismiss(True)
+
+    @on(Button.Pressed, "#cancel-btn")
+    def cancel(self) -> None:
+        self.dismiss(False)
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)
+
+
 def _get_editor_command(file_path: Path) -> Tuple[Optional[list[str]], Optional[str]]:
     """Get editor command for opening a file.
 
@@ -477,6 +562,7 @@ class RunsDashboard(App):
         Binding("r", "refresh", "Refresh"),
         Binding("enter", "attach", "Attach"),
         Binding("s", "stop", "Stop"),
+        Binding("X", "kill_session", "Kill"),
         Binding("f", "filter", "Filter"),
         Binding("ctrl+f", "clear_filters", "Clear Filters"),
     ]
@@ -655,6 +741,67 @@ class RunsDashboard(App):
             self.call_from_thread(self.refresh_data)
         except subprocess.CalledProcessError:
             pass
+
+    def action_kill_session(self) -> None:
+        """Show kill confirmation dialog for selected run."""
+        if not self.selected_run:
+            self.notify("No run selected", severity="warning")
+            return
+        if not self.selected_run.tmux_session:
+            self.notify("Run has no tmux session", severity="warning")
+            return
+        run = self.selected_run
+        tmux_session = run.tmux_session
+        run_ref = run.ref()
+
+        def on_confirm(confirmed: bool) -> None:
+            if confirmed:
+                self._do_kill_session(tmux_session, run_ref)
+
+        self.push_screen(KillConfirmScreen(run), on_confirm)
+
+    @work(thread=True)
+    def _do_kill_session(self, tmux_session: str, run_ref: str) -> None:
+        """Kill tmux session and mark run as canceled."""
+        try:
+            kill_result = subprocess.run(
+                ["tmux", "kill-session", "-t", tmux_session],
+                capture_output=True,
+            )
+            session_existed = kill_result.returncode == 0
+
+            stop_result = subprocess.run(
+                [
+                    "orch",
+                    "--vault",
+                    str(self.config.vault_path),
+                    "stop",
+                    run_ref,
+                ],
+                capture_output=True,
+            )
+
+            if stop_result.returncode != 0:
+                stderr = stop_result.stderr.decode().strip()
+                self.call_from_thread(
+                    self.notify,
+                    f"Failed to stop run: {stderr or 'unknown error'}",
+                    severity="error",
+                )
+                return
+
+            if session_existed:
+                msg = f"Killed session for {run_ref}"
+            else:
+                msg = f"Session already dead; run {run_ref} marked canceled"
+            self.call_from_thread(self.notify, msg, severity="information")
+            self.call_from_thread(self.refresh_data)
+        except Exception as e:
+            self.call_from_thread(
+                self.notify,
+                f"Failed to kill session: {e}",
+                severity="error",
+            )
 
 
 class IssuesDashboard(App):
@@ -835,6 +982,7 @@ class OrchMonitorApp(App):
         Binding("enter", "select", "Select"),
         Binding("a", "attach", "Attach"),
         Binding("s", "stop", "Stop"),
+        Binding("X", "kill_session", "Kill"),
         Binding("n", "new_run", "New Run"),
         Binding("o", "open_issue", "Open in Editor"),
         Binding("f", "filter", "Filter"),
@@ -1163,6 +1311,67 @@ class OrchMonitorApp(App):
             self.call_from_thread(self.refresh_data)
         except subprocess.CalledProcessError:
             pass
+
+    def action_kill_session(self) -> None:
+        """Show kill confirmation dialog for selected run."""
+        if not self.selected_run:
+            self.notify("No run selected", severity="warning")
+            return
+        if not self.selected_run.tmux_session:
+            self.notify("Run has no tmux session", severity="warning")
+            return
+        run = self.selected_run
+        tmux_session = run.tmux_session
+        run_ref = run.ref()
+
+        def on_confirm(confirmed: bool) -> None:
+            if confirmed:
+                self._do_kill_session(tmux_session, run_ref)
+
+        self.push_screen(KillConfirmScreen(run), on_confirm)
+
+    @work(thread=True)
+    def _do_kill_session(self, tmux_session: str, run_ref: str) -> None:
+        """Kill tmux session and mark run as canceled."""
+        try:
+            kill_result = subprocess.run(
+                ["tmux", "kill-session", "-t", tmux_session],
+                capture_output=True,
+            )
+            session_existed = kill_result.returncode == 0
+
+            stop_result = subprocess.run(
+                [
+                    "orch",
+                    "--vault",
+                    str(self.config.vault_path),
+                    "stop",
+                    run_ref,
+                ],
+                capture_output=True,
+            )
+
+            if stop_result.returncode != 0:
+                stderr = stop_result.stderr.decode().strip()
+                self.call_from_thread(
+                    self.notify,
+                    f"Failed to stop run: {stderr or 'unknown error'}",
+                    severity="error",
+                )
+                return
+
+            if session_existed:
+                msg = f"Killed session for {run_ref}"
+            else:
+                msg = f"Session already dead; run {run_ref} marked canceled"
+            self.call_from_thread(self.notify, msg, severity="information")
+            self.call_from_thread(self.refresh_data)
+        except Exception as e:
+            self.call_from_thread(
+                self.notify,
+                f"Failed to kill session: {e}",
+                severity="error",
+            )
 
     def action_new_run(self) -> None:
         if not self.selected_issue:


### PR DESCRIPTION
## Summary

- Add `X` keybinding to forcefully kill a run's tmux session with confirmation dialog
- Address orphaned sessions that may remain after graceful stop (`s`)
- Works in both Python TUI (Textual) and Go monitor (Bubbletea)

## Changes

### Go Monitor (`internal/monitor/`)
- Add `modeKillConfirm` mode with Y/N confirmation dialog
- Add `KillSession` key to KeyMap (default: `X`)
- Add `killState` struct to track selected run for kill
- Add `viewKillConfirm()` to render confirmation dialog
- Add `killSessionCmd()` to execute kill and mark as canceled
- Update help text with new kill action

### Python TUI (`orch-monitor-tui/`)
- Add `KillConfirmScreen` modal with Y/N keybindings
- Add `action_kill_session()` method to `RunsDashboard` and `OrchMonitorApp`
- Add `X` keybinding to both dashboard classes
- Handle gracefully when tmux session already dead (check=False)

## Confirmation Dialog

```
┌─────────────────────────────────────────┐
│  Kill tmux session?                     │
│                                         │
│  Run: orch-186#20260117-130416          │
│  Session: run-orch-186-20260117-130416  │
│                                         │
│  This will:                             │
│  • Kill the tmux session                │
│  • Mark the run as canceled             │
│  • Stop any running agent               │
│                                         │
│  [Y] Yes, kill    [N] No, cancel        │
└─────────────────────────────────────────┘
```

## Testing

- Go build passes: `go build ./...`
- Go tests pass: `go test ./...`
- Python syntax valid

Closes: orch-191