### PR TITLE
feat: add agent selection modal to Python TUI new run

### DIFF
--- a/orch-monitor-tui/orch_monitor/app.py
+++ b/orch-monitor-tui/orch_monitor/app.py
@@ -10,6 +10,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional, Tuple
 
+import yaml
+
 _logger: Optional[logging.Logger] = None
 
 
@@ -372,6 +374,188 @@ FILTER_SCREEN_CSS = """
         margin: 0 1;
     }
 """
+
+
+def _get_available_agents(config: "Config") -> list[str]:
+    """Get list of available agents and presets from config."""
+    agents = list(AGENTS)
+    seen = set(agents)
+
+    config_path = config.project_root / ".orch" / "config.yaml"
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                data = yaml.safe_load(f)
+
+            if not isinstance(data, dict):
+                return agents
+
+            presets = data.get("presets", [])
+            for preset in presets:
+                if isinstance(preset, dict):
+                    name = preset.get("name", "")
+                    if name:
+                        backend = preset.get("backend") or "opencode"
+                        preset_str = f"{backend}:{name}"
+                        if preset_str not in seen:
+                            agents.append(preset_str)
+                            seen.add(preset_str)
+        except yaml.YAMLError as e:
+            get_logger().debug(f"Failed to parse config for agents: {e}")
+        except OSError as e:
+            get_logger().debug(f"Failed to read config for agents: {e}")
+
+    return agents
+
+
+class AgentSelectScreen(ModalScreen[str | None]):
+    """Modal screen for selecting agent/preset before starting a run."""
+
+    CSS = """
+    AgentSelectScreen {
+        align: center middle;
+    }
+
+    #agent-dialog {
+        width: 50;
+        height: auto;
+        max-height: 80%;
+        padding: 1 2;
+        background: $surface;
+        border: thick $primary;
+    }
+
+    #agent-title {
+        text-align: center;
+        width: 100%;
+        text-style: bold;
+        padding-bottom: 1;
+    }
+
+    #agent-issue {
+        text-align: center;
+        width: 100%;
+        color: $text-muted;
+        padding-bottom: 1;
+    }
+
+    #agent-selection-list {
+        height: auto;
+        max-height: 12;
+        margin: 0 1;
+    }
+
+    #agent-empty {
+        text-align: center;
+        width: 100%;
+        color: $text-muted;
+        padding: 1;
+    }
+
+    #agent-footer {
+        text-align: center;
+        width: 100%;
+        color: $text-muted;
+        padding-top: 1;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+        Binding("enter", "confirm", "Confirm"),
+        Binding("k", "cursor_up", "Up", show=False),
+        Binding("j", "cursor_down", "Down", show=False),
+        Binding("1", "quick_select_1", "1", show=False),
+        Binding("2", "quick_select_2", "2", show=False),
+        Binding("3", "quick_select_3", "3", show=False),
+        Binding("4", "quick_select_4", "4", show=False),
+        Binding("5", "quick_select_5", "5", show=False),
+        Binding("6", "quick_select_6", "6", show=False),
+        Binding("7", "quick_select_7", "7", show=False),
+        Binding("8", "quick_select_8", "8", show=False),
+        Binding("9", "quick_select_9", "9", show=False),
+    ]
+
+    def __init__(self, issue_id: str, agents: list[str]):
+        super().__init__()
+        self.issue_id = issue_id
+        self.agents = agents
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="agent-dialog"):
+            yield Label("Select Agent", id="agent-title")
+            yield Label(f"Issue: {self.issue_id}", id="agent-issue")
+            if self.agents:
+                items = [
+                    (f"[{i + 1}] {agent}", agent, i == 0)
+                    for i, agent in enumerate(self.agents)
+                ]
+                yield SelectionList[str](*items, id="agent-selection-list")
+                yield Label("[Enter/1-9] select  [Esc] cancel", id="agent-footer")
+            else:
+                yield Label("No agents available", id="agent-empty")
+                yield Label("[Esc] cancel", id="agent-footer")
+
+    def on_mount(self) -> None:
+        if self.agents:
+            self.query_one("#agent-selection-list", SelectionList).focus()
+
+    def action_cursor_up(self) -> None:
+        if self.agents:
+            sel = self.query_one("#agent-selection-list", SelectionList)
+            sel.action_cursor_up()
+
+    def action_cursor_down(self) -> None:
+        if self.agents:
+            sel = self.query_one("#agent-selection-list", SelectionList)
+            sel.action_cursor_down()
+
+    def action_confirm(self) -> None:
+        if not self.agents:
+            self.dismiss(None)
+            return
+        sel = self.query_one("#agent-selection-list", SelectionList)
+        selected = list(sel.selected)
+        if selected:
+            self.dismiss(selected[0])
+        elif sel.highlighted is not None:
+            self.dismiss(self.agents[sel.highlighted])
+        else:
+            self.dismiss(None)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def _quick_select(self, index: int) -> None:
+        if 0 <= index < len(self.agents):
+            self.dismiss(self.agents[index])
+
+    def action_quick_select_1(self) -> None:
+        self._quick_select(0)
+
+    def action_quick_select_2(self) -> None:
+        self._quick_select(1)
+
+    def action_quick_select_3(self) -> None:
+        self._quick_select(2)
+
+    def action_quick_select_4(self) -> None:
+        self._quick_select(3)
+
+    def action_quick_select_5(self) -> None:
+        self._quick_select(4)
+
+    def action_quick_select_6(self) -> None:
+        self._quick_select(5)
+
+    def action_quick_select_7(self) -> None:
+        self._quick_select(6)
+
+    def action_quick_select_8(self) -> None:
+        self._quick_select(7)
+
+    def action_quick_select_9(self) -> None:
+        self._quick_select(8)
 
 
 class RunFilterScreen(ModalScreen[RunFilterResult | None]):
@@ -1330,36 +1514,38 @@ class IssuesDashboard(App):
         if not self.selected_issue:
             self.notify("No issue selected", severity="warning")
             return
-        issue_id = self.selected_issue.id
-        self.notify(f"Starting run for {issue_id}...")
-        self._do_new_run(issue_id)
+        agents = _get_available_agents(self.config)
+        self.push_screen(
+            AgentSelectScreen(self.selected_issue.id, agents),
+            self._on_agent_selected,
+        )
+
+    def _on_agent_selected(self, agent: str | None) -> None:
+        if agent and self.selected_issue:
+            issue_id = self.selected_issue.id
+            self.notify(f"Starting run for {issue_id} with {agent}...")
+            self._do_new_run(issue_id, agent)
 
     @work(thread=True, exclusive=True)
-    def _do_new_run(self, issue_id: str) -> None:
-        """Start a new run in background thread to avoid blocking TUI."""
+    def _do_new_run(self, issue_id: str, agent: str) -> None:
         log = get_logger()
         try:
-            result = subprocess.run(
-                [
-                    "orch",
-                    "--vault",
-                    str(self.config.vault_path),
-                    "run",
-                    issue_id,
-                ],
-                capture_output=True,
-                text=True,
-            )
+            cmd = ["orch"]
+            if self.config.vault_path:
+                cmd.extend(["--vault", str(self.config.vault_path)])
+            elif self.config.project_root:
+                cmd.extend(["--project-root", str(self.config.project_root)])
+            cmd.extend(["run", issue_id, "--agent", agent])
+
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
             if result.returncode == 0:
                 self.call_from_thread(
                     self.notify, f"Run started for {issue_id}", severity="information"
                 )
             else:
-                # Prefer stderr, fallback to stdout, include returncode
                 error_msg = (
                     result.stderr.strip() or result.stdout.strip() or "Unknown error"
                 )
-                # Truncate long messages for notification display
                 if len(error_msg) > 200:
                     error_msg = error_msg[:200] + "..."
                 log.error(
@@ -1372,6 +1558,9 @@ class IssuesDashboard(App):
                     severity="error",
                 )
             self.call_from_thread(self.refresh_data)
+        except subprocess.TimeoutExpired:
+            log.error(f"Timeout starting run for {issue_id}")
+            self.call_from_thread(self.notify, "Timeout starting run", severity="error")
         except Exception as e:
             log.exception(f"Exception starting run for {issue_id}")
             self.call_from_thread(
@@ -1927,36 +2116,38 @@ class OrchMonitorApp(App):
         if not self.selected_issue:
             self.notify("No issue selected", severity="warning")
             return
-        issue_id = self.selected_issue.id
-        self.notify(f"Starting run for {issue_id}...")
-        self._do_new_run(issue_id)
+        agents = _get_available_agents(self.config)
+        self.push_screen(
+            AgentSelectScreen(self.selected_issue.id, agents),
+            self._on_agent_selected,
+        )
+
+    def _on_agent_selected(self, agent: str | None) -> None:
+        if agent and self.selected_issue:
+            issue_id = self.selected_issue.id
+            self.notify(f"Starting run for {issue_id} with {agent}...")
+            self._do_new_run(issue_id, agent)
 
     @work(thread=True, exclusive=True)
-    def _do_new_run(self, issue_id: str) -> None:
-        """Start a new run in background thread to avoid blocking TUI."""
+    def _do_new_run(self, issue_id: str, agent: str) -> None:
         log = get_logger()
         try:
-            result = subprocess.run(
-                [
-                    "orch",
-                    "--vault",
-                    str(self.config.vault_path),
-                    "run",
-                    issue_id,
-                ],
-                capture_output=True,
-                text=True,
-            )
+            cmd = ["orch"]
+            if self.config.vault_path:
+                cmd.extend(["--vault", str(self.config.vault_path)])
+            elif self.config.project_root:
+                cmd.extend(["--project-root", str(self.config.project_root)])
+            cmd.extend(["run", issue_id, "--agent", agent])
+
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
             if result.returncode == 0:
                 self.call_from_thread(
                     self.notify, f"Run started for {issue_id}", severity="information"
                 )
             else:
-                # Prefer stderr, fallback to stdout, include returncode
                 error_msg = (
                     result.stderr.strip() or result.stdout.strip() or "Unknown error"
                 )
-                # Truncate long messages for notification display
                 if len(error_msg) > 200:
                     error_msg = error_msg[:200] + "..."
                 log.error(
@@ -1969,6 +2160,9 @@ class OrchMonitorApp(App):
                     severity="error",
                 )
             self.call_from_thread(self.refresh_data)
+        except subprocess.TimeoutExpired:
+            log.error(f"Timeout starting run for {issue_id}")
+            self.call_from_thread(self.notify, "Timeout starting run", severity="error")
         except Exception as e:
             log.exception(f"Exception starting run for {issue_id}")
             self.call_from_thread(


### PR DESCRIPTION
## Summary

- Add `AgentSelectScreen` modal dialog when pressing `n` (New Run) in the Python TUI
- Modal displays available agents and presets with arrow key navigation
- Quick select with number keys 1-9
- Pass selected agent to `orch run --agent <agent>`

Closes #289

## Changes

1. **New `AgentSelectScreen` modal class** - Displays list of available agents with:
   - Arrow key navigation (up/down/j/k)
   - Enter to confirm selection
   - Escape to cancel
   - Number keys 1-9 for quick selection

2. **New `_get_available_agents()` function** - Fetches:
   - Base agents from `AGENTS` list (claude, codex, opencode, gemini)
   - Presets from config file (e.g., `opencode:opus:high`)

3. **Updated `IssuesDashboard`** and **`OrchMonitorApp`**:
   - `action_new_run()` now shows agent selection modal first
   - `_on_agent_selected()` callback handles modal result
   - `_do_new_run()` accepts agent parameter and passes `--agent` flag

## Testing

- All existing tests pass (87 passed, 5 pre-existing Zellij timeout failures)
- Manually verified modal appears on `n` key press
- Verified agent selection is passed to `orch run`