### PR TITLE
feat(orch-monitor): enable zellij-to-zellij attach via viewer tabs

### DIFF
--- a/orch-monitor-tui/orch_monitor/macros.hy
+++ b/orch-monitor-tui/orch_monitor/macros.hy
@@ -1337,31 +1337,41 @@
        (._do_attach self self.selected_run))
      
      (defn [(work :thread True)] _do_attach [self run]
-       "Attach to run in background thread to avoid blocking TUI."
-       (setv current-mux-type (detect_current_multiplexer))
-       (setv attach-cmd (+ (_build-orch-cmd self.config) ["attach" (.ref run)]))
-       (when current-mux-type
-         (setv current-mux (get_multiplexer current-mux-type))
-         (when (= current-mux-type MultiplexerType.ZELLIJ)
-           (setv run-mux-type (get_multiplexer_type_from_run run))
-           (when (= run-mux-type MultiplexerType.ZELLIJ)
-             (setv current-session (.get_current_session current-mux))
-             (setv run-session (get_session_name run))
-             (when (and current-session run-session (!= current-session run-session))
-               (setv cmd-str (.join " " attach-cmd))
-               (.call_from_thread self self.notify
-                 (+ "Cannot attach to different Zellij session from inside Zellij.\n"
-                    f"Run in a separate terminal: {cmd-str}")
-                 :severity "warning" :timeout 15)
-               (return))))
-         (setv tab-name f"{run.issue_id}[{(.short_id run)}]")
-         (when (.new_tab_with_command current-mux tab-name attach-cmd)
-           (.call_from_thread self self.notify f"Opened tab: {tab-name}")
-           (return))
-         (.call_from_thread self self.notify
-           "Failed to create tab, falling back to exit"
-           :severity "warning"))
-       (.call_from_thread self self._exit_and_attach attach-cmd))
+        "Attach to run in background thread to avoid blocking TUI."
+        (setv current-mux-type (detect_current_multiplexer))
+        (setv attach-cmd (+ (_build-orch-cmd self.config) ["attach" (.ref run)]))
+        (when current-mux-type
+          (setv current-mux (get_multiplexer current-mux-type))
+          (when (= current-mux-type MultiplexerType.ZELLIJ)
+            (setv run-mux-type (get_multiplexer_type_from_run run))
+            (when (= run-mux-type MultiplexerType.ZELLIJ)
+              (setv run-session (get_session_name run))
+              (when run-session
+                (setv #(success msg) (.switch_to_session current-mux run-session))
+                (cond
+                  (and success (.startswith msg "created_viewer_tab"))
+                  (do
+                    (.call_from_thread self self.notify
+                      f"Opened viewer for session: {run-session}" :timeout 5)
+                    (return))
+                  (and success (.startswith msg "switched_to_existing_viewer"))
+                  (do
+                    (.call_from_thread self self.notify
+                      f"Switched to existing viewer: {run-session}" :timeout 3)
+                    (return))
+                  (and success (in msg ["already_in_session" "not_inside_zellij" "no_current_session"]))
+                  None
+                  (not success)
+                  (.call_from_thread self self.notify
+                    f"Failed to create viewer: {msg}" :severity "warning" :timeout 5)))))
+          (setv tab-name f"{run.issue_id}[{(.short_id run)}]")
+          (when (.new_tab_with_command current-mux tab-name attach-cmd)
+            (.call_from_thread self self.notify f"Opened tab: {tab-name}")
+            (return))
+          (.call_from_thread self self.notify
+            "Failed to create tab, falling back to exit"
+            :severity "warning"))
+        (.call_from_thread self self._exit_and_attach attach-cmd))
      
      (defn _exit_and_attach [self attach-cmd]
        "Exit TUI and run attach command (must be called from main thread)."

--- a/orch-monitor-tui/orch_monitor/multiplexer.py
+++ b/orch-monitor-tui/orch_monitor/multiplexer.py
@@ -110,6 +110,10 @@ class Multiplexer(Protocol):
         """
         ...
 
+    def switch_to_session(self, target_session: str) -> tuple[bool, str]:
+        """Switch to session, creating viewer tab for cross-session access if needed."""
+        ...
+
 
 class TmuxMultiplexer:
     """Tmux implementation of Multiplexer."""
@@ -270,6 +274,22 @@ class TmuxMultiplexer:
         except (subprocess.TimeoutExpired, OSError):
             return []
 
+    def switch_to_session(self, target_session: str) -> tuple[bool, str]:
+        if not self.is_inside():
+            return (True, "not_inside_tmux")
+
+        current_session = self.get_current_session()
+        if current_session == target_session:
+            return (True, "already_in_session")
+
+        result = subprocess.run(
+            ["tmux", "switch-client", "-t", target_session],
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            return (True, f"switched_to_session:{target_session}")
+        return (False, f"switch_failed:{result.stderr.decode().strip()}")
+
 
 ZELLIJ_TIMEOUT_SEC = 5
 
@@ -286,6 +306,87 @@ class ZellijMultiplexer:
 
     def is_inside(self) -> bool:
         return bool(os.environ.get("ZELLIJ"))
+
+    def switch_to_session(self, target_session: str) -> tuple[bool, str]:
+        """Switch to another zellij session, creating a viewer tab for cross-session access."""
+        if not self.is_inside():
+            return (True, "not_inside_zellij")
+
+        current_session = self.get_current_session()
+        if not current_session:
+            return (True, "no_current_session")
+
+        if current_session == target_session:
+            return (True, "already_in_session")
+
+        tab_name = f"view:{target_session[:12]}"
+
+        existing_tabs = self.list_windows()
+        if tab_name in existing_tabs:
+            self.select_window(tab_name)
+            return (True, f"switched_to_existing_viewer:{tab_name}")
+
+        viewer_script = self._create_session_viewer_script(target_session)
+        if not viewer_script:
+            return (False, "failed_to_create_viewer_script")
+
+        viewer_cmd = ["bash", "-c", viewer_script]
+        if self.new_tab_with_command(tab_name, viewer_cmd):
+            return (True, f"created_viewer_tab:{tab_name}")
+
+        return (False, "failed_to_create_viewer_tab")
+
+    def _create_session_viewer_script(self, target_session: str) -> Optional[str]:
+        """Create shell script that polls and displays target session output every 2 seconds."""
+        script = f'''
+# Session Viewer for: {target_session}
+# Press Ctrl+C to exit
+
+clear
+echo "=== Viewing Zellij Session: {target_session} ==="
+echo "Press Ctrl+C to exit, 'q' to quit viewer"
+echo ""
+
+cleanup() {{
+    echo ""
+    echo "Viewer closed."
+    exit 0
+}}
+
+trap cleanup INT TERM
+
+while true; do
+    # Clear and redraw
+    clear
+    echo "=== Viewing Zellij Session: {target_session} ==="
+    echo "Press Ctrl+C to exit | Last update: $(date '+%H:%M:%S')"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+
+    # Check if target session exists
+    if ! zellij list-sessions -n 2>/dev/null | grep -q "^{target_session}"; then
+        echo "[Session '{target_session}' not found or has ended]"
+        echo ""
+        echo "Waiting for session to appear..."
+        sleep 2
+        continue
+    fi
+
+    # Capture and display output from target session
+    tmpfile=$(mktemp)
+    if zellij --session "{target_session}" action dump-screen "$tmpfile" 2>/dev/null; then
+        # Show last 40 lines of output
+        tail -n 40 "$tmpfile" 2>/dev/null || echo "[No output captured]"
+    else
+        echo "[Failed to capture session output]"
+    fi
+    rm -f "$tmpfile"
+
+    # Wait before next refresh
+    sleep 2
+done
+'''
+        return script.strip()
 
     def has_session(self, session_name: str) -> bool:
         try:
@@ -498,7 +599,6 @@ def get_agent_multiplexer_type() -> MultiplexerType:
     env_mux = os.environ.get("ORCH_AGENT_MULTIPLEXER", "").lower()
     if env_mux == "zellij":
         return MultiplexerType.ZELLIJ
-    # Default to tmux for agents (cross-session Zellij attach doesn't work)
     return MultiplexerType.TMUX
 
 
@@ -509,19 +609,7 @@ class InvalidMultiplexerConfigError(Exception):
 
 
 def validate_multiplexer_config(monitor_mux: MultiplexerType) -> None:
-    """Validate multiplexer configuration.
-
-    Raises InvalidMultiplexerConfigError if monitor=zellij and agent=zellij
-    (cross-session Zellij attach doesn't work).
-    """
-    agent_mux = get_agent_multiplexer_type()
-    if monitor_mux == MultiplexerType.ZELLIJ and agent_mux == MultiplexerType.ZELLIJ:
-        raise InvalidMultiplexerConfigError(
-            "Invalid multiplexer configuration: monitor_multiplexer=zellij with "
-            "agent_multiplexer=zellij is not supported (cross-session Zellij attach "
-            "doesn't work).\n"
-            "Fix: Set ORCH_AGENT_MULTIPLEXER=tmux or use --multiplexer tmux for monitor"
-        )
+    pass
 
 
 # Convenience functions for working with Run objects

--- a/orch-monitor-tui/tests/test_multiplexer.py
+++ b/orch-monitor-tui/tests/test_multiplexer.py
@@ -758,3 +758,91 @@ class TestZellijCommandContracts:
         assert expected_cmd[0] == "zellij"
         assert expected_cmd[1] == "--session"
         assert "action" in expected_cmd
+
+
+class TestSwitchToSession:
+    """Tests for switch_to_session method in both multiplexers."""
+
+    def test_tmux_switch_outside_session(self):
+        """TmuxMultiplexer returns 'not_inside_tmux' when outside tmux."""
+        tmux = TmuxMultiplexer()
+        with patch.dict(os.environ, {}, clear=True):
+            success, msg = tmux.switch_to_session("target-session")
+            assert success is True
+            assert msg == "not_inside_tmux"
+
+    def test_tmux_switch_same_session(self):
+        """TmuxMultiplexer returns 'already_in_session' when already in target."""
+        tmux = TmuxMultiplexer()
+        with patch.dict(os.environ, {"TMUX": "/tmp/tmux-1001/default,12345,0"}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0, stdout="target-session\n"
+                )
+                success, msg = tmux.switch_to_session("target-session")
+                assert success is True
+                assert msg == "already_in_session"
+
+    def test_tmux_switch_to_different_session(self):
+        """TmuxMultiplexer switches client when inside different session."""
+        tmux = TmuxMultiplexer()
+        with patch.dict(os.environ, {"TMUX": "/tmp/tmux-1001/default,12345,0"}):
+            with patch("subprocess.run") as mock_run:
+                mock_run.side_effect = [
+                    MagicMock(returncode=0, stdout="current-session\n"),
+                    MagicMock(returncode=0),
+                ]
+                success, msg = tmux.switch_to_session("target-session")
+                assert success is True
+                assert "switched_to_session" in msg
+
+    def test_zellij_switch_outside_session(self):
+        """ZellijMultiplexer returns 'not_inside_zellij' when outside zellij."""
+        zellij = ZellijMultiplexer()
+        with patch.dict(os.environ, {}, clear=True):
+            success, msg = zellij.switch_to_session("target-session")
+            assert success is True
+            assert msg == "not_inside_zellij"
+
+    def test_zellij_switch_same_session(self):
+        """ZellijMultiplexer returns 'already_in_session' when already in target."""
+        zellij = ZellijMultiplexer()
+        with patch.dict(
+            os.environ, {"ZELLIJ": "0", "ZELLIJ_SESSION_NAME": "target-session"}
+        ):
+            success, msg = zellij.switch_to_session("target-session")
+            assert success is True
+            assert msg == "already_in_session"
+
+    def test_zellij_creates_viewer_for_different_session(self):
+        """ZellijMultiplexer creates viewer tab for cross-session access."""
+        zellij = ZellijMultiplexer()
+        with patch.dict(
+            os.environ, {"ZELLIJ": "0", "ZELLIJ_SESSION_NAME": "current-session"}
+        ):
+            with patch("subprocess.run") as mock_run:
+                mock_run.side_effect = [
+                    MagicMock(returncode=0, stdout="other-tab\n"),
+                    MagicMock(returncode=0, stdout="other-tab\n"),
+                    MagicMock(returncode=0),
+                    MagicMock(returncode=0),
+                    MagicMock(returncode=0),
+                ]
+                success, msg = zellij.switch_to_session("target-session")
+                assert success is True
+                assert "created_viewer_tab" in msg
+
+    def test_zellij_switches_to_existing_viewer(self):
+        """ZellijMultiplexer switches to existing viewer tab if present."""
+        zellij = ZellijMultiplexer()
+        with patch.dict(
+            os.environ, {"ZELLIJ": "0", "ZELLIJ_SESSION_NAME": "current-session"}
+        ):
+            with patch("subprocess.run") as mock_run:
+                mock_run.side_effect = [
+                    MagicMock(returncode=0, stdout="view:target-sessi\nother-tab\n"),
+                    MagicMock(returncode=0),
+                ]
+                success, msg = zellij.switch_to_session("target-session")
+                assert success is True
+                assert "switched_to_existing_viewer" in msg


### PR DESCRIPTION
## Summary

- Enable attaching to zellij runs from orch-monitor running inside zellij by creating viewer tabs
- Previously showed "Cannot attach to different Zellij session from inside Zellij" error
- Now creates a viewer tab that polls and displays output from the target session

## Changes

- Add `switch_to_session()` method to `ZellijMultiplexer` that creates viewer tabs for cross-session access
- Add `switch_to_session()` method to `TmuxMultiplexer` (uses switch-client for native session switching)
- Update `_do_attach` in `macros.hy` to use new session switching instead of showing error
- Remove validation error from `validate_multiplexer_config` since zellij-to-zellij now works
- Add comprehensive tests for the new `switch_to_session` functionality

## How It Works

When orch-monitor is inside zellij and you try to attach to a run using a different zellij session:

1. A new tab named `view:<session-name>` is created in the current zellij session
2. The tab runs a script that continuously polls the target session's output using `zellij --session <target> action dump-screen`
3. Output is refreshed every 2 seconds with a timestamp header
4. If the viewer tab already exists, it's simply focused instead of creating a duplicate

## Testing

```bash
cd orch-monitor-tui
uv run pytest tests/test_multiplexer.py::TestSwitchToSession -v
```

All 7 new tests pass:
- `test_tmux_switch_outside_session`
- `test_tmux_switch_same_session`
- `test_tmux_switch_to_different_session`
- `test_zellij_switch_outside_session`
- `test_zellij_switch_same_session`
- `test_zellij_creates_viewer_for_different_session`
- `test_zellij_switches_to_existing_viewer`

Fixes: orch-402