### PR TITLE
fix(daemon): use sub-second mtime precision in run index cache

### DIFF
--- a/internal/store/file/run_index.go
+++ b/internal/store/file/run_index.go
@@ -214,7 +214,10 @@ func (s *FileStore) listRunsIndexed(filter *store.ListRunsFilter) ([]*model.Run,
 			fileMtime := info.ModTime()
 
 			seenKeys[key] = true
-			if cached, ok := idx.Entries[key]; ok && cached.FileMtime.Unix() == fileMtime.Unix() {
+			// Use UnixNano for sub-second precision mtime comparison.
+			// Using only Unix() caused stale cache hits when events were appended
+			// within the same second, leading to incorrect status display (orch-400).
+			if cached, ok := idx.Entries[key]; ok && cached.FileMtime.UnixNano() == fileMtime.UnixNano() {
 				if !matchesRunFilters(cached, statusSet, sinceTime, timeRangeCutoff, textSearch, agentFilter) {
 					continue
 				}
@@ -245,7 +248,7 @@ func (s *FileStore) listRunsIndexed(filter *store.ListRunsFilter) ([]*model.Run,
 				UpdatedAt:         run.UpdatedAt,
 				FileMtime:         fileMtime,
 			}
-			if old, exists := idx.Entries[key]; !exists || !runEntryEqual(old, entry) || old.FileMtime.Unix() != fileMtime.Unix() {
+			if old, exists := idx.Entries[key]; !exists || !runEntryEqual(old, entry) || old.FileMtime.UnixNano() != fileMtime.UnixNano() {
 				indexDirty = true
 			}
 			idx.Entries[key] = entry


### PR DESCRIPTION
## Summary

- Fix run status showing `boot` or `fail` when runs are actually running
- Root cause: run index cache used second-granularity mtime comparison (`.Unix()`)
- When status events were appended within the same second, the cache returned stale data

## Problem

The run index cache at `internal/store/file/run_index.go` compared file modification times using `.Unix()`, which truncates to second precision. When the daemon appended a status event (e.g., `running`) and then immediately re-read the run list, the mtime comparison would pass (same second) and the stale cached status (e.g., `booting`) would be returned.

This caused:
- Runs showing `boot` status when they were actually running
- Runs showing `fail` status after dead checks when the `running` status was already written

## Fix

Changed mtime comparison from `.Unix()` to `.UnixNano()` for nanosecond-precision comparison, ensuring the cache is properly invalidated when files are modified within the same second.

## Testing

- All existing tests pass (`go test ./internal/store/file/...`, `go test ./internal/daemon/...`, `go test ./internal/agent/...`)
- Build succeeds (`go build ./...`)

## Fixes

- orch-400