### PR TITLE
feat(daemon): move alive status computation to daemon (orch-367)

### DIFF
--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -80,6 +80,7 @@ func runPs(opts *psOptions) error {
 
 	var runs []*model.Run
 	var usedDaemon bool
+	var daemonAliveInfo map[string]agentAliveInfo
 
 	if !testBypassDaemon {
 		projectRoot, _ := getProjectRoot()
@@ -96,8 +97,11 @@ func runPs(opts *psOptions) error {
 			resp, err := client.ListRuns(opts.Issue, statusFilter, limit, "")
 			if err == nil && resp != nil {
 				runs = make([]*model.Run, len(resp.Runs))
+				daemonAliveInfo = make(map[string]agentAliveInfo, len(resp.Runs))
 				for i, summary := range resp.Runs {
 					runs[i] = daemon.SummaryToRun(summary)
+					alive, known := daemon.SummaryAliveInfo(summary)
+					daemonAliveInfo[summary.RunID] = agentAliveInfo{alive: alive, known: known}
 				}
 				usedDaemon = true
 			}
@@ -162,7 +166,11 @@ func runPs(opts *psOptions) error {
 
 	var aliveByRun map[string]agentAliveInfo
 	if !opts.NoAlive {
-		aliveByRun = resolveAgentAliveInfo(runs)
+		if usedDaemon && daemonAliveInfo != nil {
+			aliveByRun = daemonAliveInfo
+		} else {
+			aliveByRun = resolveAgentAliveInfo(runs)
+		}
 	}
 
 	now := time.Now()

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -1500,9 +1500,14 @@ func (s *SocketServer) handleListRuns(req SendRequest, encoder *json.Encoder) {
 	}
 	paginatedRuns := runs[offset:end]
 
+	computeAlive := func(run *model.Run) bool {
+		manager := agent.GetManager(run)
+		return manager.IsAlive(run)
+	}
+
 	summaries := make([]*RunSummary, len(paginatedRuns))
 	for i, run := range paginatedRuns {
-		summaries[i] = RunToSummary(run)
+		summaries[i] = RunToSummaryWithAlive(run, computeAlive)
 	}
 
 	var nextCursor *string
@@ -1659,9 +1664,14 @@ func (s *SocketServer) handleGetRun(req SendRequest, encoder *json.Encoder) {
 		return
 	}
 
+	computeAlive := func(r *model.Run) bool {
+		manager := agent.GetManager(r)
+		return manager.IsAlive(r)
+	}
+
 	encoder.Encode(GetRunResponse{
 		OK:  true,
-		Run: RunToFull(run),
+		Run: RunToFullWithAlive(run, computeAlive),
 	})
 }
 

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -91,6 +91,8 @@ type RunSummary struct {
 	PRUrl        string `json:"pr_url,omitempty"`
 	Additions    int    `json:"additions"`
 	Deletions    int    `json:"deletions"`
+	Alive        bool   `json:"alive"`
+	AliveKnown   bool   `json:"alive_known"`
 	StartedAt    string `json:"started_at"`
 	UpdatedAt    string `json:"updated_at"`
 	URI          string `json:"uri"`
@@ -121,6 +123,8 @@ type RunFull struct {
 	ServerPort        int          `json:"server_port,omitempty"`
 	OpenCodeSessionID string       `json:"opencode_session_id,omitempty"`
 	ContinuedFrom     string       `json:"continued_from,omitempty"`
+	Alive             bool         `json:"alive"`
+	AliveKnown        bool         `json:"alive_known"`
 	StartedAt         string       `json:"started_at"`
 	UpdatedAt         string       `json:"updated_at"`
 	URI               string       `json:"uri"`
@@ -235,10 +239,23 @@ func RunToSummary(run *model.Run) *RunSummary {
 		PRUrl:        run.PRUrl,
 		Additions:    diffStats.Additions,
 		Deletions:    diffStats.Deletions,
+		Alive:        false,
+		AliveKnown:   false,
 		StartedAt:    formatTime(run.StartedAt),
 		UpdatedAt:    formatTime(run.UpdatedAt),
 		URI:          FileURI(run.Path),
 	}
+}
+
+// RunToSummaryWithAlive converts a model.Run to a RunSummary with alive status computed.
+// This function requires the agent package and should be called when alive status is needed.
+func RunToSummaryWithAlive(run *model.Run, computeAlive func(*model.Run) bool) *RunSummary {
+	summary := RunToSummary(run)
+	if computeAlive != nil {
+		summary.Alive = computeAlive(run)
+		summary.AliveKnown = true
+	}
+	return summary
 }
 
 // RunToFull converts a model.Run to a RunFull
@@ -270,11 +287,23 @@ func RunToFull(run *model.Run) *RunFull {
 		ServerPort:        run.ServerPort,
 		OpenCodeSessionID: run.OpenCodeSessionID,
 		ContinuedFrom:     run.ContinuedFrom,
+		Alive:             false,
+		AliveKnown:        false,
 		StartedAt:         formatTime(run.StartedAt),
 		UpdatedAt:         formatTime(run.UpdatedAt),
 		URI:               FileURI(run.Path),
 		Events:            events,
 	}
+}
+
+// RunToFullWithAlive converts a model.Run to a RunFull with alive status computed.
+func RunToFullWithAlive(run *model.Run, computeAlive func(*model.Run) bool) *RunFull {
+	full := RunToFull(run)
+	if computeAlive != nil {
+		full.Alive = computeAlive(run)
+		full.AliveKnown = true
+	}
+	return full
 }
 
 // IssueToSummary converts a model.Issue to an IssueSummary
@@ -362,4 +391,12 @@ func SummaryToRun(s *RunSummary) *model.Run {
 		StartedAt:    startedAt,
 		UpdatedAt:    updatedAt,
 	}
+}
+
+// SummaryAliveInfo extracts alive info from a RunSummary
+func SummaryAliveInfo(s *RunSummary) (alive bool, known bool) {
+	if s == nil {
+		return false, false
+	}
+	return s.Alive, s.AliveKnown
 }

--- a/orch-monitor-tui/orch_monitor/daemon.py
+++ b/orch-monitor-tui/orch_monitor/daemon.py
@@ -456,7 +456,15 @@ class DaemonClient:
 
     def get_control_agent_launch(
         self, project_root: str, agent_type: str = "", new_session: bool = False
-    ) -> tuple[bool, Optional[str], Optional[str], int, Optional[str], Optional[str], Optional[str]]:
+    ) -> tuple[
+        bool,
+        Optional[str],
+        Optional[str],
+        int,
+        Optional[str],
+        Optional[str],
+        Optional[str],
+    ]:
         """Get control agent launch command and configuration.
 
         This API:
@@ -493,7 +501,15 @@ class DaemonClient:
                     response.get("agent"),
                     None,
                 )
-            return (False, None, None, 0, None, None, response.get("error", "Unknown error"))
+            return (
+                False,
+                None,
+                None,
+                0,
+                None,
+                None,
+                response.get("error", "Unknown error"),
+            )
         except DaemonError as e:
             return (False, None, None, 0, None, None, str(e))
 
@@ -616,6 +632,8 @@ def _json_to_run(data: dict) -> Run:
         updated_at=_parse_timestamp(data.get("updated_at", "")),
         additions=data.get("additions", 0),
         deletions=data.get("deletions", 0),
+        alive=data.get("alive", False),
+        alive_known=data.get("alive_known", False),
     )
 
 
@@ -675,6 +693,8 @@ def _json_to_run_full(data: dict) -> Run:
         continued_from=data.get("continued_from", ""),
         started_at=_parse_timestamp(data.get("started_at", "")),
         updated_at=_parse_timestamp(data.get("updated_at", "")),
+        alive=data.get("alive", False),
+        alive_known=data.get("alive_known", False),
     )
 
 

--- a/orch-monitor-tui/orch_monitor/models.py
+++ b/orch-monitor-tui/orch_monitor/models.py
@@ -124,6 +124,8 @@ class Run:
     continued_from: str = ""
     additions: int = 0
     deletions: int = 0
+    alive: bool = False
+    alive_known: bool = False
 
     def ref(self) -> str:
         """Return the run reference (ISSUE_ID#RUN_ID)."""

--- a/orch-monitor-tui/orch_monitor/widgets.py
+++ b/orch-monitor-tui/orch_monitor/widgets.py
@@ -253,6 +253,21 @@ def derive_pr_status(run: Run, branch_status: str = "") -> str:
     return "-"
 
 
+def format_alive_status(run: Run) -> str:
+    if not run.alive_known:
+        return "-"
+    return "yes" if run.alive else "no"
+
+
+def color_alive_status(run: Run) -> str:
+    text = format_alive_status(run)
+    if not run.alive_known:
+        return f"[dim]{text}[/dim]"
+    if run.alive:
+        return f"[green]{text}[/green]"
+    return f"[red]{text}[/red]"
+
+
 class RunTable(CursorPreservingTable):
     def populate(
         self,
@@ -267,6 +282,7 @@ class RunTable(CursorPreservingTable):
         self.add_column("ID", width=8)
         self.add_column("Issue", width=15)
         self.add_column("Agent", width=7)
+        self.add_column("Alive", width=6)
         self.add_column("Branch", width=8)
         self.add_column("PR", width=7)
         self.add_column("CLI", width=10)
@@ -281,6 +297,7 @@ class RunTable(CursorPreservingTable):
 
         for run in runs:
             agent_str = color_agent_status(run.status)
+            alive_str = color_alive_status(run)
 
             branch_status = branch_states.get(run.ref(), "-")
             branch_str = color_branch_status(branch_status)
@@ -309,6 +326,7 @@ class RunTable(CursorPreservingTable):
                 run.short_id(),
                 run.issue_id,
                 agent_str,
+                alive_str,
                 branch_str,
                 pr_str,
                 run.agent or "-",


### PR DESCRIPTION
## Summary

- Moves alive status computation from client-side to daemon, making daemon the single source of truth
- Adds `alive` and `alive_known` fields to `list_runs` and `get_run` API responses
- Updates Python TUI to display ALIVE column using daemon-provided values
- Updates `orch ps` to use daemon-provided alive status instead of computing client-side

## Acceptance Criteria Evidence

### 1. `list_runs` API response includes `alive` and `alive_known` fields

Added to `RunSummary` struct in `internal/daemon/types.go`:
```go
type RunSummary struct {
    // ... other fields
    Alive        bool   `json:"alive"`
    AliveKnown   bool   `json:"alive_known"`
    // ...
}
```

Computed in `handleListRuns` via `RunToSummaryWithAlive` in `internal/daemon/socket.go`.

### 2. `get_run` API response includes `alive` and `alive_known` fields

Added to `RunFull` struct in `internal/daemon/types.go`:
```go
type RunFull struct {
    // ... other fields
    Alive        bool   `json:"alive"`
    AliveKnown   bool   `json:"alive_known"`
    // ...
}
```

Computed in `handleGetRun` via `RunToFullWithAlive`.

### 3. Python TUI (`orch-monitor`) displays ALIVE column correctly

- Added `alive` and `alive_known` fields to `Run` dataclass in `models.py`
- Updated `daemon.py` to parse `alive` and `alive_known` from JSON
- Added `Alive` column to `RunTable` in `widgets.py` with color coding:
  - Green for alive=true
  - Red for alive=false
  - Dim for alive_known=false

### 4. `orch ps` uses daemon-provided alive status

Updated `runPs` in `internal/cli/ps.go` to:
- Extract alive info from `RunSummary` via `daemon.SummaryAliveInfo()` when using daemon
- Use daemon-provided `aliveByRun` map instead of calling `resolveAgentAliveInfo()`

### 5. Alive status is consistent across all clients

- Single source of truth: daemon computes alive status via `agent.GetManager(run).IsAlive(run)`
- All clients (`orch ps`, Python TUI) receive and display the same daemon-computed values

## Tests

```
$ go test ./...
ok  	github.com/s22625/orch/internal/agent
ok  	github.com/s22625/orch/internal/cli
ok  	github.com/s22625/orch/internal/daemon
...
ok  	github.com/s22625/orch/test/integration
```

All existing tests pass.

## Files Changed

- `internal/daemon/types.go` - Add Alive/AliveKnown to RunSummary/RunFull
- `internal/daemon/socket.go` - Compute alive in handlers
- `internal/cli/ps.go` - Use daemon-provided alive status
- `orch-monitor-tui/orch_monitor/models.py` - Add alive fields to Run
- `orch-monitor-tui/orch_monitor/daemon.py` - Parse alive from JSON
- `orch-monitor-tui/orch_monitor/widgets.py` - Display ALIVE column

Fixes: orch-367