### PR TITLE
refactor(tui): remove client-side sorting, use daemon's pre-sorted results

### DIFF
--- a/orch-monitor-tui/orch_monitor/__main__.py
+++ b/orch-monitor-tui/orch_monitor/__main__.py
@@ -195,7 +195,6 @@ def query_latest_opencode_session(
             _launcher_logger.warning(f"No sessions found for directory: {directory}")
             return None
 
-        matching.sort(key=lambda s: s.get("time", {}).get("updated", 0), reverse=True)
         session_id = matching[0]["id"]
         _launcher_logger.info(f"Found latest session for {directory}: {session_id}")
         return session_id

--- a/orch-monitor-tui/orch_monitor/issues_dashboard.hy
+++ b/orch-monitor-tui/orch_monitor/issues_dashboard.hy
@@ -211,7 +211,6 @@
     (if-ok [response (.list_issues self.api filters)]
       (do
         (setv issues (_api_issues_to_model_issues response.issues))
-        (.sort issues :key (fn [i] i.id) :reverse True)
         (.call_from_thread self self._update_issues_table issues None))
       (.call_from_thread self self._update_issues_table None (str response))))
   

--- a/orch-monitor-tui/orch_monitor/runs_dashboard.hy
+++ b/orch-monitor-tui/orch_monitor/runs_dashboard.hy
@@ -302,7 +302,6 @@ DataTable {
         (setv runs (_api_runs_to_model_runs response.runs))
         (when (> (len run-filters.agents) 1)
           (setv runs (lfor r runs :if (in r.agent run-filters.agents) r)))
-        (.sort runs :key (fn [r] (or r.updated_at r.started_at datetime.min)) :reverse True)
         (.call_from_thread self self._update_runs_table runs None))
       (.call_from_thread self self._update_runs_table None (str response))))
   


### PR DESCRIPTION
## Summary

- Remove redundant client-side sorting in Python TUI since daemon (orch-385) now handles sorting
- Removed `.sort()` calls from runs, issues, and session fetching

## Changes

| File | Change |
|------|--------|
| `runs_dashboard.hy` | Removed `.sort` by `updated_at` (line 305) |
| `issues_dashboard.hy` | Removed `.sort` by `id` (line 214) |
| `__main__.py` | Removed `.sort` sessions by timestamp (line 198) |

## Evidence

### Git diff
```
3 files changed, 3 deletions(-)
```

### Hy modules parse correctly
```
$ uv run python -c "import hy; import orch_monitor.runs_dashboard; import orch_monitor.issues_dashboard; print('Hy files parse OK')"
Hy files parse OK
```

### Pre-commit hooks pass
```
Go CLI Architecture Lint (semgrep)...................(no files to check)Skipped
Python TUI Architecture Lint (semgrep)...................................Passed
```

## Related Issue

Closes: orch-393 (depends on orch-385)