### PR TITLE
refactor(monitor): remove local alive/worktree checks, use daemon data

### DIFF
--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -107,6 +108,7 @@ type RunSummary struct {
 	ElapsedDisplay    string         `json:"elapsed_display,omitempty"`
 	Alive             bool           `json:"alive"`
 	AliveKnown        bool           `json:"alive_known"`
+	WorktreeExists    bool           `json:"worktree_exists"`
 	StartedAt         string         `json:"started_at"`
 	UpdatedAt         string         `json:"updated_at"`
 	URI               string         `json:"uri"`
@@ -143,6 +145,7 @@ type RunFull struct {
 	ElapsedDisplay    string         `json:"elapsed_display,omitempty"`
 	Alive             bool           `json:"alive"`
 	AliveKnown        bool           `json:"alive_known"`
+	WorktreeExists    bool           `json:"worktree_exists"`
 	StartedAt         string         `json:"started_at"`
 	UpdatedAt         string         `json:"updated_at"`
 	URI               string         `json:"uri"`
@@ -308,6 +311,14 @@ func computeBranchStateString(run *model.Run) string {
 	}
 }
 
+func computeWorktreeExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 // RunToSummary converts a model.Run to a RunSummary
 func RunToSummary(run *model.Run) *RunSummary {
 	diffStats := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
@@ -342,6 +353,7 @@ func RunToSummary(run *model.Run) *RunSummary {
 		ElapsedDisplay: elapsedDisplay,
 		Alive:          false,
 		AliveKnown:     false,
+		WorktreeExists: computeWorktreeExists(run.WorktreePath),
 		StartedAt:      formatTime(run.StartedAt),
 		UpdatedAt:      formatTime(run.UpdatedAt),
 		URI:            FileURI(run.Path),
@@ -403,6 +415,7 @@ func RunToFull(run *model.Run) *RunFull {
 		ElapsedDisplay: elapsedDisplay,
 		Alive:          false,
 		AliveKnown:     false,
+		WorktreeExists: computeWorktreeExists(run.WorktreePath),
 		StartedAt:      formatTime(run.StartedAt),
 		UpdatedAt:      formatTime(run.UpdatedAt),
 		URI:            FileURI(run.Path),

--- a/internal/model/run.go
+++ b/internal/model/run.go
@@ -92,6 +92,11 @@ type Run struct {
 	ContinuedFrom string
 
 	BranchState string
+
+	// Daemon-computed fields
+	Alive          bool
+	AliveKnown     bool
+	WorktreeExists bool
 }
 
 // Ref returns the RunRef for this run

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -1035,10 +1035,8 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 			merged = "-"
 		}
 		shortID := w.Run.ShortID()
-		if w.Run.WorktreePath != "" {
-			if _, err := os.Stat(w.Run.WorktreePath); os.IsNotExist(err) {
-				shortID += "*"
-			}
+		if w.Run.WorktreePath != "" && !w.Run.WorktreeExists {
+			shortID += "*"
 		}
 		branch := formatBranchDisplay(w.Run.Branch, runTableBranchWidth)
 		worktree := formatWorktreeDisplay(w.Run.WorktreePath, runTableWorktreeWidth)
@@ -1075,9 +1073,10 @@ func runAliveLabel(run *model.Run) string {
 	if run == nil {
 		return "-"
 	}
-	manager := agent.GetManager(run)
-	alive := manager.IsAlive(run)
-	if alive {
+	if !run.AliveKnown {
+		return "-"
+	}
+	if run.Alive {
 		return "yes"
 	}
 	return "no"
@@ -1856,6 +1855,9 @@ func apiRunToModel(r *orchapi.Run) *model.Run {
 		StartedAt:         r.StartedAt,
 		UpdatedAt:         r.UpdatedAt,
 		BranchState:       string(r.BranchState),
+		Alive:             r.Alive,
+		AliveKnown:        r.AliveKnown,
+		WorktreeExists:    r.WorktreeExists,
 	}
 }
 

--- a/internal/orchapi/daemon_client.go
+++ b/internal/orchapi/daemon_client.go
@@ -454,6 +454,7 @@ func runFromDaemonFull(r *daemon.RunFull) *Run {
 		ElapsedDisplay:    r.ElapsedDisplay,
 		Alive:             r.Alive,
 		AliveKnown:        r.AliveKnown,
+		WorktreeExists:    r.WorktreeExists,
 		StartedAt:         startedAt,
 		UpdatedAt:         updatedAt,
 		Events:            events,
@@ -500,6 +501,7 @@ func runFromDaemonSummary(r *daemon.RunSummary) *Run {
 		ElapsedDisplay:    r.ElapsedDisplay,
 		Alive:             r.Alive,
 		AliveKnown:        r.AliveKnown,
+		WorktreeExists:    r.WorktreeExists,
 		StartedAt:         startedAt,
 		UpdatedAt:         updatedAt,
 	}

--- a/internal/orchapi/types.go
+++ b/internal/orchapi/types.go
@@ -152,6 +152,7 @@ type Run struct {
 	ElapsedDisplay    string
 	Alive             bool
 	AliveKnown        bool
+	WorktreeExists    bool
 	StartedAt         time.Time
 	UpdatedAt         time.Time
 	Events            []*Event


### PR DESCRIPTION
## Summary
- Remove local `agent.GetManager().IsAlive()` call from Go TUI (monitor.go:1074-1084)
- Remove local `os.Stat()` worktree check from Go TUI (monitor.go:1038-1041)
- Use daemon-provided `Alive`, `AliveKnown`, and `WorktreeExists` fields instead

## Changes
1. **model.Run**: Added `Alive`, `AliveKnown`, `WorktreeExists` fields
2. **daemon/types.go**: Added `WorktreeExists` to `RunSummary` and `RunFull`, compute it in `RunToSummary`/`RunToFull`
3. **orchapi**: Map `WorktreeExists` through the API layer
4. **monitor.go**: 
   - `runAliveLabel()` now uses `run.Alive` and `run.AliveKnown` instead of calling `agent.GetManager().IsAlive()`
   - `buildRunRows()` now uses `run.WorktreeExists` instead of calling `os.Stat()`

## Evidence
```
$ go build ./...
# Build passes

$ go test ./internal/model ./internal/daemon ./internal/orchapi ./internal/monitor -count=1
ok  	github.com/s22625/orch/internal/model
ok  	github.com/s22625/orch/internal/daemon  
ok  	github.com/s22625/orch/internal/monitor
```

## Fixes
- Closes orch-399