### PR TITLE
feat(orch-monitor): open issue in multiplexer tab when pressing Enter

### DIFF
--- a/orch-monitor-tui/README.md
+++ b/orch-monitor-tui/README.md
@@ -104,11 +104,13 @@ uv run python -m orch_monitor
 | `tab` | Switch between Runs/Issues tabs |
 | `f` | Filter runs by status |
 | `up/down` | Navigate list |
-| `enter` | Select item (attach to run / open issue in `$EDITOR`) |
+| `enter` | Select item (attach to run / open issue in `$EDITOR`*) |
 | `a` | Attach to selected run's session |
 | `s` | Stop selected run |
 | `n` | Create new run for selected issue |
-| `o` | Open issue in `$EDITOR` |
+| `o` | Open issue in `$EDITOR`* |
+
+*When running inside a multiplexer (tmux/zellij), opening issues in `$EDITOR` creates a new multiplexer tab/window, allowing you to edit without leaving the monitor. Outside a multiplexer, the TUI suspends while the editor is open.
 
 ## Configuration
 

--- a/orch-monitor-tui/orch_monitor/app.py
+++ b/orch-monitor-tui/orch_monitor/app.py
@@ -1133,7 +1133,20 @@ class IssuesDashboard(App):
             self.notify(error or "Unknown error", severity="error")
             return
 
-        # Suspend TUI, open editor, resume on exit
+        current_mux_type = detect_current_multiplexer()
+
+        if current_mux_type:
+            # Open in new multiplexer tab/window
+            current_mux = get_multiplexer(current_mux_type)
+            tab_name = f"edit-{self.selected_issue.id}"
+            if current_mux.new_tab_with_command(tab_name, cmd):
+                self.notify(f"Opened tab: {tab_name}")
+                return
+            self.notify(
+                "Failed to create tab, falling back to suspend", severity="warning"
+            )
+
+        # Fallback: Suspend TUI, open editor, resume on exit
         with self.suspend():
             subprocess.run(cmd)
         self.refresh_data()
@@ -1694,7 +1707,20 @@ class OrchMonitorApp(App):
             self.notify(error or "Unknown error", severity="error")
             return
 
-        # Suspend TUI, open editor, resume on exit
+        current_mux_type = detect_current_multiplexer()
+
+        if current_mux_type:
+            # Open in new multiplexer tab/window
+            current_mux = get_multiplexer(current_mux_type)
+            tab_name = f"edit-{self.selected_issue.id}"
+            if current_mux.new_tab_with_command(tab_name, cmd):
+                self.notify(f"Opened tab: {tab_name}")
+                return
+            self.notify(
+                "Failed to create tab, falling back to suspend", severity="warning"
+            )
+
+        # Fallback: Suspend TUI, open editor, resume on exit
         with self.suspend():
             subprocess.run(cmd)
         self.refresh_data()


### PR DESCRIPTION
## Summary

- When inside a multiplexer (tmux/zellij), pressing Enter on an issue now opens the file in `$EDITOR` in a new multiplexer tab/window
- This allows users to view/edit the full issue content without leaving the monitor
- Falls back to the previous suspend-based behavior when not inside a multiplexer
- Updated README documentation to clarify the new behavior

## Changes

- `orch-monitor-tui/orch_monitor/app.py`: Modified `action_open_issue()` in both `IssuesDashboard` and `OrchMonitorApp` to detect if inside a multiplexer and open editor in a new tab
- `orch-monitor-tui/README.md`: Updated keybindings documentation to explain multiplexer behavior

Closes #267