### PR TITLE
refactor(tui): remove client-side issue filtering from issues_dashboard.go

### DIFF
--- a/internal/monitor/issues_dashboard.go
+++ b/internal/monitor/issues_dashboard.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"sort"
 	"strings"
 	"time"
 
@@ -172,11 +171,17 @@ func (d *IssueDashboard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case issuesRefreshMsg:
 		savedCursor := d.cursor
 		d.issues = msg.rows
-		d.applyFilter()
+		d.filteredIssues = msg.rows
 		d.refreshing = false
 		d.lastRefresh = time.Now()
 
 		d.cursor = d.findIssueIndex(d.savedIssueID, savedCursor)
+		if d.cursor >= len(d.filteredIssues) {
+			d.cursor = len(d.filteredIssues) - 1
+			if d.cursor < 0 {
+				d.cursor = 0
+			}
+		}
 		d.updateSavedIssueID()
 		d.ensureCursorVisible()
 		return d, nil
@@ -563,7 +568,6 @@ func (d *IssueDashboard) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return d, nil
 	case "enter", " ":
-		// Toggle the selected filter option and persist the setting
 		switch d.filter.cursor {
 		case 0:
 			d.filter.showResolved = !d.filter.showResolved
@@ -572,8 +576,8 @@ func (d *IssueDashboard) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			d.filter.showClosed = !d.filter.showClosed
 			d.monitor.SetShowClosed(d.filter.showClosed)
 		}
-		d.applyFilter()
-		return d, nil
+		d.refreshing = true
+		return d, d.refreshCmd()
 	}
 	return d, nil
 }
@@ -877,37 +881,6 @@ func (d *IssueDashboard) viewFilter() string {
 	return strings.Join(lines, "\n")
 }
 
-// applyFilter filters the issues list based on current filter settings
-func (d *IssueDashboard) applyFilter() {
-	if d.filter.showResolved && d.filter.showClosed {
-		// No filtering needed, show all issues
-		d.filteredIssues = d.issues
-		return
-	}
-
-	filtered := make([]IssueRow, 0, len(d.issues))
-	for _, issue := range d.issues {
-		status := model.ParseIssueStatus(issue.Status)
-		if status == model.IssueStatusResolved && !d.filter.showResolved {
-			continue
-		}
-		if status == model.IssueStatusClosed && !d.filter.showClosed {
-			continue
-		}
-		filtered = append(filtered, issue)
-	}
-	d.filteredIssues = filtered
-
-	// Reset cursor if it's out of bounds
-	if d.cursor >= len(d.filteredIssues) {
-		d.cursor = len(d.filteredIssues) - 1
-		if d.cursor < 0 {
-			d.cursor = 0
-		}
-	}
-	d.ensureCursorVisible()
-}
-
 // hasActiveFilters returns true if any filters are hiding issues
 func (d *IssueDashboard) hasActiveFilters() bool {
 	return !d.filter.showResolved || !d.filter.showClosed
@@ -917,7 +890,7 @@ func (d *IssueDashboard) renderMeta() string {
 	sync := d.renderSyncStatus()
 	total := fmt.Sprintf("issues: %d", len(d.filteredIssues))
 	if d.hasActiveFilters() {
-		total = fmt.Sprintf("issues: %d/%d (filtered)", len(d.filteredIssues), len(d.issues))
+		total = fmt.Sprintf("issues: %d (filtered)", len(d.filteredIssues))
 	}
 	sortLabel := fmt.Sprintf("sort: %s", d.monitor.IssueSort())
 	nav := d.renderNav()
@@ -1650,24 +1623,4 @@ func (d *IssueDashboard) ensureContinueBranchVisible() {
 	if d.continue_.offset < 0 {
 		d.continue_.offset = 0
 	}
-}
-
-// filterBranchesForIssue filters branches that contain the issue ID in their name
-func filterBranchesForIssue(branches map[string]time.Time, issueID string) []branchInfo {
-	var result []branchInfo
-	issueIDLower := strings.ToLower(issueID)
-	for name, commitTime := range branches {
-		nameLower := strings.ToLower(name)
-		if strings.Contains(nameLower, issueIDLower) {
-			result = append(result, branchInfo{
-				name:       name,
-				commitTime: commitTime,
-			})
-		}
-	}
-	// Sort by commit time descending (most recent first)
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].commitTime.After(result[j].commitTime)
-	})
-	return result
 }

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -491,7 +492,8 @@ func (m *Monitor) SetRunFilter(filter RunFilter) {
 
 func (m *Monitor) RefreshIssues() ([]IssueRow, error) {
 	ctx := context.Background()
-	issuesResult, err := m.api.ListIssues(ctx, nil)
+	filter := m.buildIssueStatusFilter()
+	issuesResult, err := m.api.ListIssues(ctx, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -502,6 +504,17 @@ func (m *Monitor) RefreshIssues() ([]IssueRow, error) {
 	issues := apiIssuesToModel(issuesResult.Issues)
 	runs := apiRunsToModel(runsResult.Runs)
 	return m.buildIssueRows(issues, runs), nil
+}
+
+func (m *Monitor) buildIssueStatusFilter() *orchapi.ListIssuesFilter {
+	statuses := []orchapi.IssueStatus{orchapi.IssueStatusOpen}
+	if m.showResolved {
+		statuses = append(statuses, orchapi.IssueStatusResolved)
+	}
+	if m.showClosed {
+		statuses = append(statuses, orchapi.IssueStatusClosed)
+	}
+	return &orchapi.ListIssuesFilter{Status: statuses}
 }
 
 // SwitchWindow selects a window by index.
@@ -779,6 +792,24 @@ func (m *Monitor) ListBranchesForIssue(issueID string) ([]branchInfo, error) {
 	}
 
 	return filterBranchesForIssue(branches, issueID), nil
+}
+
+func filterBranchesForIssue(branches map[string]time.Time, issueID string) []branchInfo {
+	var result []branchInfo
+	issueIDLower := strings.ToLower(issueID)
+	for name, commitTime := range branches {
+		nameLower := strings.ToLower(name)
+		if strings.Contains(nameLower, issueIDLower) {
+			result = append(result, branchInfo{
+				name:       name,
+				commitTime: commitTime,
+			})
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].commitTime.After(result[j].commitTime)
+	})
+	return result
 }
 
 func (m *Monitor) ContinueRun(issueID, branch, agentType, prompt string) (string, error) {


### PR DESCRIPTION
## Summary

- Pass issue status filter to daemon `ListIssues` API instead of filtering client-side
- Remove `applyFilter()` function from `issues_dashboard.go`
- Move `filterBranchesForIssue()` from `issues_dashboard.go` to `monitor.go`

## Changes

1. **`Monitor.RefreshIssues()`** now builds a status filter based on `showResolved` and `showClosed` settings and passes it to the daemon API
2. **Removed `applyFilter()`** - the client-side filtering function that was duplicating daemon logic
3. **Filter toggle** now triggers a daemon refresh instead of local filtering
4. **Moved `filterBranchesForIssue()`** to `monitor.go` where it's called from - this is not a TUI concern but a Monitor (daemon-adjacent) concern
5. **Updated "(filtered)" UI indicator** to show just the filtered count, since we no longer have access to the unfiltered total

## Verification

- `go build ./...` passes
- `go test ./internal/monitor/...` passes (all 54 tests)
- `go test ./internal/daemon/... -run TestListIssues` passes

## Related

Resolves: orch-396
Depends on: orch-383 (daemon issue status filter support - already merged)