### PR TITLE
fix(monitor-tui): show correct multiplexer in Mux column

### DIFF
--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -86,6 +86,7 @@ type RunSummary struct {
 	Branch       string `json:"branch,omitempty"`
 	WorktreePath string `json:"worktree_path,omitempty"`
 	TmuxSession  string `json:"tmux_session,omitempty"`
+	Multiplexer  string `json:"multiplexer,omitempty"`
 	PRUrl        string `json:"pr_url,omitempty"`
 	StartedAt    string `json:"started_at"`
 	UpdatedAt    string `json:"updated_at"`
@@ -112,6 +113,7 @@ type RunFull struct {
 	Branch            string       `json:"branch,omitempty"`
 	WorktreePath      string       `json:"worktree_path,omitempty"`
 	TmuxSession       string       `json:"tmux_session,omitempty"`
+	Multiplexer       string       `json:"multiplexer,omitempty"`
 	PRUrl             string       `json:"pr_url,omitempty"`
 	ServerPort        int          `json:"server_port,omitempty"`
 	OpenCodeSessionID string       `json:"opencode_session_id,omitempty"`
@@ -223,6 +225,7 @@ func RunToSummary(run *model.Run) *RunSummary {
 		Branch:       run.Branch,
 		WorktreePath: run.WorktreePath,
 		TmuxSession:  run.TmuxSession,
+		Multiplexer:  run.Multiplexer,
 		PRUrl:        run.PRUrl,
 		StartedAt:    formatTime(run.StartedAt),
 		UpdatedAt:    formatTime(run.UpdatedAt),
@@ -254,6 +257,7 @@ func RunToFull(run *model.Run) *RunFull {
 		Branch:            run.Branch,
 		WorktreePath:      run.WorktreePath,
 		TmuxSession:       run.TmuxSession,
+		Multiplexer:       run.Multiplexer,
 		PRUrl:             run.PRUrl,
 		ServerPort:        run.ServerPort,
 		OpenCodeSessionID: run.OpenCodeSessionID,

--- a/orch-monitor-tui/orch_monitor/app.py
+++ b/orch-monitor-tui/orch_monitor/app.py
@@ -2681,7 +2681,7 @@ class OrchMonitorApp(App):
             f"Branch: {run.branch or '-'}",
             f"Worktree: {run.worktree_path or '-'}",
             f"Session: {run.tmux_session or '-'}",
-            f"Multiplexer: {run.multiplexer or 'tmux'}",
+            f"Multiplexer: {run.multiplexer or '-'}",
         ]
         # Add changed files section (uses helper for consistent formatting)
         if run.worktree_path and run.branch:

--- a/orch-monitor-tui/orch_monitor/widgets.py
+++ b/orch-monitor-tui/orch_monitor/widgets.py
@@ -227,8 +227,13 @@ class RunTable(CursorPreservingTable):
                 status_str = f"[cyan]{status_str}[/cyan]"
 
             model_str = model_display_name(run.model, run.model_variant)
-            mux = run.multiplexer or "tmux"
-            mux_short = "zj" if mux == "zellij" else "tx"
+            mux = run.multiplexer
+            if mux == "zellij":
+                mux_short = "zj"
+            elif mux == "tmux":
+                mux_short = "tx"
+            else:
+                mux_short = "-"
 
             # Format diff stats with color coding
             stats = diff_stats.get(run.ref())


### PR DESCRIPTION
## Summary
- Fixed Mux column showing "tx" for ALL runs including OpenCode and Zellij runs
- Added Multiplexer field to daemon API response (RunSummary and RunFull structs)
- Updated TUI to display "-" for runs without a multiplexer (e.g., OpenCode runs)

## Details
The Mux column in orch-monitor was showing "tx" (tmux) for all runs because:
1. The daemon API wasn't including the Multiplexer field in run data responses
2. The TUI was defaulting empty multiplexer values to "tmux"

Now:
- OpenCode runs (no multiplexer) show "-"
- tmux runs show "tx"
- Zellij runs show "zj"

## Test plan
- [x] Go daemon tests pass
- [x] Python TUI tests pass (widgets, daemon)
- [x] Go build succeeds

Fixes: orch-341

🤖 Generated with [Claude Code](https://claude.com/claude-code)