### PR TITLE
refactor(cli): remove client-side status filtering from delete.go and tick.go

### DIFF
--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -175,6 +175,13 @@ func deleteIssueRuns(ctx context.Context, api orchapi.OrchAPI, issueID string, o
 			return err
 		}
 		filter.Status = statuses
+	} else if !opts.Force {
+		// When no explicit status filter and not forcing, only fetch deletable statuses
+		filter.Status = []orchapi.RunStatus{
+			orchapi.RunStatusDone,
+			orchapi.RunStatusFailed,
+			orchapi.RunStatusCanceled,
+		}
 	}
 
 	result, err := api.ListRuns(ctx, filter)
@@ -215,6 +222,12 @@ func runDeleteByAge(opts *deleteOptions) error {
 			return err
 		}
 		filter.Status = statuses
+	} else if !opts.Force {
+		filter.Status = []orchapi.RunStatus{
+			orchapi.RunStatusDone,
+			orchapi.RunStatusFailed,
+			orchapi.RunStatusCanceled,
+		}
 	}
 
 	result, err := api.ListRuns(ctx, filter)
@@ -291,31 +304,6 @@ func deleteRuns(ctx context.Context, api orchapi.OrchAPI, runs []*orchapi.Run, o
 			fmt.Println("No matching runs to delete")
 		}
 		return nil
-	}
-
-	var activeRuns []*orchapi.Run
-	var deletableRuns []*orchapi.Run
-	for _, run := range runs {
-		if run.Status == orchapi.RunStatusRunning || run.Status == orchapi.RunStatusBooting || run.Status == orchapi.RunStatusBlocked || run.Status == orchapi.RunStatusBlockedAPI {
-			activeRuns = append(activeRuns, run)
-		} else {
-			deletableRuns = append(deletableRuns, run)
-		}
-	}
-
-	if len(activeRuns) > 0 && !opts.Force {
-		fmt.Fprintf(os.Stderr, "Skipping %d active run(s) (use 'orch stop' first or --force to delete anyway):\n", len(activeRuns))
-		for _, run := range activeRuns {
-			fmt.Fprintf(os.Stderr, "  %s#%s (%s)\n", run.IssueID, run.RunID, run.Status)
-		}
-		runs = deletableRuns
-		if len(runs) == 0 {
-			return nil
-		}
-	} else if opts.Force {
-		runs = append(deletableRuns, activeRuns...)
-	} else {
-		runs = deletableRuns
 	}
 
 	if !globalOpts.Quiet || opts.DryRun {

--- a/internal/cli/tick.go
+++ b/internal/cli/tick.go
@@ -105,7 +105,8 @@ func runTick(refStr string, opts *tickOptions) error {
 	}
 
 	for _, run := range runs {
-		if opts.OnlyBlocked && run.Status != orchapi.RunStatusBlocked && run.Status != orchapi.RunStatusBlockedAPI {
+		// Only check blocked status for single-run case; --all already filters at daemon level
+		if !opts.All && opts.OnlyBlocked && run.Status != orchapi.RunStatusBlocked && run.Status != orchapi.RunStatusBlockedAPI {
 			result.Skipped = append(result.Skipped, skippedRun{
 				IssueID: run.IssueID,
 				RunID:   run.RunID,


### PR DESCRIPTION
## Summary

- **delete.go**: Pass deletable statuses (done/failed/canceled) to daemon API instead of filtering active vs deletable runs client-side
- **tick.go**: Skip blocked-status check for `--all` case since daemon already filters by blocked status

## Changes

### delete.go (lines 296-319 → removed)
- **Before**: Fetched all runs then client-side separated `activeRuns` vs `deletableRuns`
- **After**: Pass `Status: [done, failed, canceled]` to daemon when `!opts.Force` and no explicit status filter, removing need for client-side separation

### tick.go (lines 107-115 → simplified)
- **Before**: Always checked blocked status client-side even when `--all` was used (which already passed blocked filter to daemon)
- **After**: Only check blocked status for single-run case (`!opts.All`); `--all` already filters at daemon level

## Verification

- [x] `go build ./...` - passes
- [x] `go test ./internal/cli/...` - all CLI tests pass
- [x] Integration tests have 2 pre-existing failures unrelated to this change (TestShowRun and TestOpenPrintPath)

Resolves: orch-390