### PR TITLE
fix(git): compute diff stats including uncommitted changes for dirty branches

### DIFF
--- a/internal/git/gogit.go
+++ b/internal/git/gogit.go
@@ -66,7 +66,7 @@ func GetWorktreeStatus(worktreePath, branch, baseBranch string) WorktreeStatus {
 	if isDirtyFast(worktreePath) {
 		return WorktreeStatus{
 			State:     BranchStateDirty,
-			DiffStats: getDiffStatsFast(worktreePath, baseBranch),
+			DiffStats: getWorkingTreeDiffStats(worktreePath, baseBranch),
 		}
 	}
 
@@ -144,6 +144,23 @@ func getDiffStatsFast(worktreePath, baseBranch string) DiffStats {
 	output, err := cmd.Output()
 	if err != nil {
 		cmd = exec.Command("git", "-C", worktreePath, "diff", "--numstat", baseBranch+"...HEAD")
+		output, err = cmd.Output()
+		if err != nil {
+			return DiffStats{}
+		}
+	}
+	return parseDiffNumstat(string(output))
+}
+
+// getWorkingTreeDiffStats computes diff from base branch to working tree (including uncommitted changes).
+func getWorkingTreeDiffStats(worktreePath, baseBranch string) DiffStats {
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	cmd := exec.Command("git", "-C", worktreePath, "diff", "--numstat", "origin/"+baseBranch)
+	output, err := cmd.Output()
+	if err != nil {
+		cmd = exec.Command("git", "-C", worktreePath, "diff", "--numstat", baseBranch)
 		output, err = cmd.Output()
 		if err != nil {
 			return DiffStats{}

--- a/internal/git/gogit_test.go
+++ b/internal/git/gogit_test.go
@@ -1,0 +1,121 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetWorktreeStatus_DirtyWithDiffStats(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "gogit-dirty-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	runGit := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = tmpDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	runGit("init", "-b", "main")
+	runGit("config", "user.email", "test@test.com")
+	runGit("config", "user.name", "Test User")
+
+	initialFile := filepath.Join(tmpDir, "initial.txt")
+	if err := os.WriteFile(initialFile, []byte("initial content\n"), 0644); err != nil {
+		t.Fatalf("Failed to write initial file: %v", err)
+	}
+	runGit("add", ".")
+	runGit("commit", "-m", "initial")
+
+	runGit("checkout", "-b", "feature")
+
+	newFile := filepath.Join(tmpDir, "uncommitted.txt")
+	if err := os.WriteFile(newFile, []byte("line1\nline2\nline3\nline4\nline5\n"), 0644); err != nil {
+		t.Fatalf("Failed to write uncommitted file: %v", err)
+	}
+	runGit("add", "uncommitted.txt")
+
+	status := GetWorktreeStatus(tmpDir, "feature", "main")
+
+	if status.State != BranchStateDirty {
+		t.Errorf("Expected BranchStateDirty, got %v", status.State)
+	}
+
+	if status.DiffStats.Additions != 5 {
+		t.Errorf("Expected 5 additions for uncommitted changes, got %d", status.DiffStats.Additions)
+	}
+
+	if status.DiffStats.Deletions != 0 {
+		t.Errorf("Expected 0 deletions, got %d", status.DiffStats.Deletions)
+	}
+
+	if status.DiffStats.FilesChanged != 1 {
+		t.Errorf("Expected 1 file changed, got %d", status.DiffStats.FilesChanged)
+	}
+}
+
+func TestGetWorktreeStatus_DirtyWithBothCommittedAndUncommitted(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "gogit-mixed-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	runGit := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = tmpDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	runGit("init", "-b", "main")
+	runGit("config", "user.email", "test@test.com")
+	runGit("config", "user.name", "Test User")
+
+	initialFile := filepath.Join(tmpDir, "initial.txt")
+	if err := os.WriteFile(initialFile, []byte("initial\n"), 0644); err != nil {
+		t.Fatalf("Failed to write initial file: %v", err)
+	}
+	runGit("add", ".")
+	runGit("commit", "-m", "initial")
+
+	runGit("checkout", "-b", "feature")
+
+	committedFile := filepath.Join(tmpDir, "committed.txt")
+	if err := os.WriteFile(committedFile, []byte("line1\nline2\n"), 0644); err != nil {
+		t.Fatalf("Failed to write committed file: %v", err)
+	}
+	runGit("add", ".")
+	runGit("commit", "-m", "add committed file")
+
+	uncommittedFile := filepath.Join(tmpDir, "uncommitted.txt")
+	if err := os.WriteFile(uncommittedFile, []byte("a\nb\nc\n"), 0644); err != nil {
+		t.Fatalf("Failed to write uncommitted file: %v", err)
+	}
+	runGit("add", "uncommitted.txt")
+
+	status := GetWorktreeStatus(tmpDir, "feature", "main")
+
+	if status.State != BranchStateDirty {
+		t.Errorf("Expected BranchStateDirty, got %v", status.State)
+	}
+
+	expectedAdditions := 5
+	if status.DiffStats.Additions != expectedAdditions {
+		t.Errorf("Expected %d additions (committed + uncommitted), got %d", expectedAdditions, status.DiffStats.Additions)
+	}
+
+	expectedFiles := 2
+	if status.DiffStats.FilesChanged != expectedFiles {
+		t.Errorf("Expected %d files changed, got %d", expectedFiles, status.DiffStats.FilesChanged)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `getWorkingTreeDiffStats` function that computes diff from base branch to working tree (including uncommitted changes)
- Updates `GetWorktreeStatus` to use this function when the branch is dirty
- Adds unit tests to verify diff stats are properly computed for dirty branches

## Problem

In `orch-monitor` TUI, the +/- columns showed `-` even when the branch column showed `dirty`. This happened because:

- `getDiffStatsFast` computed `git diff --numstat origin/main...HEAD` (only committed changes)
- When there are ONLY uncommitted changes, this shows 0/0, resulting in `-` in the TUI

## Solution

When the branch is dirty, compute diff stats using `git diff --numstat origin/main` (without `...HEAD`), which compares the base branch directly to the working tree and includes both committed AND uncommitted changes.

## Evidence

**Before fix** (dirty branch with only uncommitted changes):
```
WorkingTreeDiff - Additions: 0, Deletions: 0
```

**After fix**:
```
WorkingTreeDiff - Additions: 18, Deletions: 1
```

**Test output**:
```
=== RUN   TestGetWorktreeStatus_DirtyWithDiffStats
--- PASS: TestGetWorktreeStatus_DirtyWithDiffStats (0.24s)
=== RUN   TestGetWorktreeStatus_DirtyWithBothCommittedAndUncommitted
--- PASS: TestGetWorktreeStatus_DirtyWithBothCommittedAndUncommitted (0.30s)
PASS
```

## Files Changed

- `internal/git/gogit.go`: Added `getWorkingTreeDiffStats`, updated dirty branch handling
- `internal/git/gogit_test.go`: New tests for dirty worktree diff stats

Fixes: orch-401