### PR TITLE
feat(orch-monitor-tui): introduce OrchAPI abstraction layer

### DIFF
--- a/orch-monitor-tui/orch_monitor/__main__.py
+++ b/orch-monitor-tui/orch_monitor/__main__.py
@@ -19,6 +19,7 @@ from .multiplexer import (
     get_multiplexer,
     validate_multiplexer_config,
 )
+from .orch_api import OrchAPI, create_orch_api
 from .xdg import state_dir
 
 _launcher_logger = logging.getLogger("orch_monitor.launcher")
@@ -70,6 +71,17 @@ def _get_daemon_client(project_root: Path | None) -> "DaemonClient | None":
             return daemon
     except Exception as e:
         _launcher_logger.warning(f"Failed to get daemon client: {e}")
+    return None
+
+
+def _get_orch_api(project_root: Path | None) -> OrchAPI | None:
+    try:
+        config = Config.from_vault(project_root) if project_root else Config.load()
+        api = create_orch_api(config.socket_path, config.issues_root)
+        if api.is_available():
+            return api
+    except Exception as e:
+        _launcher_logger.warning(f"Failed to create OrchAPI: {e}")
     return None
 
 
@@ -417,7 +429,9 @@ class TmuxLayoutLauncher:
             if agent == "opencode":
                 session_id = query_latest_opencode_session(project_root)
                 if session_id:
-                    save_control_session(project_root, session_id, agent_type="opencode")
+                    save_control_session(
+                        project_root, session_id, agent_type="opencode"
+                    )
             elif agent == "claude":
                 session_id = load_control_session(project_root, agent_type="claude")
                 if session_id:

--- a/orch-monitor-tui/orch_monitor/app.py
+++ b/orch-monitor-tui/orch_monitor/app.py
@@ -55,6 +55,8 @@ from textual.widgets import (
     SelectionList,
 )
 
