### PR TITLE
feat: add close issue action (x key) to Python TUI

### DIFF
--- a/orch-monitor-tui/orch_monitor/app.py
+++ b/orch-monitor-tui/orch_monitor/app.py
@@ -1664,15 +1664,16 @@ class IssuesDashboard(App):
             self.notify("No issue selected", severity="warning")
             return
 
+        # Capture issue_id before modal to prevent race condition if user navigates
+        issue_id = self.selected_issue.id
+        issue_title = self.selected_issue.title
+
         def on_confirm(confirmed: bool | None) -> None:
-            if confirmed and self.selected_issue:
-                self._do_close_issue(self.selected_issue.id)
+            if confirmed:
+                self._do_close_issue(issue_id)
 
         self.push_screen(
-            CloseIssueConfirmScreen(
-                self.selected_issue.id,
-                self.selected_issue.title,
-            ),
+            CloseIssueConfirmScreen(issue_id, issue_title),
             on_confirm,
         )
 
@@ -2372,15 +2373,16 @@ class OrchMonitorApp(App):
             self.notify("No issue selected", severity="warning")
             return
 
+        # Capture issue_id before modal to prevent race condition if user navigates
+        issue_id = self.selected_issue.id
+        issue_title = self.selected_issue.title
+
         def on_confirm(confirmed: bool | None) -> None:
-            if confirmed and self.selected_issue:
-                self._do_close_issue(self.selected_issue.id)
+            if confirmed:
+                self._do_close_issue(issue_id)
 
         self.push_screen(
-            CloseIssueConfirmScreen(
-                self.selected_issue.id,
-                self.selected_issue.title,
-            ),
+            CloseIssueConfirmScreen(issue_id, issue_title),
             on_confirm,
         )
 


### PR DESCRIPTION
## Summary

- Add ability to close issues directly from the Python textual `orch-monitor` TUI using the `x` keybinding
- Add `CloseIssueConfirmScreen` modal for confirmation dialog before closing
- Works for both local issues and GitHub issues (`gh#` prefix)

Closes #296

## Changes

- **CloseIssueConfirmScreen**: New modal screen with confirmation dialog showing issue details and explaining the consequences of closing
- **IssuesDashboard**: Added `x` keybinding, `action_close_issue()` handler, and `_do_close_issue()` background worker
- **OrchMonitorApp**: Added same functionality to the main tabbed app

## How it works

1. User selects an issue in the issues view
2. User presses `x` to trigger close action
3. Confirmation dialog appears with issue details
4. User confirms with `y` or button click (or cancels with `n`/Esc)
5. Issue is closed via `orch issue close <issue-id>` command
6. Success/error notification shown
7. Issue list refreshes to reflect the change