### PR TITLE
feat(daemon): add git state fields to Run response (orch-364)

### DIFF
--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -75,27 +75,39 @@ type ListRunsResponse struct {
 	Total      int           `json:"total"`
 }
 
+// DiffStatsJSON is the JSON representation of diff statistics
+type DiffStatsJSON struct {
+	Additions    int      `json:"additions"`
+	Deletions    int      `json:"deletions"`
+	FilesChanged int      `json:"files_changed"`
+	Files        []string `json:"files,omitempty"`
+}
+
 // RunSummary is a summary view of a run for list operations
 type RunSummary struct {
-	IssueID      string `json:"issue_id"`
-	RunID        string `json:"run_id"`
-	ShortID      string `json:"short_id"`
-	Status       string `json:"status"`
-	Phase        string `json:"phase,omitempty"`
-	Agent        string `json:"agent"`
-	Model        string `json:"model,omitempty"`
-	Branch       string `json:"branch,omitempty"`
-	WorktreePath string `json:"worktree_path,omitempty"`
-	TmuxSession  string `json:"tmux_session,omitempty"`
-	Multiplexer  string `json:"multiplexer,omitempty"`
-	PRUrl        string `json:"pr_url,omitempty"`
-	Additions    int    `json:"additions"`
-	Deletions    int    `json:"deletions"`
-	Alive        bool   `json:"alive"`
-	AliveKnown   bool   `json:"alive_known"`
-	StartedAt    string `json:"started_at"`
-	UpdatedAt    string `json:"updated_at"`
-	URI          string `json:"uri"`
+	IssueID        string         `json:"issue_id"`
+	RunID          string         `json:"run_id"`
+	ShortID        string         `json:"short_id"`
+	Status         string         `json:"status"`
+	Phase          string         `json:"phase,omitempty"`
+	Agent          string         `json:"agent"`
+	Model          string         `json:"model,omitempty"`
+	Branch         string         `json:"branch,omitempty"`
+	WorktreePath   string         `json:"worktree_path,omitempty"`
+	TmuxSession    string         `json:"tmux_session,omitempty"`
+	Multiplexer    string         `json:"multiplexer,omitempty"`
+	PRUrl          string         `json:"pr_url,omitempty"`
+	Additions      int            `json:"additions"`
+	Deletions      int            `json:"deletions"`
+	DiffStats      *DiffStatsJSON `json:"diff_stats,omitempty"`
+	BranchState    string         `json:"branch_state,omitempty"`
+	ElapsedSeconds int            `json:"elapsed_seconds,omitempty"`
+	ElapsedDisplay string         `json:"elapsed_display,omitempty"`
+	Alive          bool           `json:"alive"`
+	AliveKnown     bool           `json:"alive_known"`
+	StartedAt      string         `json:"started_at"`
+	UpdatedAt      string         `json:"updated_at"`
+	URI            string         `json:"uri"`
 }
 
 // GetRunResponse is the response for get_run
