### PR TITLE
fix(send): verify orch send works correctly for opencode runs

### DIFF
--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1,7 +1,9 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -1112,5 +1114,107 @@ func TestOpenCodeManagerDirectoryScoping(t *testing.T) {
 	status := manager.GetStatus(run, "", state, false, false)
 	if status != model.StatusBlocked {
 		t.Errorf("GetStatus() = %v, want %v (blocked when agent is idle)", status, model.StatusBlocked)
+	}
+}
+
+func TestOpenCodeManagerSendMessageMissingPort(t *testing.T) {
+	manager := &OpenCodeManager{
+		Port:      0,
+		SessionID: "ses_test",
+		Directory: "/test",
+		RunRef:    "orch-310#test",
+	}
+
+	run := &model.Run{
+		IssueID:           "orch-310",
+		RunID:             "test",
+		Agent:             "opencode",
+		WorktreePath:      "/test",
+		OpenCodeSessionID: "ses_test",
+	}
+
+	ctx := context.Background()
+	err := manager.SendMessage(ctx, run, "test message", nil)
+
+	if err == nil {
+		t.Fatal("expected error for missing port, got nil")
+	}
+
+	var configErr *OpenCodeConfigError
+	if !errors.As(err, &configErr) {
+		t.Fatalf("expected OpenCodeConfigError, got %T: %v", err, err)
+	}
+
+	if configErr.RunRef != "orch-310#test" {
+		t.Errorf("error.RunRef = %q, want %q", configErr.RunRef, "orch-310#test")
+	}
+
+	if configErr.Missing != "server port" {
+		t.Errorf("error.Missing = %q, want %q", configErr.Missing, "server port")
+	}
+}
+
+func TestOpenCodeManagerSendMessageMissingSessionID(t *testing.T) {
+	manager := &OpenCodeManager{
+		Port:      4096,
+		SessionID: "",
+		Directory: "/test",
+		RunRef:    "orch-310#test",
+	}
+
+	run := &model.Run{
+		IssueID:      "orch-310",
+		RunID:        "test",
+		Agent:        "opencode",
+		WorktreePath: "/test",
+		ServerPort:   4096,
+	}
+
+	ctx := context.Background()
+	err := manager.SendMessage(ctx, run, "test message", nil)
+
+	if err == nil {
+		t.Fatal("expected error for missing session ID, got nil")
+	}
+
+	var configErr *OpenCodeConfigError
+	if !errors.As(err, &configErr) {
+		t.Fatalf("expected OpenCodeConfigError, got %T: %v", err, err)
+	}
+
+	if configErr.RunRef != "orch-310#test" {
+		t.Errorf("error.RunRef = %q, want %q", configErr.RunRef, "orch-310#test")
+	}
+
+	if configErr.Missing != "session ID" {
+		t.Errorf("error.Missing = %q, want %q", configErr.Missing, "session ID")
+	}
+}
+
+func TestOpenCodeConfigErrorMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     *OpenCodeConfigError
+		wantMsg string
+	}{
+		{
+			name:    "missing port",
+			err:     &OpenCodeConfigError{RunRef: "orch-310#abc", Missing: "server port"},
+			wantMsg: "opencode run orch-310#abc missing server port",
+		},
+		{
+			name:    "missing session",
+			err:     &OpenCodeConfigError{RunRef: "issue-1#run-2", Missing: "session ID"},
+			wantMsg: "opencode run issue-1#run-2 missing session ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.Error()
+			if got != tt.wantMsg {
+				t.Errorf("Error() = %q, want %q", got, tt.wantMsg)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Verifies and tests that `orch send` works correctly for opencode runs, addressing all acceptance criteria in orch-310.

## Changes

- Added tests for `OpenCodeManager.SendMessage` error handling (non-daemon path)
- Tests verify `OpenCodeConfigError` is properly returned for missing port/session

## Acceptance Criteria Verification

### 1. `orch send` returns error if message fails to send (not silent OK)

**Daemon path (socket.go:1440-1447):**
```go
func (s *SocketServer) handleSend(req SendRequest, encoder *json.Encoder) {
    err := s.processSend(req)
    if err != nil {
        encoder.Encode(SendResponse{OK: false, Error: err.Error()})
        return
    }
    encoder.Encode(SendResponse{OK: true})
}
```
The daemon handler is now **synchronous** - it waits for `processSend()` to complete and returns the error.

**Test evidence:**
```
=== RUN   TestSocketServerSendRequestMissingRun
--- PASS: TestSocketServerSendRequestMissingRun (5.03s)
=== RUN   TestSocketServerSendRequestMissingConfig
--- PASS: TestSocketServerSendRequestMissingConfig (5.03s)
```

### 2. Missing ServerPort or OpenCodeSessionID produces clear error message

**Daemon path (socket.go:1467-1471):**
```go
if run.ServerPort <= 0 {
    return fmt.Errorf("run %s#%s missing server port (not running or server not started)", ...)
}
if run.OpenCodeSessionID == "" {
    return fmt.Errorf("run %s#%s missing session ID (agent may still be booting)", ...)
}
```

**Non-daemon path (manager.go:380-386):**
```go
func (m *OpenCodeManager) SendMessage(...) error {
    if m.Port <= 0 {
        return &OpenCodeConfigError{RunRef: m.RunRef, Missing: "server port"}
    }
    if m.SessionID == "" {
        return &OpenCodeConfigError{RunRef: m.RunRef, Missing: "session ID"}
    }
    ...
}
```

**New test evidence (this PR):**
```
=== RUN   TestOpenCodeManagerSendMessageMissingPort
--- PASS: TestOpenCodeManagerSendMessageMissingPort (0.00s)
=== RUN   TestOpenCodeManagerSendMessageMissingSessionID
--- PASS: TestOpenCodeManagerSendMessageMissingSessionID (0.00s)
=== RUN   TestOpenCodeConfigErrorMessage
--- PASS: TestOpenCodeConfigErrorMessage (0.00s)
```

### 3. Daemon processSend errors are propagated back to CLI

The synchronous `handleSend` implementation (shown above) encodes errors directly in the JSON response. `SendViaDaemon` in send.go reads and returns this error:
```go
if !resp.OK {
    return fmt.Errorf("daemon error: %s", resp.Error)
}
```

### 4. Add `orch send --dry-run` to validate config without sending

**Already implemented in send.go:55:**
```go
cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Validate config without sending the message")
```

**CLI evidence:**
```
$ ./orch send --help
...
Flags:
      --dry-run    Validate config without sending the message
...
```

**Test evidence:**
```
=== RUN   TestSendCmdDryRunFlag
--- PASS: TestSendCmdDryRunFlag (0.00s)
```

### 5. Works correctly when daemon is not running (direct API call)

The CLI falls back to `manager.SendMessage` when daemon isn't available (send.go:109-137):
```go
if isOpenCode && daemon.IsDaemonSocketAvailable(projectRoot) {
    err = daemon.SendViaDaemon(...)
} else {
    manager := agent.GetManager(run)
    err = manager.SendMessage(ctx, run, message, sendOpts)
}
```

**New test evidence (this PR):**
Tests verify `OpenCodeManager.SendMessage` returns proper `OpenCodeConfigError` types with clear messages.

## Test Results

All tests pass:
```
ok      github.com/s22625/orch/internal/agent   0.398s
ok      github.com/s22625/orch/internal/cli     3.241s
ok      github.com/s22625/orch/internal/daemon  123.091s
```

Closes #310