### PR TITLE
refactor: eliminate tmux abstraction leaks (orch-373)

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -7,11 +7,10 @@ import (
 	"time"
 
 	"github.com/s22625/orch/internal/model"
-	"github.com/s22625/orch/internal/tmux"
+	"github.com/s22625/orch/internal/multiplexer"
 )
 
-// tmuxCache holds cached tmux session data for batch operations
-type tmuxCache struct {
+type muxCache struct {
 	mu            sync.RWMutex
 	sessions      map[string]bool
 	paneCommands  map[string][]string
@@ -19,54 +18,52 @@ type tmuxCache struct {
 	ttl           time.Duration
 }
 
-var globalTmuxCache = &tmuxCache{
+var globalMuxCache = &muxCache{
 	ttl: 5 * time.Second,
 }
 
-// RefreshTmuxCache updates the cache with current tmux state
-func RefreshTmuxCache() {
-	globalTmuxCache.mu.Lock()
-	defer globalTmuxCache.mu.Unlock()
+func RefreshMuxCache() {
+	globalMuxCache.mu.Lock()
+	defer globalMuxCache.mu.Unlock()
 
-	sessions, err := tmux.ListSessions()
+	mux := multiplexer.GetDefault()
+	sessions, err := mux.ListSessions()
 	if err == nil {
-		globalTmuxCache.sessions = make(map[string]bool)
+		globalMuxCache.sessions = make(map[string]bool)
 		for _, s := range sessions {
-			globalTmuxCache.sessions[s] = true
+			globalMuxCache.sessions[s] = true
 		}
 	}
 
-	paneCommands, err := tmux.ListPaneCommands()
+	paneCommands, err := mux.ListPaneCommands()
 	if err == nil {
-		globalTmuxCache.paneCommands = paneCommands
+		globalMuxCache.paneCommands = paneCommands
 	}
 
-	globalTmuxCache.lastRefreshed = time.Now()
+	globalMuxCache.lastRefreshed = time.Now()
 }
 
-// GetTmuxCache returns cached session and pane data, refreshing if stale
-func GetTmuxCache() (map[string]bool, map[string][]string) {
-	globalTmuxCache.mu.RLock()
-	if time.Since(globalTmuxCache.lastRefreshed) < globalTmuxCache.ttl {
-		sessions := globalTmuxCache.sessions
-		paneCommands := globalTmuxCache.paneCommands
-		globalTmuxCache.mu.RUnlock()
+func GetMuxCache() (map[string]bool, map[string][]string) {
+	globalMuxCache.mu.RLock()
+	if time.Since(globalMuxCache.lastRefreshed) < globalMuxCache.ttl {
+		sessions := globalMuxCache.sessions
+		paneCommands := globalMuxCache.paneCommands
+		globalMuxCache.mu.RUnlock()
 		return sessions, paneCommands
 	}
-	globalTmuxCache.mu.RUnlock()
+	globalMuxCache.mu.RUnlock()
 
-	RefreshTmuxCache()
+	RefreshMuxCache()
 
-	globalTmuxCache.mu.RLock()
-	defer globalTmuxCache.mu.RUnlock()
-	return globalTmuxCache.sessions, globalTmuxCache.paneCommands
+	globalMuxCache.mu.RLock()
+	defer globalMuxCache.mu.RUnlock()
+	return globalMuxCache.sessions, globalMuxCache.paneCommands
 }
 
-// InvalidateTmuxCache forces the next GetTmuxCache call to refresh
-func InvalidateTmuxCache() {
-	globalTmuxCache.mu.Lock()
-	defer globalTmuxCache.mu.Unlock()
-	globalTmuxCache.lastRefreshed = time.Time{}
+func InvalidateMuxCache() {
+	globalMuxCache.mu.Lock()
+	defer globalMuxCache.mu.Unlock()
+	globalMuxCache.lastRefreshed = time.Time{}
 }
 
 type RunState struct {
@@ -119,7 +116,7 @@ func GetManager(run *model.Run) AgentManager {
 			RunRef:    run.Ref().String(),
 		}
 	}
-	return &TmuxManager{SessionName: getSessionName(run)}
+	return &MuxManager{SessionName: getSessionName(run)}
 }
 
 func getSessionName(run *model.Run) string {
@@ -129,28 +126,29 @@ func getSessionName(run *model.Run) string {
 	return model.GenerateTmuxSession(run.IssueID, run.RunID)
 }
 
-type TmuxManager struct {
+type MuxManager struct {
 	SessionName string
 }
 
-func (m *TmuxManager) IsAlive(run *model.Run) bool {
-	sessions, paneCommands := GetTmuxCache()
+func (m *MuxManager) IsAlive(run *model.Run) bool {
+	sessions, paneCommands := GetMuxCache()
 	return m.isAliveFromCache(sessions, paneCommands)
 }
 
-func (m *TmuxManager) isAliveFromCache(sessions map[string]bool, paneCommands map[string][]string) bool {
+func (m *MuxManager) isAliveFromCache(sessions map[string]bool, paneCommands map[string][]string) bool {
+	mux := multiplexer.GetDefault()
 	if sessions != nil {
 		if !sessions[m.SessionName] {
 			return false
 		}
 	} else {
-		if !tmux.HasSession(m.SessionName) {
+		if !mux.HasSession(m.SessionName) {
 			return false
 		}
 	}
 
 	if paneCommands != nil {
-		alive, known := tmux.AgentAlive(m.SessionName, paneCommands)
+		alive, known := mux.AgentAlive(m.SessionName, paneCommands)
 		if known {
 			return alive
 		}
@@ -159,15 +157,16 @@ func (m *TmuxManager) isAliveFromCache(sessions map[string]bool, paneCommands ma
 	return true
 }
 
-func (m *TmuxManager) CaptureOutput(run *model.Run) (string, error) {
-	return tmux.CapturePane(m.SessionName, 100)
+func (m *MuxManager) CaptureOutput(run *model.Run) (string, error) {
+	mux := multiplexer.GetDefault()
+	return mux.CapturePane(m.SessionName, 100)
 }
 
-func (m *TmuxManager) DetectPrompt(output string) bool {
+func (m *MuxManager) DetectPrompt(output string) bool {
 	return IsWaitingForInput(output)
 }
 
-func (m *TmuxManager) GetStatus(run *model.Run, output string, state *RunState, outputChanged, hasPrompt bool) model.Status {
+func (m *MuxManager) GetStatus(run *model.Run, output string, state *RunState, outputChanged, hasPrompt bool) model.Status {
 	if IsAgentExited(output) {
 		return model.StatusUnknown
 	}
@@ -189,15 +188,16 @@ func (m *TmuxManager) GetStatus(run *model.Run, output string, state *RunState, 
 	return ""
 }
 
-func (m *TmuxManager) SendMessage(ctx context.Context, run *model.Run, message string, opts *SendOptions) error {
-	if !tmux.HasSession(m.SessionName) {
+func (m *MuxManager) SendMessage(ctx context.Context, run *model.Run, message string, opts *SendOptions) error {
+	mux := multiplexer.GetDefault()
+	if !mux.HasSession(m.SessionName) {
 		return &SessionNotFoundError{SessionName: m.SessionName}
 	}
 
 	if opts != nil && opts.NoEnter {
-		return tmux.SendKeysLiteral(m.SessionName, message)
+		return mux.SendKeysLiteral(m.SessionName, message)
 	}
-	return tmux.SendKeys(m.SessionName, message)
+	return mux.SendKeys(m.SessionName, message)
 }
 
 type OpenCodeManager struct {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -28,12 +28,12 @@ func TestGetManager(t *testing.T) {
 			wantType: "*agent.OpenCodeManager",
 		},
 		{
-			name: "claude run returns TmuxManager",
+			name: "claude run returns MuxManager",
 			run: &model.Run{
 				Agent:       "claude",
 				TmuxSession: "orch-test-001",
 			},
-			wantType: "*agent.TmuxManager",
+			wantType: "*agent.MuxManager",
 		},
 		{
 			name: "opencode run missing session ID still returns OpenCodeManager",
@@ -68,8 +68,8 @@ func TestGetManager(t *testing.T) {
 
 func typeName(v interface{}) string {
 	switch v.(type) {
-	case *TmuxManager:
-		return "TmuxManager"
+	case *MuxManager:
+		return "MuxManager"
 	case *OpenCodeManager:
 		return "OpenCodeManager"
 	default:
@@ -409,8 +409,8 @@ func TestIsFailed(t *testing.T) {
 	}
 }
 
-func TestTmuxManagerGetStatus(t *testing.T) {
-	manager := &TmuxManager{SessionName: "test-session"}
+func TestMuxManagerGetStatus(t *testing.T) {
+	manager := &MuxManager{SessionName: "test-session"}
 	run := &model.Run{RunID: "test-run"}
 
 	tests := []struct {

--- a/internal/cli/capture_all.go
+++ b/internal/cli/capture_all.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/multiplexer"
 	"github.com/s22625/orch/internal/store"
-	"github.com/s22625/orch/internal/tmux"
 	"github.com/spf13/cobra"
 )
 
@@ -16,8 +16,9 @@ type captureAllOptions struct {
 	Lines int
 }
 
-var captureAllHasSession = tmux.HasSession
-var captureAllCapturePane = tmux.CapturePane
+var captureAllMux = multiplexer.GetDefault()
+var captureAllHasSession = captureAllMux.HasSession
+var captureAllCapturePane = captureAllMux.CapturePane
 
 func newCaptureAllCmd() *cobra.Command {
 	opts := &captureAllOptions{}

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/s22625/orch/internal/git"
 	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/multiplexer"
 	"github.com/s22625/orch/internal/store"
-	"github.com/s22625/orch/internal/tmux"
 	"github.com/spf13/cobra"
 )
 
@@ -318,7 +318,8 @@ func deleteRuns(st store.Store, runs []*model.Run, opts *deleteOptions) error {
 			if opts.WithBranch && run.Branch != "" {
 				extras = append(extras, "branch")
 			}
-			if run.TmuxSession != "" && tmux.HasSession(run.TmuxSession) {
+			mux := multiplexer.GetDefault()
+			if run.TmuxSession != "" && mux.HasSession(run.TmuxSession) {
 				extras = append(extras, "session")
 			}
 			extraStr := ""
@@ -392,14 +393,13 @@ func performDelete(st store.Store, run *model.Run, opts *deleteOptions) (*delete
 		ShortID: run.ShortID(),
 	}
 
-	// 1. Kill tmux session if running
 	sessionName := run.TmuxSession
 	if sessionName == "" {
 		sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
 	}
-	if tmux.HasSession(sessionName) {
-		if err := tmux.KillSession(sessionName); err != nil {
-			// Log warning but continue
+	mux := multiplexer.GetDefault()
+	if mux.HasSession(sessionName) {
+		if err := mux.KillSession(sessionName); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to kill session %s: %v\n", sessionName, err)
 		} else {
 			result.SessionKilled = true

--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -769,7 +769,7 @@ func resolveAgentAliveInfo(runs []*model.Run) map[string]agentAliveInfo {
 		return nil
 	}
 
-	agent.RefreshTmuxCache()
+	agent.RefreshMuxCache()
 
 	aliveByRun := make(map[string]agentAliveInfo, len(runs))
 	var mu sync.Mutex

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -8,8 +8,8 @@ import (
 	"github.com/s22625/orch/internal/agent"
 	"github.com/s22625/orch/internal/daemon"
 	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/multiplexer"
 	"github.com/s22625/orch/internal/store"
-	"github.com/s22625/orch/internal/tmux"
 	"github.com/spf13/cobra"
 )
 
@@ -94,13 +94,14 @@ func runRepair(opts *repairOptions) error {
 	orphanedSessions := findOrphanedSessions(st)
 	if len(orphanedSessions) > 0 {
 		problemsFound += len(orphanedSessions)
-		fmt.Printf("  found %d orphaned tmux sessions:\n", len(orphanedSessions))
+		fmt.Printf("  found %d orphaned sessions:\n", len(orphanedSessions))
 		for _, s := range orphanedSessions {
 			fmt.Printf("    - %s\n", s)
 		}
 		if !opts.DryRun && opts.Force {
+			mux := multiplexer.GetDefault()
 			for _, s := range orphanedSessions {
-				if err := tmux.KillSession(s); err != nil {
+				if err := mux.KillSession(s); err != nil {
 					fmt.Fprintf(os.Stderr, "    failed to kill %s: %v\n", s, err)
 				} else {
 					problemsFixed++
@@ -229,21 +230,19 @@ func repairStaleRuns(st store.Store, opts *repairOptions) (int, error) {
 	return fixed, nil
 }
 
-// findOrphanedSessions finds tmux sessions that don't correspond to any run
+// findOrphanedSessions finds multiplexer sessions that don't correspond to any run
 func findOrphanedSessions(st store.Store) []string {
-	// Get all tmux sessions
-	sessions, err := tmux.ListSessions()
+	mux := multiplexer.GetDefault()
+	sessions, err := mux.ListSessions()
 	if err != nil || len(sessions) == 0 {
 		return nil
 	}
 
-	// Get all runs
 	runs, err := st.ListRuns(&store.ListRunsFilter{})
 	if err != nil {
 		return nil
 	}
 
-	// Build set of expected session names
 	expectedSessions := make(map[string]bool)
 	for _, run := range runs {
 		sessionName := run.TmuxSession
@@ -253,10 +252,8 @@ func findOrphanedSessions(st store.Store) []string {
 		expectedSessions[sessionName] = true
 	}
 
-	// Find orphaned sessions (orch sessions that don't match any run)
 	var orphaned []string
 	for _, s := range sessions {
-		// Only consider sessions that look like orch sessions
 		if len(s) > 4 && s[:4] == "run-" {
 			if !expectedSessions[s] {
 				orphaned = append(orphaned, s)

--- a/internal/cli/tick.go
+++ b/internal/cli/tick.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/s22625/orch/internal/agent"
 	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/multiplexer"
 	"github.com/s22625/orch/internal/store"
-	"github.com/s22625/orch/internal/tmux"
 	"github.com/spf13/cobra"
 )
 
@@ -188,7 +188,7 @@ func resumeRun(st store.Store, run *model.Run, agentType string) error {
 		IssueID:     run.IssueID,
 		RunID:       run.RunID,
 		RunPath:     run.Path,
-		IssuesRoot:   st.RootPath(),
+		IssuesRoot:  st.RootPath(),
 		Branch:      run.Branch,
 		Prompt:      buildResumePrompt(issue, run),
 		Resume:      true,
@@ -200,18 +200,16 @@ func resumeRun(st store.Store, run *model.Run, agentType string) error {
 		return err
 	}
 
-	// Check if session exists, create new window for resume
 	sessionName := run.TmuxSession
 	if sessionName == "" {
 		sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
 	}
 
-	if tmux.HasSession(sessionName) {
-		// Create new window in existing session
-		err = tmux.NewWindow(sessionName, "resume", run.WorktreePath, agentCmd)
+	mux := multiplexer.GetDefault()
+	if mux.HasSession(sessionName) {
+		err = mux.NewWindow(sessionName, "resume", run.WorktreePath, agentCmd)
 	} else {
-		// Create new session
-		err = tmux.NewSession(&tmux.SessionConfig{
+		err = mux.NewSession(&multiplexer.SessionConfig{
 			SessionName: sessionName,
 			WorkDir:     run.WorktreePath,
 			Command:     agentCmd,

--- a/internal/monitor/dashboard.go
+++ b/internal/monitor/dashboard.go
@@ -16,7 +16,6 @@ import (
 	"github.com/s22625/orch/internal/config"
 	"github.com/s22625/orch/internal/git"
 	"github.com/s22625/orch/internal/model"
-	"github.com/s22625/orch/internal/tmux"
 )
 
 type dashboardMode int
@@ -545,9 +544,9 @@ func (d *Dashboard) killSessionCmd(run *model.Run, sessionName string) tea.Cmd {
 		if run == nil {
 			return errMsg{err: fmt.Errorf("run not found")}
 		}
-		sessionExisted := tmux.HasSession(sessionName)
+		sessionExisted := d.monitor.mux.HasSession(sessionName)
 		if sessionExisted {
-			if err := tmux.KillSession(sessionName); err != nil {
+			if err := d.monitor.mux.KillSession(sessionName); err != nil {
 				return errMsg{err: fmt.Errorf("failed to kill session: %w", err)}
 			}
 		}
@@ -745,7 +744,7 @@ func (d *Dashboard) execShellCmd(run *model.Run) tea.Cmd {
 	shellCmd := strings.Join(env, " ") + " exec zsh"
 
 	return func() tea.Msg {
-		if err := tmux.NewWindow(d.monitor.session, windowName, worktreePath, shellCmd); err != nil {
+		if err := d.monitor.mux.NewWindow(d.monitor.session, windowName, worktreePath, shellCmd); err != nil {
 			return execFinishedMsg{err: fmt.Errorf("failed to open exec window: %w", err)}
 		}
 		return execFinishedMsg{err: nil}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -18,9 +18,9 @@ import (
 	"github.com/s22625/orch/internal/daemon"
 	"github.com/s22625/orch/internal/git"
 	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/multiplexer"
 	"github.com/s22625/orch/internal/pr"
 	"github.com/s22625/orch/internal/store"
-	"github.com/s22625/orch/internal/tmux"
 	"github.com/s22625/orch/internal/xdg"
 )
 
@@ -84,6 +84,7 @@ type Monitor struct {
 	presets         []config.Preset
 	projectRoot     string
 	logger          *log.Logger
+	mux             multiplexer.Multiplexer
 
 	monitorID     string
 	heartbeatStop chan struct{}
@@ -148,6 +149,8 @@ func New(st store.Store, opts Options) *Monitor {
 		logger = log.New(os.Stderr, "[monitor] ", log.LstdFlags)
 	}
 
+	mux := multiplexer.GetDefault()
+
 	return &Monitor{
 		session:         session,
 		runFilter:       newRunFilter(opts),
@@ -170,6 +173,7 @@ func New(st store.Store, opts Options) *Monitor {
 		presets:         presets,
 		projectRoot:     projectRoot,
 		logger:          logger,
+		mux:             mux,
 	}
 }
 
@@ -311,13 +315,13 @@ func sessionNameForProject(projectRoot string) string {
 	return fmt.Sprintf("orch-%s-%s", baseName, shortHash)
 }
 
-// Start creates or attaches to the monitor tmux session.
+// Start creates or attaches to the monitor session.
 func (m *Monitor) Start() error {
-	if !tmux.IsTmuxAvailable() {
-		return fmt.Errorf("tmux is not available")
+	if !m.mux.IsAvailable() {
+		return fmt.Errorf("%s is not available", m.mux.Type())
 	}
 
-	// forceNew restarts the layout (kills tmux session)
+	// forceNew restarts the layout (kills session)
 	// newControlAgent additionally restarts the control agent (clears session file)
 	if m.forceNew || m.newControlAgent {
 		// Only clear control session if explicitly requested
@@ -326,19 +330,19 @@ func (m *Monitor) Start() error {
 				return fmt.Errorf("failed to clear control session: %w", err)
 			}
 		}
-		if tmux.HasSession(m.session) {
-			if tmux.IsInsideTmux() {
-				if current, err := tmux.CurrentSession(); err == nil && current == m.session {
+		if m.mux.HasSession(m.session) {
+			if m.mux.IsInsideSession() {
+				if current, err := m.mux.CurrentSession(); err == nil && current == m.session {
 					return fmt.Errorf("cannot use --new from inside %s; detach and rerun", m.session)
 				}
 			}
-			if err := tmux.KillSession(m.session); err != nil {
+			if err := m.mux.KillSession(m.session); err != nil {
 				return fmt.Errorf("failed to kill existing monitor session: %w", err)
 			}
 		}
 	}
 
-	sessionExists := tmux.HasSession(m.session)
+	sessionExists := m.mux.HasSession(m.session)
 	if sessionExists && m.attach {
 		m.registerWithDaemon()
 		return m.attachSession()
@@ -421,14 +425,14 @@ func (m *Monitor) RefreshIssues() ([]IssueRow, error) {
 	return m.buildIssueRows(issues, runs), nil
 }
 
-// SwitchWindow selects a tmux window by index.
+// SwitchWindow selects a window by index.
 func (m *Monitor) SwitchWindow(index int) error {
-	return tmux.SelectWindow(m.session, index)
+	return m.mux.SelectWindow(m.session, index)
 }
 
 // SwitchRuns switches to the runs dashboard window.
 func (m *Monitor) SwitchRuns() error {
-	if err := tmux.SelectWindow(m.session, dashboardWindowIdx); err != nil {
+	if err := m.mux.SelectWindow(m.session, dashboardWindowIdx); err != nil {
 		return err
 	}
 	return m.selectPaneByOption(runsPaneOption, runsPaneTitle)
@@ -436,7 +440,7 @@ func (m *Monitor) SwitchRuns() error {
 
 // SwitchIssues switches to the issues dashboard window.
 func (m *Monitor) SwitchIssues() error {
-	if err := tmux.SelectWindow(m.session, dashboardWindowIdx); err != nil {
+	if err := m.mux.SelectWindow(m.session, dashboardWindowIdx); err != nil {
 		return err
 	}
 	return m.selectPaneByOption(issuesPaneOption, issuesPaneTitle)
@@ -444,14 +448,14 @@ func (m *Monitor) SwitchIssues() error {
 
 // SwitchChat switches to the agent chat window.
 func (m *Monitor) SwitchChat() error {
-	if err := tmux.SelectWindow(m.session, dashboardWindowIdx); err != nil {
+	if err := m.mux.SelectWindow(m.session, dashboardWindowIdx); err != nil {
 		return err
 	}
 	pane, err := m.findChatPane()
 	if err != nil {
 		return err
 	}
-	return tmux.SelectPane(pane)
+	return m.mux.SelectPane(pane)
 }
 
 func (m *Monitor) OpenRun(run *model.Run) error {
@@ -464,15 +468,15 @@ func (m *Monitor) OpenRun(run *model.Run) error {
 
 // CloseRun returns to the dashboard window.
 func (m *Monitor) CloseRun() error {
-	return tmux.SelectWindow(m.session, dashboardWindowIdx)
+	return m.mux.SelectWindow(m.session, dashboardWindowIdx)
 }
 
 func (m *Monitor) Quit() error {
 	m.unregisterFromDaemon()
-	return tmux.KillSession(m.session)
+	return m.mux.KillSession(m.session)
 }
 
-// StopRun kills the run tmux session and marks the run canceled.
+// StopRun kills the run session and marks the run canceled.
 func (m *Monitor) StopRun(run *model.Run) error {
 	if isTerminalStatus(run.Status) {
 		return nil
@@ -483,8 +487,8 @@ func (m *Monitor) StopRun(run *model.Run) error {
 		sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
 	}
 
-	if tmux.HasSession(sessionName) {
-		_ = tmux.KillSession(sessionName)
+	if m.mux.HasSession(sessionName) {
+		_ = m.mux.KillSession(sessionName)
 	}
 
 	return m.store.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusCanceled))
@@ -762,31 +766,31 @@ func (m *Monitor) getRepoRoot() (string, error) {
 
 func (m *Monitor) createSession() error {
 	cmd := m.runsDashboardCommand()
-	cfg := &tmux.SessionConfig{
+	cfg := &multiplexer.SessionConfig{
 		SessionName: m.session,
 		Command:     cmd,
 		WindowName:  dashboardWindowName,
 	}
-	if err := tmux.NewSession(cfg); err != nil {
+	if err := m.mux.NewSession(cfg); err != nil {
 		return fmt.Errorf("failed to create monitor session: %w", err)
 	}
 	return nil
 }
 
 func (m *Monitor) attachSession() error {
-	if os.Getenv("TMUX") != "" {
-		return tmux.SwitchClient(m.session)
+	if m.mux.IsInsideSession() {
+		return m.mux.SwitchClient(m.session)
 	}
-	return tmux.AttachSession(m.session)
+	return m.mux.AttachSession(m.session)
 }
 
 func (m *Monitor) ensurePaneLayout() error {
-	if !tmux.HasSession(m.session) {
+	if !m.mux.HasSession(m.session) {
 		return nil
 	}
 
 	target := fmt.Sprintf("%s:%d", m.session, dashboardWindowIdx)
-	panes, err := tmux.ListPanes(target)
+	panes, err := m.mux.ListPanes(target)
 	if err != nil {
 		return err
 	}
@@ -805,27 +809,27 @@ func (m *Monitor) ensurePaneLayout() error {
 		}
 		for _, p := range panes {
 			if p.ID != base.ID {
-				_ = tmux.KillPane(p.ID)
+				_ = m.mux.KillPane(p.ID)
 			}
 		}
-		_ = tmux.SetPaneTitle(base.ID, runsPaneTitle)
-		if chatPane, err := tmux.SplitWindow(base.ID, true, 25); err == nil {
-			_ = tmux.SetPaneTitle(chatPane, chatPaneTitle)
+		_ = m.mux.SetPaneTitle(base.ID, runsPaneTitle)
+		if chatPane, err := m.mux.SplitWindow(base.ID, true, 25); err == nil {
+			_ = m.mux.SetPaneTitle(chatPane, chatPaneTitle)
 			launch := m.agentChatLaunch()
-			_ = tmux.SendKeys(chatPane, launch.command)
+			_ = m.mux.SendKeys(chatPane, launch.command)
 			m.sendAgentChatPrompt(chatPane, launch)
-			_ = tmux.SetOption(m.session, chatPaneOption, chatPane)
+			_ = m.mux.SetOption(m.session, chatPaneOption, chatPane)
 		} else {
 			return err
 		}
-		if issuesPane, err := tmux.SplitWindow(base.ID, false, 0); err == nil {
-			_ = tmux.SetPaneTitle(issuesPane, issuesPaneTitle)
-			_ = tmux.SendKeys(issuesPane, m.issuesDashboardCommand())
-			_ = tmux.SetOption(m.session, issuesPaneOption, issuesPane)
+		if issuesPane, err := m.mux.SplitWindow(base.ID, false, 0); err == nil {
+			_ = m.mux.SetPaneTitle(issuesPane, issuesPaneTitle)
+			_ = m.mux.SendKeys(issuesPane, m.issuesDashboardCommand())
+			_ = m.mux.SetOption(m.session, issuesPaneOption, issuesPane)
 		} else {
 			return err
 		}
-		_ = tmux.SetOption(m.session, runsPaneOption, base.ID)
+		_ = m.mux.SetOption(m.session, runsPaneOption, base.ID)
 		return nil
 	}
 
@@ -870,13 +874,13 @@ func (m *Monitor) loadRuns() ([]*RunWindow, error) {
 }
 
 func (m *Monitor) ensureRunSession(w *RunWindow) error {
-	if tmux.HasSession(w.AgentSession) {
+	if m.mux.HasSession(w.AgentSession) {
 		return nil
 	}
 	if w.Run.WorktreePath == "" {
 		return nil
 	}
-	return tmux.NewSession(&tmux.SessionConfig{
+	return m.mux.NewSession(&multiplexer.SessionConfig{
 		SessionName: w.AgentSession,
 		WorkDir:     w.Run.WorktreePath,
 	})
@@ -1219,11 +1223,12 @@ func (m *Monitor) sendAgentChatPrompt(pane string, launch agentChatLaunch) {
 		paneID := pane
 		prompt := launch.prompt
 		pattern := launch.readyPattern
+		mux := m.mux
 		go func() {
 			if pattern != "" {
-				_ = tmux.WaitForReady(paneID, pattern, 30*time.Second)
+				_ = mux.WaitForReady(paneID, pattern, 30*time.Second)
 			}
-			_ = tmux.SendKeys(paneID, prompt)
+			_ = mux.SendKeys(paneID, prompt)
 		}()
 
 	case agent.InjectionHTTP:
@@ -1361,13 +1366,13 @@ func (m *Monitor) selectPaneByTitle(title string) error {
 	if err != nil {
 		return err
 	}
-	return tmux.SelectPane(pane)
+	return m.mux.SelectPane(pane)
 }
 
 func (m *Monitor) selectPaneByOption(option, fallbackTitle string) error {
 	pane, err := m.findPaneByOption(option)
 	if err == nil {
-		return tmux.SelectPane(pane)
+		return m.mux.SelectPane(pane)
 	}
 	return m.selectPaneByTitle(fallbackTitle)
 }
@@ -1377,7 +1382,7 @@ func (m *Monitor) findChatPane() (string, error) {
 		return pane, nil
 	}
 	target := fmt.Sprintf("%s:%d", m.session, dashboardWindowIdx)
-	panes, err := tmux.ListPanes(target)
+	panes, err := m.mux.ListPanes(target)
 	if err != nil {
 		return "", err
 	}
@@ -1398,7 +1403,7 @@ func (m *Monitor) findChatPane() (string, error) {
 }
 
 func (m *Monitor) findPaneByOption(option string) (string, error) {
-	value, err := tmux.GetOption(m.session, option)
+	value, err := m.mux.GetOption(m.session, option)
 	if err == nil && value != "" {
 		if m.paneExists(value) {
 			return value, nil
@@ -1413,7 +1418,7 @@ func (m *Monitor) findPaneByTitle(session, title string) (string, error) {
 		window = 0
 	}
 	target := fmt.Sprintf("%s:%d", session, window)
-	panes, err := tmux.ListPanes(target)
+	panes, err := m.mux.ListPanes(target)
 	if err != nil {
 		return "", err
 	}
@@ -1431,7 +1436,7 @@ func (m *Monitor) findPaneByTitle(session, title string) (string, error) {
 	return "", fmt.Errorf("pane not found: %s", title)
 }
 
-func hasPaneLayout(panes []tmux.Pane) bool {
+func hasPaneLayout(panes []multiplexer.Pane) bool {
 	if len(panes) != 3 {
 		return false
 	}
@@ -1450,7 +1455,7 @@ func hasPaneLayout(panes []tmux.Pane) bool {
 
 func (m *Monitor) paneExists(id string) bool {
 	target := fmt.Sprintf("%s:%d", m.session, dashboardWindowIdx)
-	panes, err := tmux.ListPanes(target)
+	panes, err := m.mux.ListPanes(target)
 	if err != nil {
 		return false
 	}
@@ -1462,7 +1467,7 @@ func (m *Monitor) paneExists(id string) bool {
 	return false
 }
 
-func (m *Monitor) syncPaneOptions(panes []tmux.Pane) {
+func (m *Monitor) syncPaneOptions(panes []multiplexer.Pane) {
 	var runsID, issuesID, chatID string
 	for _, pane := range panes {
 		switch pane.Title {
@@ -1479,17 +1484,17 @@ func (m *Monitor) syncPaneOptions(panes []tmux.Pane) {
 		}
 	}
 	if runsID != "" {
-		_ = tmux.SetOption(m.session, runsPaneOption, runsID)
+		_ = m.mux.SetOption(m.session, runsPaneOption, runsID)
 	}
 	if issuesID != "" {
-		_ = tmux.SetOption(m.session, issuesPaneOption, issuesID)
+		_ = m.mux.SetOption(m.session, issuesPaneOption, issuesID)
 	}
 	if chatID != "" {
-		_ = tmux.SetOption(m.session, chatPaneOption, chatID)
+		_ = m.mux.SetOption(m.session, chatPaneOption, chatID)
 	}
 }
 
-func (m *Monitor) ensureChatPaneTitle(panes []tmux.Pane) {
+func (m *Monitor) ensureChatPaneTitle(panes []multiplexer.Pane) {
 	var runsID, issuesID string
 	for _, pane := range panes {
 		switch pane.Title {
@@ -1504,7 +1509,7 @@ func (m *Monitor) ensureChatPaneTitle(panes []tmux.Pane) {
 			continue
 		}
 		if pane.Title != chatPaneTitle {
-			_ = tmux.SetPaneTitle(pane.ID, chatPaneTitle)
+			_ = m.mux.SetPaneTitle(pane.ID, chatPaneTitle)
 		}
 		return
 	}
@@ -1512,7 +1517,7 @@ func (m *Monitor) ensureChatPaneTitle(panes []tmux.Pane) {
 
 func (m *Monitor) refreshChatPaneTitle() {
 	target := fmt.Sprintf("%s:%d", m.session, dashboardWindowIdx)
-	panes, err := tmux.ListPanes(target)
+	panes, err := m.mux.ListPanes(target)
 	if err != nil {
 		return
 	}
@@ -1521,7 +1526,7 @@ func (m *Monitor) refreshChatPaneTitle() {
 
 func (m *Monitor) repairSwappedMonitorChat() error {
 	target := fmt.Sprintf("%s:%d", m.session, dashboardWindowIdx)
-	panes, err := tmux.ListPanes(target)
+	panes, err := m.mux.ListPanes(target)
 	if err != nil {
 		return err
 	}
@@ -1530,7 +1535,7 @@ func (m *Monitor) repairSwappedMonitorChat() error {
 	}
 
 	var runsID, issuesID string
-	var chatPane tmux.Pane
+	var chatPane multiplexer.Pane
 	for _, pane := range panes {
 		switch pane.Title {
 		case runsPaneTitle:
@@ -1551,20 +1556,20 @@ func (m *Monitor) repairSwappedMonitorChat() error {
 
 	ref, err := model.ParseRunRef(chatPane.Title)
 	if err != nil || ref.RunID == "" {
-		_ = tmux.SetPaneTitle(chatPane.ID, chatPaneTitle)
+		_ = m.mux.SetPaneTitle(chatPane.ID, chatPaneTitle)
 		return nil
 	}
 	run, err := m.store.GetRun(ref)
 	if err != nil {
-		_ = tmux.SetPaneTitle(chatPane.ID, chatPaneTitle)
+		_ = m.mux.SetPaneTitle(chatPane.ID, chatPaneTitle)
 		return nil
 	}
 	sessionName := run.TmuxSession
 	if sessionName == "" {
 		sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
 	}
-	if !tmux.HasSession(sessionName) {
-		_ = tmux.SetPaneTitle(chatPane.ID, chatPaneTitle)
+	if !m.mux.HasSession(sessionName) {
+		_ = m.mux.SetPaneTitle(chatPane.ID, chatPaneTitle)
 		return nil
 	}
 	if err := m.repairSwappedRunSession(run, sessionName); err != nil {
@@ -1578,7 +1583,7 @@ func (m *Monitor) repairSwappedRunSession(run *model.Run, sessionName string) er
 		return nil
 	}
 	target := fmt.Sprintf("%s:%d", sessionName, 0)
-	panes, err := tmux.ListPanes(target)
+	panes, err := m.mux.ListPanes(target)
 	if err != nil {
 		return err
 	}
@@ -1595,11 +1600,11 @@ func (m *Monitor) repairSwappedRunSession(run *model.Run, sessionName string) er
 		return nil
 	}
 	monitorTarget := fmt.Sprintf("%s:%d", m.session, dashboardWindowIdx)
-	monitorPanes, err := tmux.ListPanes(monitorTarget)
+	monitorPanes, err := m.mux.ListPanes(monitorTarget)
 	if err != nil {
 		return err
 	}
-	var monitorChatPane tmux.Pane
+	var monitorChatPane multiplexer.Pane
 	for _, pane := range monitorPanes {
 		if pane.ID == chatPaneID {
 			monitorChatPane = pane
@@ -1609,16 +1614,16 @@ func (m *Monitor) repairSwappedRunSession(run *model.Run, sessionName string) er
 	if monitorChatPane.ID == "" || monitorChatPane.Title == chatPaneTitle {
 		return nil
 	}
-	if err := tmux.SwapPane(runPane.ID, monitorChatPane.ID); err != nil {
+	if err := m.mux.SwapPane(runPane.ID, monitorChatPane.ID); err != nil {
 		return err
 	}
-	_ = tmux.SetPaneTitle(monitorChatPane.ID, chatPaneTitle)
-	_ = tmux.SetPaneTitle(runPane.ID, run.Ref().String())
+	_ = m.mux.SetPaneTitle(monitorChatPane.ID, chatPaneTitle)
+	_ = m.mux.SetPaneTitle(runPane.ID, run.Ref().String())
 	return nil
 }
 
 func (m *Monitor) resolveRunWindowID(run *model.Run, sessionName string) (string, error) {
-	windows, err := tmux.ListWindows(sessionName)
+	windows, err := m.mux.ListWindows(sessionName)
 	if err != nil {
 		return "", err
 	}
@@ -1638,7 +1643,7 @@ func (m *Monitor) resolveRunWindowID(run *model.Run, sessionName string) (string
 	return "", nil
 }
 
-func windowIndexByID(windows []tmux.Window, id string) (int, bool) {
+func windowIndexByID(windows []multiplexer.Window, id string) (int, bool) {
 	for _, window := range windows {
 		if window.ID == id {
 			return window.Index, true
@@ -1647,7 +1652,7 @@ func windowIndexByID(windows []tmux.Window, id string) (int, bool) {
 	return 0, false
 }
 
-func nextAvailableWindowIndex(windows []tmux.Window, start int) int {
+func nextAvailableWindowIndex(windows []multiplexer.Window, start int) int {
 	used := make(map[int]bool, len(windows))
 	for _, window := range windows {
 		used[window.Index] = true

--- a/internal/monitor/run_attacher.go
+++ b/internal/monitor/run_attacher.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/s22625/orch/internal/agent"
 	"github.com/s22625/orch/internal/model"
-	"github.com/s22625/orch/internal/tmux"
 )
 
 type RunAttacher interface {
@@ -19,7 +18,7 @@ func GetRunAttacher(agentType string) RunAttacher {
 	if baseAgent == string(agent.AgentOpenCode) {
 		return &OpenCodeRunAttacher{}
 	}
-	return &TmuxRunAttacher{}
+	return &MuxRunAttacher{}
 }
 
 func extractAgentName(agentType string) string {
@@ -29,9 +28,9 @@ func extractAgentName(agentType string) string {
 	return agentType
 }
 
-type TmuxRunAttacher struct{}
+type MuxRunAttacher struct{}
 
-func (a *TmuxRunAttacher) Attach(m *Monitor, run *model.Run) error {
+func (a *MuxRunAttacher) Attach(m *Monitor, run *model.Run) error {
 	sessionName := run.TmuxSession
 	if sessionName == "" {
 		sessionName = model.GenerateTmuxSession(run.IssueID, run.RunID)
@@ -57,27 +56,27 @@ func (a *TmuxRunAttacher) Attach(m *Monitor, run *model.Run) error {
 		return err
 	}
 
-	monitorWindows, err := tmux.ListWindows(m.session)
+	monitorWindows, err := m.mux.ListWindows(m.session)
 	if err != nil {
 		return err
 	}
 	if windowID != "" {
 		if _, ok := windowIndexByID(monitorWindows, windowID); ok {
-			return tmux.SelectWindowByID(windowID)
+			return m.mux.SelectWindowByID(windowID)
 		}
 	}
 
 	targetIndex := nextAvailableWindowIndex(monitorWindows, dashboardWindowIdx+1)
 	if windowID != "" {
-		if err := tmux.LinkWindowByID(windowID, m.session, targetIndex); err != nil {
+		if err := m.mux.LinkWindowByID(windowID, m.session, targetIndex); err != nil {
 			return err
 		}
-		return tmux.SelectWindowByID(windowID)
+		return m.mux.SelectWindowByID(windowID)
 	}
-	if err := tmux.LinkWindow(sessionName, 0, m.session, targetIndex); err != nil {
+	if err := m.mux.LinkWindow(sessionName, 0, m.session, targetIndex); err != nil {
 		return err
 	}
-	return tmux.SelectWindow(m.session, targetIndex)
+	return m.mux.SelectWindow(m.session, targetIndex)
 }
 
 type OpenCodeRunAttacher struct{}
@@ -96,7 +95,7 @@ func (a *OpenCodeRunAttacher) Attach(m *Monitor, run *model.Run) error {
 		attachCmd = fmt.Sprintf("%s --dir %s", attachCmd, run.WorktreePath)
 	}
 
-	monitorWindows, err := tmux.ListWindows(m.session)
+	monitorWindows, err := m.mux.ListWindows(m.session)
 	if err != nil {
 		return err
 	}
@@ -104,7 +103,7 @@ func (a *OpenCodeRunAttacher) Attach(m *Monitor, run *model.Run) error {
 	windowName := fmt.Sprintf("%s[%s]", run.IssueID, run.ShortID())
 	for _, w := range monitorWindows {
 		if w.Name == windowName {
-			return tmux.SelectWindow(m.session, w.Index)
+			return m.mux.SelectWindow(m.session, w.Index)
 		}
 	}
 
@@ -113,17 +112,17 @@ func (a *OpenCodeRunAttacher) Attach(m *Monitor, run *model.Run) error {
 		workDir, _ = os.Getwd()
 	}
 
-	if err := tmux.NewWindow(m.session, windowName, workDir, attachCmd); err != nil {
+	if err := m.mux.NewWindow(m.session, windowName, workDir, attachCmd); err != nil {
 		return fmt.Errorf("failed to create opencode window for %s: %w", run.Ref().String(), err)
 	}
 
-	updatedWindows, err := tmux.ListWindows(m.session)
+	updatedWindows, err := m.mux.ListWindows(m.session)
 	if err != nil {
 		return err
 	}
 	for _, w := range updatedWindows {
 		if w.Name == windowName {
-			return tmux.SelectWindow(m.session, w.Index)
+			return m.mux.SelectWindow(m.session, w.Index)
 		}
 	}
 	return fmt.Errorf("created window %s not found", windowName)

--- a/orch-monitor-tui/orch_monitor/multiplexer.py
+++ b/orch-monitor-tui/orch_monitor/multiplexer.py
@@ -98,6 +98,18 @@ class Multiplexer(Protocol):
         """Get the name of the current session if inside one, None otherwise."""
         ...
 
+    def capture_pane(self, session: str, lines: int = 50) -> list[str]:
+        """Capture recent output from a pane/session.
+
+        Args:
+            session: Session name (or pane target for tmux)
+            lines: Number of lines to capture (default 50)
+
+        Returns:
+            List of output lines, empty list on error
+        """
+        ...
+
 
 class TmuxMultiplexer:
     """Tmux implementation of Multiplexer."""
@@ -240,6 +252,23 @@ class TmuxMultiplexer:
         if result.returncode == 0:
             return result.stdout.strip()
         return None
+
+    def capture_pane(self, session: str, lines: int = 50) -> list[str]:
+        try:
+            result = subprocess.run(
+                ["tmux", "capture-pane", "-t", session, "-p", "-S", f"-{lines}"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            if result.returncode != 0:
+                return []
+            output_lines = [line.rstrip() for line in result.stdout.split("\n")]
+            while output_lines and not output_lines[-1]:
+                output_lines.pop()
+            return [line for line in output_lines if line.strip()]
+        except (subprocess.TimeoutExpired, OSError):
+            return []
 
 
 ZELLIJ_TIMEOUT_SEC = 5
@@ -400,6 +429,22 @@ class ZellijMultiplexer:
     def get_current_session(self) -> Optional[str]:
         """Get the current Zellij session name if inside one."""
         return os.environ.get("ZELLIJ_SESSION_NAME")
+
+    def capture_pane(self, session: str, lines: int = 50) -> list[str]:
+        try:
+            result = subprocess.run(
+                ["zellij", "action", "dump-screen", "/dev/stdout"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                env={**os.environ, "ZELLIJ_SESSION_NAME": session},
+            )
+            if result.returncode != 0:
+                return []
+            output_lines = [line.rstrip() for line in result.stdout.split("\n")]
+            return [line for line in output_lines[-lines:] if line.strip()]
+        except (subprocess.TimeoutExpired, OSError):
+            return []
 
 
 # Registry of multiplexer implementations

--- a/orch-monitor-tui/orch_monitor/orch_monitor_app.hy
+++ b/orch-monitor-tui/orch_monitor/orch_monitor_app.hy
@@ -476,7 +476,7 @@
     (.extend content-lines ["" "" (+ "[bold]" (* "-" 50) "[/bold]")
                             "[bold]Recent Messages:[/bold]" ""])
     (when run.tmux_session
-      (setv messages (._fetch_tmux_pane_output self run.tmux_session))
+      (setv messages (._fetch_session_output self run))
       (if messages
           (do
             (for [line (cut messages -15 None)]
@@ -489,20 +489,13 @@
       (.append content-lines "  [dim](No tmux session available)[/dim]"))
     (.update_content detail-panel (.join "\n" content-lines) f"Run Details: {(.ref run)}"))
   
-  (defn _fetch_tmux_pane_output [self tmux-session]
-    "Capture recent output from a tmux pane. Returns [] on any error."
-    ;; Use with-fallback-silent - cosmetic operation
-    (with-fallback-silent "fetch_tmux_output" []
-      (setv result (subprocess.run
-                     ["tmux" "capture-pane" "-t" tmux-session "-p" "-S" "-50"]
-                     :capture_output True :text True :timeout 2))
-      (when (!= result.returncode 0)
-        (return []))
-      (setv lines (lfor line (.split result.stdout "\n") (.rstrip line)))
-      ;; Remove trailing empty lines
-      (while (and lines (not (get lines -1)))
-        (.pop lines))
-      (lfor line lines :if (.strip line) line)))
+  (defn _fetch_session_output [self run]
+    "Capture recent output from a session using the appropriate multiplexer."
+    (when (not run.tmux_session)
+      (return []))
+    (with-fallback-silent "fetch_session_output" []
+      (setv mux (get_multiplexer_for_run run))
+      (.capture_pane mux run.tmux_session 50)))
   
   (defn show_issue_detail [self issue]
     (setv detail-panel (.query_one self "#detail-panel" DetailPanel))

--- a/orch-monitor-tui/orch_monitor/runs_dashboard.hy
+++ b/orch-monitor-tui/orch_monitor/runs_dashboard.hy
@@ -473,23 +473,12 @@ DataTable {
       (_api_issue_to_model issue)))
   
   (defn _capture_session_output [self run]
-    "Capture terminal session output. Returns [] on any error."
+    "Capture terminal session output using the appropriate multiplexer."
     (when (not run.tmux_session)
       (return []))
-    ;; Use with-fallback-silent - cosmetic operation
     (with-fallback-silent "capture_session_output" []
-      (setv mux-type (get_multiplexer_type_from_run run))
-      (setv result
-        (if (= mux-type MultiplexerType.ZELLIJ)
-            (subprocess.run ["zellij" "action" "dump-screen" "/dev/stdout"]
-                            :capture_output True :text True :timeout 2
-                            :env (| (dict os.environ) {"ZELLIJ_SESSION_NAME" run.tmux_session}))
-            (subprocess.run ["tmux" "capture-pane" "-t" run.tmux_session "-p" "-S" "-30"]
-                            :capture_output True :text True :timeout 2)))
-      (when (!= result.returncode 0)
-        (return []))
-      (setv lines (lfor line (.split result.stdout "\n") (.rstrip line)))
-      (lfor line lines :if (.strip line) line)))
+      (setv mux (get_multiplexer_for_run run))
+      (.capture_pane mux run.tmux_session 30)))
   
   ;; NOTE: attach, stop, diff, kill_session actions are injected by (with-run-actions) above
   )


### PR DESCRIPTION
## Summary

Eliminates tmux abstraction leaks across the entire codebase, making orch truly multiplexer-agnostic to support both tmux and zellij.

## Changes

### Go Codebase
- **Monitor package**: Replaced all `tmux.*` calls with `m.mux.*` using the `Multiplexer` interface
- **CLI commands**: Updated `repair`, `delete`, `capture_all`, `tick`, `ps` to use `multiplexer.GetDefault()`
- **Agent Manager**: Renamed `TmuxManager` → `MuxManager`, updated cache and all methods to use abstraction

### Python TUI
- **multiplexer.py**: Added `capture_pane(session, lines)` method to `Multiplexer` Protocol and both implementations
- **orch_monitor_app.hy**: Refactored `_fetch_tmux_pane_output` → `_fetch_session_output` using `get_multiplexer_for_run()`
- **runs_dashboard.hy**: Updated `_capture_session_output` to use multiplexer abstraction

## Verification
- ✅ `go build ./...` passes
- ✅ `go test ./internal/agent/... ./internal/monitor/... ./internal/cli/...` passes
- ✅ Python/Hy imports work correctly

## Files Changed (13 files)
- `internal/agent/manager.go`
- `internal/agent/manager_test.go`
- `internal/cli/capture_all.go`
- `internal/cli/delete.go`
- `internal/cli/ps.go`
- `internal/cli/repair.go`
- `internal/cli/tick.go`
- `internal/monitor/dashboard.go`
- `internal/monitor/monitor.go`
- `internal/monitor/run_attacher.go`
- `orch-monitor-tui/orch_monitor/multiplexer.py`
- `orch-monitor-tui/orch_monitor/orch_monitor_app.hy`
- `orch-monitor-tui/orch_monitor/runs_dashboard.hy`

Closes orch-373