### PR TITLE
feat(monitor): add insertion/deletion columns to run list

### DIFF
--- a/orch-monitor-tui/orch_monitor/app.py
+++ b/orch-monitor-tui/orch_monitor/app.py
@@ -1377,8 +1377,19 @@ class RunsDashboard(App):
         if runs is not None:
             self.runs = runs
         self.title = f"{self._base_title} | Last updated: {self._last_update.strftime('%H:%M:%S')}"
+        
+        # Collect diff stats for all runs with worktrees
+        diff_stats: dict[str, DiffStats] = {}
+        for run in self.runs:
+            if run.worktree_path and run.branch:
+                stats = _get_git_diff_stats(
+                    run.worktree_path, run.branch, self.config.base_branch
+                )
+                if stats:
+                    diff_stats[run.ref()] = stats
+        
         run_table = self.query_one("#runs-table", RunTable)
-        run_table.populate(self.runs)
+        run_table.populate(self.runs, diff_stats=diff_stats)
 
     @on(RunTable.RowSelected)
     def on_run_selected(self, event: RunTable.RowSelected) -> None:

--- a/orch-monitor-tui/orch_monitor/widgets.py
+++ b/orch-monitor-tui/orch_monitor/widgets.py
@@ -8,7 +8,7 @@ from textual.widgets import DataTable, Static
 from textual.widgets.data_table import RowDoesNotExist
 from textual.containers import Container
 
-from .models import Issue, Run, Status
+from .models import DiffStats, Issue, Run, Status
 
 MAX_MODEL_DISPLAY_WIDTH = 18
 
@@ -96,6 +96,24 @@ def model_display_name(model: str, variant: str) -> str:
     return result
 
 
+
+
+def format_diff_number(value: int) -> str:
+    """Format a diff number, abbreviating large values.
+    
+    Examples:
+        0 -> "0"
+        99 -> "99"
+        1234 -> "1.2k"
+        12345 -> "12.3k"
+    """
+    if value < 1000:
+        return str(value)
+    elif value < 10000:
+        return f"{value / 1000:.1f}k"
+    else:
+        return f"{value // 1000}k"
+
 class CursorPreservingTable(DataTable):
     """DataTable that preserves cursor position across repopulation."""
 
@@ -167,7 +185,17 @@ class CursorPreservingTable(DataTable):
 class RunTable(CursorPreservingTable):
     """Table widget for displaying runs."""
 
-    def populate(self, runs: list[Run]) -> None:
+    def populate(
+        self,
+        runs: list[Run],
+        diff_stats: Optional[dict[str, DiffStats]] = None,
+    ) -> None:
+        """Populate the run table with run data.
+        
+        Args:
+            runs: List of runs to display.
+            diff_stats: Optional dict mapping run.ref() to DiffStats for diff columns.
+        """
         saved_key, saved_index = self._save_cursor_state()
 
         self.clear(columns=True)
@@ -177,9 +205,13 @@ class RunTable(CursorPreservingTable):
         self.add_column("Status", width=12)
         self.add_column("Agent", width=10)
         self.add_column("Model", width=18)
+        self.add_column("+", width=6)
+        self.add_column("-", width=6)
         self.add_column("Mux", width=4)
         self.add_column("Elapsed", width=10, key="elapsed")
         self.add_column("Branch", width=20)
+
+        diff_stats = diff_stats or {}
 
         for run in runs:
             status_str = run.status.value
@@ -198,12 +230,23 @@ class RunTable(CursorPreservingTable):
             mux = run.multiplexer or "tmux"
             mux_short = "zj" if mux == "zellij" else "tx"
 
