### PR TITLE
docs: add validate-issue-files to control prompt troubleshooting

### DIFF
--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -1171,6 +1171,8 @@ The following commands are interactive and will hang if called by an AI agent:
 
 ## Troubleshooting
 
+- Issue not showing in list: `+"`orch validate-issue-files <issue-id>`"+` to check for formatting errors
+- Validate all issue files: `+"`orch validate-issue-files`"+` to find malformed issues
 - Orphaned sessions: `+"`orch repair`"+`
 - View daemon logs: Check `+"`.orch/daemon.log`"+` in project root
 - Force stop all: `+"`orch stop --all`"+`

--- a/internal/monitor/agent_prompt.go
+++ b/internal/monitor/agent_prompt.go
@@ -120,6 +120,8 @@ The following commands are interactive and will hang if called by an AI agent:
 
 ## Troubleshooting
 
+- Issue not showing in list: ` + "`orch validate-issue-files <issue-id>`" + ` to check for formatting errors
+- Validate all issue files: ` + "`orch validate-issue-files`" + ` to find malformed issues
 - Orphaned sessions: ` + "`orch repair`" + `
 - View daemon logs: Check ` + "`.orch/daemon.log`" + ` in project root
 - Force stop all: ` + "`orch stop --all`" + `


### PR DESCRIPTION
## Summary

Add `validate-issue-files` command to the control prompt troubleshooting section.

When an issue doesn't show up in `orch issue list`, agents can now use `orch validate-issue-files <issue-id>` to diagnose formatting errors.

## Changes

- `internal/monitor/agent_prompt.go` - Update control prompt template
- `internal/daemon/socket.go` - Update daemon control prompt template

Follow-up to #370 (orch-370)