### PR TITLE
feat(monitor): auto-start daemon when running orch monitor

### DIFF
--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -99,9 +99,9 @@ func runMonitorList(opts *monitorListOptions) error {
 		return err
 	}
 
-	client := daemon.NewClient(projectRoot)
-	if !client.IsAvailable() {
-		return fmt.Errorf("daemon not running; start it with 'orch ps'")
+	client, err := ensureDaemonReady(projectRoot)
+	if err != nil {
+		return err
 	}
 
 	resp, err := client.ListMonitors(projectRoot, opts.All)
@@ -198,9 +198,9 @@ func runMonitorKill(monitorID string, opts *monitorKillOptions) error {
 		return err
 	}
 
-	client := daemon.NewClient(projectRoot)
-	if !client.IsAvailable() {
-		return fmt.Errorf("daemon not running; start it with 'orch ps'")
+	client, err := ensureDaemonReady(projectRoot)
+	if err != nil {
+		return err
 	}
 
 	resp, err := client.KillMonitor(monitorID, opts.All, opts.Global, projectRoot)
@@ -239,6 +239,30 @@ func runMonitorKill(monitorID string, opts *monitorKillOptions) error {
 	return nil
 }
 
+func ensureDaemonReady(projectRoot string) (*daemon.Client, error) {
+	client := daemon.NewClient(projectRoot)
+	if client.IsAvailable() {
+		return client, nil
+	}
+
+	_, err := daemon.StartInBackground()
+	if err != nil {
+		return nil, fmt.Errorf("daemon not running and failed to start: %w\nRun 'orch repair' to fix daemon issues", err)
+	}
+
+	for i := 0; i < 20; i++ {
+		time.Sleep(100 * time.Millisecond)
+		if client.IsAvailable() {
+			if !globalOpts.Quiet {
+				fmt.Fprintln(os.Stderr, "daemon auto-started")
+			}
+			return client, nil
+		}
+	}
+
+	return nil, fmt.Errorf("daemon did not become available after starting\nRun 'orch repair' to fix daemon issues")
+}
+
 func runMonitor(opts *monitorOptions) error {
 	st, err := getStore()
 	if err != nil {
@@ -248,6 +272,10 @@ func runMonitor(opts *monitorOptions) error {
 	projectRoot, err := getProjectRoot()
 	if err != nil {
 		return fmt.Errorf("project root required for monitor: %w", err)
+	}
+
+	if _, err := ensureDaemonReady(projectRoot); err != nil {
+		return err
 	}
 
 	orchDir := monitor.GetOrchDir(projectRoot)


### PR DESCRIPTION
## Summary

- Adds `ensureDaemonReady()` function to auto-start daemon if not running
- Monitor commands now wait for daemon to become available before proceeding
- Prints "daemon auto-started" message when daemon was started automatically

## Changes

- `runMonitor()`: Now calls `ensureDaemonReady()` before starting the TUI
- `runMonitorList()`: Replaced manual daemon check with `ensureDaemonReady()`  
- `runMonitorKill()`: Replaced manual daemon check with `ensureDaemonReady()`

## Acceptance Criteria

- [x] `orch-monitor` works correctly even when daemon was not previously started
- [x] No user intervention required to start daemon manually
- [x] Startup message indicates daemon was auto-started (optional)

## Evidence

### Build passes
```
go build ./...  # Success, no errors
```

### Tests pass
```
go test ./internal/cli/... -short -count=1
ok  	github.com/s22625/orch/internal/cli	6.318s
```

### Code changes
The `ensureDaemonReady()` function:
1. Checks if daemon is available
2. If not, starts it via `daemon.StartInBackground()`
3. Waits up to 2 seconds for daemon to become available
4. Prints "daemon auto-started" message on success (unless --quiet)

Closes orch-196