### PR TITLE
feat(cli): add orch skill export command for agent integration

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -55,6 +55,7 @@ var noDaemonCommands = map[string]bool{
 	"query":      true,
 	"q":          true,
 	"schema":     true,
+	"skill":     true,
 	"tutorial":   true,
 }
 // rootCmd represents the base command
@@ -112,6 +113,7 @@ func init() {
 	rootCmd.AddCommand(newDebugCmd())
 	rootCmd.AddCommand(newQueryCmd())
 	rootCmd.AddCommand(newSchemaCmd())
+	rootCmd.AddCommand(newSkillCmd())
 	rootCmd.AddCommand(newTutorialCmd())
 }
 

--- a/internal/cli/skill.go
+++ b/internal/cli/skill.go
@@ -1,0 +1,223 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/s22625/orch/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newSkillCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "skill",
+		Short: "Manage orch skill packages for LLM agents",
+		Long: `Manage skill packages that teach LLM agents (OpenCode, Claude, Codex) how to use orch.
+
+Use 'orch skill export' to export a skill package to a directory.`,
+	}
+
+	cmd.AddCommand(newSkillExportCmd())
+
+	return cmd
+}
+
+func newSkillExportCmd() *cobra.Command {
+	var stdout bool
+
+	cmd := &cobra.Command{
+		Use:   "export <dir>",
+		Short: "Export orch skill package for LLM agents",
+		Long: `Export a skill package that teaches LLM agents how to use orch.
+
+The exported skill directory can be installed for:
+  - OpenCode: ~/.config/opencode/skills/orch/ or .opencode/skills/orch/
+  - Claude Code: ~/.claude/skills/orch/ or .claude/skills/orch/
+  - Codex: ~/.codex/skills/orch/ or .codex/skills/orch/
+
+Examples:
+  # Export to OpenCode global skills
+  orch skill export ~/.config/opencode/skills/orch/
+
+  # Export to Claude Code global skills
+  orch skill export ~/.claude/skills/orch/
+
+  # Export to project-local skills
+  orch skill export .opencode/skills/orch/
+
+  # Export concatenated content to stdout for piping
+  orch skill export --stdout`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			stdout, _ := cmd.Flags().GetBool("stdout")
+			if stdout {
+				return nil
+			}
+			if len(args) < 1 {
+				return fmt.Errorf("requires directory argument (or use --stdout)")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if stdout {
+				return exportToStdout()
+			}
+			return exportToDir(args[0])
+		},
+	}
+
+	cmd.Flags().BoolVar(&stdout, "stdout", false, "Export concatenated content to stdout for piping")
+
+	return cmd
+}
+
+func exportToDir(dir string) error {
+	// Expand ~ in path
+	if strings.HasPrefix(dir, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
+		dir = filepath.Join(home, dir[1:])
+	}
+
+	// Make path absolute
+	if !filepath.IsAbs(dir) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current directory: %w", err)
+		}
+		dir = filepath.Join(cwd, dir)
+	}
+
+	// Create directory
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// Get dynamic config for config.md
+	configContent := generateConfigContent()
+
+	// Write all skill files
+	files := map[string]string{
+		"SKILL.md":           skillMainContent,
+		"commands.md":        skillCommandsContent,
+		"workflows.md":       skillWorkflowsContent,
+		"troubleshooting.md": skillTroubleshootingContent,
+		"config.md":          configContent,
+	}
+
+	for filename, content := range files {
+		path := filepath.Join(dir, filename)
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			return fmt.Errorf("failed to write %s: %w", filename, err)
+		}
+		fmt.Printf("Created %s\n", path)
+	}
+
+	fmt.Printf("\nSkill package exported to: %s\n", dir)
+	fmt.Println("\nInstallation paths for each agent:")
+	fmt.Println("  OpenCode:    ~/.config/opencode/skills/orch/ or .opencode/skills/orch/")
+	fmt.Println("  Claude Code: ~/.claude/skills/orch/ or .claude/skills/orch/")
+	fmt.Println("  Codex:       ~/.codex/skills/orch/ or .codex/skills/orch/")
+
+	return nil
+}
+
+func exportToStdout() error {
+	configContent := generateConfigContent()
+
+	// Concatenate all content with separators
+	fmt.Print(skillMainContent)
+	fmt.Print("\n---\n\n")
+	fmt.Print(skillCommandsContent)
+	fmt.Print("\n---\n\n")
+	fmt.Print(skillWorkflowsContent)
+	fmt.Print("\n---\n\n")
+	fmt.Print(skillTroubleshootingContent)
+	fmt.Print("\n---\n\n")
+	fmt.Print(configContent)
+
+	return nil
+}
+
+func generateConfigContent() string {
+	var sb strings.Builder
+
+	sb.WriteString(skillConfigHeader)
+
+	// Try to load current repo's config
+	cfg, err := config.Load()
+	if err == nil {
+		sb.WriteString("\n## Current Repository Configuration\n\n")
+		sb.WriteString("The following shows the detected configuration for this repository:\n\n")
+		sb.WriteString("```yaml\n")
+
+		if cfg.Agent != "" {
+			sb.WriteString(fmt.Sprintf("agent: %s\n", cfg.Agent))
+		}
+		if cfg.Model != "" {
+			sb.WriteString(fmt.Sprintf("model: %s\n", cfg.Model))
+		}
+		if cfg.ModelVariant != "" {
+			sb.WriteString(fmt.Sprintf("model_variant: %s\n", cfg.ModelVariant))
+		}
+		if cfg.WorktreeDir != "" {
+			sb.WriteString(fmt.Sprintf("worktree_dir: %s\n", cfg.WorktreeDir))
+		}
+		if cfg.BaseBranch != "" {
+			sb.WriteString(fmt.Sprintf("base_branch: %s\n", cfg.BaseBranch))
+		}
+		if cfg.PRTargetBranch != "" {
+			sb.WriteString(fmt.Sprintf("pr_target_branch: %s\n", cfg.PRTargetBranch))
+		}
+		if cfg.DefaultPreset != "" {
+			sb.WriteString(fmt.Sprintf("default_preset: %s\n", cfg.DefaultPreset))
+		}
+		if cfg.Multiplexer != "" {
+			sb.WriteString(fmt.Sprintf("multiplexer: %s\n", cfg.Multiplexer))
+		}
+		if cfg.NoPR {
+			sb.WriteString("no_pr: true\n")
+		}
+
+		// Show presets if configured
+		presets := cfg.GetAllPresets()
+		if len(presets) > 0 {
+			sb.WriteString("\npresets:\n")
+			for _, p := range presets {
+				sb.WriteString(fmt.Sprintf("  - name: %s\n", p.Name))
+				if p.Backend != "" && p.Backend != "opencode" {
+					sb.WriteString(fmt.Sprintf("    backend: %s\n", p.Backend))
+				}
+				if p.Model != "" {
+					sb.WriteString(fmt.Sprintf("    model: %s\n", p.Model))
+				}
+				if p.Variant != "" {
+					sb.WriteString(fmt.Sprintf("    variant: %s\n", p.Variant))
+				}
+				if p.Profile != "" {
+					sb.WriteString(fmt.Sprintf("    profile: %s\n", p.Profile))
+				}
+			}
+		}
+
+		// Show issues config
+		if cfg.Issues.Backend != "" || cfg.Issues.Path != "" {
+			sb.WriteString("\nissues:\n")
+			if cfg.Issues.Backend != "" {
+				sb.WriteString(fmt.Sprintf("  backend: %s\n", cfg.Issues.Backend))
+			}
+			if cfg.Issues.Path != "" {
+				sb.WriteString(fmt.Sprintf("  path: %s\n", cfg.Issues.Path))
+			}
+		}
+
+		sb.WriteString("```\n")
+	}
+
+	sb.WriteString(skillConfigFooter)
+
+	return sb.String()
+}

