### PR TITLE
fix(orch-monitor): add Enter key confirmation to agent selection dialog

### DIFF
--- a/orch-monitor-tui/orch_monitor/app.py
+++ b/orch-monitor-tui/orch_monitor/app.py
@@ -573,7 +573,7 @@ class AgentSelectScreen(ModalScreen[str | None]):
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel"),
-        Binding("enter", "confirm", "Confirm"),
+        Binding("enter", "confirm", "Start", priority=True),
         Binding("k", "cursor_up", "Up", show=False),
         Binding("j", "cursor_down", "Down", show=False),
         Binding("1", "quick_select_1", "1", show=False),
@@ -602,7 +602,7 @@ class AgentSelectScreen(ModalScreen[str | None]):
                     for i, agent in enumerate(self.agents)
                 ]
                 yield SelectionList[str](*items, id="agent-selection-list")
-                yield Label("[Enter/1-9] select  [Esc] cancel", id="agent-footer")
+                yield Label("[Enter] Start  [1-9] Quick select  [Esc] Cancel", id="agent-footer")
             else:
                 yield Label("No agents available", id="agent-empty")
                 yield Label("[Esc] cancel", id="agent-footer")
@@ -626,12 +626,16 @@ class AgentSelectScreen(ModalScreen[str | None]):
             self.dismiss(None)
             return
         sel = self.query_one("#agent-selection-list", SelectionList)
-        selected = list(sel.selected)
-        if selected:
-            self.dismiss(selected[0])
-        elif sel.highlighted is not None:
+        # Prioritize highlighted item (cursor position) over checkbox selections
+        if sel.highlighted is not None:
             self.dismiss(self.agents[sel.highlighted])
         else:
+            # Fallback: find first agent in list order that is selected (deterministic)
+            selected = sel.selected
+            for agent in self.agents:
+                if agent in selected:
+                    self.dismiss(agent)
+                    return
             self.dismiss(None)
 
     def action_cancel(self) -> None:

--- a/orch-monitor-tui/tests/test_app.py
+++ b/orch-monitor-tui/tests/test_app.py
@@ -372,3 +372,169 @@ class TestDataPopulation:
 
             run_table = app.query_one("#runs-table", RunTable)
             assert run_table.row_count == 0
+
+
+# ============================================================================
+# Agent Select Screen Tests
+# ============================================================================
+
+
+class TestAgentSelectScreen:
+    """Tests for the agent selection modal screen."""
+
+    async def test_agent_select_screen_composition(self, issues_dashboard_with_mock, sample_issues):
+        """Test that agent select screen has expected widgets."""
+        from orch_monitor.app import AgentSelectScreen
+
+        app = issues_dashboard_with_mock(auto_refresh=False)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            # Push agent select screen
+            agents = ["claude", "codex", "opencode"]
+            result = []
+
+            def on_result(agent):
+                result.append(agent)
+
+            app.push_screen(AgentSelectScreen("test-issue", agents), on_result)
+            await pilot.pause()
+
+            # Verify the screen is pushed
+            assert any(
+                isinstance(screen, AgentSelectScreen) for screen in app.screen_stack
+            )
+
+    async def test_agent_select_enter_confirms(self, issues_dashboard_with_mock, sample_issues):
+        """Test that Enter key confirms the selection and starts the run."""
+        from orch_monitor.app import AgentSelectScreen
+
+        app = issues_dashboard_with_mock(auto_refresh=False)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            agents = ["claude", "codex", "opencode"]
+            result = []
+
+            def on_result(agent):
+                result.append(agent)
+
+            app.push_screen(AgentSelectScreen("test-issue", agents), on_result)
+            await pilot.pause()
+
+            # Press Enter to confirm (first agent is highlighted by default)
+            await pilot.press("enter")
+            await pilot.pause()
+
+            # Should have dismissed with the first agent
+            assert len(result) == 1
+            assert result[0] == "claude"
+
+    async def test_agent_select_escape_cancels(self, issues_dashboard_with_mock, sample_issues):
+        """Test that Escape key cancels the selection."""
+        from orch_monitor.app import AgentSelectScreen
+
+        app = issues_dashboard_with_mock(auto_refresh=False)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            agents = ["claude", "codex", "opencode"]
+            result = []
+
+            def on_result(agent):
+                result.append(agent)
+
+            app.push_screen(AgentSelectScreen("test-issue", agents), on_result)
+            await pilot.pause()
+
+            # Press Escape to cancel
+            await pilot.press("escape")
+            await pilot.pause()
+
+            # Should have dismissed with None
+            assert len(result) == 1
+            assert result[0] is None
+
+    async def test_agent_select_quick_number(self, issues_dashboard_with_mock, sample_issues):
+        """Test that number keys quickly select an agent."""
+        from orch_monitor.app import AgentSelectScreen
+
+        app = issues_dashboard_with_mock(auto_refresh=False)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            agents = ["claude", "codex", "opencode"]
+            result = []
+
+            def on_result(agent):
+                result.append(agent)
+
+            app.push_screen(AgentSelectScreen("test-issue", agents), on_result)
+            await pilot.pause()
+
+            # Press "2" to select the second agent
+            await pilot.press("2")
+            await pilot.pause()
+
+            # Should have dismissed with codex
+            assert len(result) == 1
+            assert result[0] == "codex"
+
+    async def test_agent_select_navigation_then_enter(self, issues_dashboard_with_mock, sample_issues):
+        """Test navigating with j/k then pressing Enter."""
+        from orch_monitor.app import AgentSelectScreen
+
+        app = issues_dashboard_with_mock(auto_refresh=False)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            agents = ["claude", "codex", "opencode"]
+            result = []
+
+            def on_result(agent):
+                result.append(agent)
+
+            app.push_screen(AgentSelectScreen("test-issue", agents), on_result)
+            await pilot.pause()
+
+            # Navigate down with j
+            await pilot.press("j")
+            await pilot.pause()
+
+            # Press Enter to confirm
+            await pilot.press("enter")
+            await pilot.pause()
+
+            # Should have dismissed with codex (second item)
+            assert len(result) == 1
+            assert result[0] == "codex"
+
+    async def test_agent_select_no_agents(self, issues_dashboard_with_mock):
+        """Test agent select screen with no agents available."""
+        from orch_monitor.app import AgentSelectScreen
+
+        app = issues_dashboard_with_mock(auto_refresh=False)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            # Empty agents list
+            result = []
+
+            def on_result(agent):
+                result.append(agent)
+
+            app.push_screen(AgentSelectScreen("test-issue", []), on_result)
+            await pilot.pause()
+
+            # Press Enter - should dismiss with None without crashing
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert len(result) == 1
+            assert result[0] is None


### PR DESCRIPTION
## Summary
- Adds Enter key confirmation to the agent/model selection dialog in orch-monitor TUI
- Fixes the issue where users could select agents but had no way to confirm and start the run

## Changes
- Add `priority=True` to Enter binding so it overrides SelectionList widget's internal toggle handler
- Fix `action_confirm()` to prioritize the highlighted item (cursor position) over checkbox selection state
- Update footer text to clearly indicate available keybinds: `[Enter] Start  [1-9] Quick select  [Esc] Cancel`
- Add comprehensive test suite for `AgentSelectScreen`

## Testing
- All 5 new AgentSelectScreen tests pass
- Existing app and widget tests continue to pass (52 total)
- Pre-existing Zellij test failures unrelated to this change

Fixes: orch-302