+            # Format diff stats with color coding
+            stats = diff_stats.get(run.ref())
+            if stats:
+                add_str = f"[green]+{format_diff_number(stats.total_additions)}[/green]"
+                del_str = f"[red]-{format_diff_number(stats.total_deletions)}[/red]"
+            else:
+                add_str = "-"
+                del_str = "-"
+
             self.add_row(
                 run.short_id(),
                 run.issue_id,
                 status_str,
                 run.agent or "-",
                 model_str,
+                add_str,
+                del_str,
                 mux_short,
                 run.elapsed_time(),
                 run.branch or "-",

--- a/orch-monitor-tui/tests/test_widgets.py
+++ b/orch-monitor-tui/tests/test_widgets.py
@@ -15,6 +15,7 @@ from orch_monitor.widgets import (
     DetailPanel,
     shorten_model_name,
     model_display_name,
+    format_diff_number,
 )
 
 
@@ -86,6 +87,36 @@ class TestModelDisplayName:
         result = model_display_name("claude-3-5-sonnet", "max")
         assert "/" in result
         assert "max" in result
+
+
+
+
+class TestFormatDiffNumber:
+    """Tests for diff number formatting helper."""
+
+    def test_zero(self):
+        """Test formatting zero."""
+        assert format_diff_number(0) == "0"
+
+    def test_small_number(self):
+        """Test small numbers (< 1000)."""
+        assert format_diff_number(99) == "99"
+        assert format_diff_number(500) == "500"
+        assert format_diff_number(999) == "999"
+
+    def test_thousands(self):
+        """Test numbers in thousands."""
+        assert format_diff_number(1000) == "1.0k"
+        assert format_diff_number(1234) == "1.2k"
+        assert format_diff_number(5678) == "5.7k"
+        assert format_diff_number(9999) == "10.0k"
+
+    def test_large_thousands(self):
+        """Test large numbers (>= 10000)."""
+        assert format_diff_number(10000) == "10k"
+        assert format_diff_number(12345) == "12k"
+        assert format_diff_number(99999) == "99k"
+        assert format_diff_number(100000) == "100k"
 
 
 # ============================================================================
@@ -243,6 +274,36 @@ class TestRunTableWidget:
             # Table should have rows - visual verification of colors
             # would need snapshot tests
             assert table.row_count > 0
+
+    async def test_run_table_with_diff_stats(self, sample_runs):
+        """Test that RunTable displays diff stats correctly."""
+        from textual.app import App, ComposeResult
+        from orch_monitor.models import DiffStats
+
+        class TestApp(App):
+            def compose(self) -> ComposeResult:
+                yield RunTable(id="test-table")
+
+        app = TestApp()
+        async with app.run_test() as pilot:
+            table = app.query_one("#test-table", RunTable)
+            
+            # Create diff stats for first run
+            diff_stats = {
+                sample_runs[0].ref(): DiffStats(
+                    files=[],
+                    total_additions=142,
+                    total_deletions=37,
+                )
+            }
+            
+            table.populate(sample_runs, diff_stats=diff_stats)
+            await pilot.pause()
+
+            # Table should have rows with diff columns
+            assert table.row_count == len(sample_runs)
+            # The + and - columns are now included (visual verification via snapshot tests)
+
 
 
 class TestIssueTableWidget:


### PR DESCRIPTION
## Summary
- Add `+` and `-` columns to the orch-monitor run list showing git diff stats
- Color code values: green for insertions, red for deletions
- Abbreviate large numbers (e.g., `1234` → `1.2k`)
- Shows `-` when no worktree exists or no changes

## UI Preview
```
ID      ISSUE     STATUS   AGENT       MODEL    +      -      Mux  ELAPSED  BRANCH
532e60  orch-309  running  oc:opus4.5  sonnet   +142   -37    tx   5h ago   feature/foo
```

## Changes
- `widgets.py`: Add `format_diff_number()` helper, update `RunTable.populate()` to accept optional `diff_stats` parameter
- `app.py`: Collect diff stats for all runs and pass to table
- `test_widgets.py`: Add tests for new helper and RunTable diff stats display

## Acceptance Criteria
- [x] Run list shows insertions column (`+`)
- [x] Run list shows deletions column (`-`)
- [x] Numbers are color coded (green/red)
- [x] Works for runs with existing worktrees
- [x] Shows `-` for runs without changes
- [x] Performance acceptable (uses existing cached `_get_git_diff_stats()` with 30s TTL)

Resolves: orch-313