### PR TITLE
feat(daemon): route status writes through daemon API with store fallback

### DIFF
--- a/internal/cli/continue.go
+++ b/internal/cli/continue.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/s22625/orch/internal/agent"
 	"github.com/s22625/orch/internal/config"
+	"github.com/s22625/orch/internal/daemon"
 	"github.com/s22625/orch/internal/git"
 	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/multiplexer"
@@ -105,6 +106,17 @@ func runContinue(refStr string, opts *continueOptions) error {
 	return continueFromRun(st, refStr, opts)
 }
 
+func appendStatusViaDaemon(repoRoot string, st store.Store, run *model.Run, status model.Status) error {
+	daemonClient := daemon.NewClient(repoRoot)
+	if daemonClient.IsAvailable() {
+		err := daemonClient.AppendStatusEvent(run.IssueID, run.RunID, string(status), string(model.EventSourceUser))
+		if err == nil {
+			return nil
+		}
+	}
+	return st.AppendEvent(run.Ref(), model.NewStatusEvent(status))
+}
+
 func continueFromRun(st store.Store, refStr string, opts *continueOptions) error {
 	fromRun, err := resolveRun(st, refStr)
 	if err != nil {
@@ -138,6 +150,11 @@ func continueFromRun(st store.Store, refStr string, opts *continueOptions) error
 	}
 	if currentBranch != fromRun.Branch {
 		return exitWithCode(fmt.Errorf("worktree %s is on branch %s; expected %s", fromRun.WorktreePath, currentBranch, fromRun.Branch), ExitWorktreeError)
+	}
+
+	repoRoot, err := git.FindMainRepoRoot(fromRun.WorktreePath)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("could not find git repository: %w", err), ExitWorktreeError)
 	}
 
 	issue, err := st.ResolveIssue(fromRun.IssueID)
@@ -181,7 +198,7 @@ func continueFromRun(st store.Store, refStr string, opts *continueOptions) error
 	}
 	result.RunPath = run.Path
 
-	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued)); err != nil {
+	if err := appendStatusViaDaemon(repoRoot, st, run, model.StatusQueued); err != nil {
 		return exitWithCode(err, ExitInternalError)
 	}
 
@@ -196,7 +213,7 @@ func continueFromRun(st store.Store, refStr string, opts *continueOptions) error
 		NoPR:           opts.NoPR,
 		PromptTemplate: opts.PromptTemplate,
 		PRTargetBranch: opts.PRTargetBranch,
-		IssuesRoot:      st.RootPath(),
+		IssuesRoot:     st.RootPath(),
 		IssuePath:      issue.Path,
 	}
 	if err := ensurePromptFile(fromRun.WorktreePath, issue, promptOpts); err != nil {
@@ -218,16 +235,16 @@ func continueFromRun(st store.Store, refStr string, opts *continueOptions) error
 	}
 
 	launchCfg := &agent.LaunchConfig{
-		Type:      agentType,
-		CustomCmd: opts.AgentCmd,
-		WorkDir:   fromRun.WorktreePath,
-		IssueID:   fromRun.IssueID,
-		RunID:     runID,
-		RunPath:   run.Path,
+		Type:       agentType,
+		CustomCmd:  opts.AgentCmd,
+		WorkDir:    fromRun.WorktreePath,
+		IssueID:    fromRun.IssueID,
+		RunID:      runID,
+		RunPath:    run.Path,
 		IssuesRoot: st.RootPath(),
-		Branch:    fromRun.Branch,
-		Prompt:    buildContinuePrompt(continuedFrom),
-		Profile:   opts.AgentProfile,
+		Branch:     fromRun.Branch,
+		Prompt:     buildContinuePrompt(continuedFrom),
+		Profile:    opts.AgentProfile,
 	}
 
 	agentCmd, err := adapter.LaunchCommand(launchCfg)