+from returns.result import Failure
+
 from .config import (
     Config,
     ConfigurationState,
@@ -62,14 +64,88 @@ from .config import (
     IssueFilterState,
     RunFilterState,
 )
-from .daemon import (
-    DaemonClient,
-    DaemonError,
-    DaemonNotRunningError,
-    MonitorRegistration,
-    RunFilters,
-)
 from .models import DiffStats, FileChange, Issue, IssueStatus, Run, Status
+from .orch_api import (
+    Issue as ApiIssue,
+    IssueStatus as ApiIssueStatus,
+    OrchAPI,
+    OrchError,
+    Run as ApiRun,
+    RunFilters as ApiRunFilters,
+    RunStatus as ApiRunStatus,
+    create_orch_api,
+)
+from .orch_api import DaemonNotRunningError as ApiDaemonNotRunningError
+
+
+def _api_run_status_to_model(status: ApiRunStatus) -> Status:
+    mapping = {
+        ApiRunStatus.QUEUED: Status.QUEUED,
+        ApiRunStatus.BOOTING: Status.BOOTING,
+        ApiRunStatus.RUNNING: Status.RUNNING,
+        ApiRunStatus.BLOCKED: Status.BLOCKED,
+        ApiRunStatus.BLOCKED_API: Status.BLOCKED_API,
+        ApiRunStatus.PR_OPEN: Status.PR_OPEN,
+        ApiRunStatus.DONE: Status.DONE,
+        ApiRunStatus.FAILED: Status.FAILED,
+        ApiRunStatus.CANCELED: Status.CANCELED,
+        ApiRunStatus.UNKNOWN: Status.UNKNOWN,
+    }
+    return mapping.get(status, Status.UNKNOWN)
+
+
+def _api_issue_status_to_model(status: ApiIssueStatus) -> IssueStatus:
+    mapping = {
+        ApiIssueStatus.OPEN: IssueStatus.OPEN,
+        ApiIssueStatus.RESOLVED: IssueStatus.RESOLVED,
+        ApiIssueStatus.CLOSED: IssueStatus.CLOSED,
+    }
+    return mapping.get(status, IssueStatus.OPEN)
+
+
+def _api_run_to_model(api_run: ApiRun) -> Run:
+    return Run(
+        issue_id=api_run.issue_id,
+        run_id=api_run.run_id,
+        path=Path(),
+        status=_api_run_status_to_model(api_run.status),
+        agent=api_run.agent,
+        model=api_run.model,
+        branch=api_run.branch,
+        worktree_path=api_run.worktree_path,
+        pr_url=api_run.pr_url,
+        started_at=api_run.started_at,
+        updated_at=api_run.updated_at,
+        tmux_session=api_run.tmux_session,
+        multiplexer=api_run.multiplexer,
+        server_port=api_run.server_port,
+        opencode_session_id=api_run.opencode_session_id,
+        additions=api_run.diff_stats.additions if api_run.diff_stats else 0,
+        deletions=api_run.diff_stats.deletions if api_run.diff_stats else 0,
+    )
+
+
+def _api_runs_to_model_runs(api_runs: list[ApiRun]) -> list[Run]:
+    return [_api_run_to_model(r) for r in api_runs]
+
+
+def _api_issue_to_model(api_issue: ApiIssue) -> Issue:
+    return Issue(
+        id=api_issue.id,
+        title=api_issue.title,
+        summary=api_issue.summary,
+        status=_api_issue_status_to_model(api_issue.status),
+        tags=api_issue.tags,
+        body=api_issue.body,
+        path=api_issue.path,
+        modified_at=api_issue.modified_at,
+    )
+
+
+def _api_issues_to_model_issues(api_issues: list[ApiIssue]) -> list[Issue]:
+    return [_api_issue_to_model(i) for i in api_issues]
+
+
 from .multiplexer import (
     Multiplexer,
     MultiplexerType,
@@ -1544,13 +1620,21 @@ class RunsDashboard(App):
         Binding("d", "diff", "Diff"),
     ]
 
-    def __init__(self, issues_root: Optional[Path] = None, auto_refresh: bool = True):
+    def __init__(
+        self,
+        issues_root: Optional[Path] = None,
+        auto_refresh: bool = True,
+        api: Optional[OrchAPI] = None,
+    ):
         super().__init__()
         if issues_root:
             self.config = Config.from_issues_root(issues_root)
         else:
             self.config = Config.load()
-        self.daemon = DaemonClient(self.config.socket_path, self.config.issues_root)
+        self.api: OrchAPI = api or create_orch_api(
+            self.config.socket_path,
+            self.config.issues_root,
+        )
         self.runs: list[Run] = []
         self.selected_run: Optional[Run] = None
         self.filter_state = self.config.load_filters()
@@ -1560,9 +1644,7 @@ class RunsDashboard(App):
         self._daemon_error: Optional[str] = None
         self._last_update: Optional[datetime] = None
         self._highlighted_run_ref: Optional[str] = None
-        self._monitor_registration = MonitorRegistration(
-            self.daemon, str(self.config.project_root), "runs"
-        )
+        self._monitor_id: Optional[str] = None
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
@@ -1573,7 +1655,16 @@ class RunsDashboard(App):
         yield Footer()
 
     def on_mount(self) -> None:
-        self._monitor_registration.register()
+        import os
+
+        result = self.api.register_monitor(
+            pid=os.getpid(),
+            monitor_type="python",
+            view="runs",
+            project=str(self.config.project_root),
+        )
+        if not isinstance(result, Failure):
+            self._monitor_id = result.unwrap()
         self._update_title()
         self.refresh_data()
         if self._auto_refresh_enabled:
@@ -1581,7 +1672,8 @@ class RunsDashboard(App):
         self.set_interval(ELAPSED_UPDATE_INTERVAL, self._update_elapsed_times)
 
     def on_unmount(self) -> None:
-        self._monitor_registration.unregister()
+        if self._monitor_id:
+            self.api.unregister_monitor(self._monitor_id)
 
     def _update_elapsed_times(self) -> None:
         if not self.runs:
@@ -1658,30 +1750,31 @@ class RunsDashboard(App):
 
     @work(thread=True, exclusive=True)
     def _fetch_runs(self) -> None:
-        try:
-            status_filter = []
-            for s in self.filter_state.run_filters.statuses:
-                try:
-                    status_filter.append(Status(s))
-                except ValueError:
-                    pass
-            filters = RunFilters(status=status_filter) if status_filter else None
-            response = self.daemon.list_runs(filters)
-            runs = response.runs
-            error = None
-        except DaemonNotRunningError:
-            runs = None
-            error = "Daemon not running"
-        except DaemonError as e:
-            runs = None
-            error = str(e)
+        status_filter: list[ApiRunStatus] = []
+        for s in self.filter_state.run_filters.statuses:
+            try:
+                status_filter.append(ApiRunStatus(s))
+            except ValueError:
+                pass
+        filters = ApiRunFilters(status=status_filter) if status_filter else None
+        result = self.api.list_runs(filters)
 
-        if runs is not None:
-            runs = filter_runs_client_side(runs, self.filter_state.run_filters)
-            runs.sort(
-                key=lambda r: r.updated_at or r.started_at or datetime.min, reverse=True
-            )
-        self.call_from_thread(self._update_runs_table, runs, error)
+        if isinstance(result, Failure):
+            error_obj = result.failure()
+            if isinstance(error_obj, ApiDaemonNotRunningError):
+                error = "Daemon not running"
+            else:
+                error = str(error_obj)
+            self.call_from_thread(self._update_runs_table, None, error)
+            return
+
+        response = result.unwrap()
+        runs = _api_runs_to_model_runs(response.runs)
+        runs = filter_runs_client_side(runs, self.filter_state.run_filters)
+        runs.sort(
+            key=lambda r: r.updated_at or r.started_at or datetime.min, reverse=True
+        )
+        self.call_from_thread(self._update_runs_table, runs, None)
 
     def _update_runs_table(
         self, runs: Optional[list[Run]], error: Optional[str]
@@ -1740,10 +1833,11 @@ class RunsDashboard(App):
 
     @work(thread=True, exclusive=True)
     def _fetch_run_detail(self, issue_id: str, run_id: str, run_ref: str) -> None:
-        try:
-            run = self.daemon.get_run(issue_id, run_id)
-        except DaemonError:
+        result = self.api.get_run(issue_id, run_id)
+        if isinstance(result, Failure):
             run = None
+        else:
+            run = _api_run_to_model(result.unwrap())
         self.call_from_thread(self._set_selected_run, run, run_ref)
 
     def _set_selected_run(self, run: Optional[Run], run_ref: str) -> None:
@@ -1856,10 +1950,10 @@ class RunsDashboard(App):
             return []
 
     def _get_issue_for_run(self, run: Run) -> Optional[Issue]:
-        try:
-            return self.daemon.get_issue(run.issue_id)
-        except Exception:
+        result = self.api.get_issue(run.issue_id)
+        if isinstance(result, Failure):
             return None
+        return _api_issue_to_model(result.unwrap())
 
     def _capture_session_output(self, run: Run) -> list[str]:
         if not run.tmux_session:
@@ -2068,13 +2162,21 @@ class IssuesDashboard(App):
         Binding("ctrl+f", "clear_filters", "Clear Filters"),
     ]
 
-    def __init__(self, issues_root: Optional[Path] = None, auto_refresh: bool = True):
+    def __init__(
+        self,
+        issues_root: Optional[Path] = None,
+        auto_refresh: bool = True,
+        api: Optional[OrchAPI] = None,
+    ):
         super().__init__()
         if issues_root:
             self.config = Config.from_issues_root(issues_root)
         else:
             self.config = Config.load()
-        self.daemon = DaemonClient(self.config.socket_path, self.config.issues_root)
+        self.api: OrchAPI = api or create_orch_api(
+            self.config.socket_path,
+            self.config.issues_root,
+        )
         self.issues: list[Issue] = []
         self.selected_issue: Optional[Issue] = None
         self._highlighted_issue_id: Optional[str] = None
@@ -2084,9 +2186,7 @@ class IssuesDashboard(App):
         self.title = self._base_title
         self._daemon_error: Optional[str] = None
         self._last_update: Optional[datetime] = None
-        self._monitor_registration = MonitorRegistration(
-            self.daemon, str(self.config.project_root), "issues"
-        )
+        self._monitor_id: Optional[str] = None
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
@@ -2095,14 +2195,24 @@ class IssuesDashboard(App):
         yield Footer()
 
     def on_mount(self) -> None:
-        self._monitor_registration.register()
+        import os
+
+        result = self.api.register_monitor(
+            pid=os.getpid(),
+            monitor_type="python",
+            view="issues",
+            project=str(self.config.project_root),
+        )
+        if not isinstance(result, Failure):
+            self._monitor_id = result.unwrap()
         self._update_title()
         self.refresh_data()
         if self._auto_refresh_enabled:
             self.set_interval(AUTO_REFRESH_INTERVAL, self._do_auto_refresh)
 
     def on_unmount(self) -> None:
-        self._monitor_registration.unregister()
+        if self._monitor_id:
+            self.api.unregister_monitor(self._monitor_id)
 
     def _update_title(self) -> None:
         count = self.filter_state.issue_filter_count()
@@ -2164,21 +2274,22 @@ class IssuesDashboard(App):
 
     @work(thread=True, exclusive=True)
     def _fetch_issues(self) -> None:
-        try:
-            response = self.daemon.list_issues()
-            issues = response.issues
-            error = None
-        except DaemonNotRunningError:
-            issues = None
-            error = "Daemon not running"
-        except DaemonError as e:
-            issues = None
-            error = str(e)
+        result = self.api.list_issues()
 
-        if issues is not None:
-            issues = filter_issues_client_side(issues, self.filter_state.issue_filters)
-            issues.sort(key=lambda i: i.id)
-        self.call_from_thread(self._update_issues_table, issues, error)
+        if isinstance(result, Failure):
+            error_obj = result.failure()
+            if isinstance(error_obj, ApiDaemonNotRunningError):
+                error = "Daemon not running"
+            else:
+                error = str(error_obj)
+            self.call_from_thread(self._update_issues_table, None, error)
+            return
+
+        response = result.unwrap()
+        issues = _api_issues_to_model_issues(response.issues)
+        issues = filter_issues_client_side(issues, self.filter_state.issue_filters)
+        issues.sort(key=lambda i: i.id)
+        self.call_from_thread(self._update_issues_table, issues, None)
 
     def _update_issues_table(
         self, issues: Optional[list[Issue]], error: Optional[str]
@@ -2219,10 +2330,11 @@ class IssuesDashboard(App):
 
     @work(thread=True, exclusive=True)
     def _fetch_issue_detail(self, issue_id: str) -> None:
-        try:
-            issue = self.daemon.get_issue(issue_id)
-        except DaemonError:
+        result = self.api.get_issue(issue_id)
+        if isinstance(result, Failure):
             issue = None
+        else:
+            issue = _api_issue_to_model(result.unwrap())
         self.call_from_thread(self._set_selected_issue, issue, issue_id)
 
     def _set_selected_issue(self, issue: Optional[Issue], issue_id: str) -> None:
@@ -2405,7 +2517,12 @@ class OrchMonitorApp(App):
         Binding("tab", "switch_focus", "Switch Focus"),
     ]
 
-    def __init__(self, issues_root: Optional[Path] = None, auto_refresh: bool = True):
+    def __init__(
+        self,
+        issues_root: Optional[Path] = None,
+        auto_refresh: bool = True,
+        api: Optional[OrchAPI] = None,
+    ):
         super().__init__()
 
         if issues_root:
@@ -2413,7 +2530,10 @@ class OrchMonitorApp(App):
         else:
             self.config = Config.load()
 
-        self.daemon = DaemonClient(self.config.socket_path, self.config.issues_root)
+        self.api: OrchAPI = api or create_orch_api(
+            self.config.socket_path,
+            self.config.issues_root,
+        )
         self.runs: list[Run] = []
         self.issues: list[Issue] = []
         self.selected_run: Optional[Run] = None
@@ -2426,9 +2546,7 @@ class OrchMonitorApp(App):
         self.title = self._base_title
         self._daemon_error: Optional[str] = None
         self._last_update: Optional[datetime] = None
-        self._monitor_registration = MonitorRegistration(
-            self.daemon, str(self.config.project_root), "combined"
-        )
+        self._monitor_id: Optional[str] = None
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -2447,7 +2565,16 @@ class OrchMonitorApp(App):
         yield Footer()
 
     def on_mount(self) -> None:
-        self._monitor_registration.register()
+        import os
+
+        result = self.api.register_monitor(
+            pid=os.getpid(),
+            monitor_type="python",
+            view="combined",
+            project=str(self.config.project_root),
+        )
+        if not isinstance(result, Failure):
+            self._monitor_id = result.unwrap()
         self._update_tab_titles()
         self.refresh_data()
         if self._auto_refresh_enabled:
@@ -2456,7 +2583,8 @@ class OrchMonitorApp(App):
         self.set_interval(ELAPSED_UPDATE_INTERVAL, self._update_elapsed_times)
 
     def on_unmount(self) -> None:
-        self._monitor_registration.unregister()
+        if self._monitor_id:
+            self.api.unregister_monitor(self._monitor_id)
 
     def _update_elapsed_times(self) -> None:
         if not self.runs:
@@ -2589,20 +2717,24 @@ class OrchMonitorApp(App):
         issues: Optional[list[Issue]] = None
         error: Optional[str] = None
 
-        try:
-            status_filter = []
-            for s in self.filter_state.run_filters.statuses:
-                try:
-                    status_filter.append(Status(s))
-                except ValueError:
-                    pass
-            filters = RunFilters(status=status_filter) if status_filter else None
-            runs_response = self.daemon.list_runs(filters)
-            runs = runs_response.runs
-        except DaemonNotRunningError:
-            error = "Daemon not running"
-        except DaemonError as e:
-            error = str(e)
+        status_filter: list[ApiRunStatus] = []
+        for s in self.filter_state.run_filters.statuses:
+            try:
+                status_filter.append(ApiRunStatus(s))
+            except ValueError:
+                pass
+        filters = ApiRunFilters(status=status_filter) if status_filter else None
+        runs_result = self.api.list_runs(filters)
+
+        if isinstance(runs_result, Failure):
+            error_obj = runs_result.failure()
+            if isinstance(error_obj, ApiDaemonNotRunningError):
+                error = "Daemon not running"
+            else:
+                error = str(error_obj)
+        else:
+            runs_response = runs_result.unwrap()
+            runs = _api_runs_to_model_runs(runs_response.runs)
 
         if runs is not None:
             runs = filter_runs_client_side(runs, self.filter_state.run_filters)
@@ -2610,12 +2742,13 @@ class OrchMonitorApp(App):
                 key=lambda r: r.updated_at or r.started_at or datetime.min, reverse=True
             )
 
