### PR TITLE
feat(daemon): add get_control_agent_launch API (orch-360)

### DIFF
--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -742,3 +742,52 @@ func (c *Client) ListRepos() ([]map[string]string, error) {
 
 	return resp.Repos, nil
 }
+
+// GetControlAgentLaunchRequest is the request for get_control_agent_launch
+type GetControlAgentLaunchRequest struct {
+	Type        string `json:"type"`
+	ProjectRoot string `json:"project_root"`
+	AgentType   string `json:"agent_type,omitempty"`
+	NewSession  bool   `json:"force,omitempty"` // Using "force" to match SendRequest.Force field
+	IssuesRoot  string `json:"issues_root,omitempty"`
+}
+
+// GetControlAgentLaunchResponse is the response for get_control_agent_launch
+type GetControlAgentLaunchResponse struct {
+	OK         bool   `json:"ok"`
+	Error      string `json:"error,omitempty"`
+	Command    string `json:"command,omitempty"`
+	PromptFile string `json:"prompt_file,omitempty"`
+	Port       int    `json:"port,omitempty"`
+	SessionID  string `json:"session_id,omitempty"`
+	Agent      string `json:"agent,omitempty"`
+}
+
+// GetControlAgentLaunch gets the launch command and configuration for the control agent.
+// It writes the control prompt file, resolves agent configuration, and returns
+// a ready-to-execute command.
+func (c *Client) GetControlAgentLaunch(projectRoot, agentType string, newSession bool) (*GetControlAgentLaunchResponse, error) {
+	req := GetControlAgentLaunchRequest{
+		Type:        "get_control_agent_launch",
+		ProjectRoot: projectRoot,
+		AgentType:   agentType,
+		NewSession:  newSession,
+		IssuesRoot:  c.issuesRoot,
+	}
+
+	raw, err := c.sendRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp GetControlAgentLaunchResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if !resp.OK {
+		return nil, fmt.Errorf("daemon error: %s", resp.Error)
+	}
+
+	return &resp, nil
+}

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/s22625/orch/internal/agent"
+	"github.com/s22625/orch/internal/config"
 	"github.com/s22625/orch/internal/github"
 	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/multiplexer"
@@ -377,6 +378,8 @@ func (s *SocketServer) handleConnection(conn net.Conn) {
 		s.handleEnsureOpenCodeServer(req, encoder)
 	case "append_event":
 		s.handleAppendEvent(req, encoder)
+	case "get_control_agent_launch":
+		s.handleGetControlAgentLaunch(req, encoder)
 	default:
 		encoder.Encode(SendResponse{OK: false, Error: "unknown_type"})
 	}
