### PR TITLE
feat(monitor): separate layout restart from control agent session

### DIFF
--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -21,6 +21,7 @@ type monitorOptions struct {
 	Agent           string
 	Attach          bool
 	ForceNew        bool
+	NewControlAgent bool
 	Dashboard       bool
 	IssuesDashboard bool
 	ShowResolved    bool
@@ -44,7 +45,8 @@ func newMonitorCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.SortIssues, "sort-issues", string(monitor.SortByName), "Sort issues by (name|status|title|priority|updated)")
 	cmd.Flags().StringVarP(&opts.Agent, "agent", "a", "", "Control agent to launch in monitor chat pane")
 	cmd.Flags().BoolVar(&opts.Attach, "attach", false, "Attach to existing monitor session if present")
-	cmd.Flags().BoolVar(&opts.ForceNew, "new", false, "Force create a new monitor session")
+	cmd.Flags().BoolVar(&opts.ForceNew, "new", false, "Restart layout only, preserving control agent session")
+	cmd.Flags().BoolVar(&opts.NewControlAgent, "new-control-agent", false, "Also restart control agent session (implies --new for layout)")
 	cmd.Flags().BoolVar(&opts.Dashboard, "dashboard", false, "Run dashboard UI (internal)")
 	cmd.Flags().BoolVar(&opts.IssuesDashboard, "issues-dashboard", false, "Run issues dashboard UI (internal)")
 	cmd.Flags().BoolVar(&opts.ShowResolved, "show-resolved", false, "Show resolved issues (internal)")
@@ -278,20 +280,24 @@ func runMonitor(opts *monitorOptions) error {
 		return err
 	}
 