@@ -235,7 +252,7 @@ func continueFromRun(st store.Store, refStr string, opts *continueOptions) error
 		return exitWithCode(err, ExitAgentError)
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting))
+	appendStatusViaDaemon(repoRoot, st, run, model.StatusBooting)
 
 	if opts.Tmux {
 		muxType, _ := multiplexer.ParseType(opts.Multiplexer)
@@ -260,19 +277,19 @@ func continueFromRun(st store.Store, refStr string, opts *continueOptions) error
 			Env:         launchCfg.Env(),
 		})
 		if err != nil {
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+			appendStatusViaDaemon(repoRoot, st, run, model.StatusFailed)
 			return exitWithCode(fmt.Errorf("failed to create %s session: %w", mux.Type(), err), ExitTmuxError)
 		}
 
 		if adapter.PromptInjection() == agent.InjectionTmux && launchCfg.Prompt != "" {
 			if pattern := adapter.ReadyPattern(); pattern != "" {
 				if err := mux.WaitForReady(tmuxSession, pattern, 30*time.Second); err != nil {
-					st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+					appendStatusViaDaemon(repoRoot, st, run, model.StatusFailed)
 					return exitWithCode(fmt.Errorf("agent did not become ready: %w", err), ExitAgentError)
 				}
 			}
 			if err := mux.SendKeys(tmuxSession, launchCfg.Prompt); err != nil {
-				st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+				appendStatusViaDaemon(repoRoot, st, run, model.StatusFailed)
 				return exitWithCode(fmt.Errorf("failed to send prompt to session: %w", err), ExitTmuxError)
 			}
 		}
@@ -298,7 +315,7 @@ func continueFromRun(st store.Store, refStr string, opts *continueOptions) error
 		}
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning))
+	appendStatusViaDaemon(repoRoot, st, run, model.StatusRunning)
 	result.Status = string(model.StatusRunning)
 
 	if globalOpts.JSON {
@@ -381,7 +398,7 @@ func continueFromBranch(st store.Store, refStr string, opts *continueOptions) er
 	}
 	result.RunPath = run.Path
 
-	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued)); err != nil {
+	if err := appendStatusViaDaemon(repoRoot, st, run, model.StatusQueued); err != nil {
 		return exitWithCode(err, ExitInternalError)
 	}
 
@@ -396,7 +413,7 @@ func continueFromBranch(st store.Store, refStr string, opts *continueOptions) er
 		NoPR:           opts.NoPR,
 		PromptTemplate: opts.PromptTemplate,
 		PRTargetBranch: opts.PRTargetBranch,
-		IssuesRoot:      st.RootPath(),
+		IssuesRoot:     st.RootPath(),
 		IssuePath:      issue.Path,
 	}
 	if err := ensurePromptFile(worktreePath, issue, promptOpts); err != nil {
@@ -416,16 +433,16 @@ func continueFromBranch(st store.Store, refStr string, opts *continueOptions) er
 	}
 
 	launchCfg := &agent.LaunchConfig{
-		Type:      agentType,
-		CustomCmd: opts.AgentCmd,
-		WorkDir:   worktreePath,
-		IssueID:   issueID,
-		RunID:     runID,
-		RunPath:   run.Path,
+		Type:       agentType,
+		CustomCmd:  opts.AgentCmd,
+		WorkDir:    worktreePath,
+		IssueID:    issueID,
+		RunID:      runID,
+		RunPath:    run.Path,
 		IssuesRoot: st.RootPath(),
-		Branch:    branch,
-		Prompt:    buildContinuePrompt(continuedFrom),
-		Profile:   opts.AgentProfile,
+		Branch:     branch,
+		Prompt:     buildContinuePrompt(continuedFrom),
+		Profile:    opts.AgentProfile,
 	}
 
 	agentCmd, err := adapter.LaunchCommand(launchCfg)
@@ -433,7 +450,7 @@ func continueFromBranch(st store.Store, refStr string, opts *continueOptions) er
 		return exitWithCode(err, ExitAgentError)
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting))
+	appendStatusViaDaemon(repoRoot, st, run, model.StatusBooting)
 
 	if opts.Tmux {
 		muxType, _ := multiplexer.ParseType(opts.Multiplexer)
@@ -458,19 +475,19 @@ func continueFromBranch(st store.Store, refStr string, opts *continueOptions) er
 			Env:         launchCfg.Env(),
 		})
 		if err != nil {
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+			appendStatusViaDaemon(repoRoot, st, run, model.StatusFailed)
 			return exitWithCode(fmt.Errorf("failed to create %s session: %w", mux.Type(), err), ExitTmuxError)
 		}
 
 		if adapter.PromptInjection() == agent.InjectionTmux && launchCfg.Prompt != "" {
 			if pattern := adapter.ReadyPattern(); pattern != "" {
 				if err := mux.WaitForReady(tmuxSession, pattern, 30*time.Second); err != nil {
-					st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+					appendStatusViaDaemon(repoRoot, st, run, model.StatusFailed)
 					return exitWithCode(fmt.Errorf("agent did not become ready: %w", err), ExitAgentError)
 				}
 			}
 			if err := mux.SendKeys(tmuxSession, launchCfg.Prompt); err != nil {
-				st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+				appendStatusViaDaemon(repoRoot, st, run, model.StatusFailed)
 				return exitWithCode(fmt.Errorf("failed to send prompt to session: %w", err), ExitTmuxError)
 			}
 		}
