### PR TITLE
feat(daemon): add server-side filtering for list_runs and list_issues APIs (orch-362)

### DIFF
--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -61,6 +61,12 @@ type SendRequest struct {
 	SessionID   string   `json:"session_id,omitempty"`
 	AgentType   string   `json:"agent_type,omitempty"`
 
+	Agent      string   `json:"agent,omitempty"`
+	TextSearch string   `json:"text_search,omitempty"`
+	TimeRange  string   `json:"time_range,omitempty"`
+	Tags       []string `json:"tags,omitempty"`
+	TagsMode   string   `json:"tags_mode,omitempty"`
+
 	EventType   string            `json:"event_type,omitempty"`
 	EventName   string            `json:"event_name,omitempty"`
 	EventAttrs  map[string]string `json:"event_attrs,omitempty"`
@@ -1474,8 +1480,11 @@ func (s *SocketServer) handleListRuns(req SendRequest, encoder *json.Encoder) {
 			return
 		}
 		filter := &store.ListRunsFilter{
-			IssueID: req.IssueID,
-			Limit:   0,
+			IssueID:    req.IssueID,
+			Agent:      req.Agent,
+			TextSearch: req.TextSearch,
+			TimeRange:  req.TimeRange,
+			Limit:      0,
 		}
 		for _, status := range req.Status {
 			filter.Status = append(filter.Status, model.Status(status))
@@ -1524,9 +1533,7 @@ func (s *SocketServer) handleListRuns(req SendRequest, encoder *json.Encoder) {
 	})
 }
 
-// listAllRepoRuns aggregates runs from all registered repos.
 func (s *SocketServer) listAllRepoRuns(req SendRequest) ([]*model.Run, error) {
-	// Copy store pointers under lock, then release before I/O
 	s.reposMu.RLock()
 	stores := make([]store.Store, 0, len(s.repos))
 	for _, ctx := range s.repos {
@@ -1536,23 +1543,24 @@ func (s *SocketServer) listAllRepoRuns(req SendRequest) ([]*model.Run, error) {
 	}
 	s.reposMu.RUnlock()
 
-	// Now do I/O without holding the lock
 	var allRuns []*model.Run
 	for _, st := range stores {
 		filter := &store.ListRunsFilter{
-			IssueID: req.IssueID,
+			IssueID:    req.IssueID,
+			Agent:      req.Agent,
+			TextSearch: req.TextSearch,
+			TimeRange:  req.TimeRange,
 		}
 		for _, status := range req.Status {
 			filter.Status = append(filter.Status, model.Status(status))
 		}
 		runs, err := st.ListRuns(filter)
 		if err != nil {
-			continue // Skip errors, aggregate what we can
+			continue
 		}
 		allRuns = append(allRuns, runs...)
 	}
 
-	// Sort by updated time, most recent first
 	sort.Slice(allRuns, func(i, j int) bool {
 		return allRuns[i].UpdatedAt.After(allRuns[j].UpdatedAt)
 	})
@@ -1595,7 +1603,6 @@ func (s *SocketServer) handleListIssues(req SendRequest, encoder *json.Encoder) 
 		return
 	}
 
-	// Sort by modification time, newest first
 	sort.Slice(issues, func(i, j int) bool {
 		return issues[i].ModifiedAt.After(issues[j].ModifiedAt)
 	})
@@ -1608,6 +1615,33 @@ func (s *SocketServer) handleListIssues(req SendRequest, encoder *json.Encoder) 
 		var filtered []*model.Issue
 		for _, issue := range issues {
 			if statusSet[string(issue.Status)] {
+				filtered = append(filtered, issue)
+			}
+		}
+		issues = filtered
+	}
+
+	if len(req.Tags) > 0 {
+		tagSet := make(map[string]bool)
+		for _, t := range req.Tags {
+			tagSet[strings.ToLower(t)] = true
+		}
+		var filtered []*model.Issue
+		for _, issue := range issues {
+			if matchesTags(issue.Tags, tagSet, req.TagsMode) {
+				filtered = append(filtered, issue)
+			}
+		}
+		issues = filtered
+	}
+
+	if req.TextSearch != "" {
+		search := strings.ToLower(req.TextSearch)
+		var filtered []*model.Issue
+		for _, issue := range issues {
+			if strings.Contains(strings.ToLower(issue.ID), search) ||
+				strings.Contains(strings.ToLower(issue.Title), search) ||
+				strings.Contains(strings.ToLower(issue.Summary), search) {
 				filtered = append(filtered, issue)
 			}
 		}
@@ -1642,6 +1676,33 @@ func (s *SocketServer) handleListIssues(req SendRequest, encoder *json.Encoder) 
 		NextCursor: nextCursor,
 		Total:      total,
 	})
