### PR TITLE
feat(cli): add tag-based filtering to orch issue list

### DIFF
--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -239,21 +239,35 @@ func dirExists(path string) bool {
 }
 
 type issueListOptions struct {
-	NoPath bool
+	NoPath  bool
+	Status  string
+	Tags    []string // AND logic - must have all tags
+	TagsAny []string // OR logic - must have any tag
 }
 
-var issueListOpts = &issueListOptions{}
-
 func newIssueListCmd() *cobra.Command {
+	opts := &issueListOptions{}
+
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all issues",
+		Long: `List all issues, optionally filtered by status or tags.
+
+Examples:
+  orch issue list                           # List all issues
+  orch issue list --status open             # List open issues only
+  orch issue list --tag bug                 # List issues tagged with 'bug'
+  orch issue list --tag bug --tag urgent    # AND: must have both tags
+  orch issue list --tag-any bug,enhancement # OR: has any of the tags`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runIssueList()
+			return runIssueList(opts)
 		},
 	}
 
-	cmd.Flags().BoolVar(&issueListOpts.NoPath, "no-path", false, "Hide the PATH column")
+	cmd.Flags().BoolVar(&opts.NoPath, "no-path", false, "Hide the PATH column")
+	cmd.Flags().StringVarP(&opts.Status, "status", "s", "", "Filter by status (open, closed, resolved)")
+	cmd.Flags().StringSliceVar(&opts.Tags, "tag", nil, "Filter by tag (AND logic, repeatable)")
+	cmd.Flags().StringSliceVar(&opts.TagsAny, "tag-any", nil, "Filter by any tag (OR logic, comma-separated)")
 
 	return cmd
 }
@@ -268,25 +282,44 @@ type issueInfo struct {
 	Title   string       `json:"title"`
 	Summary string       `json:"summary,omitempty"`
 	Status  string       `json:"status"`
+	Tags    []string     `json:"tags,omitempty"`
 	Path    string       `json:"path"`
 	Runs    []runSummary `json:"runs,omitempty"`
 }
 
