### PR TITLE
Auto-start orch daemon when running orch-monitor

### DIFF
--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"fmt"
 	"os"
+	"time"
 
+	"github.com/s22625/orch/internal/daemon"
 	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/monitor"
 	"github.com/spf13/cobra"
@@ -56,6 +59,19 @@ func runMonitor(opts *monitorOptions) error {
 	st, err := getStore()
 	if err != nil {
 		return err
+	}
+
+	// Auto-start daemon if not running
+	vaultPath := st.VaultPath()
+	if !daemon.IsRunning(vaultPath) {
+		fmt.Fprintf(os.Stderr, "Starting orch daemon...\n")
+		_, err := daemon.StartInBackground(vaultPath)
+		if err != nil {
+			return fmt.Errorf("failed to start daemon: %w", err)
+		}
+		// Give daemon a moment to initialize
+		time.Sleep(200 * time.Millisecond)
+		fmt.Fprintf(os.Stderr, "Daemon started\n")
 	}
 
 	// Load UI settings from .orch directory

--- a/orch-monitor-tui/orch_monitor/__main__.py
+++ b/orch-monitor-tui/orch_monitor/__main__.py
@@ -9,7 +9,7 @@ from typing import Protocol
 
 from .app import IssuesDashboard, OrchMonitorApp, RunsDashboard
 from .config import Config
-from .daemon import DaemonClient
+from .daemon import DaemonClient, ensure_daemon_running
 from .multiplexer import (
     MultiplexerType,
     get_default_multiplexer_type,
@@ -428,6 +428,17 @@ def main():
 
     args = parser.parse_args()
     vault_path = get_vault_path(args)
+
+    try:
+        config = Config.from_vault(vault_path) if vault_path else Config.load()
+    except Exception as e:
+        print(f"Error: Failed to load config: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not ensure_daemon_running(config.socket_path, config.vault_path):
+        print("Error: Daemon is not available and failed to start", file=sys.stderr)
+        print("Run 'orch repair' to fix daemon issues", file=sys.stderr)
+        sys.exit(1)
 
     if args.runs:
         app = RunsDashboard(vault_path=vault_path)

--- a/orch-monitor-tui/orch_monitor/daemon.py
+++ b/orch-monitor-tui/orch_monitor/daemon.py
@@ -7,8 +7,12 @@ The daemon is the single source of truth for all data.
 """
 
 import json
+import shutil
 import socket
 import stat
+import subprocess
+import sys
+import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -323,6 +327,49 @@ class DaemonClient:
     def close(self) -> None:
         """Close the client (no-op for socket-based client)."""
         pass
+
+
+def ensure_daemon_running(socket_path: Path, vault_path: Path) -> bool:
+    """Ensure daemon is running, starting it if necessary.
+
+    Args:
+        socket_path: Path to the daemon socket
+        vault_path: Path to the orch vault
+
+    Returns:
+        True if daemon is available, False if failed to start
+    """
+    client = DaemonClient(socket_path)
+
+    if client.is_available():
+        return True
+
+    orch_cmd = shutil.which("orch")
+    if not orch_cmd:
+        print("Error: 'orch' command not found in PATH", file=sys.stderr)
+        return False
+
+    print("Starting orch daemon...", file=sys.stderr)
+
+    try:
+        subprocess.Popen(
+            [orch_cmd, "daemon", "--vault", str(vault_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except subprocess.SubprocessError as e:
+        print(f"Error: Failed to start daemon: {e}", file=sys.stderr)
+        return False
+
+    for _ in range(10):
+        time.sleep(0.2)
+        if client.is_available():
+            print("Daemon started", file=sys.stderr)
+            return True
+
+    print("Error: Daemon did not become available after starting", file=sys.stderr)
+    return False
 
 
 def _parse_timestamp(ts_str: str) -> Optional[datetime]:


### PR DESCRIPTION
## Summary

Implements automatic daemon startup for orch-monitor commands (both Go and Python implementations).

## Changes Made

### Go Monitor (`internal/cli/monitor.go`)
- Added daemon availability check at monitor startup
- Auto-starts daemon using `daemon.StartInBackground()` if not running
- Displays startup messages to inform users

### Python Monitor (`orch-monitor-tui`)
- Created `ensure_daemon_running()` utility function in `daemon.py`
- Integrated daemon check into main() entry point
- Handles errors gracefully with user-friendly messages

## Testing

- All Go tests pass: `make test`
- Project builds successfully: `make build`
- Both monitor implementations now work without manual daemon startup

## Fixes

Closes #196

## Acceptance Criteria

- [x] `orch-monitor` works correctly even when daemon was not previously started
- [x] No user intervention required to start daemon manually
- [x] Startup message indicates daemon was auto-started