### PR TITLE
test(xdg): fix TestSanitizeRepoID to verify expected values

### DIFF
--- a/internal/xdg/paths_test.go
+++ b/internal/xdg/paths_test.go
@@ -188,14 +188,18 @@ func TestSanitizeRepoID(t *testing.T) {
 		{"owner", "repo", "owner-repo"},
 		{"my-org", "my-repo", "my-org-my-repo"},
 		{"owner_name", "repo_name", "owner_name-repo_name"},
-		{"owner/bad", "repo", "ownerbad-repo"},  // slashes removed
-		{"owner", "repo.git", "repogit-"},       // wait this is wrong
+		{"owner/bad", "repo", "ownerbad-repo"},   // slashes removed
+		{"owner", "repo.git", "owner-repogit"},   // dots removed
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.owner+"/"+tt.repo, func(t *testing.T) {
 			got := sanitizeRepoID(tt.owner, tt.repo)
-			// Just check it doesn't have unsafe chars
+			// Verify expected output
+			if got != tt.want {
+				t.Errorf("sanitizeRepoID(%q, %q) = %q, want %q", tt.owner, tt.repo, got, tt.want)
+			}
+			// Also check it doesn't have unsafe chars
 			if strings.ContainsAny(got, "/\\:*?\"<>|") {
 				t.Errorf("sanitizeRepoID(%q, %q) = %q contains unsafe characters", tt.owner, tt.repo, got)
 			}


### PR DESCRIPTION
## Summary
- Fixed `TestSanitizeRepoID` test to actually verify expected output values (the `want` field was defined but never checked)
- Corrected incorrect expected value for "repo.git" case: changed from `"repogit-"` to `"owner-repogit"`

## Related Issue
dummy-test-001

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] The fixed test now properly verifies expected values

🤖 Generated with [Claude Code](https://claude.com/claude-code)