### PR TITLE
feat(daemon): add list/kill commands and prevent duplicate daemons

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"text/tabwriter"
 	"time"
 
 	"github.com/s22625/orch/internal/daemon"
@@ -13,21 +15,220 @@ var daemonDebugMode bool
 
 func newDaemonCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "daemon",
-		Short:  "Run the background monitoring daemon",
-		Hidden: true,
-		Long: `Run the background monitoring daemon.
+		Use:   "daemon",
+		Short: "Manage the background monitoring daemon",
+		Long: `Manage the background monitoring daemon.
 
-This command is normally started automatically by other orch commands.
-You should not need to run this manually.`,
+The daemon monitors all running agent sessions and updates their status.
+It runs automatically in the background when needed.`,
+	}
+
+	runCmd := &cobra.Command{
+		Use:    "run",
+		Short:  "Run the daemon (internal use)",
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDaemon()
 		},
 	}
+	runCmd.Flags().BoolVar(&daemonDebugMode, "debug", false, "Enable verbose debug logging")
+	cmd.AddCommand(runCmd)
 
-	cmd.Flags().BoolVar(&daemonDebugMode, "debug", false, "Enable verbose debug logging")
+	cmd.AddCommand(newDaemonListCmd())
+	cmd.AddCommand(newDaemonKillCmd())
+	cmd.AddCommand(newDaemonStatusCmd())
 
 	return cmd