-        try:
-            issues_response = self.daemon.list_issues()
-            issues = issues_response.issues
-        except DaemonError as e:
+        issues_result = self.api.list_issues()
+        if isinstance(issues_result, Failure):
             if error is None:
-                error = str(e)
+                error = str(issues_result.failure())
+        else:
+            issues_response = issues_result.unwrap()
+            issues = _api_issues_to_model_issues(issues_response.issues)
 
         if issues is not None:
             issues = filter_issues_client_side(issues, self.filter_state.issue_filters)
@@ -2693,10 +2826,11 @@ class OrchMonitorApp(App):
 
     @work(thread=True, exclusive=True)
     def _fetch_run_for_detail(self, issue_id: str, run_id: str, run_ref: str) -> None:
-        try:
-            run = self.daemon.get_run(issue_id, run_id)
-        except DaemonError:
+        result = self.api.get_run(issue_id, run_id)
+        if isinstance(result, Failure):
             run = None
+        else:
+            run = _api_run_to_model(result.unwrap())
         self.call_from_thread(self._show_run_detail_callback, run, run_ref)
 
     def _show_run_detail_callback(self, run: Optional[Run], run_ref: str) -> None:
@@ -2729,10 +2863,11 @@ class OrchMonitorApp(App):
 
     @work(thread=True, exclusive=True)
     def _fetch_issue_for_detail(self, issue_id: str) -> None:
