### PR TITLE
fix(send): make orch send synchronous with proper error handling

### DIFF
--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -10,11 +10,13 @@ import (
 
 	"github.com/s22625/orch/internal/agent"
 	"github.com/s22625/orch/internal/daemon"
+	"github.com/s22625/orch/internal/model"
 	"github.com/spf13/cobra"
 )
 
 type sendOptions struct {
 	NoEnter bool
+	DryRun  bool
 }
 
 func newSendCmd() *cobra.Command {
@@ -39,7 +41,10 @@ Examples:
   orch send a3b4c5 "Continue with the implementation"
 
   # Send text without pressing Enter (tmux agents only)
-  orch send orch-023 "partial input" --no-enter`,
+  orch send orch-023 "partial input" --no-enter
+
+  # Validate the run is ready to receive messages (without sending)
+  orch send orch-023 "test" --dry-run`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSend(args[0], args[1], opts)
@@ -47,6 +52,7 @@ Examples:
 	}
 
 	cmd.Flags().BoolVar(&opts.NoEnter, "no-enter", false, "Don't press Enter after sending the message")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Validate config without sending the message")
 
 	return cmd
 }
@@ -72,6 +78,11 @@ func runSend(refStr, message string, opts *sendOptions) error {
 	}
 
 	isOpenCode := run.Agent == string(agent.AgentOpenCode)