@@ -496,7 +513,7 @@ func continueFromBranch(st store.Store, refStr string, opts *continueOptions) er
 		}
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning))
+	appendStatusViaDaemon(repoRoot, st, run, model.StatusRunning)
 	result.Status = string(model.StatusRunning)
 
 	if globalOpts.JSON {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -248,8 +248,7 @@ func runRun(issueID string, opts *runOptions) error {
 	}
 	result.RunPath = run.Path
 
-	// Append initial status event
-	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued)); err != nil {
+	if err := appendStatusEventViaDaemon(repoRoot, st, run, model.StatusQueued); err != nil {
 		return exitWithCode(err, ExitInternalError)
 	}
 
@@ -265,7 +264,7 @@ func runRun(issueID string, opts *runOptions) error {
 	})
 	if err != nil {
 		err = fmt.Errorf("failed to create worktree: %w", err)
-		setRunFailed(st, run, err)
+		setRunFailed(repoRoot, st, run, err)
 		return exitWithCode(err, ExitWorktreeError)
 	}
 
@@ -335,8 +334,7 @@ func runRun(issueID string, opts *runOptions) error {
 		return exitWithCode(err, ExitAgentError)
 	}
 
-	// Update status to booting
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting))
+	appendStatusEventViaDaemon(repoRoot, st, run, model.StatusBooting)
 
 	debug := NewDebugLogger()
 
@@ -366,14 +364,14 @@ func runRun(issueID string, opts *runOptions) error {
 			daemonClient := daemon.NewClient(repoRoot)
 			if !daemonClient.IsAvailable() {
 				err := fmt.Errorf("daemon not running; opencode agent requires daemon for server management (run 'orch daemon start')")
-				setRunFailed(st, run, err)
+				setRunFailed(repoRoot, st, run, err)
 				return exitWithCode(err, ExitAgentError)
 			}
 
 			resp, err := daemonClient.GetOpenCodeServer(worktreeResult.WorktreePath)
 			if err != nil {
 				err = fmt.Errorf("failed to get opencode server from daemon: %w", err)
-				setRunFailed(st, run, err)
+				setRunFailed(repoRoot, st, run, err)
 				return exitWithCode(err, ExitAgentError)
 			}
 
@@ -396,7 +394,7 @@ func runRun(issueID string, opts *runOptions) error {
 			})
 			if err != nil {
 				err = fmt.Errorf("failed to create %s session: %w", mux.Type(), err)
-				setRunFailed(st, run, err)
+				setRunFailed(repoRoot, st, run, err)
 				return exitWithCode(err, ExitTmuxError)
 			}
 
@@ -412,13 +410,13 @@ func runRun(issueID string, opts *runOptions) error {
 				if pattern := adapter.ReadyPattern(); pattern != "" {
 					if err := mux.WaitForReady(tmuxSession, pattern, 30*time.Second); err != nil {
 						err = fmt.Errorf("agent did not become ready: %w", err)
-						setRunFailed(st, run, err)
+						setRunFailed(repoRoot, st, run, err)
 						return exitWithCode(err, ExitAgentError)
 					}
 				}
 				if err := mux.SendKeys(tmuxSession, launchCfg.Prompt); err != nil {
 					err = fmt.Errorf("failed to send prompt to session: %w", err)
-					setRunFailed(st, run, err)
+					setRunFailed(repoRoot, st, run, err)
 					return exitWithCode(err, ExitTmuxError)
 				}
 			}
@@ -426,7 +424,7 @@ func runRun(issueID string, opts *runOptions) error {
 		case agent.InjectionHTTP:
 			if err := injectPromptViaHTTP(st, run, launchCfg, debug); err != nil {
 				err = fmt.Errorf("failed to send prompt via HTTP: %w", err)
-				setRunFailed(st, run, err)
+				setRunFailed(repoRoot, st, run, err)
 				return exitWithCode(err, ExitAgentError)
 			}
 		}
@@ -449,8 +447,7 @@ func runRun(issueID string, opts *runOptions) error {
 		}
 	}
 
-	// Update status to running
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning))
+	appendStatusEventViaDaemon(repoRoot, st, run, model.StatusRunning)
 	result.Status = string(model.StatusRunning)
 
 	// Output result
@@ -741,13 +738,30 @@ func exitWithCode(err error, code int) error {
 	return err
 }
 
