### PR TITLE
fix(zellij): use attach --create-background for reliable session creation

### DIFF
--- a/internal/multiplexer/zellij.go
+++ b/internal/multiplexer/zellij.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -81,14 +80,15 @@ func (z *ZellijMultiplexer) NewSession(cfg *SessionConfig) error {
 		workDir = "."
 	}
 
-	startScript := fmt.Sprintf(
-		`cd %q && nohup zellij --session %q </dev/null >/dev/null 2>&1 &`,
-		workDir, sessionName)
-
-	startCmd := exec.Command("sh", "-c", startScript)
+	// Use zellij attach --create-background to create a detached session.
+	// The old nohup approach caused sessions to exit immediately because
+	// zellij doesn't persist properly when started with stdin from /dev/null.
+	args := []string{"attach", "--create-background", sessionName}
+	startCmd := execCommand("zellij", args...)
+	startCmd.Dir = workDir
 	startCmd.Env = env
 	if err := startCmd.Run(); err != nil {
-		return err
+		return fmt.Errorf("failed to create zellij session: %w", err)
 	}
 
 	if err := z.waitForSession(sessionName, 5*time.Second); err != nil {


### PR DESCRIPTION
## Summary

- Fix Zellij sessions exiting immediately after creation when using `orch run`
- Replace the problematic `nohup zellij --session NAME </dev/null` approach with native `zellij attach --create-background` command
- Sessions now persist properly, matching tmux behavior

## Problem

When starting a run with Zellij multiplexer, the Zellij session was being created but would crash/exit immediately. The daemon continued to report the run as "running" or "booting" but ALIVE=no.

The root cause was the `nohup ... </dev/null` approach for creating detached sessions - Zellij doesn't persist properly when started with stdin from /dev/null.

## Solution

Use the native `zellij attach --create-background SESSION_NAME` command which properly creates detached sessions that persist as expected.

## Test plan

- [x] All existing Zellij tests pass
- [x] Full test suite passes
- [x] Manual verification: created test session persists
- [x] Manual verification: sending keys to session works

Fixes: orch-340

🤖 Generated with [Claude Code](https://claude.com/claude-code)