### PR TITLE
feat(monitor): use issue_id[run_hex] format for attach window names

### DIFF
--- a/internal/monitor/run_attacher.go
+++ b/internal/monitor/run_attacher.go
@@ -104,7 +104,7 @@ func (a *OpenCodeRunAttacher) Attach(m *Monitor, run *model.Run) error {
 		return err
 	}
 
-	windowName := fmt.Sprintf("opencode-%s", run.ShortID())
+	windowName := fmt.Sprintf("%s[%s]", run.IssueID, run.ShortID())
 	for _, w := range monitorWindows {
 		if w.Name == windowName {
 			return tmux.SelectWindow(m.session, w.Index)

--- a/orch-monitor-tui/orch_monitor/app.py
+++ b/orch-monitor-tui/orch_monitor/app.py
@@ -977,7 +977,7 @@ class RunsDashboard(App):
 
         if current_mux_type:
             current_mux = get_multiplexer(current_mux_type)
-            tab_name = f"attach-{run.short_id()}"
+            tab_name = f"{run.issue_id}[{run.short_id()}]"
             if current_mux.new_tab_with_command(tab_name, attach_cmd):
                 self.notify(f"Opened tab: {tab_name}")
                 return
@@ -1718,7 +1718,7 @@ class OrchMonitorApp(App):
 
         if current_mux_type:
             current_mux = get_multiplexer(current_mux_type)
-            tab_name = f"attach-{run.short_id()}"
+            tab_name = f"{run.issue_id}[{run.short_id()}]"
             if current_mux.new_tab_with_command(tab_name, attach_cmd):
                 self.notify(f"Opened tab: {tab_name}")
                 return


### PR DESCRIPTION
## Summary

- Changed window naming format for easier identification of which issue/run a window belongs to
- Applied to both Go monitor (orch-monitor) and Python TUI (orch-monitor-tui)
- New format: `{issue_id}[{run_hex}]` (e.g., `gh#114[bc0ada]`)

## Changes

| Component | Before | After |
|-----------|--------|-------|
| Go monitor (OpenCodeRunAttacher) | `opencode-{short_id}` | `{issue_id}[{short_id}]` |
| Python TUI (RunsDashboard, OrchMonitorApp) | `attach-{short_id}` | `{issue_id}[{short_id}]` |

## Benefits

- Easy to identify which issue/run a window belongs to
- Quick visual reference when switching between multiple attached sessions
- Consistent naming across tmux/zellij

## Testing

- Go tests pass: `go test ./...`
- Python TUI tests pass: 84 passed, 11 skipped

Fixes: gh#279