### PR TITLE
fix: use main repo .orch when running from worktree

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -461,14 +461,17 @@ func resolvePathFromConfig(path, baseDir string) string {
 	return path
 }
 
+// getMainRepoOrchDir returns the main repository's root if we're in a worktree
+// and that main repo has a .orch directory. Returns empty string otherwise.
+func getMainRepoOrchDir(startDir string) string {
+	if mainRepo, isWorktree := git.IsWorktree(startDir); isWorktree && hasOrchDir(mainRepo) {
+		return mainRepo
+	}
+	return ""
+}
+
 // GetProjectRoot returns the project root directory (where .orch/ lives).
-// It searches for .orch/config.yaml in the current directory and parent directories.
-// Returns the directory containing .orch/, or an error if not found.
-//
-// Precedence:
-// 1. ORCH_PROJECT_ROOT environment variable (must contain .orch/ directory)
-// 2. Directory containing .orch/config.yaml (searched upward from cwd)
-// 3. ORCH_VAULT as legacy fallback (only if it contains .orch/ directory)
+// When in a worktree, prefers the main repo's .orch to centralize all state.
 func GetProjectRoot() (string, error) {
 	if v := os.Getenv("ORCH_PROJECT_ROOT"); v != "" {
 		resolved := ExpandPath(v, "")
@@ -478,13 +481,23 @@ func GetProjectRoot() (string, error) {
 		return "", fmt.Errorf("ORCH_PROJECT_ROOT (%s) does not contain .orch/ directory", resolved)
 	}
 
+	if mainRepo := getMainRepoOrchDir(""); mainRepo != "" {
+		return mainRepo, nil
+	}
+
 	configPath, err := findRepoConfig()
 	if err != nil {
 		return "", err
 	}
 	if configPath != "" {
 		orchDir := filepath.Dir(configPath)
-		return filepath.Dir(orchDir), nil
+		projectRoot := filepath.Dir(orchDir)
+
+		if mainRepo := getMainRepoOrchDir(projectRoot); mainRepo != "" {
+			return mainRepo, nil
+		}
+
+		return projectRoot, nil
 	}
 
 	if v := os.Getenv("ORCH_VAULT"); v != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -1063,5 +1065,129 @@ gemini:
 	}
 	if got := cfg.GetPromptTemplate("custom"); got != "global {{issue}}" {
 		t.Errorf("GetPromptTemplate(custom) = %q, want global {{issue}}", got)
+	}
+}
+
+func TestGetProjectRootFromWorktree(t *testing.T) {
+	t.Setenv("ORCH_PROJECT_ROOT", "")
+	t.Setenv("ORCH_VAULT", "")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.email", "test@example.com")
+	runGit(t, repo, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "init")
+
+	if err := os.MkdirAll(filepath.Join(repo, ".orch"), 0755); err != nil {
+		t.Fatalf("mkdir .orch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".orch", "config.yaml"), []byte("vault: .\n"), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	worktreeDir := filepath.Join(repo, ".git-worktrees", "test-worktree")
+	runGit(t, repo, "worktree", "add", "-b", "test-branch", worktreeDir)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(worktreeDir); err != nil {
+		t.Fatalf("chdir to worktree: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	projectRoot, err := GetProjectRoot()
+	if err != nil {
+		t.Fatalf("GetProjectRoot error: %v", err)
+	}
+
+	expectedRoot, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("EvalSymlinks repo: %v", err)
+	}
+	gotRoot, err := filepath.EvalSymlinks(projectRoot)
+	if err != nil {
+		t.Fatalf("EvalSymlinks projectRoot: %v", err)
+	}
+
+	if gotRoot != expectedRoot {
+		t.Fatalf("GetProjectRoot from worktree = %q, want main repo %q", gotRoot, expectedRoot)
+	}
+}
+
+func TestGetProjectRootFromWorktreeOutsideRepo(t *testing.T) {
+	t.Setenv("ORCH_PROJECT_ROOT", "")
+	t.Setenv("ORCH_VAULT", "")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.email", "test@example.com")
+	runGit(t, repo, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "init")
+
+	if err := os.MkdirAll(filepath.Join(repo, ".orch"), 0755); err != nil {
+		t.Fatalf("mkdir .orch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".orch", "config.yaml"), []byte("vault: .\n"), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	worktreeBase := t.TempDir()
+	worktreeDir := filepath.Join(worktreeBase, "worktrees", "test-worktree")
+	runGit(t, repo, "worktree", "add", "-b", "test-branch-outside", worktreeDir)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(worktreeDir); err != nil {
+		t.Fatalf("chdir to worktree: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	projectRoot, err := GetProjectRoot()
+	if err != nil {
+		t.Fatalf("GetProjectRoot error: %v", err)
+	}
+
+	expectedRoot, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("EvalSymlinks repo: %v", err)
+	}
+	gotRoot, err := filepath.EvalSymlinks(projectRoot)
+	if err != nil {
+		t.Fatalf("EvalSymlinks projectRoot: %v", err)
+	}
+
+	if gotRoot != expectedRoot {
+		t.Fatalf("GetProjectRoot from worktree outside repo = %q, want main repo %q", gotRoot, expectedRoot)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v error: %v (%s)", args, err, strings.TrimSpace(string(out)))
 	}
 }


### PR DESCRIPTION
## Summary

- When running orch commands from a git worktree, `GetProjectRoot()` now prefers the main repository's `.orch` directory
- This ensures all runs are tracked in a single location and only one daemon runs per project
- Added `getMainRepoOrchDir()` helper function to detect worktrees and find main repo

## Problem

When running `orch run` from a git worktree, a separate `.orch/` directory could be created in the worktree, causing:
- Runs started from worktrees to be invisible from the main repo
- Multiple daemons running for the same logical project  
- Confusing UX when switching between main repo and worktrees

## Solution

Updated `GetProjectRoot()` to check if we're in a git worktree (using existing `git.IsWorktree()`) and prefer the main repo's `.orch` directory when available. This is done both:
1. Early in the function (before searching for configs)
2. After finding a config (to override worktree configs)

## Testing

- Added `TestGetProjectRootFromWorktree` - worktree inside main repo
- Added `TestGetProjectRootFromWorktreeOutsideRepo` - worktree outside main repo (e.g., `~/.orch/worktrees/`)
- All existing tests pass

Fixes #290