### PR TITLE
fix(agent): use consistent API for OpenCode session detection

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -353,17 +353,21 @@ func (m *OpenCodeManager) hasRecentActivity(ctx context.Context, client *OpenCod
 }
 
 func (m *OpenCodeManager) sessionExists(ctx context.Context, client *OpenCodeClient) bool {
-	// Query without directory filter to get all sessions across projects.
-	// OpenCode scopes sessions by git root commit hash, not by exact directory path.
-	// When worktree path does not match OpenCode internal project resolution,
-	// the session will not be found if we filter by directory.
-	// Instead, we query all sessions and match by session ID which is unique.
-	statusMap, err := client.GetSessionStatus(ctx, "")
+	// Use GetSessions (same as IsAlive) to ensure consistent session detection.
+	// Previously used GetSessionStatus which queries a different endpoint (/session/status)
+	// that may return different results than /session, causing status to show "unknown"
+	// even when the session exists.
+	// See: https://github.com/s22625/orch/issues/323
+	sessions, err := client.GetSessions(ctx)
 	if err != nil {
 		return false
 	}
-	_, exists := statusMap[m.SessionID]
-	return exists
+	for _, s := range sessions {
+		if s.ID == m.SessionID {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *OpenCodeManager) SendMessage(ctx context.Context, run *model.Run, message string, opts *SendOptions) error {


### PR DESCRIPTION
## Summary

- Fixed status showing `unknown` when `worktree_dir` is commented out in config
- Changed `sessionExists()` to use `GetSessions()` API (same as `IsAlive()`) for consistent session detection

## Problem

When `worktree_dir` is commented out in `.orch/config.yaml`, runs showed `unknown` status even though:
- ALIVE = yes (session exists)
- PR = yes (work was done)

## Root Cause

The `sessionExists()` method used `GetSessionStatus()` which queries the `/session/status` endpoint, while `IsAlive()` uses `GetSessions()` which queries the `/session` endpoint. These OpenCode API endpoints may return inconsistent results, causing `GetStatus()` to return `StatusUnknown` even when the session actually exists.

## Fix

Changed `sessionExists()` to use `GetSessions()` (same as `IsAlive()`) to ensure consistent session detection across both methods.

## Testing

- All existing tests pass
- Build succeeds

Fixes: orch-323