### PR TITLE
fix(send): align client/daemon timeouts to prevent false timeout errors

### DIFF
--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -424,7 +424,7 @@ func (s *SocketServer) processSend(req SendRequest) error {
 
 	client := agent.NewOpenCodeClient(run.ServerPort)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	err = client.SendMessagePrompt(ctx, run.OpenCodeSessionID, req.Message, run.WorktreePath)
@@ -696,7 +696,7 @@ func SendViaDaemon(projectRoot, issuesRoot string, run *model.Run, message strin
 	}
 	defer conn.Close()
 
-	conn.SetDeadline(time.Now().Add(10 * time.Second))
+	conn.SetDeadline(time.Now().Add(35 * time.Second))
 
 	req := SendRequest{
 		Type:        "send",


### PR DESCRIPTION
## Problem

`orch send` reports timeout error even though message was successfully sent:
```
error: failed to read response: read unix ->...daemon.sock: i/o timeout
```

## Root Cause

Timeout mismatch:
- Client deadline: **10 seconds**
- Daemon processSend: **10 minutes**

If OpenCode API takes >10s to respond, client times out before daemon can return OK.

## Fix

- Daemon processSend timeout: 10min → **30s** (reasonable for message send)
- Client deadline: 10s → **35s** (wait for daemon response)

## Related

- Completes fix for orch-310
- Issue identified during Oracle code review