--- a/internal/cli/skill_content.go
+++ b/internal/cli/skill_content.go
@@ -1,0 +1,905 @@
+package cli
+
+const skillMainContent = `---
+name: orch
+description: Orchestrator for managing multiple LLM agents working on issues
+---
+
+# Orch - Multi-Agent Orchestrator
+
+Orch is a command-line orchestrator for managing multiple LLM CLI agents (OpenCode, Claude, Codex, Gemini) using a unified vocabulary of issue/run/event.
+
+## Quick Start
+
+1. **Start work on an issue:**
+` + "```" + `bash
+   orch run my-issue-id
+` + "```" + `
+
+2. **Check status of all runs:**
+` + "```" + `bash
+   orch ps
+` + "```" + `
+
+3. **Interact with a running agent:**
+` + "```" + `bash
+   orch attach my-issue-id
+   # Or use short ID from 'orch ps':
+   orch attach a3b4
+` + "```" + `
+
+## Key Concepts
+
+- **Issue**: A task or problem to work on (stored as markdown files)
+- **Run**: An agent session working on an issue
+- **Event**: State changes during a run (started, blocked, done, etc.)
+
+## Skill Files
+
+This skill package includes:
+- **commands.md**: Complete command reference
+- **workflows.md**: Common usage patterns
+- **troubleshooting.md**: Debugging and repair
+- **config.md**: Configuration options
+
+## Common Commands
+
+| Command | Purpose |
+|---------|---------|
+| ` + "`orch run <issue>`" + ` | Start work on an issue |
+| ` + "`orch ps`" + ` | List all runs and their status |
+| ` + "`orch attach <run>`" + ` | Interact with running agent |
+| ` + "`orch monitor`" + ` | TUI dashboard for all runs |
+| ` + "`orch stop <issue>`" + ` | Stop all runs for an issue |
+| ` + "`orch continue <run>`" + ` | Resume a paused/blocked run |
+| ` + "`orch repair`" + ` | Fix daemon/orphaned sessions |
+`
+
+const skillCommandsContent = `# Orch Command Reference
+
+## Run Management
+
+### orch run
+Start a new run on an issue.
+
+` + "```" + `bash
+# Basic usage
+orch run my-issue
+
+# With specific agent
+orch run my-issue --agent claude
+
+# With model preset
+orch run my-issue --preset opus:max
+
+# With custom prompt
+orch run my-issue --prompt "Focus on tests"
+
+# Without creating a PR
+orch run my-issue --no-pr
+
+# Using existing worktree
+orch run my-issue --worktree /path/to/worktree
+` + "```" + `
+
+### orch ps
+List all runs with their status.
+
+` + "```" + `bash
+# Default output
+orch ps
+
+# JSON output
+orch ps --json
+
+# TSV output (for fzf/scripting)
+orch ps --tsv
+
+# Filter by status
+orch ps --status running
+orch ps --status blocked
+
+# Filter by issue
+orch ps --issue my-issue
+` + "```" + `
+
+### orch attach
+Attach to a running agent session.
+
+` + "```" + `bash
+# By issue ID
+orch attach my-issue
+
+# By run reference
+orch attach my-issue#20231220-100000
+
+# By short ID (2-6 hex chars)
+orch attach a3
+orch attach a3b4c5
+` + "```" + `
+
+### orch stop
+Stop runs for an issue.
+
+` + "```" + `bash
+# Stop all runs for an issue
+orch stop my-issue
+
+# Stop specific run
+orch stop my-issue#20231220-100000
+
+# Stop by short ID
+orch stop a3b4
+` + "```" + `
+
+### orch continue
+Resume a paused or blocked run.
+
+` + "```" + `bash
+# Continue with default behavior
+orch continue my-issue
+
+# Continue with a message
+orch continue my-issue --message "Please proceed"
+
+# Continue specific run
+orch continue my-issue#20231220-100000
+` + "```" + `
+
+### orch send
+Send a message to a running agent.
+
+` + "```" + `bash
+# Send message
+orch send my-issue "Please also add tests"
+
+# Send to specific run
+orch send my-issue#20231220-100000 "Focus on error handling"
+` + "```" + `
+
+### orch exec
+Execute a command in a run's worktree.
+
+` + "```" + `bash
+# Run a command
+orch exec my-issue -- make test
+
+# Run in specific run
+orch exec my-issue#20231220-100000 -- npm run build
+` + "```" + `
+
+## Issue Management
+
+### orch issue create
+Create a new issue.
+
+` + "```" + `bash
+# Basic creation
+orch issue create my-new-issue --title "Add feature X" --body "Description"
+
+# From file
+orch issue create my-issue --file issue.md
+` + "```" + `
+
+### orch issue list
+List all issues.
+
+` + "```" + `bash
+orch issue list
+orch issue list --json
+orch issue list --status open
+` + "```" + `
+
+### orch show
+Show issue or run details.
+
+` + "```" + `bash
+# Show issue
+orch show my-issue
+
+# Show run details
+orch show my-issue#20231220-100000
+
+# Show by short ID
+orch show a3b4
+` + "```" + `
+
+### orch open
+Open issue or run in browser/editor.
+
+` + "```" + `bash
+# Open issue
+orch open my-issue
+
+# Open run's PR
+orch open a3b4 --pr
+` + "```" + `
+
+## Monitoring
+
+### orch monitor
+Launch TUI dashboard.
+
+` + "```" + `bash
+orch monitor
+` + "```" + `
+
+Key bindings:
+- ` + "`j/k`" + `: Navigate up/down
+- ` + "`Enter`" + `: Attach to selected run
+- ` + "`s`" + `: Stop selected run
+- ` + "`c`" + `: Continue blocked run
+- ` + "`r`" + `: Refresh
+- ` + "`q`" + `: Quit
+
+### orch capture
+Capture agent session to markdown.
+
+` + "```" + `bash
+# Capture run
+orch capture my-issue
+
+# Capture with output path
+orch capture my-issue --output session.md
+
+# Capture all completed runs
+orch capture-all
+` + "```" + `
+
+## Daemon Management
+
+### orch daemon
+Manage the orch daemon.
+
+` + "```" + `bash
+# Check status
+orch daemon status
+
+# Start daemon
+orch daemon start
+
+# Stop daemon
+orch daemon stop
+
+# Restart daemon
+orch daemon restart
+` + "```" + `
+
+### orch repair
+Fix common issues with daemon and sessions.
+
+` + "```" + `bash
+# Repair all issues
+orch repair
+
+# Dry run
+orch repair --dry-run
+` + "```" + `
+
+## Query and Debug
+
+### orch query
+Query runs with SQL.
+
+` + "```" + `bash
+# List running runs
+orch query "SELECT * FROM runs WHERE status = 'running'"
+
+# Count runs by issue
+orch query "SELECT issue_id, count(*) FROM runs GROUP BY issue_id"
+
+# Find recent runs
+orch query "SELECT * FROM runs ORDER BY updated_at DESC LIMIT 10"
+` + "```" + `
+
+### orch log
+View run logs.
+
+` + "```" + `bash
+orch log my-issue
+orch log a3b4
+` + "```" + `
+
+### orch debug
+Show internal state for debugging.
+
+` + "```" + `bash
+orch debug my-issue
+orch debug a3b4
+` + "```" + `
+
+### orch schema
+Show database schema for queries.
+
+` + "```" + `bash
+orch schema
+` + "```" + `
+
+## Utility Commands
+
+### orch resolve
+Mark a run as resolved (acknowledged).
+
+` + "```" + `bash
+orch resolve my-issue
+orch resolve a3b4
+` + "```" + `
+
+### orch delete
+Delete runs or issues.
+
+` + "```" + `bash
+# Delete specific run
+orch delete run my-issue#20231220-100000
+
+# Delete all runs for an issue
+orch delete runs my-issue
+
+# Delete issue and all its runs
+orch delete issue my-issue
+` + "```" + `
+
+### orch models
+List available models (requires opencode server).
+
+` + "```" + `bash
+orch models
+` + "```" + `
+
+### orch notify
+Send test notification.
+
+` + "```" + `bash
+orch notify "Test message"
+` + "```" + `
+`
+
+const skillWorkflowsContent = `# Orch Workflows
+
+## Starting a New Task
+
+### 1. Create or locate the issue
+` + "```" + `bash
+# Create a new issue
+orch issue create my-feature --title "Implement feature X" --body "Details..."
+
+# Or list existing issues
+orch issue list
+` + "```" + `
+
+### 2. Start a run
+` + "```" + `bash
+# Start with default agent
+orch run my-feature
+
+# Or with specific preset
+orch run my-feature --preset opus:max
+` + "```" + `
+
+### 3. Monitor progress
+` + "```" + `bash
+# Check status
+orch ps
+
+# Or use TUI dashboard
+orch monitor
+` + "```" + `
+
+### 4. Interact if needed
+` + "```" + `bash
+# Attach to provide guidance
+orch attach my-feature
+
+# Or send a message
+orch send my-feature "Please add error handling"
+` + "```" + `
+
+## Handling Blocked Runs
+
+When a run status shows "blocked", the agent needs input:
+
+### 1. Check why it's blocked
+` + "```" + `bash
+orch show my-feature
+` + "```" + `
+
+### 2. Provide input
+` + "```" + `bash
+# Attach and interact
+orch attach my-feature
+
+# Or send a message and continue
+orch send my-feature "Here's the answer to your question"
+orch continue my-feature
+` + "```" + `
+
+## Multi-Agent Orchestration
+
+### Running multiple issues in parallel
+` + "```" + `bash
+# Start runs on different issues
+orch run feature-a
+orch run feature-b
+orch run bugfix-c
+
+# Monitor all runs
+orch monitor
+` + "```" + `
+
+### Using different agents for different tasks
+` + "```" + `bash
+# Use Claude for documentation
+orch run docs-update --agent claude
+
+# Use Codex for complex algorithms
+orch run algorithm-impl --agent codex
+
+# Use OpenCode with max settings for architecture
+orch run architecture-design --preset opus:max
+` + "```" + `
+
+## PR Review Flow
+
+### 1. Wait for completion
+` + "```" + `bash
+# Check status
+orch ps --status done
+
+# Show details including PR link
+orch show my-feature
+` + "```" + `
+
+### 2. Review the PR
+` + "```" + `bash
+# Open PR in browser
+orch open my-feature --pr
+` + "```" + `
+
+### 3. Request changes if needed
+` + "```" + `bash
+# Continue the run with feedback
+orch continue my-feature --message "Please address review comments"
+` + "```" + `
+
+### 4. Mark as resolved
+` + "```" + `bash
+orch resolve my-feature
+` + "```" + `
+
+## Capturing Sessions
+
+### Capture for documentation
+` + "```" + `bash
+# Capture a completed run
+orch capture my-feature --output feature-session.md
+
+# Capture all completed runs
+orch capture-all
+` + "```" + `
+
+## Working with Worktrees
+
+### Use existing worktree
+` + "```" + `bash
+# Point to existing worktree
+orch run my-feature --worktree /path/to/worktree
+` + "```" + `
+
+### Configure default worktree directory
+In ` + "`.orch/config.yaml`" + `:
+` + "```" + `yaml
+worktree_dir: ~/.git-worktrees
+` + "```" + `
+
+## Querying Run History
+
+### Find all runs for an issue
+` + "```" + `bash
+orch query "SELECT * FROM runs WHERE issue_id = 'my-feature'"
+` + "```" + `
+
+### Find failed runs
+` + "```" + `bash
+orch query "SELECT * FROM runs WHERE status = 'failed'"
+` + "```" + `
+
+### Get run statistics
+` + "```" + `bash
+orch query "SELECT status, count(*) FROM runs GROUP BY status"
+` + "```" + `
+`
+
+const skillTroubleshootingContent = `# Orch Troubleshooting
+
+## Common Issues
+
+### Run stuck in "running" but agent not responding
+
+**Symptoms:**
+- ` + "`orch ps`" + ` shows "running" status
+- ` + "`orch attach`" + ` shows no activity
+
+**Solution:**
+` + "```" + `bash
+# Try repair first
+orch repair
+
+# If still stuck, stop and restart
+orch stop my-issue
+orch run my-issue
+` + "```" + `
+
+### Daemon not responding
+
+**Symptoms:**
+- Commands hang or timeout
+- "daemon not running" errors
+
+**Solution:**
+` + "```" + `bash
+# Check daemon status
+orch daemon status
+
+# Restart daemon
+orch daemon restart
+
+# If restart fails, kill and start fresh
+pkill -f "orch daemon"
+orch daemon start
+` + "```" + `
+
+### Orphaned tmux sessions
+
+**Symptoms:**
+- tmux sessions exist but orch doesn't know about them
+- "session already exists" errors
+
+**Solution:**
+` + "```" + `bash
+# Run repair to clean up
+orch repair
+
+# Or manually list and kill tmux sessions
+tmux list-sessions
+tmux kill-session -t orch-my-issue-20231220-100000
+` + "```" + `
+
+### Worktree conflicts
+
+**Symptoms:**
+- "worktree already exists" errors
+- Can't start new runs
+
+**Solution:**
+` + "```" + `bash
+# List git worktrees
+git worktree list
+
+# Remove stale worktrees
+git worktree remove /path/to/worktree --force
+
+# Then run repair
+orch repair
+` + "```" + `
+
+### Run shows wrong status
+
+**Symptoms:**
+- Status doesn't match actual agent state
+- Run shows "running" but agent exited
+
+**Solution:**
+` + "```" + `bash
+# Repair will detect and fix state mismatches
+orch repair
+
+# Check debug info
+orch debug my-issue
+` + "```" + `
+
+## Using orch repair
+
+The ` + "`orch repair`" + ` command fixes common issues:
+
+` + "```" + `bash
+# Run repair
+orch repair
+
+# See what would be fixed without making changes
+orch repair --dry-run
+` + "```" + `
+
+**What repair fixes:**
+- Orphaned tmux sessions
+- Stale run states
+- Daemon connectivity issues
+- Worktree inconsistencies
+
+## Debug Commands
+
+### View internal state
+` + "```" + `bash
+orch debug my-issue
+` + "```" + `
+
+### View run logs
+` + "```" + `bash
+orch log my-issue
+` + "```" + `
+
+### Query database directly
+` + "```" + `bash
+# See all data
+orch query "SELECT * FROM runs"
+
+# Find problematic runs
+orch query "SELECT * FROM runs WHERE status = 'running' AND updated_at < datetime('now', '-1 hour')"
+` + "```" + `
+
+### Check database schema
+` + "```" + `bash
+orch schema
+` + "```" + `
+
+## Getting Help
+
+### View tutorial
+` + "```" + `bash
+orch tutorial
+` + "```" + `
+
+### Command help
+` + "```" + `bash
+orch --help
+orch run --help
+orch ps --help
+` + "```" + `
+
+## Recovery Procedures
+
+### Complete reset (last resort)
+
+If nothing else works:
+
+` + "```" + `bash
+# Stop all runs
+orch stop --all
+
+# Kill daemon
+orch daemon stop
+
+# Kill any remaining tmux sessions
+tmux kill-server
+
+# Clear state (careful - loses run history)
+rm -rf ~/.local/share/orch/runs/*
+
+# Restart
+orch daemon start
+` + "```" + `
+
+### Recovering a run's work
+
+If a run failed but has useful changes:
+
+` + "```" + `bash
+# Find the worktree
+orch show my-issue
+
+# Navigate to worktree and commit changes manually
+cd /path/to/worktree
+git status
+git add .
+git commit -m "WIP: changes from failed run"
+git push origin my-issue
+` + "```" + `
+`
+
+const skillConfigHeader = `# Orch Configuration
+
+## Configuration File
+
+Orch uses ` + "`.orch/config.yaml`" + ` in your project root for configuration.
+
+## Configuration Precedence
+
+1. Command-line flags (highest)
+2. Repo-local ` + "`.orch/config.yaml`" + `
+3. Parent directory ` + "`.orch/config.yaml`" + ` files
+4. Environment variables
+5. Global ` + "`~/.config/orch/config.yaml`" + ` (lowest)
+
+## Basic Configuration
+
+` + "```" + `yaml
+# Default agent (opencode, claude, codex, gemini)
+agent: opencode
+
+# Default model and variant for opencode
+opencode:
+  default_model: anthropic/claude-opus-4-5
+  default_variant: max
+
+# Where to store git worktrees
+worktree_dir: ~/.git-worktrees
+
+# Base branch for creating feature branches
+base_branch: main
+
+# Target branch for PRs
+pr_target_branch: main
+
+# Skip PR creation
+no_pr: false
+
+# Terminal multiplexer (tmux or zellij)
+multiplexer: tmux
+` + "```" + `
+
+## Presets
+
+Define reusable model configurations:
+
+` + "```" + `yaml
+presets:
+  - name: opus:max
+    backend: opencode
+    model: anthropic/claude-opus-4-5
+    variant: max
+
+  - name: sonnet:high
+    backend: opencode
+    model: anthropic/claude-sonnet-4
+    variant: high
+
+  - name: claude-direct
+    backend: claude
+    profile: default
+
+default_preset: opus:max
+` + "```" + `
+
+Use presets with:
+` + "```" + `bash
+orch run my-issue --preset opus:max
+` + "```" + `
+
+## Issues Configuration
+
+` + "```" + `yaml
+issues:
+  # Backend: local (file-based) or github
+  backend: local
+  
+  # Path to issues storage
+  path: ~/my-project-issues
+` + "```" + `
+
+Or use environment variable:
+` + "```" + `bash
+export ORCH_ISSUES_ROOT=~/my-project-issues
+` + "```" + `
+
+## GitHub Backend
+
+` + "```" + `yaml
+issues:
+  backend: github
+
+github:
+  owner: myorg
+  repo: myrepo
+  label_filter: orch  # Only sync issues with this label
+  poll_interval: 300  # Seconds between syncs
+` + "```" + `
+
+## Monitor Configuration
+
+` + "```" + `yaml
+monitor:
+  ps_columns:
+    - index
+    - id
+    - issue
+    - agent
+    - status
+    - branch
+    - pr
+    - updated
+` + "```" + `
+
+## Slack Notifications
+
+` + "```" + `yaml
+slack:
+  enabled: true
+  webhook_url: https://hooks.slack.com/services/xxx
+  # Or use bot token:
+  # bot_token: xoxb-xxx
+  # channel: "#orch-notifications"
+  notify_on:
+    - blocked
+    - done
+    - failed
+` + "```" + `
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| ` + "`ORCH_ISSUES_ROOT`" + ` | Path to issues storage |
+| ` + "`ORCH_PROJECT_ROOT`" + ` | Project root (where .orch/ lives) |
+| ` + "`ORCH_AGENT`" + ` | Default agent |
+| ` + "`ORCH_MODEL`" + ` | Default model |
+| ` + "`ORCH_MODEL_VARIANT`" + ` | Default model variant |
+| ` + "`ORCH_WORKTREE_DIR`" + ` | Worktree directory |
+| ` + "`ORCH_BASE_BRANCH`" + ` | Base branch |
+| ` + "`ORCH_PR_TARGET_BRANCH`" + ` | PR target branch |
+| ` + "`ORCH_DEFAULT_PRESET`" + ` | Default preset |
+| ` + "`ORCH_MULTIPLEXER`" + ` | Terminal multiplexer |
+| ` + "`ORCH_LOG_LEVEL`" + ` | Log level (error/warn/info/debug) |
+`
+
+const skillConfigFooter = `
+
+## Prompt Templates
+
+Customize the prompt sent to agents:
+
+` + "```" + `yaml
+# Global prompt template
+prompt_template: |
+  Please read 'ORCH_PROMPT.md' in the current directory and follow the instructions found there.
+
+# Agent-specific templates
+opencode:
+  prompt_template: |
+    Custom prompt for opencode...
+
+claude:
+  prompt_template: |
+    Custom prompt for claude...
+` + "```" + `
+
+## Agent-Specific Configuration
+
+### OpenCode
+` + "```" + `yaml
+opencode:
+  default_model: anthropic/claude-opus-4-5
+  default_variant: max
+  prompt_template: |
+    Custom opencode prompt...
+` + "```" + `
+
+### Claude
+` + "```" + `yaml
+claude:
+  prompt_template: |
+    Custom claude prompt...
+` + "```" + `
+
+### Codex
+` + "```" + `yaml
+codex:
+  prompt_template: |
+    Custom codex prompt...
+` + "```" + `
+
+### Gemini
+` + "```" + `yaml
+gemini:
+  prompt_template: |
+    Custom gemini prompt...
+` + "```" + `
+
+## Control Agent
+
+Configure the agent used for orch monitor's control features:
+
+` + "```" + `yaml
+control_agent: opencode
+control_model: anthropic/claude-sonnet-4
+control_model_variant: high
+` + "```" + `
+`