+
+	// Handle --dry-run validation
+	if opts.DryRun {
+		return validateSendConfig(run, isOpenCode)
+	}
 
 	projectRoot, err := getProjectRoot()
 	if err != nil {
@@ -143,5 +154,75 @@ func runSend(refStr, message string, opts *sendOptions) error {
 		fmt.Printf("Sent message to %s#%s\n", run.IssueID, run.RunID)
 	}
 
+	return nil
+}
+// validateSendConfig validates the run configuration for sending messages.
+func validateSendConfig(run *model.Run, isOpenCode bool) error {
+	if isOpenCode {
+		var issues []string
+
+		if run.ServerPort <= 0 {
+			issues = append(issues, "missing server port (agent may not be running)")
+		}
+		if run.OpenCodeSessionID == "" {
+			issues = append(issues, "missing session ID (agent may still be booting)")
+		}
+
+		if len(issues) > 0 {
+			if globalOpts.JSON {
+				result := map[string]interface{}{
+					"ok":       false,
+					"issue_id": run.IssueID,
+					"run_id":   run.RunID,
+					"errors":   issues,
+				}
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(result)
+			}
+			fmt.Fprintf(os.Stderr, "Run %s#%s is not ready to receive messages:\n", run.IssueID, run.RunID)
+			for _, issue := range issues {
+				fmt.Fprintf(os.Stderr, "  - %s\n", issue)
+			}
+			os.Exit(ExitAgentError)
+			return nil
+		}
+
+		if globalOpts.JSON {
+			result := map[string]interface{}{
+				"ok":         true,
+				"issue_id":   run.IssueID,
+				"run_id":     run.RunID,
+				"agent":      run.Agent,
+				"port":       run.ServerPort,
+				"session_id": run.OpenCodeSessionID,
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(result)
+		}
+
+		fmt.Printf("Run %s#%s is ready to receive messages\n", run.IssueID, run.RunID)
+		fmt.Printf("  Agent: %s\n", run.Agent)
+		fmt.Printf("  Port: %d\n", run.ServerPort)
+		fmt.Printf("  Session: %s\n", run.OpenCodeSessionID)
+		return nil
+	}
+
+	// For tmux-based agents, check session exists
+	if globalOpts.JSON {
+		result := map[string]interface{}{
+			"ok":       true,
+			"issue_id": run.IssueID,
+			"run_id":   run.RunID,
+			"agent":    run.Agent,
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	fmt.Printf("Run %s#%s is ready to receive messages\n", run.IssueID, run.RunID)
+	fmt.Printf("  Agent: %s\n", run.Agent)
 	return nil
 }

--- a/internal/cli/send_test.go
+++ b/internal/cli/send_test.go
@@ -42,3 +42,17 @@ func TestSendCmdRequiresArgs(t *testing.T) {
 		t.Error("expected error with 3 args")
 	}
 }
+
+func TestSendCmdDryRunFlag(t *testing.T) {
+	cmd := newSendCmd()
+
+	// Verify --dry-run flag exists
+	dryRunFlag := cmd.Flags().Lookup("dry-run")
+	if dryRunFlag == nil {
+		t.Error("missing --dry-run flag")
+	}
+
+	if dryRunFlag.DefValue != "false" {
+		t.Errorf("expected --dry-run default to be false, got %s", dryRunFlag.DefValue)
+	}
+}

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -389,35 +389,37 @@ func (s *SocketServer) handleListRepos(req SendRequest, encoder *json.Encoder) {
 }
 
 func (s *SocketServer) handleSend(req SendRequest, encoder *json.Encoder) {
+	err := s.processSend(req)
+	if err != nil {
+		encoder.Encode(SendResponse{OK: false, Error: err.Error()})
+		return
+	}
 	encoder.Encode(SendResponse{OK: true})
-	go s.processSend(req)
 }
 
-func (s *SocketServer) processSend(req SendRequest) {
+func (s *SocketServer) processSend(req SendRequest) error {
 	s.logger.Printf("processing send for %s#%s", req.IssueID, req.RunID)
 
 	st := s.resolveStore(req)
 	if st == nil {
-		s.logger.Printf("no store available for request")
-		return
+		return fmt.Errorf("no store available for project")
 	}
 
 	ref := &model.RunRef{IssueID: req.IssueID, RunID: req.RunID}
 	run, err := st.GetRun(ref)
 	if err != nil {
-		s.logger.Printf("failed to get run %s#%s: %v", req.IssueID, req.RunID, err)
-		return
+		return fmt.Errorf("run %s#%s not found: %w", req.IssueID, req.RunID, err)
 	}
 
 	if run.Agent != string(agent.AgentOpenCode) {
-		s.logger.Printf("run %s#%s is not opencode agent, skipping", req.IssueID, req.RunID)
-		return
+		return fmt.Errorf("run %s#%s is not an opencode agent (agent=%s)", req.IssueID, req.RunID, run.Agent)
 	}
 
-	if run.ServerPort <= 0 || run.OpenCodeSessionID == "" {
-		s.logger.Printf("run %s#%s missing server config (port=%d, session=%s)",
-			req.IssueID, req.RunID, run.ServerPort, run.OpenCodeSessionID)
-		return
+	if run.ServerPort <= 0 {
+		return fmt.Errorf("run %s#%s missing server port (not running or server not started)", req.IssueID, req.RunID)
+	}
+	if run.OpenCodeSessionID == "" {
+		return fmt.Errorf("run %s#%s missing session ID (agent may still be booting)", req.IssueID, req.RunID)
 	}
 
 	client := agent.NewOpenCodeClient(run.ServerPort)
@@ -427,11 +429,11 @@ func (s *SocketServer) processSend(req SendRequest) {
 
 	err = client.SendMessagePrompt(ctx, run.OpenCodeSessionID, req.Message, run.WorktreePath)
 	if err != nil {
-		s.logger.Printf("failed to send message to %s#%s: %v", req.IssueID, req.RunID, err)
-		return
+		return fmt.Errorf("failed to send message: %w", err)
 	}
 
 	s.logger.Printf("message sent successfully to %s#%s", req.IssueID, req.RunID)
+	return nil
 }
 
 func (s *SocketServer) handleListRuns(req SendRequest, encoder *json.Encoder) {

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -189,7 +189,7 @@ func TestSocketServerSendRequest(t *testing.T) {
 			"issue#run": {
 				IssueID:           "issue",
 				RunID:             "run",
-				Agent:             "claude",
+				Agent:             "claude", // Non-opencode agent
 				ServerPort:        4096,
 				OpenCodeSessionID: "session",
 			},
@@ -225,8 +225,108 @@ func TestSocketServerSendRequest(t *testing.T) {
 		t.Fatalf("failed to read response: %v", err)
 	}
 
-	if !resp.OK {
-		t.Errorf("expected OK=true, got error: %s", resp.Error)
+	// Non-opencode agents should return an error (they should use tmux directly)
+	if resp.OK {
+		t.Error("expected error for non-opencode agent")
+	}
+	if resp.Error == "" {
+		t.Error("expected error message for non-opencode agent")
+	}
+}
+
+func TestSocketServerSendRequestMissingRun(t *testing.T) {
+	cleanup := setupXDGTestEnv(t)
+	defer cleanup()
+
+	st := &mockStore{runs: make(map[string]*model.Run)}
+	server := newTestServer(t, st)
+	if err := server.Start(); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	defer server.Stop()
+
+	conn, err := net.DialTimeout("unix", xdg.SocketPath(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	req := SendRequest{
+		Type:    "send",
+		IssueID: "missing",
+		RunID:   "run",
+		Message: "test message",
+	}
+
+	encoder := json.NewEncoder(conn)
+	if err := encoder.Encode(req); err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+
+	decoder := json.NewDecoder(conn)
+	var resp SendResponse
+	if err := decoder.Decode(&resp); err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+
+	if resp.OK {
+		t.Error("expected error for missing run")
+	}
+	if resp.Error == "" {
+		t.Error("expected error message for missing run")
+	}
+}
+
+func TestSocketServerSendRequestMissingConfig(t *testing.T) {
+	cleanup := setupXDGTestEnv(t)
+	defer cleanup()
+
+	st := &mockStore{
+		runs: map[string]*model.Run{
+			"issue#run": {
+				IssueID:           "issue",
+				RunID:             "run",
+				Agent:             "opencode",
+				ServerPort:        0,             // Missing port
+				OpenCodeSessionID: "",            // Missing session
+			},
+		},
+	}
+	server := newTestServer(t, st)
+	if err := server.Start(); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	defer server.Stop()
+
+	conn, err := net.DialTimeout("unix", xdg.SocketPath(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	req := SendRequest{
+		Type:    "send",
+		IssueID: "issue",
+		RunID:   "run",
+		Message: "test message",
+	}
+
+	encoder := json.NewEncoder(conn)
+	if err := encoder.Encode(req); err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+
+	decoder := json.NewDecoder(conn)
+	var resp SendResponse
+	if err := decoder.Decode(&resp); err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+
+	if resp.OK {
+		t.Error("expected error for missing server config")
+	}
+	if resp.Error == "" {
+		t.Error("expected error message explaining what config is missing")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix `orch send` returning success before processing (silent failures)
- Add proper error propagation from daemon to CLI
- Add `--dry-run` flag to validate send configuration

## Changes

### Daemon (socket.go)
- Changed `handleSend` to process synchronously instead of async goroutine
- `processSend` now returns errors instead of silent returns
- Clear error messages for:
  - Missing store/project context
  - Run not found
  - Non-opencode agents (should use tmux directly)
  - Missing ServerPort (agent not running)
  - Missing OpenCodeSessionID (agent still booting)

### CLI (send.go)
- Added `--dry-run` flag to validate run configuration without sending
- Outputs detailed config info in both JSON and human-readable format

### Tests
- Updated `TestSocketServerSendRequest` to expect error for non-opencode agents
- Added `TestSocketServerSendRequestMissingRun` 
- Added `TestSocketServerSendRequestMissingConfig`
- Added `TestSendCmdDryRunFlag`

## Acceptance Criteria Checklist

- [x] `orch send` returns error if message fails to send (not silent OK)
- [x] Missing ServerPort or OpenCodeSessionID produces clear error message
- [x] Daemon processSend errors are propagated back to CLI
- [x] Add `orch send --dry-run` to validate config without sending
- [x] Works correctly when daemon is not running (direct API call - existing behavior)

Fixes: orch-310