### PR TITLE
feat(monitor): add insertion/deletion columns to run list

### DIFF
--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -278,7 +278,7 @@ func formatDuration(d time.Duration) string {
 	return fmt.Sprintf("%ds", seconds)
 }
 
-func computeBranchState(run *model.Run) string {
+func computeBranchStateString(run *model.Run) string {
 	if run.WorktreePath == "" || run.Branch == "" {
 		return ""
 	}
@@ -295,7 +295,7 @@ func RunToSummary(run *model.Run) *RunSummary {
 	diffStats := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
 
 	elapsedSeconds, elapsedDisplay := computeElapsed(run)
-	branchState := computeBranchState(run)
+	branchState := computeBranchStateString(run)
 
 	return &RunSummary{
 		IssueID:      run.IssueID,
@@ -353,7 +353,7 @@ func RunToFull(run *model.Run) *RunFull {
 
 	diffStats := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
 	elapsedSeconds, elapsedDisplay := computeElapsed(run)
-	branchState := computeBranchState(run)
+	branchState := computeBranchStateString(run)
 
 	return &RunFull{
 		IssueID:           run.IssueID,

--- a/internal/monitor/columns.go
+++ b/internal/monitor/columns.go
@@ -24,6 +24,8 @@ const (
 	ColWorktree    ColumnID = "worktree"
 	ColPR          ColumnID = "pr"
 	ColMerged      ColumnID = "merged"
+	ColInsertions  ColumnID = "insertions"
+	ColDeletions   ColumnID = "deletions"
 	ColStarted     ColumnID = "started"
 	ColUpdated     ColumnID = "updated"
 	ColTopic       ColumnID = "topic"
@@ -49,6 +51,8 @@ var columnRegistry = map[ColumnID]ColumnDef{
 	ColWorktree:    {ID: ColWorktree, Header: "WORKTREE", Width: runTableWorktreeWidth},
 	ColPR:          {ID: ColPR, Header: "PR", Width: 6},
 	ColMerged:      {ID: ColMerged, Header: "MERGED", Width: 8},
+	ColInsertions:  {ID: ColInsertions, Header: "+", Width: 6},
+	ColDeletions:   {ID: ColDeletions, Header: "-", Width: 6},
 	ColStarted:     {ID: ColStarted, Header: "STARTED", Width: 7},
 	ColUpdated:     {ID: ColUpdated, Header: "UPDATED", Width: 7},
 	ColTopic:       {ID: ColTopic, Header: "TOPIC", Width: 6, Flexible: true},
@@ -67,6 +71,8 @@ var defaultColumns = []ColumnID{
 	ColWorktree,
 	ColPR,
 	ColMerged,
+	ColInsertions,
+	ColDeletions,
 	ColStarted,
 	ColUpdated,
 	ColTopic,
@@ -180,6 +186,10 @@ func GetColumnValue(col ColumnID, row *RunRow, now time.Time) string {
 		return row.PR
 	case ColMerged:
 		return row.Merged
+	case ColInsertions:
+		return formatDiffCount(row.Insertions, "+")
+	case ColDeletions:
+		return formatDiffCount(row.Deletions, "-")
 	case ColStarted:
 		return formatRelativeTime(row.Started, now)
 	case ColUpdated:
@@ -189,6 +199,16 @@ func GetColumnValue(col ColumnID, row *RunRow, now time.Time) string {
 	default:
 		return "-"
 	}
+}
+
+func formatDiffCount(count int, prefix string) string {
+	if count == 0 {
+		return "-"
+	}
+	if count >= 1000 {
+		return fmt.Sprintf("%s%.1fk", prefix, float64(count)/1000)
+	}
+	return fmt.Sprintf("%s%d", prefix, count)
 }
 
 func GetColumnStyle(col ColumnID, row *RunRow, styles *Styles, isHeader bool) lipgloss.Style {
@@ -216,6 +236,14 @@ func GetColumnStyle(col ColumnID, row *RunRow, styles *Styles, isHeader bool) li
 	case ColMerged:
 		if style, ok := styles.Merged[row.Merged]; ok {
 			return style
+		}
+	case ColInsertions:
+		if row.Insertions > 0 {
+			return styles.DiffAdd
+		}
+	case ColDeletions:
+		if row.Deletions > 0 {
+			return styles.DiffDel
 		}
 	}
 	return styles.Text

--- a/internal/monitor/data.go
+++ b/internal/monitor/data.go
@@ -22,6 +22,8 @@ type RunRow struct {
 	PR           string
 	PRState      string
 	Merged       string
+	Insertions   int // Lines added (git diff stats)
+	Deletions    int // Lines deleted (git diff stats)
 	Started      time.Time
 	Updated      time.Time
 	Topic        string

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -931,8 +931,8 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 		baseBranch = cfg.BaseBranch
 	}
 	gitStates := gitStatesForRuns(runList, baseBranch)
+	diffStats := diffStatsForRuns(runList, baseBranch)
 
-	// Populate PR info
 	prInfoMap := pr.PopulateRunInfo(runList)
 
 	rows := make([]RunRow, 0, len(windows))
@@ -977,6 +977,8 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 
 		modelDisplay := agent.ModelDisplayName(w.Run.Model, w.Run.ModelVariant)
 
+		runDiffStats := diffStats[w.Run.RunID]
+
 		rows = append(rows, RunRow{
 			Index:        w.Index,
 			ShortID:      shortID,
@@ -992,6 +994,8 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 			PR:           prDisplay,
 			PRState:      prState,
 			Merged:       merged,
+			Insertions:   runDiffStats.Additions,
+			Deletions:    runDiffStats.Deletions,
 			Started:      w.Run.StartedAt,
 			Updated:      w.Run.UpdatedAt,
 			Topic:        topic,

--- a/internal/monitor/ps_helpers.go
+++ b/internal/monitor/ps_helpers.go
@@ -137,3 +137,14 @@ func gitStatesForRuns(runs []*model.Run, target string) map[string]string {
 	}
 	return git.GetRunMergeStates(runInfos, target)
 }
+
+func diffStatsForRuns(runs []*model.Run, baseBranch string) map[string]git.DiffStats {
+	results := make(map[string]git.DiffStats)
+	for _, r := range runs {
+		if r == nil || r.WorktreePath == "" || r.Branch == "" {
+			continue
+		}
+		results[r.RunID] = git.GetDiffStats(r.WorktreePath, r.Branch, baseBranch)
+	}
+	return results
+}

--- a/internal/monitor/styles.go
+++ b/internal/monitor/styles.go
@@ -12,6 +12,8 @@ type Styles struct {
 	Text     lipgloss.Style
 	Selected lipgloss.Style
 	Faint    lipgloss.Style
+	DiffAdd  lipgloss.Style
+	DiffDel  lipgloss.Style
 	Status   map[model.Status]lipgloss.Style
 	Alive    map[string]lipgloss.Style
 	PRState  map[string]lipgloss.Style
@@ -27,6 +29,8 @@ func DefaultStyles() Styles {
 		Text:     lipgloss.NewStyle(),
 		Selected: lipgloss.NewStyle().Foreground(lipgloss.Color("230")).Background(lipgloss.Color("237")),
 		Faint:    lipgloss.NewStyle().Foreground(lipgloss.Color("241")),
+		DiffAdd:  lipgloss.NewStyle().Foreground(lipgloss.Color("2")),
+		DiffDel:  lipgloss.NewStyle().Foreground(lipgloss.Color("1")),
 		Status: map[model.Status]lipgloss.Style{
 			model.StatusRunning:    lipgloss.NewStyle().Foreground(lipgloss.Color("2")),
 			model.StatusBlocked:    lipgloss.NewStyle().Foreground(lipgloss.Color("3")),


### PR DESCRIPTION
## Summary

Adds `+` and `-` columns to the orch-monitor run list showing lines added and deleted for each run.

- Run list shows insertions column (`+`) with green coloring
- Run list shows deletions column (`-`) with red coloring
- Large numbers abbreviated (e.g., `+1.2k`)
- Shows `-` for runs without changes or missing worktree
- Uses existing `git.GetDiffStats` for performance

## Acceptance Criteria

- [x] Run list shows insertions column (`+`)
- [x] Run list shows deletions column (`-`)
- [x] Numbers are color coded (green/red)
- [x] Works for runs with existing worktrees
- [x] Shows `-` or `0` for runs without changes
- [x] Performance acceptable (uses existing diff stats infrastructure)

## Implementation Details

### Files Changed

| File | Changes |
|------|---------|
| `internal/monitor/data.go` | Add `Insertions`, `Deletions` fields to `RunRow` |
| `internal/monitor/columns.go` | Add `ColInsertions`, `ColDeletions` columns, `formatDiffCount()` |
| `internal/monitor/styles.go` | Add `DiffAdd`, `DiffDel` styles (green/red) |
| `internal/monitor/monitor.go` | Compute diff stats in `buildRunRows()` |
| `internal/monitor/ps_helpers.go` | Add `diffStatsForRuns()` helper |

### Additional Fix

Also fixes pre-existing build error in `internal/daemon/types.go` by renaming `computeBranchState` to `computeBranchStateString` to avoid redeclaration conflict with `proto_handler.go`.

## Testing

```bash
go build ./...     # ✓ Build passes
go test ./internal/monitor/...  # ✓ All tests pass
go test ./internal/git/...      # ✓ Diff tests pass
```

Closes orch-313