-func runIssueList() error {
+func runIssueList(opts *issueListOptions) error {
 	projectRoot, _ := getProjectRoot()
 
 	client := daemon.NewClient(projectRoot)
 	if client.IsAvailable() {
-		return runIssueListViaDaemon(client)
+		return runIssueListViaDaemon(client, opts)
 	}
 
-	return runIssueListDirect()
+	return runIssueListDirect(opts)
 }
 
-func runIssueListViaDaemon(client *daemon.Client) error {
-	issuesResp, err := client.ListIssues(nil, 0, "")
-	if err != nil {
-		return err
+func runIssueListViaDaemon(client *daemon.Client, opts *issueListOptions) error {
+	// Collect all issues, handling pagination
+	// Pass status filter to daemon if set (daemon supports this)
+	var statusFilter []string
+	if opts.Status != "" {
+		statusFilter = []string{opts.Status}
+	}
+
+	var allIssues []*daemon.IssueSummary
+	cursor := ""
+	for {
+		issuesResp, err := client.ListIssues(statusFilter, 200, cursor) // Use max limit
+		if err != nil {
+			return err
+		}
+		allIssues = append(allIssues, issuesResp.Issues...)
+
+		// Check if there are more pages
+		if issuesResp.NextCursor == nil || *issuesResp.NextCursor == "" {
+			break
+		}
+		cursor = *issuesResp.NextCursor
 	}
 
 	runsResp, err := client.ListRuns("", []string{"running", "blocked", "blocked_api", "booting", "queued"}, 0, "")
@@ -300,12 +333,21 @@ func runIssueListViaDaemon(client *daemon.Client) error {
 	}
 
 	var issueInfos []issueInfo
-	for _, issue := range issuesResp.Issues {
+	for _, issue := range allIssues {
+		// Apply tag filters (status already filtered by daemon)
+		if !matchTagsAnd(issue.Tags, opts.Tags) {
+			continue
+		}
+		if !matchTagsOr(issue.Tags, opts.TagsAny) {
+			continue
+		}
+
 		info := issueInfo{
 			ID:      issue.ID,
 			Title:   issue.Title,
 			Summary: issue.Summary,
 			Status:  issue.Status,
+			Tags:    issue.Tags,
 			Path:    issue.URI,
 		}
 
@@ -319,10 +361,10 @@ func runIssueListViaDaemon(client *daemon.Client) error {
 		issueInfos = append(issueInfos, info)
 	}
 
-	return outputIssueList(issueInfos)
+	return outputIssueList(issueInfos, opts)
 }
 
-func runIssueListDirect() error {
+func runIssueListDirect(opts *issueListOptions) error {
 	st, err := getStore()
 	if err != nil {
 		return err
@@ -347,6 +389,7 @@ func runIssueListDirect() error {
 			Summary: issue.Summary,
 			Status:  string(issue.Status),
 			Path:    issue.Path,
+			Tags:    issue.Tags,
 		}
 
 		for _, run := range runsByIssue[issue.ID] {
@@ -362,13 +405,18 @@ func runIssueListDirect() error {
 			}
 		}
 
+		// Apply filters
+		if !matchIssueFilters(string(issue.Status), issue.Tags, opts) {
+			continue
+		}
+
 		issueInfos = append(issueInfos, info)
 	}
 
-	return outputIssueList(issueInfos)
+	return outputIssueList(issueInfos, opts)
 }
 
-func outputIssueList(issueInfos []issueInfo) error {
+func outputIssueList(issueInfos []issueInfo, opts *issueListOptions) error {
 	if globalOpts.JSON {
 		output := struct {
 			OK     bool        `json:"ok"`
@@ -390,7 +438,7 @@ func outputIssueList(issueInfos []issueInfo) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	if issueListOpts.NoPath {
+	if opts.NoPath {
 		fmt.Fprintln(w, "ID\tSTATUS\tSUMMARY\tRUNS")
 	} else {
 		fmt.Fprintln(w, "ID\tSTATUS\tSUMMARY\tRUNS\tPATH")
@@ -410,7 +458,7 @@ func outputIssueList(issueInfos []issueInfo) error {
 		} else if len(summary) > 40 {
 			summary = summary[:37] + "..."
 		}
-		if issueListOpts.NoPath {
+		if opts.NoPath {
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", issue.ID, status, summary, runsSummary)
 		} else {
 			path := issue.Path
@@ -440,6 +488,57 @@ func formatRunsSummary(runs []runSummary) string {
 		return "-"
 	}
 	return strings.Join(parts, ", ")
+}
+
+// matchTagsAnd returns true if the issue has ALL of the specified tags (case-insensitive)
+func matchTagsAnd(issueTags []string, filterTags []string) bool {
+	if len(filterTags) == 0 {
+		return true
+	}
+	tagSet := make(map[string]bool)
+	for _, t := range issueTags {
+		tagSet[strings.ToLower(t)] = true
+	}
+	for _, t := range filterTags {
+		if !tagSet[strings.ToLower(t)] {
+			return false
+		}
+	}
+	return true
+}
+
+// matchTagsOr returns true if the issue has ANY of the specified tags (case-insensitive)
+func matchTagsOr(issueTags []string, filterTags []string) bool {
+	if len(filterTags) == 0 {
+		return true
+	}
+	tagSet := make(map[string]bool)
+	for _, t := range issueTags {
+		tagSet[strings.ToLower(t)] = true
+	}
+	for _, t := range filterTags {
+		if tagSet[strings.ToLower(t)] {
+			return true
+		}
+	}
+	return false
+}
+
+// matchIssueFilters checks if an issue matches all filter criteria
+func matchIssueFilters(status string, tags []string, opts *issueListOptions) bool {
+	// Status filter
+	if opts.Status != "" && !strings.EqualFold(status, opts.Status) {
+		return false
+	}
+	// Tag AND filter
+	if !matchTagsAnd(tags, opts.Tags) {
+		return false
+	}
+	// Tag OR filter
+	if !matchTagsOr(tags, opts.TagsAny) {
+		return false
+	}
+	return true
 }
 
 type issueShowOptions struct {
@@ -698,7 +797,7 @@ func runIssueSync() error {
 		fmt.Println("Syncing issues from GitHub...")
 	}
 
-	err := runIssueList()
+	err := runIssueList(&issueListOptions{})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/issue_test.go
+++ b/internal/cli/issue_test.go
@@ -63,3 +63,77 @@ func TestRunIssueCreateUsesVaultIssuesDir(t *testing.T) {
 		t.Fatalf("expected issue at %q: %v", expected, err)
 	}
 }
+
+func TestMatchTagsAnd(t *testing.T) {
+	tests := []struct {
+		name       string
+		issueTags  []string
+		filterTags []string
+		want       bool
+	}{
+		{"empty filter", []string{"bug", "feature"}, nil, true},
+		{"match all", []string{"bug", "feature", "urgent"}, []string{"bug", "feature"}, true},
+		{"missing one", []string{"bug"}, []string{"bug", "feature"}, false},
+		{"case insensitive", []string{"Bug", "FEATURE"}, []string{"bug", "feature"}, true},
+		{"empty issue tags", nil, []string{"bug"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchTagsAnd(tt.issueTags, tt.filterTags); got != tt.want {
+				t.Errorf("matchTagsAnd() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchTagsOr(t *testing.T) {
+	tests := []struct {
+		name       string
+		issueTags  []string
+		filterTags []string
+		want       bool
+	}{
+		{"empty filter", []string{"bug", "feature"}, nil, true},
+		{"match one", []string{"bug"}, []string{"bug", "feature"}, true},
+		{"match none", []string{"urgent"}, []string{"bug", "feature"}, false},
+		{"case insensitive", []string{"BUG"}, []string{"bug", "feature"}, true},
+		{"empty issue tags", nil, []string{"bug"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchTagsOr(tt.issueTags, tt.filterTags); got != tt.want {
+				t.Errorf("matchTagsOr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchIssueFilters(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		tags   []string
+		opts   *issueListOptions
+		want   bool
+	}{
+		{"no filters", "open", []string{"bug"}, &issueListOptions{}, true},
+		{"status match", "open", nil, &issueListOptions{Status: "open"}, true},
+		{"status no match", "closed", nil, &issueListOptions{Status: "open"}, false},
+		{"status case insensitive", "OPEN", nil, &issueListOptions{Status: "open"}, true},
+		{"tag and match", "open", []string{"bug", "urgent"}, &issueListOptions{Tags: []string{"bug", "urgent"}}, true},
+		{"tag and no match", "open", []string{"bug"}, &issueListOptions{Tags: []string{"bug", "urgent"}}, false},
+		{"tag or match", "open", []string{"bug"}, &issueListOptions{TagsAny: []string{"bug", "feature"}}, true},
+		{"tag or no match", "open", []string{"urgent"}, &issueListOptions{TagsAny: []string{"bug", "feature"}}, false},
+		{"combined filters", "open", []string{"bug", "urgent"}, &issueListOptions{Status: "open", Tags: []string{"bug"}}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchIssueFilters(tt.status, tt.tags, tt.opts); got != tt.want {
+				t.Errorf("matchIssueFilters() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -145,7 +145,8 @@ type IssueSummary struct {
 	Title   string `json:"title"`
 	Topic   string `json:"topic,omitempty"`
 	Summary string `json:"summary,omitempty"`
-	Status  string `json:"status"`
+	Status  string   `json:"status"`
+	Tags    []string `json:"tags,omitempty"`
 	URI     string `json:"uri"`
 }
 
@@ -164,6 +165,7 @@ type IssueFull struct {
 	Summary     string            `json:"summary,omitempty"`
 	Status      string            `json:"status"`
 	Body        string            `json:"body"`
+	Tags        []string          `json:"tags,omitempty"`
 	URI         string            `json:"uri"`
 	Frontmatter map[string]string `json:"frontmatter,omitempty"`
 }
@@ -271,6 +273,7 @@ func IssueToSummary(issue *model.Issue) *IssueSummary {
 		Topic:   issue.Topic,
 		Summary: issue.Summary,
 		Status:  string(issue.Status),
+		Tags:    issue.Tags,
 		URI:     FileURI(issue.Path),
 	}
 }
@@ -284,6 +287,7 @@ func IssueToFull(issue *model.Issue) *IssueFull {
 		Summary:     issue.Summary,
 		Status:      string(issue.Status),
 		Body:        issue.Body,
+		Tags:        issue.Tags,
 		URI:         FileURI(issue.Path),
 		Frontmatter: issue.Frontmatter,
 	}

--- a/internal/model/issue.go
+++ b/internal/model/issue.go
@@ -13,6 +13,7 @@ type Issue struct {
 	Summary     string
 	Status      IssueStatus
 	Body        string
+	Tags        []string
 	Path        string
 	Frontmatter map[string]string
 }

--- a/internal/store/file/file.go
+++ b/internal/store/file/file.go
@@ -16,7 +16,7 @@ import (
 
 // FileStore implements store.Store using the filesystem
 type FileStore struct {
-	rootPath  string
+	rootPath   string
 	issueMu    sync.RWMutex
 	issueCache map[string]*model.Issue // id -> issue
 	cacheDirty bool
@@ -33,12 +33,13 @@ func New(rootPath string) (*FileStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("root path does not exist: %w", err)
 	}
+
 	if !info.IsDir() {
 		return nil, fmt.Errorf("root path is not a directory: %s", absPath)
 	}
 
 	return &FileStore{
-		rootPath:  absPath,
+		rootPath:   absPath,
 		issueCache: make(map[string]*model.Issue),
 		cacheDirty: true,
 	}, nil
@@ -67,14 +68,19 @@ func walkWithSymlinks(root string, walkFn filepath.WalkFunc) error {
 					skipChildren = true
 				} else {
 					visited[realPath] = struct{}{}
+
 				}
+
 			} else if absPath, absErr := filepath.Abs(path); absErr == nil {
 				if _, ok := visited[absPath]; ok {
 					skipChildren = true
 				} else {
 					visited[absPath] = struct{}{}
+
 				}
+
 			}
+
 		}
 
 		switch err := walkFn(path, info, nil); err {
@@ -83,6 +89,7 @@ func walkWithSymlinks(root string, walkFn filepath.WalkFunc) error {
 			if info.IsDir() {
 				return nil
 			}
+
 			return filepath.SkipDir
 		case filepath.SkipAll:
 			return filepath.SkipAll
@@ -104,6 +111,7 @@ func walkWithSymlinks(root string, walkFn filepath.WalkFunc) error {
 			default:
 				return err
 			}
+
 		}
 
 		sort.Slice(entries, func(i, j int) bool {
@@ -116,11 +124,14 @@ func walkWithSymlinks(root string, walkFn filepath.WalkFunc) error {
 				if err == filepath.SkipDir {
 					return nil
 				}
+
 				if err == filepath.SkipAll {
 					return filepath.SkipAll
 				}
+
 				return err
 			}
+
 		}
 
 		return nil
@@ -148,6 +159,7 @@ func (s *FileStore) scanIssues() error {
 			s.cacheDirty = false
 			return nil
 		}
+
 		s.cacheDirty = true
 		return err
 	}
@@ -195,6 +207,7 @@ func (s *FileStore) parseIssueFile(path string) (*model.Issue, error) {
 			bodyStart = i + 1
 			break
 		}
+
 		if inFrontmatter {
 			parts := strings.SplitN(line, ":", 2)
 			if len(parts) == 2 {
@@ -202,7 +215,9 @@ func (s *FileStore) parseIssueFile(path string) (*model.Issue, error) {
 				value := strings.TrimSpace(parts[1])
 				frontmatter[key] = value
 			}
+
 		}
+
 	}
 
 	// Check if this is an issue file
@@ -224,7 +239,9 @@ func (s *FileStore) parseIssueFile(path string) (*model.Issue, error) {
 				title = strings.TrimPrefix(line, "# ")
 				break
 			}
+
 		}
+
 	}
 
 	// Get body
@@ -243,9 +260,13 @@ func (s *FileStore) parseIssueFile(path string) (*model.Issue, error) {
 		if len(summary) > 50 {
 			summary = summary[:47] + "..."
 		}
+
 	}
 
 	// Get status (defaults to open if not set)
+
+	// Get tags (parse from YAML list or comma-separated string)
+	tags := parseTags(frontmatter["tags"])
 	status := model.ParseIssueStatus(frontmatter["status"])
 
 	return &model.Issue{
@@ -255,9 +276,43 @@ func (s *FileStore) parseIssueFile(path string) (*model.Issue, error) {
 		Summary:     summary,
 		Status:      status,
 		Body:        body,
+		Tags:        tags,
 		Path:        path,
 		Frontmatter: frontmatter,
 	}, nil
+}
+
+// parseTags parses tags from frontmatter value.
+// Supports formats: "tag1, tag2", "[tag1, tag2]", "tag1,tag2"
+// parseTags parses tags from frontmatter value.
+// Supports formats: "tag1, tag2", "[tag1, tag2]", '["tag1", "tag2"]'
+func parseTags(value string) []string {
+	if value == "" {
+		return nil
+	}
+
+	// Remove YAML list brackets if present
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "[") && strings.HasSuffix(value, "]") {
+		value = value[1 : len(value)-1]
+	}
+
+	// Split by comma and clean up
+	var tags []string
+	for _, tag := range strings.Split(value, ",") {
+		tag = strings.TrimSpace(tag)
+		// Strip surrounding quotes (single or double)
+		if len(tag) >= 2 {
+			if (tag[0] == '"' && tag[len(tag)-1] == '"') ||
+				(tag[0] == '\'' && tag[len(tag)-1] == '\'') {
+				tag = tag[1 : len(tag)-1]
+			}
+		}
+		if tag != "" {
+			tags = append(tags, tag)
+		}
+	}
+	return tags
 }
 
 func (s *FileStore) isCacheDirty() bool {
@@ -280,6 +335,7 @@ func (s *FileStore) issueFromCache(issueID string) (*model.Issue, bool) {
 		s.issueMu.RUnlock()
 		return nil, false
 	}
+
 	clone := cloneIssue(issue)
 	s.issueMu.RUnlock()
 	return clone, true
@@ -291,6 +347,7 @@ func (s *FileStore) issuesFromCache() []*model.Issue {
 	for _, issue := range s.issueCache {
 		issues = append(issues, cloneIssue(issue))
 	}
+
 	s.issueMu.RUnlock()
 	return issues
 }
@@ -306,7 +363,9 @@ func cloneIssue(issue *model.Issue) *model.Issue {
 		for k, v := range issue.Frontmatter {
 			clone.Frontmatter[k] = v
 		}
+
 	}
+
 	return &clone
 }
 
@@ -329,11 +388,13 @@ func (s *FileStore) resolveRunsDir(issueID string) string {
 		if _, err := os.Stat(canonicalDir); err == nil {
 			return canonicalDir
 		}
+
 		legacyID := "gh#" + strings.TrimPrefix(issueID, "gh-")
 		legacyDir := filepath.Join(runsRoot, legacyID)
 		if _, err := os.Stat(legacyDir); err == nil {
 			return legacyDir
 		}
+
 		return canonicalDir
 	}
 
@@ -342,11 +403,13 @@ func (s *FileStore) resolveRunsDir(issueID string) string {
 		if _, err := os.Stat(legacyDir); err == nil {
 			return legacyDir
 		}
+
 		canonicalID := "gh-" + strings.TrimPrefix(issueID, "gh#")
 		canonicalDir := filepath.Join(runsRoot, canonicalID)
 		if _, err := os.Stat(canonicalDir); err == nil {
 			return canonicalDir
 		}
+
 		return legacyDir
 	}
 
@@ -360,6 +423,7 @@ func (s *FileStore) ResolveIssue(issueID string) (*model.Issue, error) {
 		if err := s.scanIssues(); err != nil {
 			return nil, err
 		}
+
 	}
 
 	issue, ok := s.issueFromCache(issueID)
@@ -369,10 +433,12 @@ func (s *FileStore) ResolveIssue(issueID string) (*model.Issue, error) {
 		if err := s.scanIssues(); err != nil {
 			return nil, err
 		}
+
 		issue, ok = s.issueFromCache(issueID)
 		if !ok {
 			return nil, fmt.Errorf("issue not found: %s", issueID)
 		}
+
 	}
 
 	return issue, nil
@@ -397,6 +463,7 @@ func (s *FileStore) CreateRun(issueID, runID string, metadata map[string]string)
 		if err != nil {
 			return nil, err
 		}
+
 	}
 
 	// Create runs directory for issue if needed
@@ -420,6 +487,7 @@ func (s *FileStore) CreateRun(issueID, runID string, metadata map[string]string)
 	for k, v := range metadata {
 		sb.WriteString(fmt.Sprintf("%s: %s\n", k, v))
 	}
+
 	sb.WriteString("---\n\n")
 	sb.WriteString("# Events\n\n")
 
@@ -452,6 +520,7 @@ func (s *FileStore) AppendEvent(ref *model.RunRef, event *model.Event) error {
 	if err != nil {
 		return fmt.Errorf("failed to open run file: %w", err)
 	}
+
 	defer f.Close()
 
 	line := event.String() + "\n"
@@ -485,6 +554,7 @@ func (s *FileStore) GetLatestRun(issueID string) (*model.Run, error) {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("no runs found for issue: %s", issueID)
 		}
+
 		return nil, err
 	}
 
@@ -494,10 +564,12 @@ func (s *FileStore) GetLatestRun(issueID string) (*model.Run, error) {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
 			continue
 		}
+
 		name := strings.TrimSuffix(e.Name(), ".md")
 		if name > latestName {
 			latestName = name
 		}
+
 	}
 
 	if latestName == "" {
@@ -521,11 +593,13 @@ func (s *FileStore) GetRunByShortID(shortID string) (*model.Run, error) {
 		if strings.HasPrefix(run.ShortID(), shortID) {
 			matches = append(matches, run)
 		}
+
 	}
 
 	if len(matches) == 0 {
 		return nil, fmt.Errorf("run not found: %s", shortID)
 	}
+
 	if len(matches) > 1 {
 		return nil, formatAmbiguousError(shortID, matches)
 	}
@@ -543,13 +617,16 @@ func formatAmbiguousError(shortID string, matches []*model.Run) error {
 	if len(matches) < limit {
 		limit = len(matches)
 	}
+
 	for i := 0; i < limit; i++ {
 		run := matches[i]
 		sb.WriteString(fmt.Sprintf("  %s  %s#%s\n", run.ShortID(), run.IssueID, run.RunID))
 	}
+
 	if len(matches) > 5 {
 		sb.WriteString(fmt.Sprintf("  ... and %d more\n", len(matches)-5))
 	}
+
 	sb.WriteString("Hint: use more characters to disambiguate")
 
 	return fmt.Errorf("%s", sb.String())
@@ -562,6 +639,7 @@ func (s *FileStore) loadRun(issueID, runID, path string) (*model.Run, error) {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("run not found: %s#%s", issueID, runID)
 		}
+
 		return nil, err
 	}
 
@@ -584,6 +662,7 @@ func (s *FileStore) loadRun(issueID, runID, path string) (*model.Run, error) {
 				bodyStart = i + 1
 				break
 			}
+
 			if inFrontmatter {
 				parts := strings.SplitN(line, ":", 2)
 				if len(parts) == 2 {
@@ -599,9 +678,13 @@ func (s *FileStore) loadRun(issueID, runID, path string) (*model.Run, error) {
 					case "continued_from":
 						run.ContinuedFrom = value
 					}
+
 				}
+
 			}
+
 		}
+
 	}
 
 	// Parse events from body
@@ -613,7 +696,9 @@ func (s *FileStore) loadRun(issueID, runID, path string) (*model.Run, error) {
 			if err == nil {
 				run.Events = append(run.Events, event)
 			}
+
 		}
+
 	}
 
 	run.DeriveState()
@@ -663,6 +748,7 @@ func (s *FileStore) SetIssueStatus(issueID string, status model.IssueStatus) err
 					// Add status if not found in frontmatter
 					newLines = append(newLines, fmt.Sprintf("status: %s", statusStr))
 				}
+
 				newLines = append(newLines, line)
 				inFrontmatter = false
 				continue
@@ -675,9 +761,11 @@ func (s *FileStore) SetIssueStatus(issueID string, status model.IssueStatus) err
 			} else {
 				newLines = append(newLines, line)
 			}
+
 		} else {
 			newLines = append(newLines, line)
 		}
+
 	}
 
 	if err := os.WriteFile(issue.Path, []byte(strings.Join(newLines, "\n")), 0644); err != nil {

--- a/internal/store/file/file_test.go
+++ b/internal/store/file/file_test.go
@@ -602,3 +602,124 @@ func TestGitHubIssueIDAliasing(t *testing.T) {
 		t.Errorf("expected run ID %s, got %s", runID, run.RunID)
 	}
 }
+
+func TestParseTags(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{"empty", "", nil},
+		{"single tag", "bug", []string{"bug"}},
+		{"comma separated", "bug, feature", []string{"bug", "feature"}},
+		{"no space", "bug,feature", []string{"bug", "feature"}},
+		{"yaml list", "[bug, feature]", []string{"bug", "feature"}},
+		{"yaml list no space", "[bug,feature]", []string{"bug", "feature"}},
+		{"with whitespace", "  bug ,  feature  ", []string{"bug", "feature"}},
+		{"empty items", "bug,,feature", []string{"bug", "feature"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTags(tt.value)
+			if len(got) != len(tt.want) {
+				t.Errorf("parseTags(%q) = %v, want %v", tt.value, got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseTags(%q)[%d] = %q, want %q", tt.value, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestListIssuesWithTags(t *testing.T) {
+	vault, cleanup := setupTestVault(t)
+	defer cleanup()
+
+	// Create issues with tags
+	createTestIssue(t, vault, "issue-1", `---
+type: issue
+id: issue-1
+title: Bug issue
+status: open
+tags: bug, urgent
+---
+
+# Bug issue
+`)
+	createTestIssue(t, vault, "issue-2", `---
+type: issue
+id: issue-2
+title: Feature issue
+status: open
+tags: [feature, enhancement]
+---
+
+# Feature issue
+`)
+	createTestIssue(t, vault, "issue-3", `---
+type: issue
+id: issue-3
+title: No tags issue
+status: open
+---
+
+# No tags issue
+`)
+
+	s, err := New(vault)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	issues, err := s.ListIssues()
+	if err != nil {
+		t.Fatalf("ListIssues() error = %v", err)
+	}
+
+	if len(issues) != 3 {
+		t.Fatalf("ListIssues() returned %d issues, want 3", len(issues))
+	}
+
+	// Check tags were parsed correctly
+	issueMap := make(map[string]*model.Issue)
+	for _, issue := range issues {
+		issueMap[issue.ID] = issue
+	}
+
+	// Check issue-1 tags
+	if issue, ok := issueMap["issue-1"]; ok {
+		if len(issue.Tags) != 2 {
+			t.Errorf("issue-1 has %d tags, want 2", len(issue.Tags))
+		}
+		if issue.Tags[0] != "bug" || issue.Tags[1] != "urgent" {
+			t.Errorf("issue-1 tags = %v, want [bug, urgent]", issue.Tags)
+		}
+	} else {
+		t.Error("issue-1 not found")
+	}
+
+	// Check issue-2 tags (YAML list format)
+	if issue, ok := issueMap["issue-2"]; ok {
+		if len(issue.Tags) != 2 {
+			t.Errorf("issue-2 has %d tags, want 2", len(issue.Tags))
+		}
+		if issue.Tags[0] != "feature" || issue.Tags[1] != "enhancement" {
+			t.Errorf("issue-2 tags = %v, want [feature, enhancement]", issue.Tags)
+		}
+	} else {
+		t.Error("issue-2 not found")
+	}
+
+	// Check issue-3 has no tags
+	if issue, ok := issueMap["issue-3"]; ok {
+		if len(issue.Tags) != 0 {
+			t.Errorf("issue-3 has %d tags, want 0", len(issue.Tags))
+		}
+	} else {
+		t.Error("issue-3 not found")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `--tag` and `--tag-any` flags to `orch issue list` for filtering issues by tags
- Add `--status` flag for filtering by issue status
- Tags field is now parsed from issue frontmatter and included in issue data

## Changes

### CLI (`internal/cli/issue.go`)
- New `issueListOptions` struct with `Status`, `Tags`, and `TagsAny` fields
- New flags:
  - `--tag` (repeatable): AND logic - issue must have all specified tags
  - `--tag-any` (comma-separated): OR logic - issue must have any specified tag  
  - `--status`: Filter by status (open, closed, resolved)
- Case-insensitive tag matching
- Comprehensive test coverage for filtering functions

### Model (`internal/model/issue.go`)
- Added `Tags []string` field to `Issue` struct

### Store (`internal/store/file/file.go`)
- Parse `tags` from frontmatter
- Support both YAML list format `[tag1, tag2]` and CSV format `tag1, tag2`
- Added `parseTags` helper function with tests

### Daemon (`internal/daemon/types.go`)
- Added `Tags` field to `IssueSummary` for daemon responses
- Updated `IssueToSummary` to include tags

## Usage Examples

```bash
# Filter by single tag
orch issue list --tag bug

# Filter by multiple tags (AND - must have all)
orch issue list --tag bug --tag urgent

# Filter by multiple tags (OR - any match)
orch issue list --tag-any "bug,enhancement"

# Combine with status filter
orch issue list --status open --tag bug
```

## Testing

All existing tests pass + new tests added:
- `TestParseTags` - tests various tag formats
- `TestListIssuesWithTags` - integration test for tag loading
- `TestMatchTagsAnd`, `TestMatchTagsOr`, `TestMatchIssueFilters` - unit tests for filtering logic

Fixes orch-304