@@ -950,6 +953,427 @@ func (s *SocketServer) getOrCreateOpenCodeControlSession(projectRoot string, por
 
 func getControlPromptInstruction() string {
 	return "ultrathink Please read 'ORCH_CONTROL_PROMPT.md' in the current directory and follow the instructions found there."
+}
+
+const controlPromptFileName = "ORCH_CONTROL_PROMPT.md"
+
+// writeControlPromptFile writes the control agent prompt to a file in the current working directory.
+// This is the daemon's implementation to avoid circular imports with the monitor package.
+func (s *SocketServer) writeControlPromptFile(st store.Store) (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	prompt, err := s.buildControlAgentPrompt(st)
+	if err != nil {
+		return "", err
+	}
+
+	promptPath := filepath.Join(cwd, controlPromptFileName)
+	if err := os.WriteFile(promptPath, []byte(prompt), 0644); err != nil {
+		return "", fmt.Errorf("failed to write control prompt file: %w", err)
+	}
+
+	return promptPath, nil
+}
+
+// buildControlAgentPrompt builds the control agent prompt with dynamic repo context.
+func (s *SocketServer) buildControlAgentPrompt(st store.Store) (string, error) {
+	cwd, _ := os.Getwd()
+	issuesRoot := st.RootPath()
+
+	// Get existing issues
+	issues, _ := st.ListIssues()
+
+	// Get active runs
+	runs, _ := st.ListRuns(&store.ListRunsFilter{
+		Status: []model.Status{
+			model.StatusRunning,
+			model.StatusBlocked,
+			model.StatusBlockedAPI,
+			model.StatusBooting,
+			model.StatusQueued,
+			model.StatusPROpen,
+		},
+		Limit: 20,
+	})
+
+	// Build issues table
+	var issuesText string
+	if len(issues) > 0 {
+		var sb strings.Builder
+		sb.WriteString("| ID | Status | Title |\n")
+		sb.WriteString("|----|--------|-------|\n")
+		for i, issue := range issues {
+			if i >= 20 {
+				break
+			}
+			status := string(issue.Status)
+			if status == "" {
+				status = string(model.IssueStatusOpen)
+			}
+			title := issue.Title
+			if title == "" {
+				title = "-"
+			}
+			if len(title) > 50 {
+				title = title[:47] + "..."
+			}
+			sb.WriteString(fmt.Sprintf("| %s | %s | %s |\n", issue.ID, status, title))
+		}
+		issuesText = sb.String()
+	} else {
+		issuesText = "No issues found."
+	}
+
+	// Build runs table
+	var runsText string
+	if len(runs) > 0 {
+		var sb strings.Builder
+		sb.WriteString("| Issue | Run ID | Status |\n")
+		sb.WriteString("|-------|--------|--------|\n")
+		for i, run := range runs {
+			if i >= 10 {
+				break
+			}
+			sb.WriteString(fmt.Sprintf("| %s | %s | %s |\n", run.IssueID, run.ShortID(), string(run.Status)))
+		}
+		runsText = sb.String()
+	} else {
+		runsText = "No active runs."
+	}
+
+	// Get git info
+	gitBranch := s.getGitBranch(cwd)
+	uncommittedChanges := s.getUncommittedChangesStatus(cwd)
+
+	// Get agent config
+	cfg, _ := config.Load()
+	defaultAgent := "opencode"
+	if cfg != nil {
+		if cfg.ControlAgent != "" {
+			defaultAgent = cfg.ControlAgent
+		} else if cfg.Agent != "" {
+			defaultAgent = cfg.Agent
+		}
+	}
+
+	prompt := fmt.Sprintf(`You are the orch control agent for this repository.
+You can run orch commands directly via bash to manage issues and runs.
+
+## Repository Context
+
+- IssuesRoot: %s
+- Working directory: %s
+
+## Git Context
+%s
+- Uncommitted changes: %s
+
+## Available Agents
+
+- Default: %s
+- Configured backends: opencode, claude, codex, gemini, custom
+
+Use `+"`--agent <name>`"+` to specify a different agent when starting runs.
+
+## Existing Issues
+
+%s
+
+## Active Runs
+
+%s
+
+## Workflows
+
+### Starting New Work
+1. Create issue: `+"`orch issue create <id> --title \"...\" --body \"...\"`"+`
+2. Start run: `+"`orch run <issue-id>`"+`
+3. Monitor: Watch the runs table or use `+"`orch ps`"+`
+
+### Handling Blocked Runs
+When a run shows "blocked" status:
+1. Capture: `+"`orch capture <run-ref>`"+` to see what the agent needs
+2. Send feedback: `+"`orch send <issue-id> \"<message>\"`"+` to provide input
+3. The agent will resume automatically after receiving input
+
+### Continuing Work
+- From a branch: `+"`orch continue <issue> --branch <branch-name>`"+`
+- From a run: `+"`orch continue <issue>#<run-id>`"+`
+
+## Available Orch Commands
+
+Run these commands directly using bash (do not use any special protocol):
+
+### Issue Management
+- Create issue: `+"`orch issue create <id> --title \"<title>\" --body \"<body>\"`"+`
+- List issues: `+"`orch issue list`"+`
+- Open issue in editor: `+"`orch open <issue-id>`"+`
+
+### Run Management
+- Start a run: `+"`orch run <issue-id>`"+`
+- Continue from branch: `+"`orch continue <issue> --branch <branch>`"+`
+- List runs: `+"`orch ps`"+` (use `+"`--status running,blocked`"+` to filter)
+- Stop a run: `+"`orch stop <issue-id>#<run-id>`"+`
+- Resolve a run: `+"`orch resolve <issue-id>#<run-id>`"+`
+- Show run details: `+"`orch show <issue-id>#<run-id>`"+`
+- Capture run state: `+"`orch capture <run-ref>`"+` - see agent's last message
+- Send feedback: `+"`orch send <issue-id> \"<message>\"`"+` - provide input to blocked agent
+
+### Interactive Commands (DO NOT USE)
+The following commands are interactive and will hang if called by an AI agent:
+- `+"`orch attach`"+` - interactive tmux session (for humans only)
+- `+"`orch monitor`"+` - interactive TUI (for humans only)
+
+## Troubleshooting
+
+- Orphaned sessions: `+"`orch repair`"+`
+- View daemon logs: Check `+"`.orch/daemon.log`"+` in project root
+- Force stop all: `+"`orch stop --all`"+`
+
+## Instructions
+
+- Execute orch commands directly via bash - no special protocol needed
+- Follow the issue ID naming convention when creating new issues
+`, issuesRoot, cwd, gitBranch, uncommittedChanges, defaultAgent, issuesText, runsText)
+
+	return prompt, nil
+}
+
+// getGitBranch returns the current git branch name.
+func (s *SocketServer) getGitBranch(workDir string) string {
+	cmd := exec.Command("git", "-C", workDir, "rev-parse", "--abbrev-ref", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	branch := strings.TrimSpace(string(output))
+	if branch != "" {
+		return "- Current branch: " + branch
+	}
+	return ""
+}
+
+// getUncommittedChangesStatus returns "Yes" or "No" based on git status.
+func (s *SocketServer) getUncommittedChangesStatus(workDir string) string {
+	cmd := exec.Command("git", "-C", workDir, "status", "--porcelain")
+	output, err := cmd.Output()
+	if err != nil {
+		return "Unknown"
+	}
+	if len(strings.TrimSpace(string(output))) > 0 {
+		return "Yes"
+	}
+	return "No"
+}
+
+// handleGetControlAgentLaunch handles the get_control_agent_launch API request.
+// It writes the control prompt file, resolves agent configuration, and returns
+// a ready-to-execute command for launching the control agent.
+func (s *SocketServer) handleGetControlAgentLaunch(req SendRequest, encoder *json.Encoder) {
+	if req.ProjectRoot == "" {
+		encoder.Encode(map[string]interface{}{
+			"ok":    false,
+			"error": "project_root required",
+		})
+		return
+	}
+
+	// Resolve the store for the project
+	st := s.resolveStore(req)
+	if st == nil {
+		encoder.Encode(map[string]interface{}{
+			"ok":    false,
+			"error": "no store available for project",
+		})
+		return
+	}
+
+	// Write the control prompt file
+	promptPath, err := s.writeControlPromptFile(st)
+	if err != nil {
+		s.logger.Printf("failed to write control prompt file: %v", err)
+		encoder.Encode(map[string]interface{}{
+			"ok":    false,
+			"error": fmt.Sprintf("failed to write control prompt file: %v", err),
+		})
+		return
+	}
+
+	// Load configuration
+	cfg, cfgErr := config.Load()
+
+	// Resolve agent type
+	agentName := req.AgentType
+	if agentName == "" && cfgErr == nil {
+		agentName = cfg.ControlAgent
+		if agentName == "" {
+			agentName = cfg.Agent
+		}
+	}
+	if agentName == "" {
+		agentName = "opencode"
+	}
+
+	// Get model configuration
+	var modelName, modelVariant string
+	if cfgErr == nil {
+		modelName = cfg.ControlModel
+		if modelName == "" {
+			modelName = cfg.Model
+		}
+		modelVariant = cfg.ControlModelVariant
+		if modelVariant == "" {
+			modelVariant = cfg.ModelVariant
+		}
+	}
+
+	// Parse and validate agent type
+	aType, err := agent.ParseAgentType(agentName)
+	if err != nil {
+		encoder.Encode(map[string]interface{}{
+			"ok":    false,
+			"error": fmt.Sprintf("invalid agent type: %v", err),
+		})
+		return
+	}
+
+	adapter, err := agent.GetAdapter(aType)
+	if err != nil {
+		encoder.Encode(map[string]interface{}{
+			"ok":    false,
+			"error": fmt.Sprintf("failed to get adapter: %v", err),
+		})
+		return
+	}
+
+	if !adapter.IsAvailable() {
+		encoder.Encode(map[string]interface{}{
+			"ok":    false,
+			"error": fmt.Sprintf("%s CLI not available", agentName),
+		})
+		return
+	}
+
+	prompt := getControlPromptInstruction()
+	var command string
+	var port int
+	var sessionID string
+	var newSession bool
+
+	// Handle session clearing for new_session request
+	if req.Force { // Using Force as the "new_session" flag
+		lock := s.getControlSessionLock(req.ProjectRoot)
+		lock.Lock()
+		sessionPath := s.controlSessionPath(req.ProjectRoot)
+		os.Remove(sessionPath)
+		lock.Unlock()
+		newSession = true
+	}
+
+	// Handle based on injection method
+	if adapter.PromptInjection() == agent.InjectionHTTP {
+		// OpenCode uses HTTP injection via a managed server
+		serverPort, err := s.ensureOpenCodeServerRunning(req.ProjectRoot)
+		if err != nil {
+			encoder.Encode(map[string]interface{}{
+				"ok":    false,
+				"error": fmt.Sprintf("failed to ensure opencode server: %v", err),
+			})
+			return
+		}
+		port = serverPort
+
+		// Get or create session
+		session, err := s.getOrCreateOpenCodeControlSession(req.ProjectRoot, port)
+		if err != nil {
+			s.logger.Printf("warning: server running but failed to get session: %v", err)
+			// Still return the command, but without session
+			command = fmt.Sprintf("opencode attach http://127.0.0.1:%d", port)
+		} else {
+			sessionID = session
+			command = fmt.Sprintf("opencode attach http://127.0.0.1:%d --session %s", port, sessionID)
+		}
+	} else {
+		// CLI-based agents (claude, codex, gemini, custom)
+		// Get extra args for control agent
+		var extraArgs []string
+		if cfgErr == nil {
+			extraArgs = cfg.GetControlExtraArgs(agentName)
+		}
+
+		// Build launch config
+		launchCfg := &agent.LaunchConfig{
+			Type:            aType,
+			IssuesRoot:      st.RootPath(),
+			Prompt:          prompt,
+			ContinueSession: !newSession,
+			Model:           modelName,
+			ModelVariant:    modelVariant,
+			ExtraArgs:       extraArgs,
+		}
+
+		// For claude, try to get existing session
+		if agentName == "claude" && !newSession {
+			stored := s.getStoredControlSession(req.ProjectRoot)
+			if stored != "" {
+				launchCfg.Resume = true
+				launchCfg.SessionName = stored
+				sessionID = stored
+			} else {
+				// Try to discover Claude session
+				discovered := s.discoverClaudeSession(req.ProjectRoot)
+				if discovered != "" {
+					launchCfg.Resume = true
+					launchCfg.SessionName = discovered
+					sessionID = discovered
+					// Save discovered session
+					s.saveControlSession(req.ProjectRoot, discovered, "claude")
+				}
+			}
+		}
+
+		cmd, err := adapter.LaunchCommand(launchCfg)
+		if err != nil {
+			encoder.Encode(map[string]interface{}{
+				"ok":    false,
+				"error": fmt.Sprintf("failed to build launch command: %v", err),
+			})
+			return
+		}
+		command = cmd
+	}
+
+	s.logger.Printf("get_control_agent_launch: agent=%s, command=%s, port=%d, session=%s",
+		agentName, command, port, sessionID)
+
+	encoder.Encode(map[string]interface{}{
+		"ok":          true,
+		"command":     command,
+		"prompt_file": promptPath,
+		"port":        port,
+		"session_id":  sessionID,
+		"agent":       agentName,
+	})
+}
+
+// getStoredControlSession returns the stored session ID for a project, or empty string if none.
+func (s *SocketServer) getStoredControlSession(projectRoot string) string {
+	sessionPath := s.controlSessionPath(projectRoot)
+	data, err := os.ReadFile(sessionPath)
+	if err != nil {
+		return ""
+	}
+	var stored struct {
+		SessionID string `json:"session_id"`
+		AgentType string `json:"agent_type"`
+	}
+	if json.Unmarshal(data, &stored) != nil {
+		return ""
+	}
+	return stored.SessionID
 }
 
 func findAvailablePort(start, end int) int {

--- a/orch-monitor-tui/orch_monitor/__main__.py
+++ b/orch-monitor-tui/orch_monitor/__main__.py
@@ -156,94 +156,6 @@ def query_latest_opencode_session(
         return None
 
 
-def write_control_prompt(vault_path: Path | None) -> bool:
-    try:
-        config = Config.from_vault(vault_path) if vault_path else Config.load()
-        daemon = DaemonClient(config.socket_path, config.issues_root)
-
-        if not daemon.is_available():
-            return False
-
-        cwd = os.getcwd()
-
-        issues_text = "No issues found."
-        runs_text = "No active runs."
-
-        try:
-            issues_resp = daemon.list_issues()
-            if issues_resp.issues:
-                lines = ["| ID | Status | Title |", "|----|--------|-------|"]
-                for issue in issues_resp.issues[:20]:
-                    title = (issue.title or issue.summary or "-")[:50]
-                    lines.append(f"| {issue.id} | {issue.status.value} | {title} |")
-                issues_text = "\n".join(lines)
-        except Exception:
-            pass
-
-        try:
-            runs_resp = daemon.list_runs()
-            active = [
-                r
-                for r in runs_resp.runs
-                if r.status.value
-                in ("running", "blocked", "blocked_api", "booting", "queued")
-            ]
-            if active:
-                lines = ["| Issue | Run ID | Status |", "|-------|--------|--------|"]
-                for run in active[:10]:
-                    lines.append(
-                        f"| {run.issue_id} | {run.short_id()} | {run.status.value} |"
-                    )
-                runs_text = "\n".join(lines)
-        except Exception:
-            pass
-
-        prompt = f"""You are the orch control agent for this repository.
-You can run orch commands directly via bash to manage issues and runs.
-
-## Repository Context
-
-- Issues Root: {config.issues_root}
-- Working directory: {cwd}
-
-## Existing Issues
-
-{issues_text}
-
-## Active Runs
-
-{runs_text}
-
-## Available Orch Commands
-
-Run these commands directly using bash:
-
-### Issue Management
-- Create issue: `orch issue create <id> --title "<title>" --body "<body>"`
-- List issues: `orch issue list`
-- Open issue in editor: `orch open <issue-id>`
-
-### Run Management
-- Start a run: `orch run <issue-id>`
-- List runs: `orch ps`
-- Attach to run: `orch attach <run-ref>`
-- Stop a run: `orch stop <issue-id>#<run-id>`
-- Resolve a run: `orch resolve <issue-id>#<run-id>`
-
-## Instructions
-
-- Execute orch commands directly via bash
-- Use `orch ps` to check run status
-- Use `orch attach` to interact with blocked runs
-"""
-
-        prompt_path = Path(cwd) / CONTROL_PROMPT_FILE
-        prompt_path.write_text(prompt)
-        return True
-    except Exception:
-        return False
-
-
 def get_issues_root(args) -> Path | None:
     if getattr(args, "issues_root", None):
         return args.issues_root
@@ -452,63 +364,41 @@ class TmuxLayoutLauncher:
             f'{env_export}"{python_exec}" -m orch_monitor --issues {orch_args}'.strip()
         )
 
-        write_control_prompt(vault_path)
+        # Use daemon API to get control agent launch command
+        # The daemon handles: writing control prompt file, resolving agent config,
+        # session management, and building the command
+        agent_cmd = agent  # fallback to raw agent command
         need_capture_session = False
-        opencode_server_port = 0
 
-        if agent == "opencode":
-            if new_control_agent:
-                clear_control_session(project_root)
-
-            daemon = _get_daemon_client(project_root)
-            if daemon:
-                project_str = str(project_root) if project_root else str(Path.cwd())
-                ok, port, session_id, err = daemon.ensure_opencode_server(project_str)
-                if ok and port > 0:
-                    opencode_server_port = port
-                    server_url = f"http://127.0.0.1:{port}"
-                    if session_id:
-                        _launcher_logger.info(
-                            f"Using opencode server on port {port}, session: {session_id}"
-                        )
-                        agent_cmd = (
-                            f"opencode attach {server_url} --session {session_id}"
-                        )
-                    else:
-                        _launcher_logger.info(
-                            f"Using opencode server on port {port}, no session yet"
-                        )
-                        agent_cmd = f"opencode attach {server_url}"
-                else:
-                    _launcher_logger.warning(
-                        f"Failed to ensure opencode server: {err}, falling back to interactive mode"
-                    )
-                    agent_cmd = f'opencode --prompt "{CONTROL_PROMPT_INSTRUCTION}"'
-                    need_capture_session = True
+        daemon = _get_daemon_client(project_root)
+        if daemon:
+            project_str = str(project_root) if project_root else str(Path.cwd())
+            ok, command, prompt_file, port, session_id, resolved_agent, err = (
+                daemon.get_control_agent_launch(
+                    project_str, agent_type=agent, new_session=new_control_agent
+                )
+            )
+            if ok and command:
+                agent_cmd = command
+                _launcher_logger.info(
+                    f"Using daemon launch: agent={resolved_agent}, command={command}, "
+                    f"port={port}, session={session_id}"
+                )
             else:
                 _launcher_logger.warning(
-                    "Daemon not available, falling back to interactive mode"
+                    f"Failed to get control agent launch from daemon: {err}"
                 )
-                agent_cmd = f'opencode --prompt "{CONTROL_PROMPT_INSTRUCTION}"'
-                need_capture_session = True
-
-        elif agent == "claude":
-            if new_control_agent:
-                clear_control_session(project_root)
-                agent_cmd = "claude"
-                need_capture_session = True
-            else:
-                # Daemon handles agent type change detection and session discovery
-                session_id = load_control_session(project_root, agent_type="claude")
-                if session_id:
-                    _launcher_logger.info(f"Using Claude session: {session_id}")
-                    agent_cmd = f"claude --resume {session_id}"
-                else:
-                    _launcher_logger.info("No Claude session found, starting fresh")
-                    agent_cmd = "claude"
+                # Fall back to simple command
+                if agent in ("opencode", "claude", "codex", "gemini"):
+                    agent_cmd = f'{agent} --prompt "{CONTROL_PROMPT_INSTRUCTION}"'
                     need_capture_session = True
         else:
-            agent_cmd = agent
+            _launcher_logger.warning(
+                "Daemon not available, using fallback agent command"
+            )
+            if agent in ("opencode", "claude", "codex", "gemini"):
+                agent_cmd = f'{agent} --prompt "{CONTROL_PROMPT_INSTRUCTION}"'
+                need_capture_session = True
 
         subprocess.run(
             ["tmux", "send-keys", "-t", f"{session_name}:0.0", runs_cmd, "Enter"]
@@ -520,20 +410,18 @@ class TmuxLayoutLauncher:
             ["tmux", "send-keys", "-t", f"{session_name}:0.2", agent_cmd, "Enter"]
         )
 
-        if need_capture_session and agent == "opencode":
-            _launcher_logger.info("Waiting to capture opencode session ID...")
+        # Capture session for fallback cases
+        if need_capture_session:
+            _launcher_logger.info(f"Waiting to capture {agent} session ID...")
             time.sleep(3)
-            session_id = query_latest_opencode_session(project_root)
-            if session_id:
-                save_control_session(project_root, session_id, agent_type="opencode")
-
-        if need_capture_session and agent == "claude":
-            _launcher_logger.info("Waiting to capture Claude session ID...")
-            time.sleep(3)
-            # Ask daemon to discover the new session
-            session_id = load_control_session(project_root, agent_type="claude")
-            if session_id:
-                _launcher_logger.info(f"Captured Claude session: {session_id}")
+            if agent == "opencode":
+                session_id = query_latest_opencode_session(project_root)
+                if session_id:
+                    save_control_session(project_root, session_id, agent_type="opencode")
+            elif agent == "claude":
+                session_id = load_control_session(project_root, agent_type="claude")
+                if session_id:
+                    _launcher_logger.info(f"Captured Claude session: {session_id}")
 
         subprocess.run(["tmux", "select-pane", "-t", f"{session_name}:0.2"])
 
@@ -610,62 +498,43 @@ class ZellijLayoutLauncher:
         runs_cmd = f"{python_exec} -m orch_monitor --runs {orch_args}".strip()
         issues_cmd = f"{python_exec} -m orch_monitor --issues {orch_args}".strip()
 
-        write_control_prompt(vault_path)
+        # Use daemon API to get control agent launch command
+        # The daemon handles: writing control prompt file, resolving agent config,
+        # session management, and building the command
+        agent_cmd = agent  # fallback to raw agent command
         need_capture_session = False
 
-        if agent == "opencode":
-            prompt_escaped = CONTROL_PROMPT_INSTRUCTION.replace('"', '\\"')
-            if new_control_agent:
-                clear_control_session(project_root)
-
-            daemon = _get_daemon_client(project_root)
-            if daemon:
-                project_str = str(project_root) if project_root else str(Path.cwd())
-                ok, port, session_id, err = daemon.ensure_opencode_server(project_str)
-                if ok and port > 0:
-                    server_url = f"http://127.0.0.1:{port}"
-                    if session_id:
-                        _launcher_logger.info(
-                            f"Using opencode server on port {port}, session: {session_id}"
-                        )
-                        agent_cmd = (
-                            f"opencode attach {server_url} --session {session_id}"
-                        )
-                    else:
-                        _launcher_logger.info(
-                            f"Using opencode server on port {port}, no session yet"
-                        )
-                        agent_cmd = f"opencode attach {server_url}"
-                else:
-                    _launcher_logger.warning(
-                        f"Failed to ensure opencode server: {err}, falling back to interactive mode"
-                    )
-                    agent_cmd = f'opencode --prompt \\"{prompt_escaped}\\"'
-                    need_capture_session = True
+        daemon = _get_daemon_client(project_root)
+        if daemon:
+            project_str = str(project_root) if project_root else str(Path.cwd())
+            ok, command, prompt_file, port, session_id, resolved_agent, err = (
+                daemon.get_control_agent_launch(
+                    project_str, agent_type=agent, new_session=new_control_agent
+                )
+            )
+            if ok and command:
+                agent_cmd = command
+                _launcher_logger.info(
+                    f"Using daemon launch: agent={resolved_agent}, command={command}, "
+                    f"port={port}, session={session_id}"
+                )
             else:
                 _launcher_logger.warning(
-                    "Daemon not available, falling back to interactive mode"
+                    f"Failed to get control agent launch from daemon: {err}"
                 )
-                agent_cmd = f'opencode --prompt \\"{prompt_escaped}\\"'
-                need_capture_session = True
-
-        elif agent == "claude":
-            if new_control_agent:
-                clear_control_session(project_root)
-                agent_cmd = "claude"
-                need_capture_session = True
-            else:
-                # Daemon handles agent type change detection and session discovery
-                session_id = load_control_session(project_root, agent_type="claude")
-                if session_id:
-                    _launcher_logger.info(f"Using Claude session: {session_id}")
-                    agent_cmd = f"claude --resume {session_id}"
-                else:
-                    _launcher_logger.info("No Claude session found, starting fresh")
-                    agent_cmd = "claude"
+                # Fall back to simple command with escaped prompt for zellij
+                prompt_escaped = CONTROL_PROMPT_INSTRUCTION.replace('"', '\\"')
+                if agent in ("opencode", "claude", "codex", "gemini"):
+                    agent_cmd = f'{agent} --prompt \\"{prompt_escaped}\\"'
                     need_capture_session = True
         else:
-            agent_cmd = agent
+            _launcher_logger.warning(
+                "Daemon not available, using fallback agent command"
+            )
+            prompt_escaped = CONTROL_PROMPT_INSTRUCTION.replace('"', '\\"')
+            if agent in ("opencode", "claude", "codex", "gemini"):
+                agent_cmd = f'{agent} --prompt \\"{prompt_escaped}\\"'
+                need_capture_session = True
 
         layout_content = f'''
 layout {{
@@ -763,20 +632,19 @@ layout {{
                 if session_name in result.stdout.split("\n"):
                     break
 
-            if need_capture_session and agent == "opencode":
+            # Capture session for fallback cases
+            if need_capture_session:
                 time.sleep(2)
-                session_id = query_latest_opencode_session(project_root)
-                if session_id:
-                    save_control_session(
-                        project_root, session_id, agent_type="opencode"
-                    )
-
-            if need_capture_session and agent == "claude":
-                time.sleep(2)
-                # Ask daemon to discover the new session
-                session_id = load_control_session(project_root, agent_type="claude")
-                if session_id:
-                    _launcher_logger.info(f"Captured Claude session: {session_id}")
+                if agent == "opencode":
+                    session_id = query_latest_opencode_session(project_root)
+                    if session_id:
+                        save_control_session(
+                            project_root, session_id, agent_type="opencode"
+                        )
+                elif agent == "claude":
+                    session_id = load_control_session(project_root, agent_type="claude")
+                    if session_id:
+                        _launcher_logger.info(f"Captured Claude session: {session_id}")
 
             os.execvp("zellij", ["zellij", "attach", session_name])
         else:

--- a/orch-monitor-tui/orch_monitor/daemon.py
+++ b/orch-monitor-tui/orch_monitor/daemon.py
@@ -454,6 +454,49 @@ class DaemonClient:
         except DaemonError:
             return False
 
+    def get_control_agent_launch(
+        self, project_root: str, agent_type: str = "", new_session: bool = False
+    ) -> tuple[bool, Optional[str], Optional[str], int, Optional[str], Optional[str], Optional[str]]:
+        """Get control agent launch command and configuration.
+
+        This API:
+        - Writes the ORCH_CONTROL_PROMPT.md file to cwd
+        - Resolves agent type from config if not specified
+        - Builds full command via agent.LaunchCommand()
+        - Handles session continuity
+
+        Args:
+            project_root: The project root directory.
+            agent_type: Optional agent type (e.g., "opencode", "claude"). Defaults to config.
+            new_session: If True, clear existing session and start fresh.
+
+        Returns:
+            Tuple of (ok, command, prompt_file, port, session_id, agent, error)
+        """
+        request = {
+            "type": "get_control_agent_launch",
+            "project_root": project_root,
+            "agent_type": agent_type,
+            "force": new_session,  # Using 'force' field for new_session
+            "issues_root": self._issues_root_str(),
+        }
+
+        try:
+            response = self._send_request(request)
+            if response.get("ok", False):
+                return (
+                    True,
+                    response.get("command"),
+                    response.get("prompt_file"),
+                    response.get("port", 0),
+                    response.get("session_id"),
+                    response.get("agent"),
+                    None,
+                )
+            return (False, None, None, 0, None, None, response.get("error", "Unknown error"))
+        except DaemonError as e:
+            return (False, None, None, 0, None, None, str(e))
+
 
 class MonitorRegistration:
     def __init__(self, client: DaemonClient, project: str, view: str = "dashboard"):

--- a/orch-monitor-tui/tests/test_session_continuation.py
+++ b/orch-monitor-tui/tests/test_session_continuation.py
@@ -1,8 +1,10 @@
 """Tests for session continuation behavior in control agent launchers.
 
-These tests verify that orch-monitor uses explicit session IDs instead of
-the --continue flag, which can attach to the wrong session when multiple
-sessions are running.
+These tests verify that orch-monitor uses the daemon's get_control_agent_launch API
+to get the correct command for launching the control agent, which includes:
+- Writing the control prompt file
+- Resolving agent configuration
+- Building the appropriate command with session IDs
 """
 
 from pathlib import Path
@@ -11,16 +13,37 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-class TestOpenCodeSessionContinuation:
-    """Test OpenCode session continuation behavior."""
+def mock_daemon_client_with_launch(command, port=0, session_id=None, agent="opencode"):
+    """Create a mock daemon client that returns a specific launch command."""
+    mock_daemon = MagicMock()
+    mock_daemon.is_available.return_value = True
+    mock_daemon.get_control_agent_launch.return_value = (
+        True,  # ok
+        command,  # command
+        "/tmp/ORCH_CONTROL_PROMPT.md",  # prompt_file
+        port,  # port
+        session_id,  # session_id
+        agent,  # agent
+        None,  # error
+    )
+    return mock_daemon
 
-    def test_tmux_launcher_uses_explicit_session_id_when_stored(self):
-        """When a session ID is stored, TmuxLayoutLauncher should use --session flag."""
+
+def mock_daemon_client_unavailable():
+    """Create a mock daemon client that is unavailable."""
+    mock_daemon = MagicMock()
+    mock_daemon.is_available.return_value = False
+    return mock_daemon
+
+
+class TestOpenCodeSessionContinuation:
+    """Test OpenCode session continuation behavior with daemon API."""
+
+    def test_tmux_launcher_uses_daemon_command_with_session(self):
+        """When daemon returns a command with session ID, it should be used."""
         from orch_monitor.__main__ import TmuxLayoutLauncher
 
         launcher = TmuxLayoutLauncher()
-
-        # Mock subprocess.run to capture the command
         commands_sent = []
 
         def mock_run(args, **kwargs):
@@ -29,9 +52,16 @@ class TestOpenCodeSessionContinuation:
             mock_result.returncode = 0
             return mock_result
 
+        # Daemon returns command with session ID
+        mock_daemon = mock_daemon_client_with_launch(
+            command="opencode attach http://127.0.0.1:4096 --session session-123",
+            port=4096,
+            session_id="session-123",
+            agent="opencode",
+        )
+
         with patch("subprocess.run", side_effect=mock_run), \
-             patch("orch_monitor.__main__.load_control_session", return_value="session-123"), \
-             patch("orch_monitor.__main__.write_control_prompt", return_value=True):
+             patch("orch_monitor.__main__._get_daemon_client", return_value=mock_daemon):
 
             launcher.launch_layout(
                 session_name="test-session",
@@ -54,12 +84,11 @@ class TestOpenCodeSessionContinuation:
         assert "--session session-123" in cmd_str, f"Should use explicit --session flag, got: {cmd_str}"
         assert "--continue" not in cmd_str, f"Should NOT use --continue flag, got: {cmd_str}"
 
-    def test_tmux_launcher_starts_fresh_when_no_session_stored(self):
-        """When no session ID is stored, TmuxLayoutLauncher should start fresh (no --continue)."""
+    def test_tmux_launcher_uses_daemon_command_without_session(self):
+        """When daemon returns a command without session ID, it should be used."""
         from orch_monitor.__main__ import TmuxLayoutLauncher
 
         launcher = TmuxLayoutLauncher()
-
         commands_sent = []
 
         def mock_run(args, **kwargs):
@@ -68,11 +97,16 @@ class TestOpenCodeSessionContinuation:
             mock_result.returncode = 0
             return mock_result
 
+        # Daemon returns command without session (new server)
+        mock_daemon = mock_daemon_client_with_launch(
+            command="opencode attach http://127.0.0.1:4096",
+            port=4096,
+            session_id=None,
+            agent="opencode",
+        )
+
         with patch("subprocess.run", side_effect=mock_run), \
-             patch("orch_monitor.__main__.load_control_session", return_value=None), \
-             patch("orch_monitor.__main__.write_control_prompt", return_value=True), \
-             patch("orch_monitor.__main__.query_latest_opencode_session", return_value=None), \
-             patch("orch_monitor.__main__.save_control_session", return_value=True):
+             patch("orch_monitor.__main__._get_daemon_client", return_value=mock_daemon):
 
             launcher.launch_layout(
                 session_name="test-session",
@@ -92,19 +126,18 @@ class TestOpenCodeSessionContinuation:
 
         assert agent_cmd is not None, "Should have sent opencode command"
         cmd_str = " ".join(str(c) for c in agent_cmd)
+        assert "opencode attach" in cmd_str, f"Should use attach command, got: {cmd_str}"
         assert "--continue" not in cmd_str, f"Should NOT use --continue flag, got: {cmd_str}"
-        assert "--prompt" in cmd_str, f"Should use --prompt flag, got: {cmd_str}"
 
 
 class TestClaudeSessionContinuation:
-    """Test Claude session continuation behavior."""
+    """Test Claude session continuation behavior with daemon API."""
 
-    def test_tmux_launcher_uses_resume_with_session_id(self):
-        """When a session ID is stored, TmuxLayoutLauncher should use --resume flag for Claude."""
+    def test_tmux_launcher_uses_daemon_command_with_resume(self):
+        """When daemon returns a claude --resume command, it should be used."""
         from orch_monitor.__main__ import TmuxLayoutLauncher
 
         launcher = TmuxLayoutLauncher()
-
         commands_sent = []
 
         def mock_run(args, **kwargs):
@@ -113,9 +146,16 @@ class TestClaudeSessionContinuation:
             mock_result.returncode = 0
             return mock_result
 
+        # Daemon returns claude command with resume
+        mock_daemon = mock_daemon_client_with_launch(
+            command="claude --dangerously-skip-permissions --resume claude-session-456",
+            port=0,
+            session_id="claude-session-456",
+            agent="claude",
+        )
+
         with patch("subprocess.run", side_effect=mock_run), \
-             patch("orch_monitor.__main__.load_control_session", return_value="claude-session-456"), \
-             patch("orch_monitor.__main__.write_control_prompt", return_value=True):
+             patch("orch_monitor.__main__._get_daemon_client", return_value=mock_daemon):
 
             launcher.launch_layout(
                 session_name="test-session",
@@ -138,12 +178,11 @@ class TestClaudeSessionContinuation:
         assert "--resume claude-session-456" in cmd_str, f"Should use --resume with session ID, got: {cmd_str}"
         assert "--continue" not in cmd_str, f"Should NOT use --continue flag, got: {cmd_str}"
 
-    def test_tmux_launcher_starts_fresh_when_no_claude_session(self):
-        """When no session ID is stored, TmuxLayoutLauncher should start fresh Claude (no --continue)."""
+    def test_tmux_launcher_uses_daemon_fresh_claude_command(self):
+        """When daemon returns a fresh claude command, it should be used."""
         from orch_monitor.__main__ import TmuxLayoutLauncher
 
         launcher = TmuxLayoutLauncher()
-
         commands_sent = []
 
         def mock_run(args, **kwargs):
@@ -152,9 +191,16 @@ class TestClaudeSessionContinuation:
             mock_result.returncode = 0
             return mock_result
 
+        # Daemon returns fresh claude command (no session)
+        mock_daemon = mock_daemon_client_with_launch(
+            command='claude --dangerously-skip-permissions "ultrathink Please read \'ORCH_CONTROL_PROMPT.md\'"',
+            port=0,
+            session_id=None,
+            agent="claude",
+        )
+
         with patch("subprocess.run", side_effect=mock_run), \
-             patch("orch_monitor.__main__.load_control_session", return_value=None), \
-             patch("orch_monitor.__main__.write_control_prompt", return_value=True):
+             patch("orch_monitor.__main__._get_daemon_client", return_value=mock_daemon):
 
             launcher.launch_layout(
                 session_name="test-session",
@@ -168,16 +214,11 @@ class TestClaudeSessionContinuation:
         # Find the send-keys command for the agent pane
         agent_cmd = None
         for cmd in commands_sent:
-            if "send-keys" in cmd:
-                # Get the command string (usually the second-to-last argument)
-                for i, arg in enumerate(cmd):
-                    if arg == "-t" and i + 2 < len(cmd):
-                        # Next is pane target, then the command
-                        if "0.2" in str(cmd[i + 1]):
-                            agent_cmd = cmd
-                            break
+            if "send-keys" in cmd and "claude" in str(cmd):
+                agent_cmd = cmd
+                break
 
-        assert agent_cmd is not None, "Should have sent agent command to pane 0.2"
+        assert agent_cmd is not None, "Should have sent claude command"
         cmd_str = " ".join(str(c) for c in agent_cmd)
         assert "--continue" not in cmd_str, f"Should NOT use --continue flag, got: {cmd_str}"
 
@@ -185,14 +226,12 @@ class TestClaudeSessionContinuation:
 class TestNewControlAgentFlag:
     """Test that --new-control-agent properly starts fresh sessions."""
 
-    def test_new_control_agent_clears_session_and_starts_fresh(self):
-        """When new_control_agent=True, should clear session and start fresh."""
+    def test_new_control_agent_passes_flag_to_daemon(self):
+        """When new_control_agent=True, should pass new_session=True to daemon."""
         from orch_monitor.__main__ import TmuxLayoutLauncher
 
         launcher = TmuxLayoutLauncher()
-
         commands_sent = []
-        clear_called = False
 
         def mock_run(args, **kwargs):
             commands_sent.append(args)
@@ -200,16 +239,27 @@ class TestNewControlAgentFlag:
             mock_result.returncode = 0
             return mock_result
 
-        def mock_clear_session(project_root):
-            nonlocal clear_called
-            clear_called = True
-            return True
+        # Create a mock daemon that records the new_session flag
+        mock_daemon = MagicMock()
+        mock_daemon.is_available.return_value = True
+        new_session_values = []
+
+        def capture_get_control_agent_launch(project_str, agent_type="", new_session=False):
+            new_session_values.append(new_session)
+            return (
+                True,
+                "opencode attach http://127.0.0.1:4096",
+                "/tmp/ORCH_CONTROL_PROMPT.md",
+                4096,
+                None,
+                "opencode",
+                None,
+            )
+
+        mock_daemon.get_control_agent_launch.side_effect = capture_get_control_agent_launch
 
         with patch("subprocess.run", side_effect=mock_run), \
-             patch("orch_monitor.__main__.clear_control_session", side_effect=mock_clear_session), \
-             patch("orch_monitor.__main__.write_control_prompt", return_value=True), \
-             patch("orch_monitor.__main__.query_latest_opencode_session", return_value=None), \
-             patch("orch_monitor.__main__.save_control_session", return_value=True):
+             patch("orch_monitor.__main__._get_daemon_client", return_value=mock_daemon):
 
             launcher.launch_layout(
                 session_name="test-session",
@@ -220,7 +270,8 @@ class TestNewControlAgentFlag:
                 new_control_agent=True,  # Force new session
             )
 
-        assert clear_called, "Should have called clear_control_session"
+        assert len(new_session_values) == 1, "Should have called get_control_agent_launch once"
+        assert new_session_values[0] is True, "Should have passed new_session=True to daemon"
 
         # Find the send-keys command for the agent pane
         agent_cmd = None
@@ -232,4 +283,3 @@ class TestNewControlAgentFlag:
         assert agent_cmd is not None, "Should have sent opencode command"
         cmd_str = " ".join(str(c) for c in agent_cmd)
         assert "--continue" not in cmd_str, f"Should NOT use --continue flag, got: {cmd_str}"
-        assert "--session" not in cmd_str, f"Should NOT use --session flag (fresh start), got: {cmd_str}"


### PR DESCRIPTION
## Summary

- Add new daemon API `get_control_agent_launch` that centralizes control agent launch logic
- Refactor Python TUI to use the new daemon API, removing duplicated code
- Single source of truth for both Go monitor and Python TUI

## Changes

### Go Daemon (`internal/daemon/socket.go`, `internal/daemon/client.go`)

1. **New API handler `handleGetControlAgentLaunch`**:
   - Writes control prompt file (`ORCH_CONTROL_PROMPT.md`) with live issue/run data
   - Resolves agent type from config (ControlAgent → Agent → "opencode")
   - Handles session continuity for opencode HTTP and CLI-based agents
   - Returns ready-to-execute command, prompt file path, port, session_id, agent name

2. **Helper functions**:
   - `writeControlPromptFile()` - Writes prompt to cwd
   - `buildControlAgentPrompt()` - Builds prompt with live data from store
   - `getStoredControlSession()` - Retrieves stored session ID

### Python TUI (`orch_monitor/__main__.py`, `orch_monitor/daemon.py`)

1. **Added `get_control_agent_launch()` method** to `DaemonClient`

2. **Deleted `write_control_prompt()` function** (~85 lines removed)

3. **Simplified both layout launchers** (~95 lines simplified):
   - Now call `daemon.get_control_agent_launch()` to get the command
   - Fall back to simple prompt command only if daemon unavailable

4. **Updated tests** to mock the new daemon API

## Test plan

- [x] All Go tests pass (`go test ./...`)
- [x] All Python daemon tests pass (`pytest tests/test_daemon.py`)
- [x] Session continuation tests pass (`pytest tests/test_session_continuation.py`)
- [x] Project builds successfully (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)