### PR TITLE
fix(capture): display tool calls meaningfully instead of empty lines

### DIFF
--- a/internal/agent/opencode_client.go
+++ b/internal/agent/opencode_client.go
@@ -118,10 +118,15 @@ func (s *Session) UpdatedAt() time.Time {
 	return time.UnixMilli(s.Time.Updated)
 }
 
-// MessagePart represents a part of a message
+// MessagePart represents a part of a message.
+// Types: "text", "tool_use", "tool_result", "thinking", "redacted_thinking"
 type MessagePart struct {
-	Type string `json:"type"`
-	Text string `json:"text,omitempty"`
+	Type      string `json:"type"`
+	Text      string `json:"text,omitempty"`
+	ToolName  string `json:"name,omitempty"`        // tool_use only
+	ToolID    string `json:"id,omitempty"`          // tool_use only
+	ToolInput any    `json:"input,omitempty"`       // tool_use only
+	ToolUseID string `json:"tool_use_id,omitempty"` // tool_result only
 }
 
 // Message represents an opencode message

--- a/internal/cli/capture.go
+++ b/internal/cli/capture.go
@@ -70,8 +70,9 @@ type openCodeCaptureResult struct {
 }
 
 type openCodeCaptureMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role    string              `json:"role"`
+	Content string              `json:"content"`
+	Parts   []agent.MessagePart `json:"parts"`
 }
 
 func runCapture(refStr string, opts *captureOptions) error {
@@ -145,6 +146,7 @@ func captureOpenCode(run *model.Run, opts *captureOptions) error {
 			result.Messages[i] = openCodeCaptureMessage{
 				Role:    msg.Info.Role,
 				Content: formatMessageParts(msg.Parts),
+				Parts:   msg.Parts,
 			}
 		}
 		enc := json.NewEncoder(os.Stdout)
@@ -161,15 +163,38 @@ func captureOpenCode(run *model.Run, opts *captureOptions) error {
 	return nil
 }
 
-// formatMessageParts concatenates text parts of a message
 func formatMessageParts(parts []agent.MessagePart) string {
 	var texts []string
 	for _, part := range parts {
-		if part.Type == "text" && part.Text != "" {
-			texts = append(texts, part.Text)
+		switch part.Type {
+		case "text":
+			if part.Text != "" {
+				texts = append(texts, part.Text)
+			}
+		case "tool_use":
+			toolName := part.ToolName
+			if toolName == "" {
+				toolName = "unknown"
+			}
+			texts = append(texts, fmt.Sprintf("<tool: %s>", toolName))
+		case "tool_result":
+			resultText := truncateText(part.Text, 100)
+			if resultText == "" {
+				resultText = "..."
+			}
+			texts = append(texts, fmt.Sprintf("<result: %s>", resultText))
+		case "thinking", "redacted_thinking":
+			texts = append(texts, "<thinking...>")
 		}
 	}
 	return strings.Join(texts, "\n")
+}
+
+func truncateText(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }
 
 // outputCaptureError outputs an error in the appropriate format

--- a/internal/cli/capture_test.go
+++ b/internal/cli/capture_test.go
@@ -77,13 +77,13 @@ func TestFormatMessageParts(t *testing.T) {
 			expected: "First\nSecond",
 		},
 		{
-			name: "mixed parts with non-text",
+			name: "mixed parts with tool_use",
 			parts: []agent.MessagePart{
 				{Type: "text", Text: "Hello"},
-				{Type: "tool_use", Text: ""},
+				{Type: "tool_use", ToolName: "read_file"},
 				{Type: "text", Text: "World"},
 			},
-			expected: "Hello\nWorld",
+			expected: "Hello\n<tool: read_file>\nWorld",
 		},
 		{
 			name: "text parts with empty text",
@@ -95,16 +95,46 @@ func TestFormatMessageParts(t *testing.T) {
 			expected: "Hello\nWorld",
 		},
 		{
-			name: "only non-text parts",
+			name: "tool_use and tool_result",
 			parts: []agent.MessagePart{
-				{Type: "tool_use", Text: "ignored"},
-				{Type: "tool_result", Text: "also ignored"},
+				{Type: "tool_use", ToolName: "bash"},
+				{Type: "tool_result", Text: "success"},
 			},
-			expected: "",
+			expected: "<tool: bash>\n<result: success>",
+		},
+		{
+			name:     "tool_use without name",
+			parts:    []agent.MessagePart{{Type: "tool_use"}},
+			expected: "<tool: unknown>",
+		},
+		{
+			name:     "tool_result with long text truncated",
+			parts:    []agent.MessagePart{{Type: "tool_result", Text: "This is a very long result text that should be truncated at some point to keep the output readable and not overwhelming"}},
+			expected: "<result: This is a very long result text that should be truncated at some point to keep the output readable a...>",
+		},
+		{
+			name:     "tool_result with empty text",
+			parts:    []agent.MessagePart{{Type: "tool_result", Text: ""}},
+			expected: "<result: ...>",
+		},
+		{
+			name:     "thinking part",
+			parts:    []agent.MessagePart{{Type: "thinking", Text: "internal thoughts"}},
+			expected: "<thinking...>",
+		},
+		{
+			name:     "redacted_thinking part",
+			parts:    []agent.MessagePart{{Type: "redacted_thinking"}},
+			expected: "<thinking...>",
 		},
 		{
 			name:     "nil parts",
 			parts:    nil,
+			expected: "",
+		},
+		{
+			name:     "unknown type is ignored",
+			parts:    []agent.MessagePart{{Type: "unknown_type", Text: "ignored"}},
 			expected: "",
 		},
 	}
@@ -114,6 +144,49 @@ func TestFormatMessageParts(t *testing.T) {
 			result := formatMessageParts(tt.parts)
 			if result != tt.expected {
 				t.Errorf("formatMessageParts() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTruncateText(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxLen   int
+		expected string
+	}{
+		{
+			name:     "short text unchanged",
+			input:    "hello",
+			maxLen:   10,
+			expected: "hello",
+		},
+		{
+			name:     "exact length unchanged",
+			input:    "hello",
+			maxLen:   5,
+			expected: "hello",
+		},
+		{
+			name:     "long text truncated",
+			input:    "hello world",
+			maxLen:   5,
+			expected: "hello...",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			maxLen:   10,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := truncateText(tt.input, tt.maxLen)
+			if result != tt.expected {
+				t.Errorf("truncateText(%q, %d) = %q, want %q", tt.input, tt.maxLen, result, tt.expected)
 			}
 		})
 	}
@@ -288,8 +361,16 @@ func TestOpenCodeCaptureResultJSON(t *testing.T) {
 		RunID:     "20240101-120000",
 		SessionID: "ses_abc123",
 		Messages: []openCodeCaptureMessage{
-			{Role: "user", Content: "Hello"},
-			{Role: "assistant", Content: "Hi there!"},
+			{
+				Role:    "user",
+				Content: "Hello",
+				Parts:   []agent.MessagePart{{Type: "text", Text: "Hello"}},
+			},
+			{
+				Role:    "assistant",
+				Content: "<tool: read_file>",
+				Parts:   []agent.MessagePart{{Type: "tool_use", ToolName: "read_file"}},
+			},
 		},
 	}
 
@@ -334,6 +415,41 @@ func TestOpenCodeCaptureResultJSON(t *testing.T) {
 	}
 	if msg0["content"] != "Hello" {
 		t.Errorf("message[0].content = %v, want %q", msg0["content"], "Hello")
+	}
+	parts0, ok := msg0["parts"].([]interface{})
+	if !ok {
+		t.Fatal("message[0].parts should be an array")
+	}
+	if len(parts0) != 1 {
+		t.Errorf("message[0].parts length = %d, want 1", len(parts0))
+	}
+
+	msg1, ok := messages[1].(map[string]interface{})
+	if !ok {
+		t.Fatal("message[1] should be an object")
+	}
+	if msg1["role"] != "assistant" {
+		t.Errorf("message[1].role = %v, want %q", msg1["role"], "assistant")
+	}
+	if msg1["content"] != "<tool: read_file>" {
+		t.Errorf("message[1].content = %v, want %q", msg1["content"], "<tool: read_file>")
+	}
+	parts1, ok := msg1["parts"].([]interface{})
+	if !ok {
+		t.Fatal("message[1].parts should be an array")
+	}
+	if len(parts1) != 1 {
+		t.Errorf("message[1].parts length = %d, want 1", len(parts1))
+	}
+	part1, ok := parts1[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("message[1].parts[0] should be an object")
+	}
+	if part1["type"] != "tool_use" {
+		t.Errorf("message[1].parts[0].type = %v, want %q", part1["type"], "tool_use")
+	}
+	if part1["name"] != "read_file" {
+		t.Errorf("message[1].parts[0].name = %v, want %q", part1["name"], "read_file")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Display tool calls with meaningful indicators instead of empty `[assistant]` lines
- Preserve full message structure in JSON output for tooling

## Changes

- **opencode_client.go**: Expanded `MessagePart` struct to capture tool metadata (name, id, input, tool_use_id)
- **capture.go**: Updated `formatMessageParts()` to handle all part types with meaningful output:
  - `text` → displays as-is
  - `tool_use` → `<tool: tool_name>`
  - `tool_result` → `<result: truncated_text>`
  - `thinking`/`redacted_thinking` → `<thinking...>`
- **capture_test.go**: Added comprehensive test coverage for all message part types

## Acceptance Criteria Evidence

### 1. ✅ `orch capture <opencode-run>` produces readable output without empty lines

**Before:**
```
[user] ultrathink Please read 'ORCH_PROMPT.md'...
[assistant]
[assistant]
[assistant]
```

**After:**
```
[user] ultrathink Please read 'ORCH_PROMPT.md'...
[assistant] <tool: read_file>
[assistant] <result: file contents...>
[assistant] <thinking...>
[assistant] The solution is...
```

### 2. ✅ Tool calls are displayed meaningfully (not empty)

Implemented as Option A from the issue - show tool calls with indicators:
- `tool_use` parts display as `<tool: tool_name>`
- `tool_result` parts display as `<result: text>` (truncated to 100 chars)
- `thinking` parts display as `<thinking...>`

### 3. ✅ JSON output (`--json`) preserves full message structure for tooling

The `openCodeCaptureMessage` struct now includes raw `Parts` array alongside formatted `Content`:

```json
{
  "messages": [
    {
      "role": "assistant",
      "content": "<tool: read_file>",
      "parts": [
        {
          "type": "tool_use",
          "name": "read_file",
          "id": "tool_abc123",
          "input": {"path": "/file.txt"}
        }
      ]
    }
  ]
}
```

### 4. ✅ Test coverage for different message part types

Added/updated tests in `capture_test.go`:
- `TestFormatMessageParts` - 14 test cases covering all part types
- `TestTruncateText` - 4 test cases for text truncation helper
- `TestOpenCodeCaptureResultJSON` - verifies JSON structure preserves parts

**Test output:**
```
=== RUN   TestFormatMessageParts
--- PASS: TestFormatMessageParts (0.00s)
=== RUN   TestTruncateText
--- PASS: TestTruncateText (0.00s)
ok  	github.com/s22625/orch/internal/cli
```

## Testing

```bash
$ go test ./internal/cli/... ./internal/agent/...
ok  	github.com/s22625/orch/internal/cli	2.584s
ok  	github.com/s22625/orch/internal/agent	0.301s

$ go build ./...
# Build successful
```

Closes orch-366