### PR TITLE
feat(monitor): add Model column to runs list

### DIFF
--- a/internal/monitor/columns.go
+++ b/internal/monitor/columns.go
@@ -17,6 +17,7 @@ const (
 	ColIssue       ColumnID = "issue"
 	ColIssueStatus ColumnID = "issue_status"
 	ColAgent       ColumnID = "agent"
+	ColModel       ColumnID = "model"
 	ColStatus      ColumnID = "status"
 	ColAlive       ColumnID = "alive"
 	ColBranch      ColumnID = "branch"
@@ -41,6 +42,7 @@ var columnRegistry = map[ColumnID]ColumnDef{
 	ColIssue:       {ID: ColIssue, Header: "ISSUE", Width: 14},
 	ColIssueStatus: {ID: ColIssueStatus, Header: "ISSUE-ST", Width: 8},
 	ColAgent:       {ID: ColAgent, Header: "AGENT", Width: agent.MaxAgentDisplayWidth},
+	ColModel:       {ID: ColModel, Header: "MODEL", Width: 18},
 	ColStatus:      {ID: ColStatus, Header: "STATUS", Width: 10},
 	ColAlive:       {ID: ColAlive, Header: "ALIVE", Width: 5},
 	ColBranch:      {ID: ColBranch, Header: "BRANCH", Width: runTableBranchWidth},
@@ -57,6 +59,7 @@ var defaultColumns = []ColumnID{
 	ColID,
 	ColIssue,
 	ColAgent,
+	ColModel,
 	ColStatus,
 	ColPR,
 	ColMerged,
@@ -163,6 +166,8 @@ func GetColumnValue(col ColumnID, row *RunRow, now time.Time) string {
 		return row.IssueStatus
 	case ColAgent:
 		return row.Agent
+	case ColModel:
+		return row.Model
 	case ColStatus:
 		return string(row.Status)
 	case ColAlive:

--- a/internal/monitor/data.go
+++ b/internal/monitor/data.go
@@ -14,6 +14,7 @@ type RunRow struct {
 	IssueStatus  string
 	IssueSummary string // Short one-line summary from issue frontmatter
 	Agent        string
+	Model        string
 	Status       model.Status
 	Alive        string
 	Branch       string

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -892,7 +892,17 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 			topic = "-"
 		}
 
-		agentDisplay := agent.AgentDisplayName(w.Run.Agent, w.Run.Model, w.Run.ModelVariant)
+		agentDisplay := w.Run.Agent
+		if agentDisplay == "" {
+			agentDisplay = "-"
+		}
+
+		modelDisplay := w.Run.Model
+		if modelDisplay == "" {
+			modelDisplay = "-"
+		} else if w.Run.ModelVariant != "" {
+			modelDisplay = fmt.Sprintf("%s/%s", w.Run.Model, w.Run.ModelVariant)
+		}
 
 		// Build PR display string and state
 		prDisplay := "-"
@@ -923,6 +933,7 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 			IssueStatus:  issueStatus,
 			IssueSummary: info.summary,
 			Agent:        agentDisplay,
+			Model:        modelDisplay,
 			Status:       w.Run.Status,
 			Alive:        runAliveLabel(w.Run),
 			Branch:       branch,

--- a/orch-monitor-tui/orch_monitor/widgets.py
+++ b/orch-monitor-tui/orch_monitor/widgets.py
@@ -66,6 +66,7 @@ class RunTable(CursorPreservingTable):
         self.add_column("Issue", width=15)
         self.add_column("Status", width=12)
         self.add_column("Agent", width=10)
+        self.add_column("Model", width=18)
         self.add_column("Elapsed", width=10, key="elapsed")
         self.add_column("Branch", width=25)
 
@@ -82,11 +83,16 @@ class RunTable(CursorPreservingTable):
             elif run.status == Status.PR_OPEN:
                 status_str = f"[cyan]{status_str}[/cyan]"
 
+            model_str = run.model or "-"
+            if run.model and run.model_variant:
+                model_str = f"{run.model}/{run.model_variant}"
+
             self.add_row(
                 run.short_id(),
                 run.issue_id,
                 status_str,
                 run.agent or "-",
+                model_str,
                 run.elapsed_time(),
                 run.branch or "-",
                 key=run.ref(),


### PR DESCRIPTION
## Summary
- Added Model column to both Python TUI and Go monitor runs list
- Model column displays model name from run metadata
- Shows variant if available (e.g., `sonnet-4/max`)
- Shows `-` if model not recorded
- Separated Agent and Model columns for better clarity

## Changes Made

### Python TUI (`orch-monitor-tui/widgets.py`)
- Added Model column between Agent and Elapsed columns (width=18)
- Formats model display as `model/variant` when variant is present
- Falls back to `-` when model is not available

### Go Monitor
- Added `ColModel` to column registry in `columns.go`
- Added `Model` field to `RunRow` struct in `data.go`
- Updated `buildRunRows()` in `monitor.go` to populate Model field
- Updated `GetColumnValue()` to handle Model column
- Changed Agent column to show only agent backend (not combined with model)

## Testing
- All Go tests pass (`make test`)
- Build succeeds without errors
- Python changes follow existing patterns

## Fixes
Fixes orch-195