-        try:
-            issue = self.daemon.get_issue(issue_id)
-        except DaemonError:
+        result = self.api.get_issue(issue_id)
+        if isinstance(result, Failure):
             issue = None
+        else:
+            issue = _api_issue_to_model(result.unwrap())
         self.call_from_thread(self._show_issue_detail_callback, issue, issue_id)
 
     def _show_issue_detail_callback(

--- a/orch-monitor-tui/orch_monitor/daemon_api.py
+++ b/orch-monitor-tui/orch_monitor/daemon_api.py
@@ -1,0 +1,831 @@
+"""DaemonOrchAPI implementation using DaemonClient and subprocess fallbacks."""
+
+import logging
+import subprocess
+import threading
+from datetime import datetime
+from functools import lru_cache
+from pathlib import Path
+from time import time as _time
+from typing import Optional
+
+from returns.result import Failure, Result, Success
+
+from .daemon import DaemonClient, DaemonError, DaemonNotRunningError
+from .daemon import ListIssuesResponse as DaemonListIssuesResponse
+from .daemon import ListRunsResponse as DaemonListRunsResponse
+from .daemon import RunFilters as DaemonRunFilters
+from .models import Issue as ModelIssue
+from .models import IssueStatus as ModelIssueStatus
+from .models import Run as ModelRun
+from .models import Status as ModelStatus
+from .orch_api import (
+    AttachInfo,
+    BranchState,
+    ControlAgentLaunch,
+    DiffStats,
+    Issue,
+    IssueFilters,
+    IssueStatus,
+    ListIssuesResponse,
+    ListRunsResponse,
+    NotFoundError,
+    OrchError,
+    Run,
+    RunFilters,
+    RunStatus,
+    SessionCapture,
+    StartRunResult,
+)
+from .orch_api import DaemonNotRunningError as ApiDaemonNotRunningError
+
+_logger = logging.getLogger("orch_monitor.daemon_api")
+
+
+def _model_status_to_api(status: ModelStatus) -> RunStatus:
+    """Convert models.Status to orch_api.RunStatus."""
+    mapping = {
+        ModelStatus.QUEUED: RunStatus.QUEUED,
+        ModelStatus.BOOTING: RunStatus.BOOTING,
+        ModelStatus.RUNNING: RunStatus.RUNNING,
+        ModelStatus.BLOCKED: RunStatus.BLOCKED,
+        ModelStatus.BLOCKED_API: RunStatus.BLOCKED_API,
+        ModelStatus.PR_OPEN: RunStatus.PR_OPEN,
+        ModelStatus.DONE: RunStatus.DONE,
+        ModelStatus.FAILED: RunStatus.FAILED,
+        ModelStatus.CANCELED: RunStatus.CANCELED,
+        ModelStatus.UNKNOWN: RunStatus.UNKNOWN,
+    }
+    return mapping.get(status, RunStatus.UNKNOWN)
+
+
+def _model_issue_status_to_api(status: ModelIssueStatus) -> IssueStatus:
+    """Convert models.IssueStatus to orch_api.IssueStatus."""
+    mapping = {
+        ModelIssueStatus.OPEN: IssueStatus.OPEN,
+        ModelIssueStatus.RESOLVED: IssueStatus.RESOLVED,
+        ModelIssueStatus.CLOSED: IssueStatus.CLOSED,
+    }
+    return mapping.get(status, IssueStatus.OPEN)
+
+
+def _api_run_status_to_model(status: RunStatus) -> ModelStatus:
+    """Convert orch_api.RunStatus to models.Status."""
+    mapping = {
+        RunStatus.QUEUED: ModelStatus.QUEUED,
+        RunStatus.BOOTING: ModelStatus.BOOTING,
+        RunStatus.RUNNING: ModelStatus.RUNNING,
+        RunStatus.BLOCKED: ModelStatus.BLOCKED,
+        RunStatus.BLOCKED_API: ModelStatus.BLOCKED_API,
+        RunStatus.PR_OPEN: ModelStatus.PR_OPEN,
+        RunStatus.DONE: ModelStatus.DONE,
+        RunStatus.FAILED: ModelStatus.FAILED,
+        RunStatus.CANCELED: ModelStatus.CANCELED,
+        RunStatus.UNKNOWN: ModelStatus.UNKNOWN,
+    }
+    return mapping.get(status, ModelStatus.UNKNOWN)
+
+
+def _model_run_to_api(run: ModelRun) -> Run:
+    """Convert models.Run to orch_api.Run."""
+    return Run(
+        issue_id=run.issue_id,
+        run_id=run.run_id,
+        status=_model_status_to_api(run.status),
+        agent=run.agent,
+        model=run.model,
+        branch=run.branch,
+        worktree_path=run.worktree_path,
+        pr_url=run.pr_url,
+        started_at=run.started_at,
+        updated_at=run.updated_at,
+        tmux_session=run.tmux_session,
+        multiplexer=run.multiplexer,
+        server_port=run.server_port,
+        opencode_session_id=run.opencode_session_id,
+        diff_stats=DiffStats(
+            additions=run.additions,
+            deletions=run.deletions,
+            files_changed=0,
+            file_list=[],
+        )
+        if run.additions > 0 or run.deletions > 0
+        else None,
+    )
+
+
+def _model_issue_to_api(issue: ModelIssue) -> Issue:
+    """Convert models.Issue to orch_api.Issue."""
+    return Issue(
+        id=issue.id,
+        title=issue.title,
+        summary=issue.summary,
+        status=_model_issue_status_to_api(issue.status),
+        tags=issue.tags,
+        body=issue.body,
+        path=issue.path,
+        modified_at=issue.modified_at,
+    )
+
+
+# TTL cache for git diff stats (30 second TTL)
+_diff_stats_cache_time: dict[str, float] = {}
+_DIFF_STATS_TTL = 30.0
+
+# TTL cache for branch state
+_branch_state_cache: dict[str, tuple[str, float]] = {}
+_BRANCH_STATE_TTL = 30.0
+
+
+@lru_cache(maxsize=256)
+def _get_git_diff_stats_cached(
+    worktree_path: str, branch: str, base_branch: str
+) -> Optional[DiffStats]:
+    """Internal cached implementation of git diff stats retrieval."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--numstat", f"{base_branch}...{branch}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=worktree_path,
+            encoding="utf-8",
+            errors="replace",
+        )
+
+        if result.returncode != 0:
+            result = subprocess.run(
+                ["git", "diff", "--numstat", f"{base_branch}..{branch}"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                cwd=worktree_path,
+                encoding="utf-8",
+                errors="replace",
+            )
+
+        if result.returncode != 0:
+            _logger.debug(
+                f"git diff failed for {branch} vs {base_branch}: {result.stderr}"
+            )
+            return None
+
+        file_list: list[str] = []
+        total_additions = 0
+        total_deletions = 0
+
+        for line in result.stdout.strip().split("\n"):
+            if not line:
+                continue
+            parts = line.split("\t")
+            if len(parts) != 3:
+                continue
+
+            add_str, del_str, path = parts
+            additions = int(add_str) if add_str != "-" else 0
+            deletions = int(del_str) if del_str != "-" else 0
+
+            file_list.append(path)
+            total_additions += additions
+            total_deletions += deletions
+
+        return DiffStats(
+            additions=total_additions,
+            deletions=total_deletions,
+            files_changed=len(file_list),
+            file_list=file_list,
+        )
+
+    except (
+        subprocess.TimeoutExpired,
+        subprocess.SubprocessError,
+        OSError,
+        ValueError,
+    ) as e:
+        _logger.debug(f"git diff exception for {branch}: {e}")
+        return None
+
+
+def _compute_branch_state(
+    worktree_path: str, branch: str, base_branch: str
+) -> BranchState:
+    """Compute the branch state by running git commands."""
+    try:
+        dirty_result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=worktree_path,
+        )
+        if dirty_result.returncode == 0 and dirty_result.stdout.strip():
+            return BranchState.DIRTY
+
+        merged_result = subprocess.run(
+            ["git", "branch", "--merged", base_branch, "--format=%(refname:short)"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=worktree_path,
+        )
+        if merged_result.returncode == 0:
+            merged_branches = set(merged_result.stdout.strip().split("\n"))
+            if branch in merged_branches:
+                return BranchState.MERGED
+
+        conflict_result = subprocess.run(
+            ["git", "merge-tree", "--write-tree", "--messages", branch, base_branch],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=worktree_path,
+        )
+        if conflict_result.returncode != 0:
+            output = conflict_result.stdout + conflict_result.stderr
+            if "CONFLICT" in output or "<<<<<<<" in output:
+                return BranchState.CONFLICT
+
+        return BranchState.CLEAN
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, OSError) as e:
+        _logger.debug(f"git state check failed for {branch}: {e}")
+        return BranchState.UNKNOWN
+
+
+class MonitorHeartbeat:
+    """Handles periodic heartbeat for monitor registration."""
+
+    def __init__(self, client: DaemonClient, project: str, view: str = "dashboard"):
+        self._client = client
+        self._project = project
+        self._view = view
+        self._monitor_id: Optional[str] = None
+        self._tmux_session: str = ""
+        self._heartbeat_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+
+    def start(self, tmux_session: str = "") -> Optional[str]:
+        import os
+
+        if not self._client.is_available():
+            return None
+
+        self._tmux_session = tmux_session
+        self._monitor_id = self._client.register_monitor(
+            pid=os.getpid(),
+            monitor_type="python",
+            view=self._view,
+            project=self._project,
+            tmux_session=tmux_session,
+        )
+
+        if self._monitor_id:
+            self._start_heartbeat_thread()
+
+        return self._monitor_id
+
+    def stop(self) -> None:
+        self._stop_heartbeat_thread()
+
+        if self._monitor_id and self._client.is_available():
+            self._client.unregister_monitor(self._monitor_id)
+            self._monitor_id = None
+
+    def _start_heartbeat_thread(self) -> None:
+        if self._heartbeat_thread is not None:
+            return
+
+        self._stop_event.clear()
+        self._heartbeat_thread = threading.Thread(
+            target=self._heartbeat_loop, daemon=True
+        )
+        self._heartbeat_thread.start()
+
+    def _stop_heartbeat_thread(self) -> None:
+        if self._heartbeat_thread is None:
+            return
+
+        self._stop_event.set()
+        self._heartbeat_thread.join(timeout=2.0)
+        self._heartbeat_thread = None
+
+    def _heartbeat_loop(self) -> None:
+        import os
+
+        while not self._stop_event.wait(timeout=30.0):
+            if self._monitor_id and self._client.is_available():
+                success = self._client.monitor_heartbeat(self._monitor_id)
+                if not success:
+                    new_id = self._client.register_monitor(
+                        pid=os.getpid(),
+                        monitor_type="python",
+                        view=self._view,
+                        project=self._project,
+                        tmux_session=self._tmux_session,
+                    )
+                    if new_id:
+                        self._monitor_id = new_id
+
+
+class DaemonOrchAPI:
+    """OrchAPI implementation that wraps DaemonClient with subprocess fallbacks."""
+
+    def __init__(
+        self,
+        socket_path: Optional[Path] = None,
+        issues_root: Optional[Path] = None,
+        project_root: Optional[Path] = None,
+        base_branch: str = "main",
+    ):
+        if socket_path is None:
+            from .config import Config
+
+            config = Config.load()
+            socket_path = config.socket_path
+            if issues_root is None:
+                issues_root = config.issues_root
+            if project_root is None:
+                project_root = config.project_root
+
+        self._socket_path = socket_path
+        self._issues_root = issues_root
+        self._project_root = project_root or Path.cwd()
+        self._base_branch = base_branch
+        self._daemon = DaemonClient(socket_path, issues_root)
+        self._monitor_heartbeat: Optional[MonitorHeartbeat] = None
+
+    def _build_orch_cmd(self) -> list[str]:
+        """Build base orch command with project/issues root args."""
+        cmd = ["orch"]
+        if self._project_root:
+            cmd.extend(["--project-root", str(self._project_root)])
+        if self._issues_root:
+            cmd.extend(["--issues-root", str(self._issues_root)])
+        return cmd
+
+    # === Lifecycle ===
+
+    def is_available(self) -> bool:
+        return self._daemon.is_available()
+
+    def ensure_running(self) -> Result[bool, OrchError]:
+        if self._daemon.is_available():
+            return Success(True)
+
+        try:
+            cmd = self._build_orch_cmd() + ["daemon", "start"]
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+            if result.returncode != 0:
+                return Failure(
+                    OrchError(f"Failed to start daemon: {result.stderr.strip()}")
+                )
+
+            import time
+
+            for _ in range(75):  # 15 seconds
+                time.sleep(0.2)
+                if self._daemon.is_available():
+                    return Success(True)
+
+            return Failure(OrchError("Daemon did not become available within timeout"))
+        except subprocess.TimeoutExpired:
+            return Failure(OrchError("Daemon start command timed out"))
+        except FileNotFoundError:
+            return Failure(OrchError("'orch' command not found"))
+        except Exception as e:
+            return Failure(OrchError(str(e)))
+
+    # === Runs ===
+
+    def list_runs(
+        self, filters: Optional[RunFilters] = None
+    ) -> Result[ListRunsResponse, OrchError]:
+        try:
+            daemon_filters = None
+            if filters:
+                status_list = [_api_run_status_to_model(s) for s in filters.status]
+                daemon_filters = DaemonRunFilters(
+                    issue_id=filters.issue_id, status=status_list
+                )
+            response: DaemonListRunsResponse = self._daemon.list_runs(daemon_filters)
+            runs = [_model_run_to_api(r) for r in response.runs]
+            return Success(ListRunsResponse(runs=runs, total=response.total))
+        except DaemonNotRunningError:
+            return Failure(ApiDaemonNotRunningError("Daemon not running"))
+        except DaemonError as e:
+            return Failure(OrchError(str(e)))
+
+    def get_run(self, issue_id: str, run_id: str) -> Result[Run, OrchError]:
+        try:
+            run = self._daemon.get_run(issue_id, run_id)
+            if run is None:
+                return Failure(NotFoundError(f"Run {issue_id}#{run_id} not found"))
+            return Success(_model_run_to_api(run))
+        except DaemonNotRunningError:
+            return Failure(ApiDaemonNotRunningError("Daemon not running"))
+        except DaemonError as e:
+            return Failure(OrchError(str(e)))
+
+    def start_run(
+        self,
+        issue_id: str,
+        agent: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> Result[StartRunResult, OrchError]:
+        try:
+            cmd = self._build_orch_cmd() + ["run", issue_id]
+            if agent:
+                cmd.extend(["--agent", agent])
+            if model:
+                cmd.extend(["--model", model])
+
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+            if result.returncode != 0:
+                error_msg = (
+                    result.stderr.strip() or result.stdout.strip() or "Unknown error"
+                )
+                return Failure(OrchError(f"Failed to start run: {error_msg}"))
+
+            # Parse output for run_id, branch, worktree_path
+            # For now, return minimal info since orch run output format varies
+            return Success(StartRunResult(run_id="", branch="", worktree_path=""))
+        except subprocess.TimeoutExpired:
+            return Failure(OrchError("Timeout starting run"))
+        except FileNotFoundError:
+            return Failure(OrchError("'orch' command not found"))
+        except Exception as e:
+            return Failure(OrchError(str(e)))
+
+    def stop_run(self, issue_id: str, run_id: str) -> Result[None, OrchError]:
+        try:
+            run_ref = f"{issue_id}#{run_id}" if run_id else issue_id
+            cmd = self._build_orch_cmd() + ["stop", run_ref]
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            if result.returncode != 0:
+                error_msg = (
+                    result.stderr.strip() or result.stdout.strip() or "Unknown error"
+                )
+                return Failure(OrchError(f"Failed to stop run: {error_msg}"))
+            return Success(None)
+        except subprocess.TimeoutExpired:
+            return Failure(OrchError("Timeout stopping run"))
+        except Exception as e:
+            return Failure(OrchError(str(e)))
+
+    def resolve_run(self, issue_id: str, run_id: str) -> Result[None, OrchError]:
+        try:
+            run_ref = f"{issue_id}#{run_id}" if run_id else issue_id
+            cmd = self._build_orch_cmd() + ["resolve", run_ref]
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            if result.returncode != 0:
+                error_msg = (
+                    result.stderr.strip() or result.stdout.strip() or "Unknown error"
+                )
+                return Failure(OrchError(f"Failed to resolve run: {error_msg}"))
+            return Success(None)
+        except subprocess.TimeoutExpired:
+            return Failure(OrchError("Timeout resolving run"))
+        except Exception as e:
+            return Failure(OrchError(str(e)))
+
+    # === Issues ===
+
+    def list_issues(
+        self, filters: Optional[IssueFilters] = None
+    ) -> Result[ListIssuesResponse, OrchError]:
+        try:
+            response: DaemonListIssuesResponse = self._daemon.list_issues()
+            issues = [_model_issue_to_api(i) for i in response.issues]
+            return Success(ListIssuesResponse(issues=issues, total=response.total))
+        except DaemonNotRunningError:
+            return Failure(ApiDaemonNotRunningError("Daemon not running"))
+        except DaemonError as e:
+            return Failure(OrchError(str(e)))
+
+    def get_issue(self, issue_id: str) -> Result[Issue, OrchError]:
+        try:
+            issue = self._daemon.get_issue(issue_id)
+            if issue is None:
+                return Failure(NotFoundError(f"Issue {issue_id} not found"))
+            return Success(_model_issue_to_api(issue))
+        except DaemonNotRunningError:
+            return Failure(ApiDaemonNotRunningError("Daemon not running"))
+        except DaemonError as e:
+            return Failure(OrchError(str(e)))
+
+    def create_issue(
+        self,
+        issue_id: str,
+        title: str,
+        body: str,
+    ) -> Result[None, OrchError]:
+        try:
+            cmd = self._build_orch_cmd() + [
+                "issue",
+                "create",
+                issue_id,
+                "--title",
+                title,
+            ]
+            result = subprocess.run(
+                cmd, input=body, capture_output=True, text=True, timeout=30
+            )
+            if result.returncode != 0:
+                error_msg = (
+                    result.stderr.strip() or result.stdout.strip() or "Unknown error"
+                )
+                return Failure(OrchError(f"Failed to create issue: {error_msg}"))
+            return Success(None)
+        except subprocess.TimeoutExpired:
+            return Failure(OrchError("Timeout creating issue"))
+        except Exception as e:
+            return Failure(OrchError(str(e)))
+
+    def close_issue(self, issue_id: str) -> Result[None, OrchError]:
+        try:
+            cmd = self._build_orch_cmd() + ["issue", "close", issue_id]
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+            if result.returncode != 0:
+                error_msg = (
+                    result.stderr.strip() or result.stdout.strip() or "Unknown error"
+                )
+                return Failure(OrchError(f"Failed to close issue: {error_msg}"))
+            return Success(None)
+        except subprocess.TimeoutExpired:
+            return Failure(OrchError("Timeout closing issue"))
+        except Exception as e:
+            return Failure(OrchError(str(e)))
+
+    # === Control Agent ===
+
+    def get_control_agent_launch(
+        self,
+        project_root: str,
+        agent: str = "",
+        new_session: bool = False,
+    ) -> Result[ControlAgentLaunch, OrchError]:
+        try:
+            ok, command, prompt_file, port, session_id, resolved_agent, error = (
+                self._daemon.get_control_agent_launch(project_root, agent, new_session)
+            )
+            if not ok:
+                return Failure(OrchError(error or "Failed to get control agent launch"))
+            return Success(
+                ControlAgentLaunch(
+                    command=command or "",
+                    prompt_file=prompt_file or "",
+                    port=port,
+                    session_id=session_id,
+                )
+            )
+        except DaemonNotRunningError:
+            return Failure(ApiDaemonNotRunningError("Daemon not running"))
+        except DaemonError as e:
+            return Failure(OrchError(str(e)))
+
+    # === Sessions ===
+
+    def get_attach_info(
+        self, issue_id: str, run_id: str
+    ) -> Result[AttachInfo, OrchError]:
+        # Get run info and build attach command
+        run_result = self.get_run(issue_id, run_id)
+        if isinstance(run_result, Failure):
+            return run_result
+
+        run = run_result.unwrap()
+        attach_cmd = self._build_orch_cmd() + ["attach", run.ref()]
+
+        return Success(
+            AttachInfo(
+                command=attach_cmd,
+                multiplexer=run.multiplexer,
+                session_name=run.tmux_session,
+                worktree_path=run.worktree_path,
+            )
+        )
+
+    def capture_session(
+        self, issue_id: str, run_id: str
+    ) -> Result[SessionCapture, OrchError]:
+        run_result = self.get_run(issue_id, run_id)
+        if isinstance(run_result, Failure):
+            return run_result
+
+        run = run_result.unwrap()
+        if not run.tmux_session:
+            return Failure(OrchError("Run has no session"))
+
+        try:
+            # Detect multiplexer type from run
+            if run.multiplexer == "zellij":
+                import os
+
+                result = subprocess.run(
+                    ["zellij", "action", "dump-screen", "/dev/stdout"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    env={**os.environ, "ZELLIJ_SESSION_NAME": run.tmux_session},
+                )
+            else:
+                result = subprocess.run(
+                    ["tmux", "capture-pane", "-t", run.tmux_session, "-p", "-S", "-50"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+
+            if result.returncode != 0:
+                return Failure(OrchError("Failed to capture session"))
+
+            return Success(
+                SessionCapture(
+                    content=result.stdout,
+                    timestamp=datetime.now(),
+                    source=run.multiplexer or "tmux",
+                )
+            )
+        except subprocess.TimeoutExpired:
+            return Failure(OrchError("Timeout capturing session"))
+        except Exception as e:
+            return Failure(OrchError(str(e)))
+
+    def send_message(
+        self,
+        issue_id: str,
+        run_id: str,
+        message: str,
+    ) -> Result[None, OrchError]:
+        try:
+            self._daemon.send_message(issue_id, run_id, message)
+            return Success(None)
+        except DaemonNotRunningError:
+            return Failure(ApiDaemonNotRunningError("Daemon not running"))
+        except DaemonError as e:
+            return Failure(OrchError(str(e)))
+
+    # === Git ===
+
+    def get_diff_stats(
+        self, issue_id: str, run_id: str
+    ) -> Result[DiffStats, OrchError]:
+        run_result = self.get_run(issue_id, run_id)
+        if isinstance(run_result, Failure):
+            return run_result
+
+        run = run_result.unwrap()
+        if not run.worktree_path or not run.branch:
+            return Failure(OrchError("Run has no worktree or branch"))
+
+        cache_key = f"{run.worktree_path}:{run.branch}:{self._base_branch}"
+        now = _time()
+
+        if cache_key in _diff_stats_cache_time:
+            if now - _diff_stats_cache_time[cache_key] > _DIFF_STATS_TTL:
+                _get_git_diff_stats_cached.cache_clear()
+                _diff_stats_cache_time.clear()
+
+        stats = _get_git_diff_stats_cached(
+            run.worktree_path, run.branch, self._base_branch
+        )
+        _diff_stats_cache_time[cache_key] = now
+
+        if stats is None:
+            return Failure(OrchError("Failed to get diff stats"))
+        return Success(stats)
+
+    def get_branch_state(
+        self, issue_id: str, run_id: str
+    ) -> Result[BranchState, OrchError]:
+        run_result = self.get_run(issue_id, run_id)
+        if isinstance(run_result, Failure):
+            return run_result
+
+        run = run_result.unwrap()
+        if not run.worktree_path or not run.branch:
+            return Failure(OrchError("Run has no worktree or branch"))
+
+        cache_key = f"{run.worktree_path}:{run.branch}:{self._base_branch}"
+        now = _time()
+
+        if cache_key in _branch_state_cache:
+            cached_state, cached_time = _branch_state_cache[cache_key]
+            if now - cached_time < _BRANCH_STATE_TTL:
+                return Success(BranchState(cached_state))
+
+        state = _compute_branch_state(run.worktree_path, run.branch, self._base_branch)
+        _branch_state_cache[cache_key] = (state.value, now)
+        return Success(state)
+
+    def get_diff(self, issue_id: str, run_id: str) -> Result[str, OrchError]:
+        run_result = self.get_run(issue_id, run_id)
+        if isinstance(run_result, Failure):
+            return run_result
+
+        run = run_result.unwrap()
+        if not run.worktree_path or not run.branch:
+            return Failure(OrchError("Run has no worktree or branch"))
+
+        try:
+            result = subprocess.run(
+                ["git", "diff", f"{self._base_branch}...{run.branch}"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=run.worktree_path,
+            )
+            if result.returncode != 0:
+                # Try without merge-base syntax
+                result = subprocess.run(
+                    ["git", "diff", f"{self._base_branch}..{run.branch}"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    cwd=run.worktree_path,
+                )
+            return Success(result.stdout)
+        except subprocess.TimeoutExpired:
+            return Failure(OrchError("Timeout getting diff"))
+        except Exception as e:
+            return Failure(OrchError(str(e)))
+
+    # === Monitor ===
+
+    def register_monitor(
+        self,
+        pid: int,
+        monitor_type: str,
+        view: str,
+        project: str,
+        session_name: str = "",
+    ) -> Result[str, OrchError]:
+        try:
+            monitor_id = self._daemon.register_monitor(
+                pid=pid,
+                monitor_type=monitor_type,
+                view=view,
+                project=project,
+                tmux_session=session_name,
+            )
+            if monitor_id is None:
+                return Failure(OrchError("Failed to register monitor"))
+
+            # Start heartbeat
+            self._monitor_heartbeat = MonitorHeartbeat(self._daemon, project, view)
+            self._monitor_heartbeat.start(session_name)
+
+            return Success(monitor_id)
+        except DaemonNotRunningError:
+            return Failure(ApiDaemonNotRunningError("Daemon not running"))
+        except DaemonError as e:
+            return Failure(OrchError(str(e)))
+
+    def unregister_monitor(self, monitor_id: str) -> Result[None, OrchError]:
+        try:
+            if self._monitor_heartbeat:
+                self._monitor_heartbeat.stop()
+                self._monitor_heartbeat = None
+
+            success = self._daemon.unregister_monitor(monitor_id)
+            if not success:
+                return Failure(OrchError("Failed to unregister monitor"))
+            return Success(None)
+        except DaemonNotRunningError:
+            return Failure(ApiDaemonNotRunningError("Daemon not running"))
+        except DaemonError as e:
+            return Failure(OrchError(str(e)))
+
+    def heartbeat(self, monitor_id: str) -> Result[None, OrchError]:
+        try:
+            success = self._daemon.monitor_heartbeat(monitor_id)
+            if not success:
+                return Failure(OrchError("Heartbeat failed"))
+            return Success(None)
+        except DaemonNotRunningError:
+            return Failure(ApiDaemonNotRunningError("Daemon not running"))
+        except DaemonError as e:
+            return Failure(OrchError(str(e)))
+
+    # === Additional methods for backward compatibility ===
+
+    def get_control_session(
+        self, project_root: str, agent_type: str = ""
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Get control session info (backward compatibility)."""
+        return self._daemon.get_control_session(project_root, agent_type)
+
+    def set_control_session(
+        self, project_root: str, session_id: str, agent_type: str = ""
+    ) -> bool:
+        """Set control session (backward compatibility)."""
+        return self._daemon.set_control_session(project_root, session_id, agent_type)
+
+    def clear_control_session(self, project_root: str) -> bool:
+        """Clear control session (backward compatibility)."""
+        return self._daemon.clear_control_session(project_root)
+
+    def ensure_opencode_server(
+        self, project_root: str
+    ) -> tuple[bool, int, Optional[str], Optional[str]]:
+        """Ensure opencode server is running (backward compatibility)."""
+        return self._daemon.ensure_opencode_server(project_root)

--- a/orch-monitor-tui/orch_monitor/orch_api.py
+++ b/orch-monitor-tui/orch_monitor/orch_api.py
@@ -230,11 +230,18 @@ class OrchAPI(Protocol):
 def create_orch_api(
     socket_path: Optional[Path] = None,
     issues_root: Optional[Path] = None,
+    project_root: Optional[Path] = None,
+    base_branch: str = "main",
     fallback_to_cli: bool = True,
 ) -> OrchAPI:
     from .daemon_api import DaemonOrchAPI
 
-    api = DaemonOrchAPI(socket_path, issues_root)
+    api = DaemonOrchAPI(
+        socket_path=socket_path,
+        issues_root=issues_root,
+        project_root=project_root,
+        base_branch=base_branch,
+    )
 
     if api.is_available():
         return api


### PR DESCRIPTION
## Summary
- Introduces `OrchAPI` abstraction layer in Python TUI to decouple from direct `DaemonClient`, subprocess calls to `orch` CLI, and `git` commands
- Creates `DaemonOrchAPI` implementation wrapping all external dependencies
- Refactors `app.py` and `__main__.py` to use OrchAPI via dependency injection

## Changes
| File | Change |
|------|--------|
| `daemon_api.py` | NEW - `DaemonOrchAPI` implementing `OrchAPI` protocol |
| `app.py` | Refactored to use `OrchAPI` instead of direct daemon calls |
| `__main__.py` | Added `_get_orch_api()` helper |
| `orch_api.py` | Updated factory function with `project_root`/`base_branch` params |

## Acceptance Criteria Evidence
- [x] `orch_api.py` created with Protocol and domain models (pre-existing)
- [x] `daemon_api.py` created implementing OrchAPI using current DaemonClient
- [x] `app.py` refactored to use `OrchAPI` instead of direct `DaemonClient`
- [x] `__main__.py` refactored to use `OrchAPI` instead of direct calls
- [x] All `subprocess` calls to `orch` CLI go through OrchAPI (in daemon_api.py)
- [x] All `subprocess` calls to `git` go through OrchAPI (in daemon_api.py)
- [x] Factory function `create_orch_api()` handles implementation selection

## Benefits
- **Testability**: TUI can be tested in isolation with mock APIs
- **Swappability**: Can swap socket/CLI/HTTP implementations
- **Clarity**: Clean API boundaries for daemon communication

## Note on Pre-existing Test Failures
The failing tests are NOT caused by these changes:
- `test_app.py`: Uses deprecated `vault_path` parameter in fixture
- `test_multiplexer.py`: Tests expect commands without timeout parameter

Resolves: orch-361