### PR TITLE
fix(multiplexer): prefer tmux over zellij in GetAuto()

### DIFF
--- a/internal/multiplexer/multiplexer.go
+++ b/internal/multiplexer/multiplexer.go
@@ -178,7 +178,9 @@ func GetWithFallback(preferred Type) (Multiplexer, string, error) {
 }
 
 // GetAuto returns the best available multiplexer based on environment.
-// Priority: current session > zellij (if available) > tmux (if available).
+// Priority: current session > tmux > zellij.
+// Tmux is preferred because cross-session zellij attach doesn't work,
+// so orch-monitor (in zellij) needs agents to run in tmux.
 func GetAuto() (Multiplexer, error) {
 	tmux, _ := GetMultiplexer(TypeTmux)
 	zellij, _ := GetMultiplexer(TypeZellij)
@@ -190,11 +192,11 @@ func GetAuto() (Multiplexer, error) {
 		return zellij, nil
 	}
 
-	if zellij != nil && zellij.IsAvailable() {
-		return zellij, nil
-	}
 	if tmux != nil && tmux.IsAvailable() {
 		return tmux, nil
+	}
+	if zellij != nil && zellij.IsAvailable() {
+		return zellij, nil
 	}
 
 	return nil, fmt.Errorf("no terminal multiplexer available (install tmux or zellij)")


### PR DESCRIPTION
## Summary

- Fix inconsistent multiplexer selection where opencode runs sometimes used zellij instead of tmux
- Change `GetAuto()` priority from `zellij > tmux` to `tmux > zellij` when not inside an existing session
- Ensures orch-monitor (in zellij) can always attach to agent runs

## Problem

Some opencode runs were launched with zellij (Mux: zj) instead of tmux, making them inaccessible from orch-monitor running in zellij. Cross-session zellij attach doesn't work, so agents must run in tmux.

## Root Cause

The `GetAuto()` function in `internal/multiplexer/multiplexer.go` had priority order:
1. Current session (if inside one)
2. **Zellij** (if available)
3. Tmux (if available)

This caused zellij to be selected when:
- Running `orch run` outside of any multiplexer session
- Config had `agent_multiplexer: auto` or was not set

## Fix

Changed `GetAuto()` priority to:
1. Current session (if inside one)
2. **Tmux** (if available)
3. Zellij (if available)

This aligns with:
- The config default (`agent_multiplexer` defaults to "tmux")
- The validation that prevents zellij+zellij configuration
- The intended architecture where monitor=zellij and agents=tmux

## Evidence

```
$ go build ./...
# (success, no errors)

$ go test ./internal/multiplexer/...
ok      github.com/s22625/orch/internal/multiplexer  0.710s

$ go test ./...
# All tests pass except pre-existing integration test failures unrelated to this change
```

## Reference

Closes: orch-403