--- a/internal/cli/tutorial.go
+++ b/internal/cli/tutorial.go
@@ -17,7 +17,8 @@ This tutorial covers:
   - Agent and model configuration
   - Basic workflow commands
   - Run statuses and what they mean
-  - Troubleshooting tips`,
+  - Troubleshooting tips
+  - LLM agent skill installation`,
 		Run: func(cmd *cobra.Command, args []string) {
 			printTutorial()
 		},
@@ -177,6 +178,61 @@ Query runs with SQL:
 Capture all completed runs:
 
     orch capture-all
+
+--------------------------------------------------------------------------------
+8. LLM AGENT SKILL INSTALLATION
+--------------------------------------------------------------------------------
+
+Export orch skill package so your LLM agents know how to use orch:
+
+    orch skill export <directory>
+
+OPENCODE INSTALLATION:
+
+    Global:  orch skill export ~/.config/opencode/skills/orch/
+    Project: orch skill export .opencode/skills/orch/
+
+    Discovery paths (searched upward from cwd):
+    - .opencode/skills/<name>/SKILL.md
+    - .claude/skills/<name>/SKILL.md (Claude-compat)
+    - ~/.config/opencode/skills/<name>/SKILL.md
+    - ~/.claude/skills/<name>/SKILL.md (Claude-compat)
+
+CLAUDE CODE INSTALLATION:
+
+    Global:  orch skill export ~/.claude/skills/orch/
+    Project: orch skill export .claude/skills/orch/
+
+    Discovery paths:
+    - .claude/skills/<name>/SKILL.md
+    - ~/.claude/skills/<name>/SKILL.md
+
+    Also auto-loads CLAUDE.md from project root.
+
+CODEX (OPENAI) INSTALLATION:
+
+    Global:  orch skill export ~/.codex/skills/orch/
+    Project: orch skill export .codex/skills/orch/
+
+    Discovery paths:
+    - .codex/skills/<name>/SKILL.md
+    - ~/.codex/skills/<name>/SKILL.md
+
+    Also auto-loads AGENTS.md from project root.
+
+EXPORTED FILES:
+
+    orch/
+    ├── SKILL.md              # Main entry (frontmatter + overview)
+    ├── commands.md           # All orch commands reference
+    ├── workflows.md          # Common workflow patterns
+    ├── troubleshooting.md    # Repair, debugging, common issues
+    └── config.md             # Configuration options (includes current repo config)
+
+EXPORT TO STDOUT:
+
+    orch skill export --stdout | pbcopy  # Copy to clipboard
+    orch skill export --stdout > orch-skill.md  # Save to file
 
 ================================================================================
 For more information, see: https://github.com/s22625/orch