+	// --new-control-agent implies --new for layout restart
+	forceNew := opts.ForceNew || opts.NewControlAgent
+
 	m := monitor.New(st, monitor.Options{
-		Issue:        opts.Issue,
-		Statuses:     statuses,
-		RunSort:      runSort,
-		IssueSort:    issueSort,
-		Agent:        opts.Agent,
-		Attach:       opts.Attach,
-		ForceNew:     opts.ForceNew,
-		OrchPath:     os.Args[0],
-		GlobalFlags:  monitorGlobalFlags(projectRoot, st.RootPath()),
-		ShowResolved: opts.ShowResolved,
-		ShowClosed:   opts.ShowClosed,
-		UISettings:   settings,
-		ProjectRoot:  projectRoot,
+		Issue:           opts.Issue,
+		Statuses:        statuses,
+		RunSort:         runSort,
+		IssueSort:       issueSort,
+		Agent:           opts.Agent,
+		Attach:          opts.Attach,
+		ForceNew:        forceNew,
+		NewControlAgent: opts.NewControlAgent,
+		OrchPath:        os.Args[0],
+		GlobalFlags:     monitorGlobalFlags(projectRoot, st.RootPath()),
+		ShowResolved:    opts.ShowResolved,
+		ShowClosed:      opts.ShowClosed,
+		UISettings:      settings,
+		ProjectRoot:     projectRoot,
 	})
 
 	if opts.Dashboard {

--- a/internal/monitor/control_session.go
+++ b/internal/monitor/control_session.go
@@ -63,7 +63,8 @@ func SaveControlSession(orchDir string, session *ControlSession) error {
 }
 
 // ClearControlSession removes the stored control session file.
-// This is used when --new flag is set to force a fresh session.
+// This is used when --new-control-agent flag is set to force a fresh control agent session.
+// Note: --new alone (layout restart) does NOT clear the control session.
 func ClearControlSession(orchDir string) error {
 	if orchDir == "" {
 		return nil

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -43,45 +43,47 @@ const (
 )
 
 type Options struct {
-	Session      string
-	Issue        string
-	Statuses     []model.Status
-	RunSort      SortKey
-	IssueSort    SortKey
-	Agent        string
-	Attach       bool
-	ForceNew     bool
-	OrchPath     string
-	GlobalFlags  []string
-	ShowResolved bool
-	ShowClosed   bool
-	UISettings   *UISettings
-	ProjectRoot  string
+	Session         string
+	Issue           string
+	Statuses        []model.Status
+	RunSort         SortKey
+	IssueSort       SortKey
+	Agent           string
+	Attach          bool
+	ForceNew        bool
+	NewControlAgent bool  // If true, also restart the control agent session
+	OrchPath        string
+	GlobalFlags     []string
+	ShowResolved    bool
+	ShowClosed      bool
+	UISettings      *UISettings
+	ProjectRoot     string
 }
 
 type Monitor struct {
-	session      string
-	runFilter    RunFilter
-	runSort      SortKey
-	runSortDir   SortDirection
-	issueSort    SortKey
-	issueSortDir SortDirection
-	store        store.Store
-	daemonClient *daemon.Client
-	orchPath     string
-	globalFlags  []string
-	agent        string
-	attach       bool
-	forceNew     bool
-	runs         []*RunWindow
-	dashboard    *Dashboard
-	showResolved bool
-	showClosed   bool
-	uiSettings   *UISettings
-	orchDir      string
-	presets      []config.Preset
-	projectRoot  string
-	logger       *log.Logger
+	session         string
+	runFilter       RunFilter
+	runSort         SortKey
+	runSortDir      SortDirection
+	issueSort       SortKey
+	issueSortDir    SortDirection
+	store           store.Store
+	daemonClient    *daemon.Client
+	orchPath        string
+	globalFlags     []string
+	agent           string
+	attach          bool
+	forceNew        bool
+	newControlAgent bool
+	runs            []*RunWindow
+	dashboard       *Dashboard
+	showResolved    bool
+	showClosed      bool
+	uiSettings      *UISettings
+	orchDir         string
+	presets         []config.Preset
+	projectRoot     string
+	logger          *log.Logger
 
 	monitorID     string
 	heartbeatStop chan struct{}
@@ -147,26 +149,27 @@ func New(st store.Store, opts Options) *Monitor {
 	}
 
 	return &Monitor{
-		session:      session,
-		runFilter:    newRunFilter(opts),
-		runSort:      runSort,
-		runSortDir:   runSortDir,
-		issueSort:    issueSort,
-		issueSortDir: issueSortDir,
-		store:        st,
-		daemonClient: daemonClient,
-		orchPath:     orchPath,
-		globalFlags:  opts.GlobalFlags,
-		agent:        opts.Agent,
-		attach:       opts.Attach,
-		forceNew:     opts.ForceNew,
-		showResolved: opts.ShowResolved,
-		showClosed:   opts.ShowClosed,
-		uiSettings:   uiSettings,
-		orchDir:      orchDir,
-		presets:      presets,
-		projectRoot:  projectRoot,
-		logger:       logger,
+		session:         session,
+		runFilter:       newRunFilter(opts),
+		runSort:         runSort,
+		runSortDir:      runSortDir,
+		issueSort:       issueSort,
+		issueSortDir:    issueSortDir,
+		store:           st,
+		daemonClient:    daemonClient,
+		orchPath:        orchPath,
+		globalFlags:     opts.GlobalFlags,
+		agent:           opts.Agent,
+		attach:          opts.Attach,
+		forceNew:        opts.ForceNew,
+		newControlAgent: opts.NewControlAgent,
+		showResolved:    opts.ShowResolved,
+		showClosed:      opts.ShowClosed,
+		uiSettings:      uiSettings,
+		orchDir:         orchDir,
+		presets:         presets,
+		projectRoot:     projectRoot,
+		logger:          logger,
 	}
 }
 
@@ -314,9 +317,14 @@ func (m *Monitor) Start() error {
 		return fmt.Errorf("tmux is not available")
 	}
 
-	if m.forceNew {
-		if err := ClearControlSession(m.orchDir); err != nil {
-			return fmt.Errorf("failed to clear control session: %w", err)
+	// forceNew restarts the layout (kills tmux session)
+	// newControlAgent additionally restarts the control agent (clears session file)
+	if m.forceNew || m.newControlAgent {
+		// Only clear control session if explicitly requested
+		if m.newControlAgent {
+			if err := ClearControlSession(m.orchDir); err != nil {
+				return fmt.Errorf("failed to clear control session: %w", err)
+			}
 		}
 		if tmux.HasSession(m.session) {
 			if tmux.IsInsideTmux() {

--- a/orch-monitor-tui/README.md
+++ b/orch-monitor-tui/README.md
@@ -16,7 +16,7 @@ Python Textual-based terminal user interface for `orch monitor`.
 New to orch-monitor? Here's how to get started:
 
 1. **Install orch-monitor**: `uv tool install /path/to/orch/orch-monitor-tui`
-2. **Launch the TUI**: `orch-monitor --new`
+2. **Launch the TUI**: `orch-monitor` (or `orch-monitor --new-control-agent` for fresh start)
 3. **Press `?`** to see all keybindings and workflow tips
 4. **Navigate** with arrow keys, **Tab** to switch panels
 5. **Start a run** on an issue with `n`, select an agent
@@ -175,12 +175,28 @@ export ORCH_MULTIPLEXER=zellij
 orch-monitor
 ```
 
+### Session Management
+
+```bash
+# Restart layout only (preserves control agent session/conversation)
+orch-monitor --new
+
+# Restart both layout AND control agent (fresh start)
+orch-monitor --new-control-agent
+
+# Or explicitly combine flags
+orch-monitor --new --new-control-agent
+```
+
+The `--new` flag restarts the multiplexer layout while preserving your control agent's conversation context. This is useful when:
+- Layout gets corrupted or panes are misaligned
+- You want to refresh the TUI panels without losing your chat history
+
+Use `--new-control-agent` when you want a completely fresh start, including a new control agent session.
+
 ### Other Options
 
 ```bash
-# Start fresh (kill existing session)
-orch-monitor --new
-
 # Use a different control agent
 orch-monitor --agent claude
 ```

--- a/orch-monitor-tui/orch_monitor/__main__.py
+++ b/orch-monitor-tui/orch_monitor/__main__.py
@@ -267,8 +267,19 @@ class LayoutLauncher(Protocol):
         vault_path: Path | None,
         agent: str,
         cwd: str,
+        new_control_agent: bool = False,
     ) -> None:
-        """Launch a new layout with runs, issues, and agent panes."""
+        """Launch a new layout with runs, issues, and agent panes.
+        
+        Args:
+            session_name: Name of the multiplexer session
+            project_root: Path to project root
+            vault_path: Path to issues root
+            agent: Agent command to use
+            cwd: Working directory
+            new_control_agent: If True, start fresh control agent session.
+                              If False, continue existing session (use --continue).
+        """
         ...
 
 
@@ -295,6 +306,7 @@ class TmuxLayoutLauncher:
         vault_path: Path | None,
         agent: str,
         cwd: str,
+        new_control_agent: bool = False,
     ) -> None:
         python_exec = sys.executable
         orch_args = ""
@@ -365,7 +377,12 @@ class TmuxLayoutLauncher:
 
         write_control_prompt(vault_path)
         if agent == "opencode":
-            agent_cmd = f'opencode --prompt "{CONTROL_PROMPT_INSTRUCTION}"'
+            # Use --continue to preserve session on layout restart,
+            # unless explicitly starting fresh with new_control_agent
+            if new_control_agent:
+                agent_cmd = f'opencode --prompt "{CONTROL_PROMPT_INSTRUCTION}"'
+            else:
+                agent_cmd = f'opencode --continue --prompt "{CONTROL_PROMPT_INSTRUCTION}"'
         else:
             agent_cmd = agent
 
@@ -586,12 +603,25 @@ def launch_monitor_layout(
     vault_path: Path | None,
     agent: str = "opencode",
     new: bool = False,
+    new_control_agent: bool = False,
     multiplexer: MultiplexerType | None = None,
     log: callable = lambda msg: None,
 ) -> None:
+    """Launch the orch-monitor layout in a terminal multiplexer.
+    
+    Args:
+        project_root: Path to project root
+        vault_path: Path to issues root
+        agent: Agent command to use (default: opencode)
+        new: If True, restart the layout (kill existing session)
+        new_control_agent: If True, also restart the control agent session.
+                          If False, preserve control agent session on layout restart.
+        multiplexer: Which multiplexer to use (auto-detected if None)
+        log: Logging function
+    """
     _setup_launcher_logging()
     _launcher_logger.info(
-        f"launch_monitor_layout: project_root={project_root}, vault_path={vault_path}"
+        f"launch_monitor_layout: project_root={project_root}, vault_path={vault_path}, new={new}, new_control_agent={new_control_agent}"
     )
 
     if multiplexer is None:
@@ -607,7 +637,7 @@ def launch_monitor_layout(
     _launcher_logger.info("checking has_session...")
     if launcher.has_session(session_name):
         _launcher_logger.info("session exists")
-        if new:
+        if new or new_control_agent:
             _launcher_logger.info("killing existing session...")
             launcher.kill_session(session_name)
             _launcher_logger.info("session killed")
@@ -627,7 +657,7 @@ def launch_monitor_layout(
         sys.exit(1)
 
     _launcher_logger.info("launching layout...")
-    launcher.launch_layout(session_name, project_root, vault_path, agent, cwd)
+    launcher.launch_layout(session_name, project_root, vault_path, agent, cwd, new_control_agent)
     _launcher_logger.info("launch complete")
 
 
@@ -667,7 +697,13 @@ def main():
     parser.add_argument(
         "--new",
         action="store_true",
-        help="Kill existing session and start fresh",
+        help="Restart layout only, preserving control agent session",
+    )
+    parser.add_argument(
+        "--new-control-agent",
+        action="store_true",
+        dest="new_control_agent",
+        help="Also restart control agent session (implies --new for layout)",
     )
     parser.add_argument(
         "--multiplexer",
@@ -731,8 +767,10 @@ def main():
         if args.multiplexer:
             mux_type = MultiplexerType(args.multiplexer)
         _log("starting launch_monitor_layout")
+        # --new-control-agent implies --new for layout restart
+        new = args.new or args.new_control_agent
         launch_monitor_layout(
-            project_root, vault_path, args.agent, args.new, mux_type, log=_log
+            project_root, vault_path, args.agent, new, args.new_control_agent, mux_type, log=_log
         )
 
 


### PR DESCRIPTION
## Summary

Separates layout restart from control agent session restart in orch-monitor.

- `--new` now only restarts the layout, preserving control agent session/conversation
- New `--new-control-agent` flag to explicitly restart both layout AND control agent

Resolves: orch-331

## Changes

### Python (`orch-monitor-tui`)
- Add `--new-control-agent` flag to CLI
- Update `launch_layout()` methods to accept `new_control_agent` parameter
- On layout restart (`--new`), use `opencode --continue` to preserve session
- On control agent restart (`--new-control-agent`), start fresh without `--continue`
- Update help text for `--new` flag

### Go (`orch monitor`)
- Add `NewControlAgent` option to `Options` struct
- Add `newControlAgent` field to `Monitor` struct
- Add `--new-control-agent` flag to CLI
- Modify `Start()` to only call `ClearControlSession()` when `NewControlAgent` is true
- Update `ClearControlSession()` comment to reflect new behavior

### Documentation
- Update README with session management section explaining the new flags

## Testing

- Go tests pass: `go test ./internal/monitor/...` 
- Go code builds: `go build ./...`
- Python syntax valid: `ast.parse()`
- Python tests pass (excluding pre-existing fixture issues): `pytest tests/test_daemon.py tests/test_widgets.py tests/test_help_screen.py`
- CLI help shows correct flags for both Python and Go

## Usage

```bash
# Restart layout only (preserves control agent session/conversation)
orch-monitor --new

# Restart both layout AND control agent (fresh start)
orch-monitor --new-control-agent

# Or explicitly combine flags
orch-monitor --new --new-control-agent
```