### PR TITLE
Auto-start orch daemon when running orch-monitor

### DIFF
--- a/orch-monitor-tui/orch_monitor/__main__.py
+++ b/orch-monitor-tui/orch_monitor/__main__.py
@@ -136,10 +136,10 @@ Run these commands directly using bash:
 def get_vault_path(args) -> Path | None:
     """Get vault path from args or environment."""
     if args.vault:
-        return args.vault
+        return Path(args.vault).expanduser().resolve()
     vault_env = os.getenv("ORCH_VAULT")
     if vault_env:
-        return Path(vault_env)
+        return Path(vault_env).expanduser().resolve()
     return None
 
 

--- a/orch-monitor-tui/orch_monitor/__main__.py
+++ b/orch-monitor-tui/orch_monitor/__main__.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Protocol
 
@@ -21,6 +22,8 @@ SESSION_NAME = "orch-monitor-tui"
 CONTROL_PROMPT_FILE = "ORCH_CONTROL_PROMPT.md"
 CONTROL_PROMPT_INSTRUCTION = f"ultrathink Please read '{CONTROL_PROMPT_FILE}' in the current directory and follow the instructions found there."
 CONTROL_SESSION_FILE = "control-session.json"
+DAEMON_STARTUP_TIMEOUT_MS = 100
+DAEMON_STARTUP_MAX_RETRIES = 10
 
 
 def load_control_session(vault_path: Path | None) -> str | None:
@@ -138,6 +141,45 @@ def get_vault_path(args) -> Path | None:
     if vault_env:
         return Path(vault_env)
     return None
+
+
+def ensure_daemon(vault_path: Path | None) -> bool:
+    """Ensure daemon is running, starting it if necessary.
+
+    Returns True if daemon was auto-started, False if it was already running.
+    Raises RuntimeError if daemon fails to start.
+    """
+    try:
+        config = Config.from_vault(vault_path) if vault_path else Config.load()
+        client = DaemonClient(config.socket_path)
+
+        if client.is_available():
+            return False
+
+        cmd = ["orch", "daemon"]
+        if vault_path:
+            cmd.extend(["--vault", str(vault_path)])
+
+        subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+        for _ in range(DAEMON_STARTUP_MAX_RETRIES):
+            time.sleep(DAEMON_STARTUP_TIMEOUT_MS / 1000)
+            if client.is_available():
+                return True
+
+        raise RuntimeError(
+            "Daemon did not become available after starting.\n"
+            "Run 'orch repair' to fix daemon issues."
+        )
+
+    except Exception as e:
+        raise RuntimeError(f"Failed to start daemon: {e}")
 
 
 class LayoutLauncher(Protocol):
@@ -428,6 +470,14 @@ def main():
 
     args = parser.parse_args()
     vault_path = get_vault_path(args)
+
+    try:
+        daemon_was_started = ensure_daemon(vault_path)
+        if daemon_was_started:
+            print("Started orch daemon", file=sys.stderr)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
     if args.runs:
         app = RunsDashboard(vault_path=vault_path)

--- a/orch-monitor-tui/orch_monitor/config.py
+++ b/orch-monitor-tui/orch_monitor/config.py
@@ -180,6 +180,7 @@ class Config:
     @classmethod
     def from_vault(cls, vault_path: Path) -> "Config":
         """Load configuration from a specific vault path."""
+        vault_path = vault_path.expanduser().resolve()
         config_file = vault_path / ".orch" / "config.yaml"
         config = cls.load(config_file)
         config.vault_path = vault_path

--- a/orch-monitor-tui/orch_monitor/daemon.py
+++ b/orch-monitor-tui/orch_monitor/daemon.py
@@ -78,11 +78,27 @@ class DaemonClient:
         self._timeout = timeout
 
     def is_available(self) -> bool:
-        """Check if the daemon socket is available and is actually a socket."""
+        """Check if the daemon is running and reachable.
+
+        Tests actual connectivity to avoid false positives from stale socket files.
+        """
+        if not self.socket_path.exists():
+            return False
+
         try:
             mode = self.socket_path.stat().st_mode
-            return stat.S_ISSOCK(mode)
+            if not stat.S_ISSOCK(mode):
+                return False
         except (OSError, FileNotFoundError):
+            return False
+
+        try:
+            test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            test_socket.settimeout(0.1)
+            test_socket.connect(str(self.socket_path))
+            test_socket.close()
+            return True
+        except (socket.error, OSError):
             return False
 
     def _send_request(self, request: dict) -> dict:


### PR DESCRIPTION
## Summary

- Automatically check if daemon is running when launching orch-monitor
- Start daemon if not running before showing TUI
- No user intervention required

## Changes

- Added `ensure_daemon()` function to check daemon status and start if needed
- Waits up to 1 second for daemon socket to become available (matches Go CLI behavior)
- Prints "Started orch daemon" message when daemon is auto-started
- Exits with error if daemon fails to start

## Implementation

The Python monitor now mirrors the Go CLI's `PersistentPreRun` behavior:
1. Checks if daemon socket is available via `DaemonClient.is_available()`
2. If not available, spawns `orch daemon` as background process
3. Waits for socket to become available (10 retries × 100ms = 1 second timeout)
4. Exits with helpful error message if daemon fails to start

## Testing

- ✅ All Go tests pass
- ✅ Build succeeds
- ✅ Python syntax validation passes
- ✅ LSP diagnostics clean

Closes: #196