### PR TITLE
refactor(cli): remove client-side tag filtering from issue.go

### DIFF
--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -309,27 +309,45 @@ func runIssueList(opts *issueListOptions) error {
 }
 
 func runIssueListViaDaemon(client *daemon.ProtoClient, opts *issueListOptions) error {
-	// Collect all issues, handling pagination
-	// Pass status filter to daemon if set (daemon supports this)
 	var statusFilter []string
 	if opts.Status != "" {
 		statusFilter = []string{opts.Status}
 	}
 
+	var tags []string
+	var tagsMode string
+	if len(opts.Tags) > 0 {
+		tags = opts.Tags
+		tagsMode = "and"
+	} else if len(opts.TagsAny) > 0 {
+		tags = opts.TagsAny
+		tagsMode = "or"
+	}
+
 	var allIssues []*daemon.IssueSummary
 	cursor := ""
 	for {
-		issuesResp, err := client.ListIssues(statusFilter, 200, cursor) // Use max limit
+		issuesResp, err := client.ListIssues(statusFilter, tags, tagsMode, 200, cursor)
 		if err != nil {
 			return err
 		}
 		allIssues = append(allIssues, issuesResp.Issues...)
 
-		// Check if there are more pages
 		if issuesResp.NextCursor == nil || *issuesResp.NextCursor == "" {
 			break
 		}
 		cursor = *issuesResp.NextCursor
+	}
+
+	// Secondary filter when both --tag (AND) and --tag-any (OR) are specified
+	if len(opts.Tags) > 0 && len(opts.TagsAny) > 0 {
+		var filtered []*daemon.IssueSummary
+		for _, issue := range allIssues {
+			if matchTagsOr(issue.Tags, opts.TagsAny) {
+				filtered = append(filtered, issue)
+			}
+		}
+		allIssues = filtered
 	}
 
 	runsResp, err := client.ListRuns("", []string{"running", "blocked", "blocked_api", "booting", "queued"}, 0, "")
@@ -344,14 +362,6 @@ func runIssueListViaDaemon(client *daemon.ProtoClient, opts *issueListOptions) e
 
 	var issueInfos []issueInfo
 	for _, issue := range allIssues {
-		// Apply tag filters (status already filtered by daemon)
-		if !matchTagsAnd(issue.Tags, opts.Tags) {
-			continue
-		}
-		if !matchTagsOr(issue.Tags, opts.TagsAny) {
-			continue
-		}
-
 		info := issueInfo{
 			ID:         issue.ID,
 			Title:      issue.Title,
@@ -449,23 +459,6 @@ func formatRunsSummary(runs []runSummary) string {
 	return strings.Join(parts, ", ")
 }
 
-// matchTagsAnd returns true if the issue has ALL of the specified tags (case-insensitive)
-func matchTagsAnd(issueTags []string, filterTags []string) bool {
-	if len(filterTags) == 0 {
-		return true
-	}
-	tagSet := make(map[string]bool)
-	for _, t := range issueTags {
-		tagSet[strings.ToLower(t)] = true
-	}
-	for _, t := range filterTags {
-		if !tagSet[strings.ToLower(t)] {
-			return false
-		}
-	}
-	return true
-}
-
 // matchTagsOr returns true if the issue has ANY of the specified tags (case-insensitive)
 func matchTagsOr(issueTags []string, filterTags []string) bool {
 	if len(filterTags) == 0 {
@@ -481,23 +474,6 @@ func matchTagsOr(issueTags []string, filterTags []string) bool {
 		}
 	}
 	return false
-}
-
-// matchIssueFilters checks if an issue matches all filter criteria
-func matchIssueFilters(status string, tags []string, opts *issueListOptions) bool {
-	// Status filter
-	if opts.Status != "" && !strings.EqualFold(status, opts.Status) {
-		return false
-	}
-	// Tag AND filter
-	if !matchTagsAnd(tags, opts.Tags) {
-		return false
-	}
-	// Tag OR filter
-	if !matchTagsOr(tags, opts.TagsAny) {
-		return false
-	}
-	return true
 }
 
 type issueShowOptions struct {

--- a/internal/cli/issue_test.go
+++ b/internal/cli/issue_test.go
@@ -65,29 +65,6 @@ func TestRunIssueCreateUsesVaultIssuesDir(t *testing.T) {
 	}
 }
 
-func TestMatchTagsAnd(t *testing.T) {
-	tests := []struct {
-		name       string
-		issueTags  []string
-		filterTags []string
-		want       bool
-	}{
-		{"empty filter", []string{"bug", "feature"}, nil, true},
-		{"match all", []string{"bug", "feature", "urgent"}, []string{"bug", "feature"}, true},
-		{"missing one", []string{"bug"}, []string{"bug", "feature"}, false},
-		{"case insensitive", []string{"Bug", "FEATURE"}, []string{"bug", "feature"}, true},
-		{"empty issue tags", nil, []string{"bug"}, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := matchTagsAnd(tt.issueTags, tt.filterTags); got != tt.want {
-				t.Errorf("matchTagsAnd() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestMatchTagsOr(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -175,34 +152,6 @@ func TestRunIssueCreateQuotesSpecialCharacters(t *testing.T) {
 				if !strings.Contains(string(content), want) {
 					t.Errorf("issue file missing %q\ngot:\n%s", want, content)
 				}
-			}
-		})
-	}
-}
-
-func TestMatchIssueFilters(t *testing.T) {
-	tests := []struct {
-		name   string
-		status string
-		tags   []string
-		opts   *issueListOptions
-		want   bool
-	}{
-		{"no filters", "open", []string{"bug"}, &issueListOptions{}, true},
-		{"status match", "open", nil, &issueListOptions{Status: "open"}, true},
-		{"status no match", "closed", nil, &issueListOptions{Status: "open"}, false},
-		{"status case insensitive", "OPEN", nil, &issueListOptions{Status: "open"}, true},
-		{"tag and match", "open", []string{"bug", "urgent"}, &issueListOptions{Tags: []string{"bug", "urgent"}}, true},
-		{"tag and no match", "open", []string{"bug"}, &issueListOptions{Tags: []string{"bug", "urgent"}}, false},
-		{"tag or match", "open", []string{"bug"}, &issueListOptions{TagsAny: []string{"bug", "feature"}}, true},
-		{"tag or no match", "open", []string{"urgent"}, &issueListOptions{TagsAny: []string{"bug", "feature"}}, false},
-		{"combined filters", "open", []string{"bug", "urgent"}, &issueListOptions{Status: "open", Tags: []string{"bug"}}, true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := matchIssueFilters(tt.status, tt.tags, tt.opts); got != tt.want {
-				t.Errorf("matchIssueFilters() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/daemon/proto_client.go
+++ b/internal/daemon/proto_client.go
@@ -218,7 +218,7 @@ func (c *ProtoClient) GetRunByShortID(shortID string) (*GetRunResponse, error) {
 	}, nil
 }
 
-func (c *ProtoClient) ListIssues(status []string, limit int, cursor string) (*ListIssuesResponse, error) {
+func (c *ProtoClient) ListIssues(status []string, tags []string, tagsMode string, limit int, cursor string) (*ListIssuesResponse, error) {
 	protoStatuses := make([]orchpb.IssueStatus, 0, len(status))
 	for _, s := range status {
 		protoStatuses = append(protoStatuses, stringToProtoIssueStatus(s))
@@ -229,6 +229,8 @@ func (c *ProtoClient) ListIssues(status []string, limit int, cursor string) (*Li
 			ListIssues: &orchpb.ListIssuesRequest{
 				IssuesRoot: c.issuesRoot,
 				Status:     protoStatuses,
+				Tags:       tags,
+				TagsMode:   tagsMode,
 				Limit:      int32(limit),
 				Cursor:     cursor,
 			},

--- a/internal/orchapi/daemon_client.go
+++ b/internal/orchapi/daemon_client.go
@@ -39,6 +39,8 @@ func (c *DaemonClient) GetIssue(ctx context.Context, issueID string) (*Issue, er
 
 func (c *DaemonClient) ListIssues(ctx context.Context, filter *ListIssuesFilter) (*ListIssuesResult, error) {
 	var statuses []string
+	var tags []string
+	var tagsMode string
 	var limit int
 	var cursor string
 
@@ -46,11 +48,13 @@ func (c *DaemonClient) ListIssues(ctx context.Context, filter *ListIssuesFilter)
 		for _, s := range filter.Status {
 			statuses = append(statuses, string(s))
 		}
+		tags = filter.Tags
+		tagsMode = filter.TagsMode
 		limit = filter.Limit
 		cursor = filter.Cursor
 	}
 
-	resp, err := c.proto.ListIssues(statuses, limit, cursor)
+	resp, err := c.proto.ListIssues(statuses, tags, tagsMode, limit, cursor)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Pass `--tag` and `--tag-any` filters to daemon API instead of filtering client-side
- Remove `matchTagsAnd` and `matchIssueFilters` functions from issue.go (daemon handles this server-side)
- Keep `matchTagsOr` for edge case when both `--tag` and `--tag-any` are specified

## Changes

| File | Change |
|------|--------|
| `internal/daemon/proto_client.go` | Add `tags` and `tagsMode` parameters to `ListIssues` |
| `internal/orchapi/daemon_client.go` | Pass tag filters through to proto client |
| `internal/cli/issue.go` | Use daemon API for tag filtering, remove client-side functions |
| `internal/cli/issue_test.go` | Remove tests for deleted functions |

## Verification

```bash
# All tests pass
go test ./internal/cli/... ./internal/daemon/... ./internal/orchapi/...

# Build succeeds
go build ./...
```

## Notes

The daemon already supported server-side tag filtering via `ListIssuesRequest.tags` and `ListIssuesRequest.tags_mode` (implemented in orch-383). This PR updates the CLI to leverage that capability instead of duplicating the filtering logic client-side.

When both `--tag` (AND) and `--tag-any` (OR) are specified, we pass `--tag` to daemon and do secondary filtering client-side for `--tag-any` since the daemon only supports one tag mode at a time.

Closes orch-389