### PR TITLE
fix(send): pass IssuesRoot to daemon for store resolution

### DIFF
--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -90,7 +90,7 @@ func runSend(refStr, message string, opts *sendOptions) error {
 	}
 
 	if isOpenCode && daemon.IsDaemonSocketAvailable(projectRoot) {
-		err = daemon.SendViaDaemon(projectRoot, run, message, opts.NoEnter)
+		err = daemon.SendViaDaemon(projectRoot, st.RootPath(), run, message, opts.NoEnter)
 		if err != nil {
 			if globalOpts.JSON {
 				result := map[string]interface{}{

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -687,7 +687,7 @@ func (s *SocketServer) handleGetIssue(req SendRequest, encoder *json.Encoder) {
 	})
 }
 
-func SendViaDaemon(projectRoot string, run *model.Run, message string, noEnter bool) error {
+func SendViaDaemon(projectRoot, issuesRoot string, run *model.Run, message string, noEnter bool) error {
 	socketPath := xdg.SocketPath()
 
 	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
@@ -705,6 +705,7 @@ func SendViaDaemon(projectRoot string, run *model.Run, message string, noEnter b
 		Message:     message,
 		NoEnter:     noEnter,
 		ProjectRoot: projectRoot,
+		IssuesRoot:  issuesRoot,
 	}
 
 	encoder := json.NewEncoder(conn)


### PR DESCRIPTION
## Summary

Follow-up fix to PR #313 (orch-310). `SendViaDaemon` was not passing `IssuesRoot` to the daemon, causing "no store available" errors after daemon restart.

## Problem

After merging PR #313, E2E testing revealed that `orch send` failed with:
```
error: daemon error: no store available for project
```

This happened because `SendViaDaemon` only passed `projectRoot` but not `issuesRoot`. When the daemon restarted, it couldn't resolve the store without `issuesRoot`.

## Fix

- Update `SendViaDaemon` signature to accept `issuesRoot` parameter
- Pass `st.RootPath()` from CLI to daemon
- Include `IssuesRoot` in the `SendRequest`

## E2E Verified

```bash
$ orch send 4dcf4d "test ping from orch-310 fix"
Sent message to orch-315#20260119-211145

# Agent confirmed receipt:
"Received the ping from orch-310. The test message came through successfully."
```

Fixes: orch-310 (complete fix)