### PR TITLE
fix: replace # with - in worktree paths to fix uv tool install

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -175,13 +175,14 @@ func runRun(issueID string, opts *runOptions) error {
 
 	// Compute worktree path (absolute to ensure correct directory regardless of cwd)
 	worktreeName := model.GenerateWorktreeName(issueID, runID, opts.Agent)
+	pathSafeIssueID := model.PathSafeIssueID(issueID)
 	var worktreePath string
 	if filepath.IsAbs(opts.WorktreeDir) {
 		// Absolute path: use directly without joining with repoRoot
-		worktreePath = filepath.Join(opts.WorktreeDir, issueID, worktreeName)
+		worktreePath = filepath.Join(opts.WorktreeDir, pathSafeIssueID, worktreeName)
 	} else {
 		// Relative path: join with repoRoot
-		worktreePath = filepath.Join(repoRoot, opts.WorktreeDir, issueID, worktreeName)
+		worktreePath = filepath.Join(repoRoot, opts.WorktreeDir, pathSafeIssueID, worktreeName)
 	}
 
 	result := &runResult{

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -40,7 +40,7 @@ type WorktreeInfo struct {
 func normalizeWorktreePath(cfg *WorktreeConfig) error {
 	if cfg.WorktreePath == "" {
 		worktreeName := model.GenerateWorktreeName(cfg.IssueID, cfg.RunID, cfg.Agent)
-		cfg.WorktreePath = filepath.Join(cfg.WorktreeDir, cfg.IssueID, worktreeName)
+		cfg.WorktreePath = filepath.Join(cfg.WorktreeDir, model.PathSafeIssueID(cfg.IssueID), worktreeName)
 	}
 
 	if filepath.IsAbs(cfg.WorktreePath) {

--- a/internal/model/issue.go
+++ b/internal/model/issue.go
@@ -49,3 +49,11 @@ func ParseGitHubIssueNumber(id string) (int, error) {
 	}
 	return n, nil
 }
+
+// PathSafeIssueID converts an issue ID to a format safe for use in file paths.
+// The '#' character in GitHub issue IDs (e.g., "gh#285") is interpreted as a URL
+// fragment delimiter by tools like uv, causing path resolution failures.
+// This function replaces '#' with '-' (e.g., "gh#285" becomes "gh-285").
+func PathSafeIssueID(id string) string {
+	return strings.ReplaceAll(id, "#", "-")
+}

--- a/internal/model/issue_test.go
+++ b/internal/model/issue_test.go
@@ -1,0 +1,97 @@
+package model
+
+import "testing"
+
+func TestPathSafeIssueID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"gh#285", "gh-285"},
+		{"gh#1", "gh-1"},
+		{"gh#12345", "gh-12345"},
+		{"plc124", "plc124"},
+		{"issue-with-dash", "issue-with-dash"},
+		{"no-hash", "no-hash"},
+		{"", ""},
+		{"#123", "-123"},
+		{"multiple#hash#chars", "multiple-hash-chars"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := PathSafeIssueID(tt.input)
+			if got != tt.want {
+				t.Errorf("PathSafeIssueID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsGitHubIssueID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"gh#285", true},
+		{"gh#1", true},
+		{"#123", true},
+		{"123", true},
+		{"plc124", false},
+		{"issue-123", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := IsGitHubIssueID(tt.input)
+			if got != tt.want {
+				t.Errorf("IsGitHubIssueID(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeGitHubIssueID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"gh#285", "gh#285"},
+		{"#123", "gh#123"},
+		{"123", "gh#123"},
+		{"plc124", "plc124"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := NormalizeGitHubIssueID(tt.input)
+			if got != tt.want {
+				t.Errorf("NormalizeGitHubIssueID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGitHubIssueNumber(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{"gh#285", 285, false},
+		{"#123", 123, false},
+		{"456", 456, false},
+		{"invalid", 0, true},
+		{"gh#abc", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseGitHubIssueNumber(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseGitHubIssueNumber(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseGitHubIssueNumber(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `PathSafeIssueID()` function to convert issue IDs to a path-safe format (replaces `#` with `-`)
- Updates worktree path generation in `internal/git/worktree.go` and `internal/cli/run.go`
- Adds comprehensive unit tests for all issue ID functions

## Problem

When orch creates worktrees for GitHub issues, paths like `.git-worktrees/gh#285/...` break `uv tool install` because the `#` is interpreted as a URL fragment delimiter.

## Solution

Replace `#` with `-` when building file paths:
- Before: `.git-worktrees/gh#285/...`
- After: `.git-worktrees/gh-285/...`

Fixes #287