@@ -107,28 +119,32 @@ type GetRunResponse struct {
 
 // RunFull is the full view of a run including events
 type RunFull struct {
-	IssueID           string       `json:"issue_id"`
-	RunID             string       `json:"run_id"`
-	ShortID           string       `json:"short_id"`
-	Status            string       `json:"status"`
-	Phase             string       `json:"phase,omitempty"`
-	Agent             string       `json:"agent"`
-	Model             string       `json:"model,omitempty"`
-	ModelVariant      string       `json:"model_variant,omitempty"`
-	Branch            string       `json:"branch,omitempty"`
-	WorktreePath      string       `json:"worktree_path,omitempty"`
-	TmuxSession       string       `json:"tmux_session,omitempty"`
-	Multiplexer       string       `json:"multiplexer,omitempty"`
-	PRUrl             string       `json:"pr_url,omitempty"`
-	ServerPort        int          `json:"server_port,omitempty"`
-	OpenCodeSessionID string       `json:"opencode_session_id,omitempty"`
-	ContinuedFrom     string       `json:"continued_from,omitempty"`
-	Alive             bool         `json:"alive"`
-	AliveKnown        bool         `json:"alive_known"`
-	StartedAt         string       `json:"started_at"`
-	UpdatedAt         string       `json:"updated_at"`
-	URI               string       `json:"uri"`
-	Events            []*EventJSON `json:"events"`
+	IssueID           string         `json:"issue_id"`
+	RunID             string         `json:"run_id"`
+	ShortID           string         `json:"short_id"`
+	Status            string         `json:"status"`
+	Phase             string         `json:"phase,omitempty"`
+	Agent             string         `json:"agent"`
+	Model             string         `json:"model,omitempty"`
+	ModelVariant      string         `json:"model_variant,omitempty"`
+	Branch            string         `json:"branch,omitempty"`
+	WorktreePath      string         `json:"worktree_path,omitempty"`
+	TmuxSession       string         `json:"tmux_session,omitempty"`
+	Multiplexer       string         `json:"multiplexer,omitempty"`
+	PRUrl             string         `json:"pr_url,omitempty"`
+	ServerPort        int            `json:"server_port,omitempty"`
+	OpenCodeSessionID string         `json:"opencode_session_id,omitempty"`
+	ContinuedFrom     string         `json:"continued_from,omitempty"`
+	DiffStats         *DiffStatsJSON `json:"diff_stats,omitempty"`
+	BranchState       string         `json:"branch_state,omitempty"`
+	ElapsedSeconds    int            `json:"elapsed_seconds,omitempty"`
+	ElapsedDisplay    string         `json:"elapsed_display,omitempty"`
+	Alive             bool           `json:"alive"`
+	AliveKnown        bool           `json:"alive_known"`
+	StartedAt         string         `json:"started_at"`
+	UpdatedAt         string         `json:"updated_at"`
+	URI               string         `json:"uri"`
+	Events            []*EventJSON   `json:"events"`
 }
 
 // EventJSON is the JSON representation of an event
@@ -220,9 +236,66 @@ func FileURI(path string) string {
 	return "file://" + path
 }
 
+func computeElapsed(run *model.Run) (int, string) {
+	if run.StartedAt.IsZero() {
+		return 0, ""
+	}
+
+	var elapsed time.Duration
+	if isActiveStatus(run.Status) {
+		elapsed = time.Since(run.StartedAt)
+	} else if !run.UpdatedAt.IsZero() {
+		elapsed = run.UpdatedAt.Sub(run.StartedAt)
+	} else {
+		elapsed = time.Since(run.StartedAt)
+	}
+
+	seconds := int(elapsed.Seconds())
+	return seconds, formatDuration(elapsed)
+}
+
+func isActiveStatus(status model.Status) bool {
+	switch status {
+	case model.StatusQueued, model.StatusBooting, model.StatusRunning, model.StatusBlocked, model.StatusBlockedAPI:
+		return true
+	default:
+		return false
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	totalSeconds := int(d.Seconds())
+	hours := totalSeconds / 3600
+	minutes := (totalSeconds % 3600) / 60
+	seconds := totalSeconds % 60
+
+	if hours > 0 {
+		return fmt.Sprintf("%dh%dm", hours, minutes)
+	}
+	if minutes > 0 {
+		return fmt.Sprintf("%dm%ds", minutes, seconds)
+	}
+	return fmt.Sprintf("%ds", seconds)
+}
+
+func computeBranchState(run *model.Run) string {
+	if run.WorktreePath == "" || run.Branch == "" {
+		return ""
+	}
+
+	states := git.GetBranchMergeStates("", "main", []string{run.Branch})
+	if state, ok := states[run.Branch]; ok {
+		return state
+	}
+	return ""
+}
+
 // RunToSummary converts a model.Run to a RunSummary
 func RunToSummary(run *model.Run) *RunSummary {
 	diffStats := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
+
+	elapsedSeconds, elapsedDisplay := computeElapsed(run)
+	branchState := computeBranchState(run)
 
 	return &RunSummary{
 		IssueID:      run.IssueID,
@@ -239,11 +312,19 @@ func RunToSummary(run *model.Run) *RunSummary {
 		PRUrl:        run.PRUrl,
 		Additions:    diffStats.Additions,
 		Deletions:    diffStats.Deletions,
-		Alive:        false,
-		AliveKnown:   false,
-		StartedAt:    formatTime(run.StartedAt),
-		UpdatedAt:    formatTime(run.UpdatedAt),
-		URI:          FileURI(run.Path),
+		DiffStats: &DiffStatsJSON{
+			Additions:    diffStats.Additions,
+			Deletions:    diffStats.Deletions,
+			FilesChanged: diffStats.FilesChanged,
+		},
+		BranchState:    branchState,
+		ElapsedSeconds: elapsedSeconds,
+		ElapsedDisplay: elapsedDisplay,
+		Alive:          false,
+		AliveKnown:     false,
+		StartedAt:      formatTime(run.StartedAt),
+		UpdatedAt:      formatTime(run.UpdatedAt),
+		URI:            FileURI(run.Path),
 	}
 }
 
@@ -270,6 +351,10 @@ func RunToFull(run *model.Run) *RunFull {
 		}
 	}
 
+	diffStats := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
+	elapsedSeconds, elapsedDisplay := computeElapsed(run)
+	branchState := computeBranchState(run)
+
 	return &RunFull{
 		IssueID:           run.IssueID,
 		RunID:             run.RunID,
@@ -287,12 +372,21 @@ func RunToFull(run *model.Run) *RunFull {
 		ServerPort:        run.ServerPort,
 		OpenCodeSessionID: run.OpenCodeSessionID,
 		ContinuedFrom:     run.ContinuedFrom,
-		Alive:             false,
-		AliveKnown:        false,
-		StartedAt:         formatTime(run.StartedAt),
-		UpdatedAt:         formatTime(run.UpdatedAt),
-		URI:               FileURI(run.Path),
-		Events:            events,
+		DiffStats: &DiffStatsJSON{
+			Additions:    diffStats.Additions,
+			Deletions:    diffStats.Deletions,
+			FilesChanged: diffStats.FilesChanged,
+			Files:        diffStats.Files,
+		},
+		BranchState:    branchState,
+		ElapsedSeconds: elapsedSeconds,
+		ElapsedDisplay: elapsedDisplay,
+		Alive:          false,
+		AliveKnown:     false,
+		StartedAt:      formatTime(run.StartedAt),
+		UpdatedAt:      formatTime(run.UpdatedAt),
+		URI:            FileURI(run.Path),
+		Events:         events,
 	}
 }
 

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -9,8 +9,10 @@ import (
 
 // DiffStats represents git diff statistics for a worktree.
 type DiffStats struct {
-	Additions int
-	Deletions int
+	Additions    int
+	Deletions    int
+	FilesChanged int
+	Files        []string // List of changed file paths
 }
 
 // GetDiffStats calculates the diff stats for a worktree compared to its base branch.
@@ -81,9 +83,6 @@ func getUncommittedDiffStats(worktreePath string) DiffStats {
 	return parseDiffNumstat(string(output))
 }
 
-// parseDiffNumstat parses the output of git diff --numstat.
-// Format: <additions>\t<deletions>\t<filename>
-// Binary files show as "-\t-\t<filename>"
 func parseDiffNumstat(output string) DiffStats {
 	var stats DiffStats
 
@@ -98,7 +97,10 @@ func parseDiffNumstat(output string) DiffStats {
 			continue
 		}
 
-		// Handle binary files (shown as "-")
+		fileName := parts[2]
+		stats.Files = append(stats.Files, fileName)
+		stats.FilesChanged++
+
 		if parts[0] != "-" {
 			if add, err := strconv.Atoi(parts[0]); err == nil {
 				stats.Additions += add

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -9,46 +9,60 @@ import (
 
 func TestParseDiffNumstat(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		wantAdd int
-		wantDel int
+		name           string
+		input          string
+		wantAdd        int
+		wantDel        int
+		wantFilesCount int
+		wantFiles      []string
 	}{
 		{
-			name:    "empty",
-			input:   "",
-			wantAdd: 0,
-			wantDel: 0,
+			name:           "empty",
+			input:          "",
+			wantAdd:        0,
+			wantDel:        0,
+			wantFilesCount: 0,
+			wantFiles:      nil,
 		},
 		{
-			name:    "single file",
-			input:   "10\t5\tfile.go\n",
-			wantAdd: 10,
-			wantDel: 5,
+			name:           "single file",
+			input:          "10\t5\tfile.go\n",
+			wantAdd:        10,
+			wantDel:        5,
+			wantFilesCount: 1,
+			wantFiles:      []string{"file.go"},
 		},
 		{
-			name:    "multiple files",
-			input:   "10\t5\tfile1.go\n20\t3\tfile2.go\n",
-			wantAdd: 30,
-			wantDel: 8,
+			name:           "multiple files",
+			input:          "10\t5\tfile1.go\n20\t3\tfile2.go\n",
+			wantAdd:        30,
+			wantDel:        8,
+			wantFilesCount: 2,
+			wantFiles:      []string{"file1.go", "file2.go"},
 		},
 		{
-			name:    "binary file",
-			input:   "-\t-\timage.png\n5\t2\tfile.go\n",
-			wantAdd: 5,
-			wantDel: 2,
+			name:           "binary file",
+			input:          "-\t-\timage.png\n5\t2\tfile.go\n",
+			wantAdd:        5,
+			wantDel:        2,
+			wantFilesCount: 2,
+			wantFiles:      []string{"image.png", "file.go"},
 		},
 		{
-			name:    "only additions",
-			input:   "100\t0\tnew_file.go\n",
-			wantAdd: 100,
-			wantDel: 0,
+			name:           "only additions",
+			input:          "100\t0\tnew_file.go\n",
+			wantAdd:        100,
+			wantDel:        0,
+			wantFilesCount: 1,
+			wantFiles:      []string{"new_file.go"},
 		},
 		{
-			name:    "only deletions",
-			input:   "0\t50\tdeleted_content.go\n",
-			wantAdd: 0,
-			wantDel: 50,
+			name:           "only deletions",
+			input:          "0\t50\tdeleted_content.go\n",
+			wantAdd:        0,
+			wantDel:        50,
+			wantFilesCount: 1,
+			wantFiles:      []string{"deleted_content.go"},
 		},
 	}
 
@@ -60,6 +74,17 @@ func TestParseDiffNumstat(t *testing.T) {
 			}
 			if stats.Deletions != tt.wantDel {
 				t.Errorf("Deletions = %d, want %d", stats.Deletions, tt.wantDel)
+			}
+			if stats.FilesChanged != tt.wantFilesCount {
+				t.Errorf("FilesChanged = %d, want %d", stats.FilesChanged, tt.wantFilesCount)
+			}
+			if len(stats.Files) != len(tt.wantFiles) {
+				t.Errorf("Files count = %d, want %d", len(stats.Files), len(tt.wantFiles))
+			}
+			for i, f := range tt.wantFiles {
+				if i >= len(stats.Files) || stats.Files[i] != f {
+					t.Errorf("Files[%d] = %q, want %q", i, stats.Files[i], f)
+				}
 			}
 		})
 	}

--- a/orch-monitor-tui/orch_monitor/daemon.py
+++ b/orch-monitor-tui/orch_monitor/daemon.py
@@ -693,6 +693,16 @@ def _json_to_run(data: dict) -> Run:
     except ValueError:
         phase = None
 
+    diff_stats = data.get("diff_stats") or {}
+    additions = (
+        diff_stats.get("additions", 0) if diff_stats else data.get("additions", 0)
+    )
+    deletions = (
+        diff_stats.get("deletions", 0) if diff_stats else data.get("deletions", 0)
+    )
+    files_changed = diff_stats.get("files_changed", 0) if diff_stats else 0
+    files = diff_stats.get("files") or []
+
     return Run(
         issue_id=data.get("issue_id", ""),
         run_id=data.get("run_id", ""),
@@ -710,8 +720,13 @@ def _json_to_run(data: dict) -> Run:
         pr_url=data.get("pr_url", ""),
         started_at=_parse_timestamp(data.get("started_at", "")),
         updated_at=_parse_timestamp(data.get("updated_at", "")),
-        additions=data.get("additions", 0),
-        deletions=data.get("deletions", 0),
+        additions=additions,
+        deletions=deletions,
+        files_changed=files_changed,
+        files=files,
+        branch_state=data.get("branch_state", ""),
+        elapsed_seconds=data.get("elapsed_seconds", 0),
+        elapsed_display=data.get("elapsed_display", ""),
         alive=data.get("alive", False),
         alive_known=data.get("alive_known", False),
     )
@@ -729,7 +744,6 @@ def _json_to_run_full(data: dict) -> Run:
     except ValueError:
         phase = None
 
-    # Parse events
     events = []
     for event_data in data.get("events", []):
         try:
@@ -750,6 +764,12 @@ def _json_to_run_full(data: dict) -> Run:
                 raw="",
             )
         )
+
+    diff_stats = data.get("diff_stats") or {}
+    additions = diff_stats.get("additions", 0) if diff_stats else 0
+    deletions = diff_stats.get("deletions", 0) if diff_stats else 0
+    files_changed = diff_stats.get("files_changed", 0) if diff_stats else 0
+    files = diff_stats.get("files") or []
 
     return Run(
         issue_id=data.get("issue_id", ""),
@@ -773,6 +793,13 @@ def _json_to_run_full(data: dict) -> Run:
         continued_from=data.get("continued_from", ""),
         started_at=_parse_timestamp(data.get("started_at", "")),
         updated_at=_parse_timestamp(data.get("updated_at", "")),
+        additions=additions,
+        deletions=deletions,
+        files_changed=files_changed,
+        files=files,
+        branch_state=data.get("branch_state", ""),
+        elapsed_seconds=data.get("elapsed_seconds", 0),
+        elapsed_display=data.get("elapsed_display", ""),
         alive=data.get("alive", False),
         alive_known=data.get("alive_known", False),
     )

--- a/orch-monitor-tui/orch_monitor/models.py
+++ b/orch-monitor-tui/orch_monitor/models.py
@@ -124,6 +124,11 @@ class Run:
     continued_from: str = ""
     additions: int = 0
     deletions: int = 0
+    files_changed: int = 0
+    files: List[str] = field(default_factory=list)
+    branch_state: str = ""
+    elapsed_seconds: int = 0
+    elapsed_display: str = ""
     alive: bool = False
     alive_known: bool = False
 


### PR DESCRIPTION
## Summary

- Extends `git.DiffStats` with `FilesChanged int` and `Files []string` fields
- Adds `DiffStatsJSON` struct to daemon response types
- Includes `diff_stats`, `branch_state`, `elapsed_seconds`, `elapsed_display` in `RunSummary` and `RunFull` responses
- Updates Python `orch_monitor` models and daemon.py to parse the new fields

## Why

TUI clients (like orch-monitor) currently make their own git subprocess calls to compute diff stats, branch state, and elapsed time. By pre-computing these in the daemon:
- Reduces N+1 git calls from client
- Provides consistent calculations across clients
- Improves monitor startup/refresh performance

## Acceptance Criteria

- [x] `list_runs` includes `diff_stats` summary (additions, deletions, files_changed)
- [x] `get_run` includes full `diff_stats` with file list
- [x] `branch_state` field added to Run response
- [x] `elapsed_seconds` and `elapsed_display` pre-calculated by daemon
- [ ] TUI can remove git subprocess calls (follow-up work - fields now available)

## Testing

- Go tests pass: `go test ./...`
- Python daemon tests pass: `pytest tests/test_daemon.py`

Fixes: orch-364