### PR TITLE
fix(daemon): derive issues_root from project config for control agent prompt

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,29 +133,29 @@ func (s *SlackConfig) IsConfigured() bool {
 
 // Config holds orch configuration
 type Config struct {
-	Agent           string           `yaml:"agent"`
-	Model           string           `yaml:"model"`
-	ModelVariant    string           `yaml:"model_variant"`
-	WorktreeDir     string           `yaml:"worktree_dir"`
-	BaseBranch      string           `yaml:"base_branch"`
-	PRTargetBranch  string           `yaml:"pr_target_branch"`
+	Agent              string           `yaml:"agent"`
+	Model              string           `yaml:"model"`
+	ModelVariant       string           `yaml:"model_variant"`
+	WorktreeDir        string           `yaml:"worktree_dir"`
+	BaseBranch         string           `yaml:"base_branch"`
+	PRTargetBranch     string           `yaml:"pr_target_branch"`
 	LogLevel           string           `yaml:"log_level"`
 	PromptTemplate     string           `yaml:"prompt_template"`
 	Multiplexer        string           `yaml:"multiplexer"`         // Deprecated: use MonitorMultiplexer/AgentMultiplexer
 	MonitorMultiplexer string           `yaml:"monitor_multiplexer"` // Multiplexer for orch-monitor: "zellij" (default) or "tmux"
 	AgentMultiplexer   string           `yaml:"agent_multiplexer"`   // Multiplexer for agent sessions: "tmux" (default) or "zellij"
 	NoPR               bool             `yaml:"no_pr"`
-	Monitor         MonitorConfig    `yaml:"monitor"`
-	Presets         []Preset         `yaml:"presets"`
-	OpenCodePresets []OpenCodePreset `yaml:"opencode_presets"` // Deprecated: use Presets instead
-	OpenCode        OpenCodeConfig   `yaml:"opencode"`
-	Claude          ClaudeConfig     `yaml:"claude"`
-	Codex           CodexConfig      `yaml:"codex"`
-	Gemini          GeminiConfig     `yaml:"gemini"`
-	DefaultPreset   string           `yaml:"default_preset"` // Default preset to use when no --preset flag is provided
-	Slack           SlackConfig      `yaml:"slack"`
-	Issues          IssuesConfig     `yaml:"issues"`
-	GitHub          GitHubConfig     `yaml:"github"`
+	Monitor            MonitorConfig    `yaml:"monitor"`
+	Presets            []Preset         `yaml:"presets"`
+	OpenCodePresets    []OpenCodePreset `yaml:"opencode_presets"` // Deprecated: use Presets instead
+	OpenCode           OpenCodeConfig   `yaml:"opencode"`
+	Claude             ClaudeConfig     `yaml:"claude"`
+	Codex              CodexConfig      `yaml:"codex"`
+	Gemini             GeminiConfig     `yaml:"gemini"`
+	DefaultPreset      string           `yaml:"default_preset"` // Default preset to use when no --preset flag is provided
+	Slack              SlackConfig      `yaml:"slack"`
+	Issues             IssuesConfig     `yaml:"issues"`
+	GitHub             GitHubConfig     `yaml:"github"`
 
 	// Control agent settings (for orch monitor 'c' keybinding)
 	// Falls back to run agent defaults if not set
@@ -230,6 +230,28 @@ func Load() (*Config, error) {
 	}
 	for _, repoPath := range repoPaths {
 		if err := loadFromFile(repoPath, cfg); err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+
+	return cfg, nil
+}
+
+func LoadFromProjectRoot(projectRoot string) (*Config, error) {
+	cfg := &Config{}
+
+	globalPath := globalConfigPath()
+	if globalPath != "" {
+		if err := loadFromFile(globalPath, cfg); err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+
+	applyEnv(cfg)
+
+	configPath := filepath.Join(projectRoot, ".orch", configFile)
+	if _, err := os.Stat(configPath); err == nil {
+		if err := loadFromFile(configPath, cfg); err != nil {
 			return nil, err
 		}
 	}
@@ -472,9 +494,9 @@ func loadFromFile(path string, cfg *Config) error {
 		cfg.ControlModel = fileCfg.ControlModel
 	}
 	if fileCfg.ControlModelVariant != "" {
-	if fileCfg.DiffTool != "" {
-		cfg.DiffTool = fileCfg.DiffTool
-	}
+		if fileCfg.DiffTool != "" {
+			cfg.DiffTool = fileCfg.DiffTool
+		}
 		cfg.ControlModelVariant = fileCfg.ControlModelVariant
 	}
 

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -923,20 +923,25 @@ func getControlPromptInstruction() string {
 
 const controlPromptFileName = "ORCH_CONTROL_PROMPT.md"
 
-// writeControlPromptFile writes the control agent prompt to a file in the current working directory.
+// writeControlPromptFile writes the control agent prompt to a file in the specified project directory.
 // This is the daemon's implementation to avoid circular imports with the monitor package.
-func (s *SocketServer) writeControlPromptFile(st store.Store) (string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("failed to get working directory: %w", err)
+func (s *SocketServer) writeControlPromptFile(st store.Store, projectRoot string) (string, error) {
+	// Use project root if provided, otherwise fall back to cwd
+	targetDir := projectRoot
+	if targetDir == "" {
+		var err error
+		targetDir, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("failed to get working directory: %w", err)
+		}
 	}
 
-	prompt, err := s.buildControlAgentPrompt(st)
+	prompt, err := s.buildControlAgentPrompt(st, projectRoot)
 	if err != nil {
 		return "", err
 	}
 
-	promptPath := filepath.Join(cwd, controlPromptFileName)
+	promptPath := filepath.Join(targetDir, controlPromptFileName)
 	if err := os.WriteFile(promptPath, []byte(prompt), 0644); err != nil {
 		return "", fmt.Errorf("failed to write control prompt file: %w", err)
 	}
@@ -945,8 +950,11 @@ func (s *SocketServer) writeControlPromptFile(st store.Store) (string, error) {
 }
 
 // buildControlAgentPrompt builds the control agent prompt with dynamic repo context.
-func (s *SocketServer) buildControlAgentPrompt(st store.Store) (string, error) {
-	cwd, _ := os.Getwd()
+func (s *SocketServer) buildControlAgentPrompt(st store.Store, projectRoot string) (string, error) {
+	workDir := projectRoot
+	if workDir == "" {
+		workDir, _ = os.Getwd()
+	}
 	issuesRoot := st.RootPath()
 
 	// Get existing issues
@@ -1010,9 +1018,8 @@ func (s *SocketServer) buildControlAgentPrompt(st store.Store) (string, error) {
 		runsText = "No active runs."
 	}
 
-	// Get git info
-	gitBranch := s.getGitBranch(cwd)
-	uncommittedChanges := s.getUncommittedChangesStatus(cwd)
+	gitBranch := s.getGitBranch(workDir)
+	uncommittedChanges := s.getUncommittedChangesStatus(workDir)
 
 	// Get agent config
 	cfg, _ := config.Load()
@@ -1105,7 +1112,7 @@ The following commands are interactive and will hang if called by an AI agent:
 
 - Execute orch commands directly via bash - no special protocol needed
 - Follow the issue ID naming convention when creating new issues
-`, issuesRoot, cwd, gitBranch, uncommittedChanges, defaultAgent, issuesText, runsText)
+`, issuesRoot, workDir, gitBranch, uncommittedChanges, defaultAgent, issuesText, runsText)
 
 	return prompt, nil
 }
@@ -1149,7 +1156,13 @@ func (s *SocketServer) handleGetControlAgentLaunch(req SendRequest, encoder *jso
 		return
 	}
 
-	// Resolve the store for the project
+	if req.IssuesRoot == "" {
+		if cfg, err := config.LoadFromProjectRoot(req.ProjectRoot); err == nil && cfg != nil {
+			req.IssuesRoot = cfg.GetIssuesPath()
+			s.logger.Printf("derived issues_root=%q from project config", req.IssuesRoot)
+		}
+	}
+
 	st := s.resolveStore(req)
 	if st == nil {
 		encoder.Encode(map[string]interface{}{
@@ -1159,8 +1172,7 @@ func (s *SocketServer) handleGetControlAgentLaunch(req SendRequest, encoder *jso
 		return
 	}
 
-	// Write the control prompt file
-	promptPath, err := s.writeControlPromptFile(st)
+	promptPath, err := s.writeControlPromptFile(st, req.ProjectRoot)
 	if err != nil {
 		s.logger.Printf("failed to write control prompt file: %v", err)
 		encoder.Encode(map[string]interface{}{


### PR DESCRIPTION
## Summary

- Fixes ORCH_CONTROL_PROMPT.md showing runs from wrong IssuesRoot when daemon serves multiple projects
- Control prompt now correctly uses project-specific context

## Changes

1. **Added `LoadFromProjectRoot` in config.go** - Loads config from a specific project directory instead of relying on cwd

2. **Updated `handleGetControlAgentLaunch` in socket.go** - Derives `issues_root` from project config when not provided in the request

3. **Updated `writeControlPromptFile`/`buildControlAgentPrompt`** - Uses provided `projectRoot` instead of daemon's `os.Getwd()` for:
   - Writing the prompt file to correct directory
   - Getting git context (branch, uncommitted changes)
   - Setting working directory in the prompt

## Root Cause

The `get_control_agent_launch` proto request only included `project_root` but not `issues_root`. When the daemon tried to resolve the store, it could return a cached store from a different project. Additionally, the prompt file was written to the daemon's cwd instead of the project directory.

## Testing

- All existing tests pass
- Build succeeds

## Acceptance Criteria

- [x] Investigate how ORCH_CONTROL_PROMPT.md is generated
- [x] Ensure the generator uses live `orch ps` data for the current context
- [x] Active runs section should match actual orch ps output

Fixes: orch-371