### PR DESCRIPTION
## Summary

- Adds `orch skill export <dir>` command for exporting skill packages that teach LLM agents how to use orch
- Exports a skill directory with multiple markdown files (SKILL.md, commands.md, workflows.md, troubleshooting.md, config.md)
- Includes dynamic config info from current repo in config.md
- Adds `--stdout` flag for piping concatenated content
- Updates `orch tutorial` with installation paths for OpenCode, Claude Code, and Codex

## Exported Files

```
orch/
├── SKILL.md              # Main entry (frontmatter + overview)
├── commands.md           # All orch commands reference
├── workflows.md          # Common workflow patterns
├── troubleshooting.md    # Repair, debugging, common issues
└── config.md             # Configuration options (includes current repo config)
```

## Usage

```bash
# Export to OpenCode global skills
orch skill export ~/.config/opencode/skills/orch/

# Export to Claude Code global skills
orch skill export ~/.claude/skills/orch/

# Export to project-local skills
orch skill export .opencode/skills/orch/

# Export concatenated content to stdout
orch skill export --stdout
```

## Testing

- All existing tests pass
- Manual testing confirms:
  - `orch skill --help` shows command documentation
  - `orch skill export <dir>` creates all expected files
  - `orch skill export --stdout` outputs concatenated content
  - `orch tutorial` shows skill installation instructions
  - Dynamic config is included in config.md

Closes: orch-319