+}
+
+func newDaemonListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all running daemons",
+		Long: `List all running orch daemons across all projects.
+
+Shows PID, project directory, socket status, and uptime for each daemon.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDaemonList()
+		},
+	}
+}
+
+type daemonKillOptions struct {
+	All     bool
+	Project string
+}
+
+func newDaemonKillCmd() *cobra.Command {
+	opts := &daemonKillOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "kill",
+		Short: "Kill running daemon(s)",
+		Long: `Kill orch daemon(s).
+
+By default, kills the daemon for the current project.
+Use --all to kill all running daemons across all projects.
+Use --project to kill a daemon for a specific project.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDaemonKill(opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.All, "all", false, "Kill all running daemons")
+	cmd.Flags().StringVar(&opts.Project, "project", "", "Kill daemon for specific project path")
+
+	return cmd
+}
+
+func newDaemonStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show daemon status for current project",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDaemonStatus()
+		},
+	}
+}
+
+func runDaemonList() error {
+	if err := daemon.CleanupStaleRegistrations(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to cleanup stale registrations: %v\n", err)
+	}
+
+	infos, err := daemon.ListAllDaemons()
+	if err != nil {
+		return fmt.Errorf("failed to list daemons: %w", err)
+	}
+
+	if len(infos) == 0 {
+		fmt.Println("No daemons running.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "PID\tPROJECT\tSOCKET\tUPTIME")
+
+	for _, info := range infos {
+		socketStatus := "ok"
+		if !info.IsHealthy {
+			socketStatus = "unavailable"
+		}
+
+		projectDisplay := info.ProjectRoot
+		if home, err := os.UserHomeDir(); err == nil {
+			if rel, err := filepath.Rel(home, info.ProjectRoot); err == nil && len(rel) < len(info.ProjectRoot) {
+				projectDisplay = "~/" + rel
+			}
+		}
+
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\n",
+			info.PID,
+			projectDisplay,
+			socketStatus,
+			formatUptime(info.Uptime),
+		)
+	}
+
+	w.Flush()
+	return nil
+}
+
+func runDaemonKill(opts *daemonKillOptions) error {
+	if opts.All {
+		count, err := daemon.KillAllDaemons()
+		if err != nil {
+			return fmt.Errorf("failed to kill daemons: %w", err)
+		}
+		if count == 0 {
+			fmt.Println("No daemons were running.")
+		} else {
+			fmt.Printf("Killed %d daemon(s).\n", count)
+		}
+		return nil
+	}
+
+	var projectRoot string
+	var err error
+
+	if opts.Project != "" {
+		projectRoot, err = filepath.Abs(opts.Project)
+		if err != nil {
+			return fmt.Errorf("invalid project path: %w", err)
+		}
+	} else {
+		projectRoot, err = getProjectRoot()
+		if err != nil {
+			return fmt.Errorf("could not determine project root: %w\nUse --project to specify a path or --all to kill all daemons", err)
+		}
+	}
+
+	if !daemon.IsRunning(projectRoot) {
+		fmt.Printf("No daemon running for %s\n", projectRoot)
+		return nil
+	}
+
+	pid := daemon.GetRunningPID(projectRoot)
+	if err := daemon.KillDaemon(projectRoot); err != nil {
+		return fmt.Errorf("failed to kill daemon (pid=%d): %w", pid, err)
+	}
+
+	fmt.Printf("Killed daemon (pid=%d) for %s\n", pid, projectRoot)
+	return nil
+}
+
+func runDaemonStatus() error {
+	projectRoot, err := getProjectRoot()
+	if err != nil {
+		return fmt.Errorf("could not determine project root: %w", err)
+	}
+
+	fmt.Printf("Project: %s\n", projectRoot)
+
+	if !daemon.IsRunning(projectRoot) {
+		fmt.Println("Status: not running")
+		return nil
+	}
+
+	pid := daemon.GetRunningPID(projectRoot)
+	fmt.Printf("Status: running (pid=%d)\n", pid)
+
+	if daemon.IsDaemonSocketAvailable(projectRoot) {
+		fmt.Println("Socket: available")
+	} else {
+		fmt.Println("Socket: unavailable")
+	}
+
+	if meta, err := daemon.ReadMetadata(projectRoot); err == nil {
+		fmt.Printf("Started: %s\n", meta.StartedAt.Format(time.RFC3339))
+		fmt.Printf("Uptime: %s\n", formatUptime(time.Since(meta.StartedAt)))
+	}
+
+	stale, err := daemon.IsStaleBinary(projectRoot)
+	if err == nil && stale {
+		fmt.Println("Warning: daemon is running stale binary (code updated since start)")
+	}
+
+	fmt.Printf("Log: %s\n", daemon.LogFilePath(projectRoot))
+
+	return nil
+}
+
+func formatUptime(d time.Duration) string {
+	d = d.Round(time.Second)
+	h := d / time.Hour
+	d -= h * time.Hour
+	m := d / time.Minute
+	d -= m * time.Minute
+	s := d / time.Second
+
+	if h > 0 {
+		return fmt.Sprintf("%dh %dm", h, m)
+	}
+	if m > 0 {
+		return fmt.Sprintf("%dm %ds", m, s)
+	}
+	return fmt.Sprintf("%ds", s)
 }
 
 func newDaemonRestartCmd() *cobra.Command {

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -54,6 +54,18 @@ func runRepair(opts *repairOptions) error {
 	problemsFound := 0
 	problemsFixed := 0
 
+	fmt.Println("Checking daemon registry...")
+	registryFixed, err := repairDaemonRegistry(opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  error: %v\n", err)
+	}
+	if registryFixed > 0 {
+		problemsFound += registryFixed
+		if !opts.DryRun {
+			problemsFixed += registryFixed
+		}
+	}
+
 	fmt.Println("Checking daemon...")
 	daemonFixed, err := repairDaemon(projectRoot, opts)
 	if err != nil {
@@ -275,4 +287,50 @@ func waitForDaemonRestart(vaultPath string, oldMeta *daemon.DaemonMetadata, time
 		time.Sleep(50 * time.Millisecond)
 	}
 	return false
+}
+
+func repairDaemonRegistry(opts *repairOptions) (int, error) {
+	if err := daemon.CleanupStaleRegistrations(); err != nil {
+		return 0, err
+	}
+
+	infos, err := daemon.ListAllDaemons()
+	if err != nil {
+		return 0, err
+	}
+
+	fixed := 0
+	var unhealthy []*daemon.DaemonInfo
+
+	for _, info := range infos {
+		if !info.IsHealthy {
+			unhealthy = append(unhealthy, info)
+		}
+	}
+
+	if len(unhealthy) > 0 {
+		fmt.Printf("  found %d unhealthy daemon(s) (running but socket unavailable):\n", len(unhealthy))
+		for _, info := range unhealthy {
+			fmt.Printf("    - pid=%d project=%s\n", info.PID, info.ProjectRoot)
+			fixed++
+			if !opts.DryRun && opts.Force {
+				if err := daemon.KillDaemon(info.ProjectRoot); err != nil {
+					fmt.Fprintf(os.Stderr, "      failed to kill: %v\n", err)
+				} else {
+					fmt.Printf("      killed unhealthy daemon\n")
+				}
+			}
+		}
+		if !opts.DryRun && !opts.Force && len(unhealthy) > 0 {
+			fmt.Println("  use --force to kill unhealthy daemons")
+		}
+	}
+
+	if len(infos) > 0 && len(unhealthy) == 0 {
+		fmt.Printf("  %d daemon(s) registered, all healthy\n", len(infos))
+	} else if len(infos) == 0 {
+		fmt.Println("  no daemons registered")
+	}
+
+	return fixed, nil
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -40,6 +40,10 @@ var globalOpts = &GlobalOptions{}
 var noDaemonCommands = map[string]bool{
 	"show":       true,
 	"daemon":     true,
+	"run":        true,
+	"list":       true,
+	"kill":       true,
+	"status":     true,
 	"repair":     true,
 	"delete":     true,
 	"help":       true,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -137,11 +137,16 @@ func (d *Daemon) Run() error {
 		return err
 	}
 	defer func() {
+		UnregisterDaemon(d.projectRoot)
 		RemovePID(d.projectRoot)
 		if d.lockFile != nil {
 			d.lockFile.Close()
 		}
 	}()
+
+	if err := RegisterDaemon(d.projectRoot); err != nil {
+		d.logger.Printf("warning: failed to register daemon: %v", err)
+	}
 
 	d.logger.Printf("daemon started (pid=%d, vault=%s, binary=%s)", os.Getpid(), d.projectRoot, d.executablePath)
 
@@ -255,7 +260,7 @@ func (d *Daemon) checkBinaryStaleness() {
 func (d *Daemon) restartWithNewBinary() error {
 	d.logger.Printf("restarting daemon with new binary via exec...")
 
-	args := []string{d.executablePath, "daemon", "--project-root", d.projectRoot}
+	args := []string{d.executablePath, "daemon", "run", "--project-root", d.projectRoot}
 	return syscall.Exec(d.executablePath, args, os.Environ())
 }
 
@@ -371,7 +376,7 @@ func StartInBackground(projectRoot string) (int, error) {
 
 	cmd := &exec.Cmd{
 		Path: executable,
-		Args: []string{executable, "daemon", "--project-root", projectRoot},
+		Args: []string{executable, "daemon", "run", "--project-root", projectRoot},
 		SysProcAttr: &syscall.SysProcAttr{
 			Setsid: true,
 		},

--- a/internal/daemon/pid.go
+++ b/internal/daemon/pid.go
@@ -19,10 +19,21 @@ const (
 )
 
 type DaemonMetadata struct {
-	PID       int       `json:"pid"`
-	StartedAt time.Time `json:"started_at"`
-	ExecPath  string    `json:"exec_path"`
-	ExecMtime time.Time `json:"exec_mtime"`
+	PID         int       `json:"pid"`
+	StartedAt   time.Time `json:"started_at"`
+	ExecPath    string    `json:"exec_path"`
+	ExecMtime   time.Time `json:"exec_mtime"`
+	ProjectRoot string    `json:"project_root,omitempty"`
+}
+
+// DaemonInfo contains information about a running daemon for listing
+type DaemonInfo struct {
+	PID         int
+	ProjectRoot string
+	SocketPath  string
+	StartedAt   time.Time
+	Uptime      time.Duration
+	IsHealthy   bool
 }
 
 func OrchDir(projectRoot string) string {
@@ -201,4 +212,203 @@ func RestartDaemon(projectRoot string) error {
 	}
 
 	return process.Signal(syscall.SIGHUP)
+}
+
+func globalOrchDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".orch")
+}
+
+func globalRegistryPath() string {
+	dir := globalOrchDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "daemons.json")
+}
+
+type daemonRegistry struct {
+	Daemons map[string]registryEntry `json:"daemons"`
+}
+
+type registryEntry struct {
+	PID        int       `json:"pid"`
+	StartedAt  time.Time `json:"started_at"`
+	SocketPath string    `json:"socket_path"`
+}
+
+func loadRegistry() (*daemonRegistry, error) {
+	path := globalRegistryPath()
+	if path == "" {
+		return &daemonRegistry{Daemons: make(map[string]registryEntry)}, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &daemonRegistry{Daemons: make(map[string]registryEntry)}, nil
+		}
+		return nil, err
+	}
+
+	var reg daemonRegistry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		return &daemonRegistry{Daemons: make(map[string]registryEntry)}, nil
+	}
+	if reg.Daemons == nil {
+		reg.Daemons = make(map[string]registryEntry)
+	}
+	return &reg, nil
+}
+
+func saveRegistry(reg *daemonRegistry) error {
+	path := globalRegistryPath()
+	if path == "" {
+		return nil
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(reg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+func RegisterDaemon(projectRoot string) error {
+	reg, err := loadRegistry()
+	if err != nil {
+		return err
+	}
+
+	absPath, err := filepath.Abs(projectRoot)
+	if err != nil {
+		absPath = projectRoot
+	}
+
+	reg.Daemons[absPath] = registryEntry{
+		PID:        os.Getpid(),
+		StartedAt:  time.Now(),
+		SocketPath: SocketFilePath(absPath),
+	}
+
+	return saveRegistry(reg)
+}
+
+func UnregisterDaemon(projectRoot string) error {
+	reg, err := loadRegistry()
+	if err != nil {
+		return err
+	}
+
+	absPath, err := filepath.Abs(projectRoot)
+	if err != nil {
+		absPath = projectRoot
+	}
+
+	delete(reg.Daemons, absPath)
+	return saveRegistry(reg)
+}
+
+func ListAllDaemons() ([]*DaemonInfo, error) {
+	reg, err := loadRegistry()
+	if err != nil {
+		return nil, err
+	}
+
+	var infos []*DaemonInfo
+	for projectRoot, entry := range reg.Daemons {
+		if !IsProcessRunning(entry.PID) {
+			continue
+		}
+
+		info := &DaemonInfo{
+			PID:         entry.PID,
+			ProjectRoot: projectRoot,
+			SocketPath:  entry.SocketPath,
+			StartedAt:   entry.StartedAt,
+			Uptime:      time.Since(entry.StartedAt),
+			IsHealthy:   IsDaemonSocketAvailable(projectRoot),
+		}
+		infos = append(infos, info)
+	}
+
+	return infos, nil
+}
+
+func CleanupStaleRegistrations() error {
+	reg, err := loadRegistry()
+	if err != nil {
+		return err
+	}
+
+	changed := false
+	for projectRoot, entry := range reg.Daemons {
+		if !IsProcessRunning(entry.PID) {
+			delete(reg.Daemons, projectRoot)
+			changed = true
+		}
+	}
+
+	if changed {
+		return saveRegistry(reg)
+	}
+	return nil
+}
+
+func KillDaemon(projectRoot string) error {
+	pid := GetRunningPID(projectRoot)
+	if pid == 0 {
+		return nil
+	}
+
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		return err
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !IsProcessRunning(pid) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if IsProcessRunning(pid) {
+		process.Signal(syscall.SIGKILL)
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	RemovePID(projectRoot)
+	UnregisterDaemon(projectRoot)
+
+	return nil
+}
+
+func KillAllDaemons() (int, error) {
+	infos, err := ListAllDaemons()
+	if err != nil {
+		return 0, err
+	}
+
+	killed := 0
+	for _, info := range infos {
+		if err := KillDaemon(info.ProjectRoot); err == nil {
+			killed++
+		}
+	}
+
+	return killed, nil
 }


### PR DESCRIPTION
## Summary

Implements daemon management to prevent duplicate daemons and provide visibility into running daemons:

- Add global daemon registry (`~/.orch/daemons.json`) to track running daemons across all projects
- Add `orch daemon list` command to show all running daemons
- Add `orch daemon kill` command with `--all` and `--project` flags
- Add `orch daemon status` command for current project daemon info
- Daemons now register on startup and unregister on shutdown
- Enhanced `orch repair` to cleanup stale registrations and report unhealthy daemons

## Changes

### New Commands

```bash
# List all running daemons
$ orch daemon list
PID     PROJECT                          SOCKET   UPTIME
12345   ~/repos/orch                     ok       2h 15m
12346   ~/repos/doeff                    ok       1h 30m

# Kill daemon for current project
$ orch daemon kill

# Kill all daemons
$ orch daemon kill --all

# Kill specific project's daemon
$ orch daemon kill --project /path/to/project

# Show status for current project
$ orch daemon status
```

### Existing Behavior (Already Implemented)

The lock file mechanism (`flock` with `LOCK_EX|LOCK_NB`) already prevents multiple daemons per project. Starting a second daemon fails gracefully:
```
daemon already running (pid=12345)
```

## Acceptance Criteria

- [x] Only one daemon can run per project root (existing lock file mechanism)
- [x] Starting a second daemon fails gracefully with clear message (existing behavior)
- [x] Stale lock/pid files are cleaned up automatically (existing behavior)
- [x] `orch daemon list` shows all running daemons
- [x] `orch daemon kill` can stop daemons selectively or all
- [x] `orch repair` detects and reports unhealthy daemons

Closes #298