+// appendStatusEventViaDaemon attempts to append a status event through the daemon API.
+// If the daemon is unavailable, it falls back to direct store write.
+// This ensures status transitions are validated by the daemon when available.
+func appendStatusEventViaDaemon(repoRoot string, st storeForRunFailed, run *model.Run, status model.Status) error {
+	daemonClient := daemon.NewClient(repoRoot)
+	if daemonClient.IsAvailable() {
+		err := daemonClient.AppendStatusEvent(run.IssueID, run.RunID, string(status), string(model.EventSourceUser))
+		if err == nil {
+			return nil
+		}
+		// Fall through to direct store write on daemon error
+	}
+	// Fallback: direct store write (store layer will validate transitions)
+	return st.AppendEvent(run.Ref(), model.NewStatusEvent(status))
+}
+
 type storeForRunFailed interface {
 	AppendEvent(*model.RunRef, *model.Event) error
 }
 
-func setRunFailed(st storeForRunFailed, run *model.Run, err error) {
+func setRunFailed(repoRoot string, st storeForRunFailed, run *model.Run, err error) {
 	st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+	// Route status change through daemon API
+	appendStatusEventViaDaemon(repoRoot, st, run, model.StatusFailed)
 }
 
 func injectPromptViaHTTP(st interface {

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -278,7 +278,7 @@ func formatDuration(d time.Duration) string {
 	return fmt.Sprintf("%ds", seconds)
 }
 
-func computeBranchState(run *model.Run) string {
+func computeBranchStateString(run *model.Run) string {
 	if run.WorktreePath == "" || run.Branch == "" {
 		return ""
 	}
@@ -295,7 +295,7 @@ func RunToSummary(run *model.Run) *RunSummary {
 	diffStats := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
 
 	elapsedSeconds, elapsedDisplay := computeElapsed(run)
-	branchState := computeBranchState(run)
+	branchState := computeBranchStateString(run)
 
 	return &RunSummary{
 		IssueID:      run.IssueID,
@@ -353,7 +353,7 @@ func RunToFull(run *model.Run) *RunFull {
 
 	diffStats := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
 	elapsedSeconds, elapsedDisplay := computeElapsed(run)
-	branchState := computeBranchState(run)
+	branchState := computeBranchStateString(run)
 
 	return &RunFull{
 		IssueID:           run.IssueID,

--- a/internal/store/file/file.go
+++ b/internal/store/file/file.go
@@ -704,7 +704,17 @@ func (s *FileStore) AppendEvent(ref *model.RunRef, event *model.Event) error {
 		return err
 	}
 
-	// Append event line to file
+	if event.Type == model.EventTypeStatus {
+		newStatus := model.Status(event.Name)
+		source := model.EventSource(event.Attrs["source"])
+		if source == "" {
+			source = model.EventSourceDaemon
+		}
+		if !model.CanTransitionStatus(run.Status, newStatus, source) {
+			return fmt.Errorf("cannot transition from %s to %s (source: %s)", run.Status, newStatus, source)
+		}
+	}
+
 	f, err := os.OpenFile(run.Path, os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open run file: %w", err)
@@ -717,7 +727,6 @@ func (s *FileStore) AppendEvent(ref *model.RunRef, event *model.Event) error {
 		return fmt.Errorf("failed to append event: %w", err)
 	}
 
-	// Sync ensures daemon writes are immediately visible to monitor (fixes orch-127)
 	if err := f.Sync(); err != nil {
 		return fmt.Errorf("failed to sync run file: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Route CLI status event writes through daemon API when available, with direct store fallback
- Add transition validation at the store layer as a secondary safeguard
- Fix pre-existing `computeBranchState` name collision in daemon/types.go

## Changes

### CLI Commands (run.go, continue.go)
- Add `appendStatusEventViaDaemon` / `appendStatusViaDaemon` helper functions
- These try daemon API first (`client.AppendStatusEvent`) with `EventSourceUser`
- Fall back to direct store write if daemon unavailable
- All status transitions (queued, booting, running, failed) now routed through this pattern

### Store Layer (file/file.go)
- Add `CanTransitionStatus` validation in `AppendEvent`
- Validates status transitions when events are written directly to store
- Uses event attrs source or defaults to `EventSourceDaemon`
- Rejects transitions that violate state machine rules

### Bug Fix (daemon/types.go)
- Rename `computeBranchState` to `computeBranchStateString` to resolve pre-existing name collision with proto_handler.go version

## Acceptance Criteria

- [x] `orch run` and `orch continue` route status events through daemon when available
- [x] Falls back gracefully to direct store write when daemon unavailable
- [x] Store layer validates transitions as secondary safeguard
- [x] Terminal states (done/canceled/failed) protected from daemon overwrites
- [x] All tests pass

Closes orch-359