### PR TITLE
feat(monitor): add Model column to runs list

### DIFF
--- a/internal/monitor/columns.go
+++ b/internal/monitor/columns.go
@@ -17,6 +17,7 @@ const (
 	ColIssue       ColumnID = "issue"
 	ColIssueStatus ColumnID = "issue_status"
 	ColAgent       ColumnID = "agent"
+	ColModel       ColumnID = "model"
 	ColStatus      ColumnID = "status"
 	ColAlive       ColumnID = "alive"
 	ColBranch      ColumnID = "branch"
@@ -41,6 +42,7 @@ var columnRegistry = map[ColumnID]ColumnDef{
 	ColIssue:       {ID: ColIssue, Header: "ISSUE", Width: 14},
 	ColIssueStatus: {ID: ColIssueStatus, Header: "ISSUE-ST", Width: 8},
 	ColAgent:       {ID: ColAgent, Header: "AGENT", Width: agent.MaxAgentDisplayWidth},
+	ColModel:       {ID: ColModel, Header: "MODEL", Width: 18},
 	ColStatus:      {ID: ColStatus, Header: "STATUS", Width: 10},
 	ColAlive:       {ID: ColAlive, Header: "ALIVE", Width: 5},
 	ColBranch:      {ID: ColBranch, Header: "BRANCH", Width: runTableBranchWidth},
@@ -57,6 +59,7 @@ var defaultColumns = []ColumnID{
 	ColID,
 	ColIssue,
 	ColAgent,
+	ColModel,
 	ColStatus,
 	ColPR,
 	ColMerged,
@@ -110,6 +113,8 @@ func GetColumnValue(col ColumnID, row *RunRow, now time.Time) string {
 		return row.IssueStatus
 	case ColAgent:
 		return row.Agent
+	case ColModel:
+		return row.Model
 	case ColStatus:
 		return string(row.Status)
 	case ColAlive:

--- a/internal/monitor/data.go
+++ b/internal/monitor/data.go
@@ -14,6 +14,7 @@ type RunRow struct {
 	IssueStatus  string
 	IssueSummary string // Short one-line summary from issue frontmatter
 	Agent        string
+	Model        string
 	Status       model.Status
 	Alive        string
 	Branch       string

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -833,7 +833,17 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 			topic = "-"
 		}
 
-		agentDisplay := agent.AgentDisplayName(w.Run.Agent, w.Run.Model, w.Run.ModelVariant)
+		agentDisplay := w.Run.Agent
+		if agentDisplay == "" {
+			agentDisplay = "-"
+		}
+
+		modelDisplay := w.Run.Model
+		if modelDisplay == "" {
+			modelDisplay = "-"
+		} else if w.Run.ModelVariant != "" {
+			modelDisplay = fmt.Sprintf("%s/%s", w.Run.Model, w.Run.ModelVariant)
+		}
 
 		// Build PR display string and state
 		prDisplay := "-"
@@ -864,6 +874,7 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 			IssueStatus:  issueStatus,
 			IssueSummary: info.summary,
 			Agent:        agentDisplay,
+			Model:        modelDisplay,
 			Status:       w.Run.Status,
 			Alive:        runAliveLabel(w.Run),
 			Branch:       branch,

--- a/orch-monitor-tui/orch_monitor/widgets.py
+++ b/orch-monitor-tui/orch_monitor/widgets.py
@@ -66,6 +66,7 @@ class RunTable(CursorPreservingTable):
         self.add_column("Issue", width=15)
         self.add_column("Status", width=12)
         self.add_column("Agent", width=10)
+        self.add_column("Model", width=18)
         self.add_column("Elapsed", width=10)
         self.add_column("Branch", width=25)
 
@@ -82,11 +83,16 @@ class RunTable(CursorPreservingTable):
             elif run.status == Status.PR_OPEN:
                 status_str = f"[cyan]{status_str}[/cyan]"
 
+            model_str = run.model or "-"
+            if run.model_variant:
+                model_str = f"{run.model}/{run.model_variant}"
+
             self.add_row(
                 run.short_id(),
                 run.issue_id,
                 status_str,
                 run.agent or "-",
+                model_str,
                 run.elapsed_time(),
                 run.branch or "-",
                 key=run.ref(),


### PR DESCRIPTION
## Summary

- Adds a separate Model column to display agent model information in both Python TUI and Go monitor
- Separates agent backend (opencode/claude/codex) from the specific model name
- Shows model variant when available (e.g., `claude-sonnet-4/max`)

## Changes

**Python TUI (`orch-monitor-tui/orch_monitor/widgets.py`)**:
- Added Model column (width 18) between Agent and Elapsed columns
- Displays model name with variant in format `model/variant` when variant is present
- Shows "-" when no model is recorded

**Go Monitor**:
- Added `Model` field to `RunRow` struct (`internal/monitor/data.go`)
- Added `ColModel` column definition (`internal/monitor/columns.go`)
- Updated `buildRunRows` to populate model display (`internal/monitor/monitor.go`)
- Simplified Agent column to show just the backend name

## Example Output

```
│ ID    │ Issue      │ Status   │ Agent    │ Model              │ Elapsed │
│ a1b2  │ orch-186   │ running  │ opencode │ claude-sonnet-4    │ 5m32s   │
│ c3d4  │ orch-187   │ running  │ claude   │ claude-sonnet-4    │ 3m15s   │
│ e5f6  │ orch-188   │ running  │ opencode │ o3                 │ 2m45s   │
```

## Testing

- All existing Go tests pass (`go test ./...`)
- Go build succeeds without errors
- Python package installs successfully

Fixes: #195