### PR TITLE
refactor(cli): remove agent package import from send.go, attach.go, models.go

### DIFF
--- a/.semgrep/architecture.yaml
+++ b/.semgrep/architecture.yaml
@@ -129,3 +129,26 @@ rules:
     metadata:
       category: architecture
       issue: orch-405
+
+  - id: cli-no-agent-import-in-send-attach-models
+    patterns:
+      - pattern: |
+          import (
+            ...
+            "github.com/s22625/orch/internal/agent"
+            ...
+          )
+    paths:
+      include:
+        - /internal/cli/send.go
+        - /internal/cli/attach.go
+        - /internal/cli/models.go
+    message: |
+      send.go, attach.go, and models.go must not import internal/agent.
+      Use string literals for agent type comparisons ("opencode").
+      Use local constants for port values.
+    severity: ERROR
+    languages: [go]
+    metadata:
+      category: architecture
+      issue: orch-413

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/s22625/orch/internal/agent"
 	"github.com/s22625/orch/internal/config"
 	"github.com/s22625/orch/internal/daemon"
 	"github.com/s22625/orch/internal/model"
@@ -72,7 +71,7 @@ func runAttach(refStr string, opts *attachOptions) error {
 		return fmt.Errorf("cannot attach: %s", resp.Error)
 	}
 
-	if resp.Agent == string(agent.AgentOpenCode) {
+	if resp.Agent == "opencode" {
 		return attachOpenCodeFromInfo(resp)
 	}
 

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/s22625/orch/internal/agent"
 	"github.com/s22625/orch/internal/orchapi"
 	"github.com/spf13/cobra"
 )
 
-const defaultOpenCodePort = agent.OpenCodeServerPortStart
+// defaultOpenCodePort is the default port for the OpenCode server.
+// This value matches agent.OpenCodeServerPortStart but is defined here
+// to avoid importing the agent package for a single constant.
+const defaultOpenCodePort = 4096
 
 type modelsOptions struct {
 	Port    int

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/s22625/orch/internal/agent"
 	"github.com/s22625/orch/internal/daemon"
 	"github.com/s22625/orch/internal/orchapi"
 	"github.com/spf13/cobra"
@@ -78,7 +77,7 @@ func runSend(refStr, message string, opts *sendOptions) error {
 		return err
 	}
 
-	isOpenCode := run.Agent == string(agent.AgentOpenCode)
+	isOpenCode := run.Agent == "opencode"
 
 	if opts.DryRun {
 		return validateSendConfig(run, isOpenCode)


### PR DESCRIPTION
## Summary

Remove unnecessary coupling between CLI files and the agent package by:
- Replacing `agent.AgentOpenCode` with `"opencode"` string literal in send.go and attach.go
- Replacing `agent.OpenCodeServerPortStart` with local constant `4096` in models.go
- Adding semgrep rule to prevent future agent package imports in these files

## Changes Made

| File | Change |
|------|--------|
| send.go | Replaced `run.Agent == string(agent.AgentOpenCode)` with `run.Agent == "opencode"`, removed agent import |
| attach.go | Replaced `resp.Agent == string(agent.AgentOpenCode)` with `resp.Agent == "opencode"`, removed agent import |
| models.go | Replaced `agent.OpenCodeServerPortStart` with local constant `4096`, removed agent import |
| .semgrep/architecture.yaml | Added `cli-no-agent-import-in-send-attach-models` rule |

## Acceptance Criteria Verification

- [x] send.go: Replace `agent.AgentOpenCode` with string literal `"opencode"`
- [x] attach.go: Replace `agent.AgentOpenCode` with string literal `"opencode"`
- [x] models.go: Move port constant to local constant (value 4096)
- [x] Remove `agent` import from all three files
- [x] Add semgrep rule blocking send.go/attach.go/models.go from importing agent package
- [x] `go build ./...` passes
- [x] `go test ./internal/...` passes
- [x] `make lint` passes (semgrep 0 findings)

## Evidence

### Build passes
```
$ go build ./...
(no output - success)
```

### Tests pass
```
$ go test ./internal/...
ok      github.com/s22625/orch/internal/agent     0.760s
ok      github.com/s22625/orch/internal/cli       4.883s
ok      github.com/s22625/orch/internal/config    3.896s
ok      github.com/s22625/orch/internal/daemon    3.159s
ok      github.com/s22625/orch/internal/git       9.321s
ok      github.com/s22625/orch/internal/github    0.687s
ok      github.com/s22625/orch/internal/model     1.729s
ok      github.com/s22625/orch/internal/monitor   2.353s
ok      github.com/s22625/orch/internal/multiplexer 1.338s
ok      github.com/s22625/orch/internal/notify    2.322s
ok      github.com/s22625/orch/internal/query     1.684s
ok      github.com/s22625/orch/internal/store/file 1.491s
ok      github.com/s22625/orch/internal/tmux      1.210s
ok      github.com/s22625/orch/internal/xdg       0.707s
```

### Lint passes
```
$ make lint
semgrep --error --config .semgrep/ ./internal/cli/
✅ Scan completed successfully.
 • Findings: 0 (0 blocking)
 • Rules run: 8
 • Targets scanned: 29
```

Closes: orch-413