### PR TITLE
fix(cli): make orch ps use daemon API for consistency with orch-monitor

### DIFF
--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -76,28 +76,56 @@ func runPs(opts *psOptions) error {
 		return err
 	}
 
-	// Build filter
 	requestedLimit := opts.Limit
-	filter := &store.ListRunsFilter{
-		IssueID: opts.Issue,
-		Limit:   opts.Limit,
-		Since:   opts.Since,
-	}
-	if len(opts.IssueStatus) > 0 {
-		filter.Limit = 0
-	}
 
-	if len(opts.Status) > 0 {
-		for _, s := range opts.Status {
-			filter.Status = append(filter.Status, model.Status(s))
+	var runs []*model.Run
+	var usedDaemon bool
+
+	if !testBypassDaemon {
+		projectRoot, _ := getProjectRoot()
+		client := daemon.NewClientWithIssuesRoot(projectRoot, st.RootPath())
+		if client.IsAvailable() {
+			statusFilter := make([]string, len(opts.Status))
+			for i, s := range opts.Status {
+				statusFilter[i] = s
+			}
+			limit := opts.Limit
+			if len(opts.IssueStatus) > 0 || (!opts.All && len(opts.Status) == 0) {
+				limit = 0
+			}
+			resp, err := client.ListRuns(opts.Issue, statusFilter, limit, "")
+			if err == nil && resp != nil {
+				runs = make([]*model.Run, len(resp.Runs))
+				for i, summary := range resp.Runs {
+					runs[i] = daemon.SummaryToRun(summary)
+				}
+				usedDaemon = true
+			}
 		}
-	} else if !opts.All {
-		filter.Limit = 0
 	}
 
-	runs, err := st.ListRuns(filter)
-	if err != nil {
-		return err
+	if !usedDaemon {
+		filter := &store.ListRunsFilter{
+			IssueID: opts.Issue,
+			Limit:   opts.Limit,
+			Since:   opts.Since,
+		}
+		if len(opts.IssueStatus) > 0 {
+			filter.Limit = 0
+		}
+
+		if len(opts.Status) > 0 {
+			for _, s := range opts.Status {
+				filter.Status = append(filter.Status, model.Status(s))
+			}
+		} else if !opts.All {
+			filter.Limit = 0
+		}
+
+		runs, err = st.ListRuns(filter)
+		if err != nil {
+			return err
+		}
 	}
 
 	issueStatusFilter := make(map[string]bool)

--- a/internal/cli/ps_test.go
+++ b/internal/cli/ps_test.go
@@ -327,6 +327,8 @@ func TestFormatRelativeTime(t *testing.T) {
 
 func TestRunPsExcludesResolvedIssuesByDefault(t *testing.T) {
 	resetGlobalOpts(t)
+	testBypassDaemon = true
+	t.Cleanup(func() { testBypassDaemon = false })
 
 	vault := t.TempDir()
 	globalOpts.IssuesRoot = vault
@@ -385,6 +387,8 @@ func TestRunPsExcludesResolvedIssuesByDefault(t *testing.T) {
 
 func TestRunPsAllIncludesResolvedIssues(t *testing.T) {
 	resetGlobalOpts(t)
+	testBypassDaemon = true
+	t.Cleanup(func() { testBypassDaemon = false })
 
 	vault := t.TempDir()
 	globalOpts.IssuesRoot = vault

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -143,13 +143,13 @@ type ListIssuesResponse struct {
 
 // IssueSummary is a summary view of an issue for list operations
 type IssueSummary struct {
-	ID      string `json:"id"`
-	Title   string `json:"title"`
-	Topic   string `json:"topic,omitempty"`
-	Summary string `json:"summary,omitempty"`
+	ID      string   `json:"id"`
+	Title   string   `json:"title"`
+	Topic   string   `json:"topic,omitempty"`
+	Summary string   `json:"summary,omitempty"`
 	Status  string   `json:"status"`
 	Tags    []string `json:"tags,omitempty"`
-	URI     string `json:"uri"`
+	URI     string   `json:"uri"`
 }
 
 // GetIssueResponse is the response for get_issue
@@ -302,4 +302,31 @@ func formatTime(t time.Time) string {
 		return ""
 	}
 	return t.Format(time.RFC3339)
+}
+
+// SummaryToRun converts a RunSummary back to a model.Run
+// This is used by orch ps to convert daemon API responses to model.Run for display
+func SummaryToRun(s *RunSummary) *model.Run {
+	if s == nil {
+		return nil
+	}
+
+	startedAt, _ := time.Parse(time.RFC3339, s.StartedAt)
+	updatedAt, _ := time.Parse(time.RFC3339, s.UpdatedAt)
+
+	return &model.Run{
+		IssueID:      s.IssueID,
+		RunID:        s.RunID,
+		Status:       model.Status(s.Status),
+		Phase:        model.Phase(s.Phase),
+		Agent:        s.Agent,
+		Model:        s.Model,
+		Branch:       s.Branch,
+		WorktreePath: s.WorktreePath,
+		TmuxSession:  s.TmuxSession,
+		Multiplexer:  s.Multiplexer,
+		PRUrl:        s.PRUrl,
+		StartedAt:    startedAt,
+		UpdatedAt:    updatedAt,
+	}
 }

--- a/internal/daemon/types_test.go
+++ b/internal/daemon/types_test.go
@@ -1,6 +1,10 @@
 package daemon
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/s22625/orch/internal/model"
+)
 
 func TestFileURI(t *testing.T) {
 	tests := []struct {
@@ -60,5 +64,162 @@ func TestDecodeCursorNegative(t *testing.T) {
 	_, err := DecodeCursor(cursor)
 	if err == nil {
 		t.Error("DecodeCursor should fail for negative offset")
+	}
+}
+
+func TestSummaryToRun(t *testing.T) {
+	tests := []struct {
+		name    string
+		summary *RunSummary
+		check   func(t *testing.T, run *model.Run)
+	}{
+		{
+			name:    "nil summary returns nil",
+			summary: nil,
+			check: func(t *testing.T, run *model.Run) {
+				if run != nil {
+					t.Error("expected nil run for nil summary")
+				}
+			},
+		},
+		{
+			name: "converts all fields correctly",
+			summary: &RunSummary{
+				IssueID:      "issue-123",
+				RunID:        "run-456",
+				ShortID:      "r456",
+				Status:       "running",
+				Phase:        "implement",
+				Agent:        "claude",
+				Model:        "claude-3-opus",
+				Branch:       "feature/test",
+				WorktreePath: "/tmp/worktree",
+				TmuxSession:  "orch-issue-123",
+				Multiplexer:  "tmux",
+				PRUrl:        "https://github.com/test/repo/pull/1",
+				StartedAt:    "2024-01-15T10:30:00Z",
+				UpdatedAt:    "2024-01-15T11:00:00Z",
+				URI:          "file:///path/to/run.json",
+			},
+			check: func(t *testing.T, run *model.Run) {
+				if run == nil {
+					t.Fatal("expected non-nil run")
+				}
+				if run.IssueID != "issue-123" {
+					t.Errorf("IssueID = %q, want %q", run.IssueID, "issue-123")
+				}
+				if run.RunID != "run-456" {
+					t.Errorf("RunID = %q, want %q", run.RunID, "run-456")
+				}
+				if run.Status != model.StatusRunning {
+					t.Errorf("Status = %q, want %q", run.Status, model.StatusRunning)
+				}
+				if run.Phase != model.PhaseImplement {
+					t.Errorf("Phase = %q, want %q", run.Phase, model.PhaseImplement)
+				}
+				if run.Agent != "claude" {
+					t.Errorf("Agent = %q, want %q", run.Agent, "claude")
+				}
+				if run.Model != "claude-3-opus" {
+					t.Errorf("Model = %q, want %q", run.Model, "claude-3-opus")
+				}
+				if run.Branch != "feature/test" {
+					t.Errorf("Branch = %q, want %q", run.Branch, "feature/test")
+				}
+				if run.WorktreePath != "/tmp/worktree" {
+					t.Errorf("WorktreePath = %q, want %q", run.WorktreePath, "/tmp/worktree")
+				}
+				if run.TmuxSession != "orch-issue-123" {
+					t.Errorf("TmuxSession = %q, want %q", run.TmuxSession, "orch-issue-123")
+				}
+				if run.Multiplexer != "tmux" {
+					t.Errorf("Multiplexer = %q, want %q", run.Multiplexer, "tmux")
+				}
+				if run.PRUrl != "https://github.com/test/repo/pull/1" {
+					t.Errorf("PRUrl = %q, want %q", run.PRUrl, "https://github.com/test/repo/pull/1")
+				}
+				if run.StartedAt.IsZero() {
+					t.Error("StartedAt should not be zero")
+				}
+				if run.UpdatedAt.IsZero() {
+					t.Error("UpdatedAt should not be zero")
+				}
+			},
+		},
+		{
+			name: "handles empty timestamps gracefully",
+			summary: &RunSummary{
+				IssueID:   "issue-789",
+				RunID:     "run-xyz",
+				Status:    "done",
+				StartedAt: "",
+				UpdatedAt: "",
+			},
+			check: func(t *testing.T, run *model.Run) {
+				if run == nil {
+					t.Fatal("expected non-nil run")
+				}
+				if !run.StartedAt.IsZero() {
+					t.Error("StartedAt should be zero for empty string")
+				}
+				if !run.UpdatedAt.IsZero() {
+					t.Error("UpdatedAt should be zero for empty string")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			run := SummaryToRun(tt.summary)
+			tt.check(t, run)
+		})
+	}
+}
+
+func TestRunToSummaryRoundTrip(t *testing.T) {
+	original := &model.Run{
+		IssueID:      "issue-roundtrip",
+		RunID:        "run-roundtrip-123",
+		Status:       model.StatusBlocked,
+		Phase:        model.PhasePlan,
+		Agent:        "opencode",
+		Model:        "gpt-4",
+		Branch:       "fix/bug-123",
+		WorktreePath: "/home/user/worktrees/fix-bug",
+		TmuxSession:  "orch-roundtrip",
+		Multiplexer:  "tmux",
+		PRUrl:        "",
+	}
+
+	summary := RunToSummary(original)
+	roundTripped := SummaryToRun(summary)
+
+	if roundTripped.IssueID != original.IssueID {
+		t.Errorf("IssueID mismatch: got %q, want %q", roundTripped.IssueID, original.IssueID)
+	}
+	if roundTripped.RunID != original.RunID {
+		t.Errorf("RunID mismatch: got %q, want %q", roundTripped.RunID, original.RunID)
+	}
+	if roundTripped.Status != original.Status {
+		t.Errorf("Status mismatch: got %q, want %q", roundTripped.Status, original.Status)
+	}
+	if roundTripped.Phase != original.Phase {
+		t.Errorf("Phase mismatch: got %q, want %q", roundTripped.Phase, original.Phase)
+	}
+	if roundTripped.Agent != original.Agent {
+		t.Errorf("Agent mismatch: got %q, want %q", roundTripped.Agent, original.Agent)
+	}
+	if roundTripped.Model != original.Model {
+		t.Errorf("Model mismatch: got %q, want %q", roundTripped.Model, original.Model)
+	}
+	if roundTripped.Branch != original.Branch {
+		t.Errorf("Branch mismatch: got %q, want %q", roundTripped.Branch, original.Branch)
+	}
+	if roundTripped.WorktreePath != original.WorktreePath {
+		t.Errorf("WorktreePath mismatch: got %q, want %q", roundTripped.WorktreePath, original.WorktreePath)
+	}
+	if roundTripped.TmuxSession != original.TmuxSession {
+		t.Errorf("TmuxSession mismatch: got %q, want %q", roundTripped.TmuxSession, original.TmuxSession)
 	}
 }


### PR DESCRIPTION
## Summary
- Fix `orch ps` to query daemon API instead of direct file store, ensuring consistency with `orch-monitor`
- Add `SummaryToRun()` helper to convert daemon API responses back to `model.Run` for display
- Add comprehensive tests for the new conversion functions

## Root Cause
`orch ps` was querying the file store directly while `orch-monitor` queried the daemon API. Because each process maintains its own store instance with a separate in-memory run index, newly created runs would appear in one tool but not the other depending on which process created them.

## Changes
| File | Change |
|------|--------|
| `internal/cli/ps.go` | Query daemon API when available, fallback to direct store when daemon unavailable |
| `internal/daemon/types.go` | Add `SummaryToRun()` to convert `RunSummary` back to `model.Run` |
| `internal/daemon/types_test.go` | Add tests for `SummaryToRun()` and round-trip conversion |
| `internal/cli/ps_test.go` | Add `testBypassDaemon` for isolated test execution |

## Testing
- All existing tests pass
- Added unit tests for `SummaryToRun()` with edge cases (nil input, empty timestamps)
- Added round-trip test: `model.Run` -> `RunSummary` -> `model.Run` preserves all key fields

Fixes #349