### PR TITLE
fix(continue): skip session artifact for opencode runs

### DIFF
--- a/internal/cli/continue.go
+++ b/internal/cli/continue.go
@@ -299,19 +299,22 @@ func continueFromRun(ctx context.Context, api orchapi.OrchAPI, refStr string, op
 			}
 		}
 
-		api.AppendEvent(ctx, runRef, &orchapi.Event{Type: "artifact", Name: "session", Attrs: map[string]string{"name": tmuxSession, "multiplexer": string(mux.Type())}})
+		// Only create session artifact for non-HTTP agents (opencode uses HTTP, no tmux session)
+		if adapter.PromptInjection() != agent.InjectionHTTP {
+			api.AppendEvent(ctx, runRef, &orchapi.Event{Type: "artifact", Name: "session", Attrs: map[string]string{"name": tmuxSession, "multiplexer": string(mux.Type())}})
 
-		windowID := ""
-		if windows, err := mux.ListWindows(tmuxSession); err == nil {
-			for _, window := range windows {
-				if window.Index == 0 {
-					windowID = window.ID
-					break
+			windowID := ""
+			if windows, err := mux.ListWindows(tmuxSession); err == nil {
+				for _, window := range windows {
+					if window.Index == 0 {
+						windowID = window.ID
+						break
+					}
 				}
 			}
-		}
-		if windowID != "" {
-			api.AppendEvent(ctx, runRef, &orchapi.Event{Type: "artifact", Name: "window", Attrs: map[string]string{"id": windowID}})
+			if windowID != "" {
+				api.AppendEvent(ctx, runRef, &orchapi.Event{Type: "artifact", Name: "window", Attrs: map[string]string{"id": windowID}})
+			}
 		}
 	}
 
@@ -495,19 +498,22 @@ func continueFromBranch(ctx context.Context, api orchapi.OrchAPI, refStr string,
 			}
 		}
 
-		api.AppendEvent(ctx, runRef, &orchapi.Event{Type: "artifact", Name: "session", Attrs: map[string]string{"name": tmuxSession, "multiplexer": string(mux.Type())}})
+		// Only create session artifact for non-HTTP agents (opencode uses HTTP, no tmux session)
+		if adapter.PromptInjection() != agent.InjectionHTTP {
+			api.AppendEvent(ctx, runRef, &orchapi.Event{Type: "artifact", Name: "session", Attrs: map[string]string{"name": tmuxSession, "multiplexer": string(mux.Type())}})
 
-		windowID := ""
-		if windows, err := mux.ListWindows(tmuxSession); err == nil {
-			for _, window := range windows {
-				if window.Index == 0 {
-					windowID = window.ID
-					break
+			windowID := ""
+			if windows, err := mux.ListWindows(tmuxSession); err == nil {
+				for _, window := range windows {
+					if window.Index == 0 {
+						windowID = window.ID
+						break
+					}
 				}
 			}
-		}
-		if windowID != "" {
-			api.AppendEvent(ctx, runRef, &orchapi.Event{Type: "artifact", Name: "window", Attrs: map[string]string{"id": windowID}})
+			if windowID != "" {
+				api.AppendEvent(ctx, runRef, &orchapi.Event{Type: "artifact", Name: "window", Attrs: map[string]string{"id": windowID}})
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Opencode runs were incorrectly showing multiplexer values (zj/tx) when they should show empty (-)
- Fixed by guarding session artifact creation in `continue.go` with `adapter.PromptInjection() != agent.InjectionHTTP`

## Problem

`orch continue` was creating session artifacts with multiplexer info for ALL agents, including opencode. Since opencode uses HTTP-based server communication (not tmux sessions), it should not have multiplexer session artifacts.

## Root Cause

In `internal/cli/continue.go`, both `continueFromRun()` and `continueFromBranch()` created session artifacts unconditionally for all agents inside the `if opts.Tmux` block.

## Fix

Added conditional check to skip session artifact creation for HTTP-based agents (opencode):
```go
if adapter.PromptInjection() != agent.InjectionHTTP {
    // Only create session artifact for non-HTTP agents
}
```

This matches the pattern already used in `internal/cli/run.go` and `internal/daemon/socket.go`.

## Evidence

- Build passes: `go build ./...` ✅
- Tests pass: `go test ./internal/cli/...` ✅  
- Existing test `TestAgentOpenCodeNoMultiplexer` validates opencode should not have multiplexer_session

## Reference

- Issue: orch-404