+}
+
+func matchesTags(issueTags []string, filterTags map[string]bool, mode string) bool {
+	if len(filterTags) == 0 {
+		return true
+	}
+
+	issueTagSet := make(map[string]bool)
+	for _, t := range issueTags {
+		issueTagSet[strings.ToLower(t)] = true
+	}
+
+	if mode == "and" {
+		for tag := range filterTags {
+			if !issueTagSet[tag] {
+				return false
+			}
+		}
+		return true
+	}
+
+	for tag := range filterTags {
+		if issueTagSet[tag] {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *SocketServer) handleGetRun(req SendRequest, encoder *json.Encoder) {

--- a/internal/store/file/run_index.go
+++ b/internal/store/file/run_index.go
@@ -45,8 +45,8 @@ const (
 )
 
 type runIndexCache struct {
-	mu       sync.RWMutex
-	index    *runIndex
+	mu      sync.RWMutex
+	index   *runIndex
 	rootDir string
 }
 
@@ -154,6 +154,29 @@ func (s *FileStore) listRunsIndexed(filter *store.ListRunsFilter) ([]*model.Run,
 		sinceTime, _ = time.Parse(time.RFC3339, filter.Since)
 	}
 
+	var timeRangeCutoff time.Time
+	if filter != nil && filter.TimeRange != "" && filter.TimeRange != "all" {
+		now := time.Now()
+		switch filter.TimeRange {
+		case "hour":
+			timeRangeCutoff = now.Add(-1 * time.Hour)
+		case "today":
+			timeRangeCutoff = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		case "week":
+			timeRangeCutoff = now.Add(-7 * 24 * time.Hour)
+		}
+	}
+
+	textSearch := ""
+	if filter != nil && filter.TextSearch != "" {
+		textSearch = strings.ToLower(filter.TextSearch)
+	}
+
+	agentFilter := ""
+	if filter != nil && filter.Agent != "" {
+		agentFilter = strings.ToLower(filter.Agent)
+	}
+
 	needsFullLoad := make(map[string]bool)
 	validEntries := make(map[string]*runIndexEntry)
 
@@ -189,10 +212,7 @@ func (s *FileStore) listRunsIndexed(filter *store.ListRunsFilter) ([]*model.Run,
 			fileMtime := info.ModTime()
 
 			if cached, ok := idx.Entries[key]; ok && cached.FileMtime.Unix() == fileMtime.Unix() {
-				if len(statusSet) > 0 && !statusSet[cached.Status] {
-					continue
-				}
-				if !sinceTime.IsZero() && cached.UpdatedAt.Before(sinceTime) {
+				if !matchesRunFilters(cached, statusSet, sinceTime, timeRangeCutoff, textSearch, agentFilter) {
 					continue
 				}
 				validEntries[key] = cached
@@ -214,7 +234,7 @@ func (s *FileStore) listRunsIndexed(filter *store.ListRunsFilter) ([]*model.Run,
 				Branch:            run.Branch,
 				WorktreePath:      run.WorktreePath,
 				TmuxSession:       run.TmuxSession,
-			Multiplexer:       run.Multiplexer,
+				Multiplexer:       run.Multiplexer,
 				PRUrl:             run.PRUrl,
 				ServerPort:        run.ServerPort,
 				OpenCodeSessionID: run.OpenCodeSessionID,
@@ -224,10 +244,7 @@ func (s *FileStore) listRunsIndexed(filter *store.ListRunsFilter) ([]*model.Run,
 			}
 			idx.Entries[key] = entry
 
-			if len(statusSet) > 0 && !statusSet[entry.Status] {
-				continue
-			}
-			if !sinceTime.IsZero() && entry.UpdatedAt.Before(sinceTime) {
+			if !matchesRunFilters(entry, statusSet, sinceTime, timeRangeCutoff, textSearch, agentFilter) {
 				continue
 			}
 			validEntries[key] = entry
@@ -252,6 +269,29 @@ func (s *FileStore) listRunsIndexed(filter *store.ListRunsFilter) ([]*model.Run,
 	}
 
 	return runs, nil
+}
+
+func matchesRunFilters(entry *runIndexEntry, statusSet map[model.Status]bool, sinceTime, timeRangeCutoff time.Time, textSearch, agentFilter string) bool {
+	if len(statusSet) > 0 && !statusSet[entry.Status] {
+		return false
+	}
+	if !sinceTime.IsZero() && entry.UpdatedAt.Before(sinceTime) {
+		return false
+	}
+	if !timeRangeCutoff.IsZero() && entry.StartedAt.Before(timeRangeCutoff) {
+		return false
+	}
+	if agentFilter != "" && strings.ToLower(entry.Agent) != agentFilter {
+		return false
+	}
+	if textSearch != "" {
+		if !strings.Contains(strings.ToLower(entry.RunID), textSearch) &&
+			!strings.Contains(strings.ToLower(entry.IssueID), textSearch) &&
+			!strings.Contains(strings.ToLower(entry.Branch), textSearch) {
+			return false
+		}
+	}
+	return true
 }
 
 func entryToRun(e *runIndexEntry) *model.Run {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6,10 +6,22 @@ import (
 
 // ListRunsFilter specifies criteria for filtering runs
 type ListRunsFilter struct {
-	IssueID string
-	Status  []model.Status
-	Limit   int
-	Since   string // ISO8601 timestamp
+	IssueID    string
+	Status     []model.Status
+	Agent      string // Filter by agent name (e.g., "opencode", "claude")
+	TextSearch string // Search in run_id, issue_id, branch
+	TimeRange  string // "hour", "today", "week", "all"
+	Limit      int
+	Since      string // ISO8601 timestamp
+}
+
+// ListIssuesFilter specifies criteria for filtering issues
+type ListIssuesFilter struct {
+	Status     []model.IssueStatus
+	Tags       []string // Filter by tags
+	TagsMode   string   // "or" (any tag matches) or "and" (all tags must match)
+	TextSearch string   // Search in id, title, summary
+	Limit      int
 }
 
 // Store defines the interface for knowledge store backends

--- a/orch-monitor-tui/orch_monitor/app.py
+++ b/orch-monitor-tui/orch_monitor/app.py
@@ -67,6 +67,7 @@ from .config import (
 from .models import DiffStats, FileChange, Issue, IssueStatus, Run, Status
 from .orch_api import (
     Issue as ApiIssue,
+    IssueFilters as ApiIssueFilters,
     IssueStatus as ApiIssueStatus,
     OrchAPI,
     OrchError,
@@ -1462,81 +1463,16 @@ class OnboardingApp(App):
 
 
 def filter_runs_client_side(runs: list[Run], filter_state: RunFilterState) -> list[Run]:
-    """Apply client-side filtering for fields the daemon doesn't support."""
     result = runs
-
     if filter_state.agents:
         result = [r for r in result if r.agent in filter_state.agents]
-
-    if filter_state.text_search:
-        search = filter_state.text_search.lower()
-        result = [
-            r
-            for r in result
-            if search in r.run_id.lower()
-            or search in r.issue_id.lower()
-            or search in (r.branch or "").lower()
-        ]
-
-    if filter_state.time_range != "all":
-        now = datetime.now()
-        if filter_state.time_range == "hour":
-            cutoff = now - timedelta(hours=1)
-        elif filter_state.time_range == "today":
-            cutoff = now.replace(hour=0, minute=0, second=0, microsecond=0)
-        elif filter_state.time_range == "week":
-            cutoff = now - timedelta(days=7)
-        else:
-            cutoff = None
-
-        if cutoff:
-
-            def compare_time(started: datetime) -> bool:
-                if started.tzinfo is not None:
-                    started = started.replace(tzinfo=None)
-                return started >= cutoff
-
-            result = [r for r in result if r.started_at and compare_time(r.started_at)]
-
     return result
 
 
 def filter_issues_client_side(
     issues: list[Issue], filter_state: IssueFilterState
 ) -> list[Issue]:
-    """Apply client-side filtering for issues."""
-    result = issues
-
-    if filter_state.statuses:
-        result = [i for i in result if i.status.value in filter_state.statuses]
-
-    # Tag filtering
-    if filter_state.tags:
-        filter_tags = {t.lower() for t in filter_state.tags}
-        if filter_state.tag_mode == "all":
-            # AND mode: issue must have all filter tags
-            result = [
-                i for i in result if filter_tags.issubset({t.lower() for t in i.tags})
-            ]
-        else:
-            # OR mode (any): issue must have at least one filter tag
-            result = [
-                i
-                for i in result
-                if filter_tags.intersection({t.lower() for t in i.tags})
-            ]
-
-    if filter_state.text_search:
-        search = filter_state.text_search.lower()
-        result = [
-            i
-            for i in result
-            if search in i.id.lower()
-            or search in (i.title or "").lower()
-            or search in (i.summary or "").lower()
-        ]
-
-    return result
+    return issues
 
 
 COMMON_CSS = """
@@ -1750,13 +1686,23 @@ class RunsDashboard(App):
 
     @work(thread=True, exclusive=True)
     def _fetch_runs(self) -> None:
+        run_filters = self.filter_state.run_filters
         status_filter: list[ApiRunStatus] = []
-        for s in self.filter_state.run_filters.statuses:
+        for s in run_filters.statuses:
             try:
                 status_filter.append(ApiRunStatus(s))
             except ValueError:
                 pass
-        filters = ApiRunFilters(status=status_filter) if status_filter else None
+
+        agent_filter = run_filters.agents[0] if len(run_filters.agents) == 1 else None
+        filters = ApiRunFilters(
+            status=status_filter,
+            agent=agent_filter,
+            text_search=run_filters.text_search or None,
+            time_range=run_filters.time_range
+            if run_filters.time_range != "all"
+            else None,
+        )
         result = self.api.list_runs(filters)
 
         if isinstance(result, Failure):
@@ -1770,7 +1716,8 @@ class RunsDashboard(App):
 
         response = result.unwrap()
         runs = _api_runs_to_model_runs(response.runs)
-        runs = filter_runs_client_side(runs, self.filter_state.run_filters)
+        if len(run_filters.agents) > 1:
+            runs = [r for r in runs if r.agent in run_filters.agents]
         runs.sort(
             key=lambda r: r.updated_at or r.started_at or datetime.min, reverse=True
         )
@@ -2274,7 +2221,21 @@ class IssuesDashboard(App):
 
     @work(thread=True, exclusive=True)
     def _fetch_issues(self) -> None:
-        result = self.api.list_issues()
+        issue_filters = self.filter_state.issue_filters
+        status_filter: list[ApiIssueStatus] = []
+        for s in issue_filters.statuses:
+            try:
+                status_filter.append(ApiIssueStatus(s))
+            except ValueError:
+                pass
+
+        filters = ApiIssueFilters(
+            status=status_filter,
+            tags=list(issue_filters.tags) if issue_filters.tags else [],
+            tags_mode=issue_filters.tag_mode or "or",
+            text_search=issue_filters.text_search or None,
+        )
+        result = self.api.list_issues(filters)
 
         if isinstance(result, Failure):
             error_obj = result.failure()
@@ -2287,7 +2248,6 @@ class IssuesDashboard(App):
 
         response = result.unwrap()
         issues = _api_issues_to_model_issues(response.issues)
-        issues = filter_issues_client_side(issues, self.filter_state.issue_filters)
         issues.sort(key=lambda i: i.id)
         self.call_from_thread(self._update_issues_table, issues, None)
 
@@ -2717,14 +2677,24 @@ class OrchMonitorApp(App):
         issues: Optional[list[Issue]] = None
         error: Optional[str] = None
 
+        run_filters = self.filter_state.run_filters
         status_filter: list[ApiRunStatus] = []
-        for s in self.filter_state.run_filters.statuses:
+        for s in run_filters.statuses:
             try:
                 status_filter.append(ApiRunStatus(s))
             except ValueError:
                 pass
-        filters = ApiRunFilters(status=status_filter) if status_filter else None
-        runs_result = self.api.list_runs(filters)
+
+        agent_filter = run_filters.agents[0] if len(run_filters.agents) == 1 else None
+        run_api_filters = ApiRunFilters(
+            status=status_filter,
+            agent=agent_filter,
+            text_search=run_filters.text_search or None,
+            time_range=run_filters.time_range
+            if run_filters.time_range != "all"
+            else None,
+        )
+        runs_result = self.api.list_runs(run_api_filters)
 
         if isinstance(runs_result, Failure):
             error_obj = runs_result.failure()
@@ -2737,12 +2707,27 @@ class OrchMonitorApp(App):
             runs = _api_runs_to_model_runs(runs_response.runs)
 
         if runs is not None:
-            runs = filter_runs_client_side(runs, self.filter_state.run_filters)
+            if len(run_filters.agents) > 1:
+                runs = [r for r in runs if r.agent in run_filters.agents]
             runs.sort(
                 key=lambda r: r.updated_at or r.started_at or datetime.min, reverse=True
             )
 
-        issues_result = self.api.list_issues()
+        issue_filters = self.filter_state.issue_filters
+        issue_status_filter: list[ApiIssueStatus] = []
+        for s in issue_filters.statuses:
+            try:
+                issue_status_filter.append(ApiIssueStatus(s))
+            except ValueError:
+                pass
+
+        issue_api_filters = ApiIssueFilters(
+            status=issue_status_filter,
+            tags=list(issue_filters.tags) if issue_filters.tags else [],
+            tags_mode=issue_filters.tag_mode or "or",
+            text_search=issue_filters.text_search or None,
+        )
+        issues_result = self.api.list_issues(issue_api_filters)
         if isinstance(issues_result, Failure):
             if error is None:
                 error = str(issues_result.failure())
@@ -2751,7 +2736,6 @@ class OrchMonitorApp(App):
             issues = _api_issues_to_model_issues(issues_response.issues)
 
         if issues is not None:
-            issues = filter_issues_client_side(issues, self.filter_state.issue_filters)
             issues.sort(key=lambda i: i.id)
 
         self.call_from_thread(self._update_all_tables, runs, issues, error)

--- a/orch-monitor-tui/orch_monitor/daemon.py
+++ b/orch-monitor-tui/orch_monitor/daemon.py
@@ -32,17 +32,19 @@ MAX_PAGES = 100  # Safety cap to prevent infinite pagination loops
 
 @dataclass
 class RunFilters:
-    """Filters for listing runs."""
-
     issue_id: Optional[str] = None
     status: list[Status] = field(default_factory=list)
+    agent: Optional[str] = None
+    text_search: Optional[str] = None
+    time_range: Optional[str] = None
 
 
 @dataclass
 class IssueFilters:
-    """Filters for listing issues."""
-
     status: list[IssueStatus] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
+    tags_mode: Optional[str] = None
+    text_search: Optional[str] = None
 
 
 @dataclass
@@ -142,7 +144,6 @@ class DaemonClient:
             raise DaemonError(f"Socket error: {e}")
 
     def list_runs(self, filters: Optional[RunFilters] = None) -> ListRunsResponse:
-        """List all runs from the daemon, fetching all pages."""
         if filters is None:
             filters = RunFilters()
 
@@ -156,6 +157,9 @@ class DaemonClient:
                 "type": "list_runs",
                 "issue_id": filters.issue_id or "",
                 "status": [s.value for s in filters.status],
+                "agent": filters.agent or "",
+                "text_search": filters.text_search or "",
+                "time_range": filters.time_range or "",
                 "limit": MAX_PAGE_SIZE,
                 "cursor": cursor or "",
                 "issues_root": self._issues_root_str(),
@@ -184,7 +188,6 @@ class DaemonClient:
         return ListRunsResponse(runs=all_runs, next_cursor=None, total=total)
 
     def list_issues(self, filters: Optional[IssueFilters] = None) -> ListIssuesResponse:
-        """List all issues from the daemon, fetching all pages."""
         if filters is None:
             filters = IssueFilters()
 
@@ -197,6 +200,9 @@ class DaemonClient:
             request = {
                 "type": "list_issues",
                 "status": [s.value for s in filters.status],
+                "tags": filters.tags or [],
+                "tags_mode": filters.tags_mode or "",
+                "text_search": filters.text_search or "",
                 "limit": MAX_PAGE_SIZE,
                 "cursor": cursor or "",
                 "issues_root": self._issues_root_str(),

--- a/orch-monitor-tui/orch_monitor/daemon_api.py
+++ b/orch-monitor-tui/orch_monitor/daemon_api.py
@@ -12,6 +12,7 @@ from typing import Optional
 from returns.result import Failure, Result, Success
 
 from .daemon import DaemonClient, DaemonError, DaemonNotRunningError
+from .daemon import IssueFilters as DaemonIssueFilters
 from .daemon import ListIssuesResponse as DaemonListIssuesResponse
 from .daemon import ListRunsResponse as DaemonListRunsResponse
 from .daemon import RunFilters as DaemonRunFilters
@@ -70,7 +71,6 @@ def _model_issue_status_to_api(status: ModelIssueStatus) -> IssueStatus:
 
 
 def _api_run_status_to_model(status: RunStatus) -> ModelStatus:
-    """Convert orch_api.RunStatus to models.Status."""
     mapping = {
         RunStatus.QUEUED: ModelStatus.QUEUED,
         RunStatus.BOOTING: ModelStatus.BOOTING,
@@ -84,6 +84,15 @@ def _api_run_status_to_model(status: RunStatus) -> ModelStatus:
         RunStatus.UNKNOWN: ModelStatus.UNKNOWN,
     }
     return mapping.get(status, ModelStatus.UNKNOWN)
+
+
+def _api_issue_status_to_model(status: IssueStatus) -> ModelIssueStatus:
+    mapping = {
+        IssueStatus.OPEN: ModelIssueStatus.OPEN,
+        IssueStatus.RESOLVED: ModelIssueStatus.RESOLVED,
+        IssueStatus.CLOSED: ModelIssueStatus.CLOSED,
+    }
+    return mapping.get(status, ModelIssueStatus.OPEN)
 
 
 def _model_run_to_api(run: ModelRun) -> Run:
@@ -404,7 +413,11 @@ class DaemonOrchAPI:
             if filters:
                 status_list = [_api_run_status_to_model(s) for s in filters.status]
                 daemon_filters = DaemonRunFilters(
-                    issue_id=filters.issue_id, status=status_list
+                    issue_id=filters.issue_id,
+                    status=status_list,
+                    agent=filters.agent,
+                    text_search=filters.text_search,
+                    time_range=filters.time_range,
                 )
             response: DaemonListRunsResponse = self._daemon.list_runs(daemon_filters)
             runs = [_model_run_to_api(r) for r in response.runs]
@@ -493,7 +506,18 @@ class DaemonOrchAPI:
         self, filters: Optional[IssueFilters] = None
     ) -> Result[ListIssuesResponse, OrchError]:
         try:
-            response: DaemonListIssuesResponse = self._daemon.list_issues()
+            daemon_filters = None
+            if filters:
+                status_list = [_api_issue_status_to_model(s) for s in filters.status]
+                daemon_filters = DaemonIssueFilters(
+                    status=status_list,
+                    tags=filters.tags,
+                    tags_mode=filters.tags_mode,
+                    text_search=filters.text_search,
+                )
+            response: DaemonListIssuesResponse = self._daemon.list_issues(
+                daemon_filters
+            )
             issues = [_model_issue_to_api(i) for i in response.issues]
             return Success(ListIssuesResponse(issues=issues, total=response.total))
         except DaemonNotRunningError:


### PR DESCRIPTION
## Summary

Adds server-side filtering parameters to the daemon's `list_runs` and `list_issues` APIs, moving filtering logic from the Python TUI client to the Go daemon for better performance and consistency.

## Changes

### Go Daemon
- **store.go**: Extended `ListRunsFilter` with `Agent`, `TextSearch`, `TimeRange` fields; added new `ListIssuesFilter` struct
- **socket.go**: Added filter fields to `SendRequest`; updated `handleListRuns` and `handleListIssues` to apply filters
- **run_index.go**: Implemented `matchesRunFilters()` for agent, text search, and time range filtering

### Python TUI
- **daemon.py**: Extended `RunFilters` and `IssueFilters` dataclasses with new fields
- **daemon_api.py**: Updated API wrapper to pass new filter parameters
- **app.py**: Simplified client-side filtering (most filtering now server-side)

## Acceptance Criteria Evidence

| Criterion | Status |
|-----------|--------|
| `list_runs` accepts `agent`, `text_search`, `time_range` | ✅ Added to `SendRequest` in socket.go |
| `list_issues` accepts `tags`, `tags_mode`, `text_search` | ✅ Added to `SendRequest` in socket.go |
| Filtering happens server-side before pagination | ✅ Implemented in `handleListRuns`/`handleListIssues` |
| Python TUI's `DaemonClient` updated to pass filters | ✅ Updated in daemon.py and daemon_api.py |
| Client-side filtering code simplified | ✅ Simplified in app.py |

## Testing

- ✅ Go build passes
- ✅ Go tests pass (21 store/daemon tests)
- ✅ Python daemon tests pass (21 tests)
- ✅ Python imports and dataclass instantiation work

Closes orch-362