### PR TITLE
fix(daemon): throttle OpenCode capture retries for dead server ports

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -64,6 +64,11 @@ type RunState struct {
 	PRRecorded     bool
 	WasAlive       bool
 	DeadCheckCount int
+
+	CaptureFailCount   int
+	LastCaptureFailAt  time.Time
+	NextCaptureRetryAt time.Time
+	LastCaptureError   string
 }
 
 func New(factory StoreFactory) *Daemon {

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -3,8 +3,11 @@ package daemon
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
+	"net"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/s22625/orch/internal/agent"
@@ -15,6 +18,12 @@ import (
 )
 
 const deadChecksBeforeFailed = 3
+
+const (
+	captureInitialBackoff = 10 * time.Second
+	captureMaxBackoff     = 60 * time.Second
+	captureBackoffFactor  = 2
+)
 
 func (d *Daemon) monitorRun(run *model.Run, st store.Store) error {
 	if run.Status == model.StatusCanceled {
@@ -93,11 +102,17 @@ func (d *Daemon) monitorRun(run *model.Run, st store.Store) error {
 		return d.updateStatus(run, model.StatusFailed, st)
 	}
 
-	output, err := mgr.CaptureOutput(run)
-	if err != nil {
-		d.logger.Printf("%s#%s: failed to capture output: %v", run.IssueID, run.RunID, err)
+	if d.shouldSkipCapture(state, run) {
 		return nil
 	}
+
+	output, err := mgr.CaptureOutput(run)
+	if err != nil {
+		d.handleCaptureError(state, run, err)
+		return nil
+	}
+
+	d.resetCaptureBackoff(state)
 
 	contentHash := hashContent(output)
 	outputChanged := contentHash != state.OutputHash
@@ -297,6 +312,84 @@ func (d *Daemon) notifyStatusChange(run *model.Run, newStatus model.Status, last
 	} else {
 		d.logger.Printf("%s#%s: sent slack notification for status %s", run.IssueID, run.RunID, newStatus)
 	}
+}
+
+func (d *Daemon) shouldSkipCapture(state *RunState, run *model.Run) bool {
+	if state.NextCaptureRetryAt.IsZero() {
+		return false
+	}
+	if time.Now().Before(state.NextCaptureRetryAt) {
+		d.debug("%s#%s: skipping capture (backoff until %s)", run.IssueID, run.RunID, state.NextCaptureRetryAt.Format(time.RFC3339))
+		return true
+	}
+	return false
+}
+
+func (d *Daemon) handleCaptureError(state *RunState, run *model.Run, err error) {
+	state.CaptureFailCount++
+	state.LastCaptureFailAt = time.Now()
+
+	backoff := d.calculateCaptureBackoff(state.CaptureFailCount, err)
+	state.NextCaptureRetryAt = time.Now().Add(backoff)
+
+	errStr := err.Error()
+	isNewError := state.LastCaptureError != errStr
+	state.LastCaptureError = errStr
+
+	if state.CaptureFailCount == 1 || isNewError {
+		if isConnectionRefused(err) {
+			d.logger.Printf("%s#%s: capture failed (connection refused), backing off %s", run.IssueID, run.RunID, backoff)
+		} else {
+			d.logger.Printf("%s#%s: capture failed: %v, backing off %s", run.IssueID, run.RunID, err, backoff)
+		}
+	} else {
+		d.debug("%s#%s: repeated capture failure (%d), backing off %s", run.IssueID, run.RunID, state.CaptureFailCount, backoff)
+	}
+}
+
+func (d *Daemon) resetCaptureBackoff(state *RunState) {
+	if state.CaptureFailCount > 0 {
+		state.CaptureFailCount = 0
+		state.NextCaptureRetryAt = time.Time{}
+		state.LastCaptureError = ""
+	}
+}
+
+func (d *Daemon) calculateCaptureBackoff(failCount int, err error) time.Duration {
+	backoff := captureInitialBackoff
+	for i := 1; i < failCount; i++ {
+		backoff *= captureBackoffFactor
+		if backoff > captureMaxBackoff {
+			backoff = captureMaxBackoff
+			break
+		}
+	}
+
+	if isConnectionRefused(err) && backoff < captureMaxBackoff {
+		backoff = min(backoff*2, captureMaxBackoff)
+	}
+
+	return backoff
+}
+
+func isConnectionRefused(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		if sysErr, ok := opErr.Err.(*syscall.Errno); ok {
+			return *sysErr == syscall.ECONNREFUSED
+		}
+		if errors.Is(opErr.Err, syscall.ECONNREFUSED) {
+			return true
+		}
+	}
+
+	errStr := err.Error()
+	return strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "connect: connection refused")
 }
 
 // inferStatusFromGitState infers a run's status from git state when the agent session

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -289,3 +289,146 @@ func TestCheckPRMergedWithURLReturnsURLWhenFound(t *testing.T) {
 	}
 	_ = merged
 }
+
+func TestShouldSkipCapture(t *testing.T) {
+	d := newTestDaemon()
+	run := &model.Run{IssueID: "test", RunID: "1"}
+
+	t.Run("no backoff state allows capture", func(t *testing.T) {
+		state := &RunState{}
+		if d.shouldSkipCapture(state, run) {
+			t.Error("expected capture to be allowed with no backoff state")
+		}
+	})
+
+	t.Run("future NextCaptureRetryAt skips capture", func(t *testing.T) {
+		state := &RunState{NextCaptureRetryAt: time.Now().Add(time.Minute)}
+		if !d.shouldSkipCapture(state, run) {
+			t.Error("expected capture to be skipped when in backoff period")
+		}
+	})
+
+	t.Run("past NextCaptureRetryAt allows capture", func(t *testing.T) {
+		state := &RunState{NextCaptureRetryAt: time.Now().Add(-time.Second)}
+		if d.shouldSkipCapture(state, run) {
+			t.Error("expected capture to be allowed after backoff expires")
+		}
+	})
+}
+
+func TestCalculateCaptureBackoff(t *testing.T) {
+	d := newTestDaemon()
+
+	t.Run("first failure uses initial backoff", func(t *testing.T) {
+		backoff := d.calculateCaptureBackoff(1, nil)
+		if backoff != captureInitialBackoff {
+			t.Errorf("expected %v, got %v", captureInitialBackoff, backoff)
+		}
+	})
+
+	t.Run("exponential backoff increases", func(t *testing.T) {
+		b1 := d.calculateCaptureBackoff(1, nil)
+		b2 := d.calculateCaptureBackoff(2, nil)
+		b3 := d.calculateCaptureBackoff(3, nil)
+
+		if b2 <= b1 {
+			t.Errorf("backoff should increase: b1=%v, b2=%v", b1, b2)
+		}
+		if b3 <= b2 {
+			t.Errorf("backoff should increase: b2=%v, b3=%v", b2, b3)
+		}
+	})
+
+	t.Run("backoff caps at max", func(t *testing.T) {
+		backoff := d.calculateCaptureBackoff(100, nil)
+		if backoff > captureMaxBackoff {
+			t.Errorf("backoff %v exceeds max %v", backoff, captureMaxBackoff)
+		}
+	})
+}
+
+func TestHandleCaptureError(t *testing.T) {
+	d := newTestDaemon()
+	run := &model.Run{IssueID: "test", RunID: "1"}
+
+	t.Run("first error sets backoff state", func(t *testing.T) {
+		state := &RunState{}
+		err := &mockError{msg: "connection refused"}
+
+		d.handleCaptureError(state, run, err)
+
+		if state.CaptureFailCount != 1 {
+			t.Errorf("expected CaptureFailCount=1, got %d", state.CaptureFailCount)
+		}
+		if state.NextCaptureRetryAt.IsZero() {
+			t.Error("expected NextCaptureRetryAt to be set")
+		}
+		if state.LastCaptureError == "" {
+			t.Error("expected LastCaptureError to be set")
+		}
+	})
+
+	t.Run("consecutive errors increase fail count", func(t *testing.T) {
+		state := &RunState{CaptureFailCount: 2}
+		err := &mockError{msg: "connection refused"}
+
+		d.handleCaptureError(state, run, err)
+
+		if state.CaptureFailCount != 3 {
+			t.Errorf("expected CaptureFailCount=3, got %d", state.CaptureFailCount)
+		}
+	})
+}
+
+func TestResetCaptureBackoff(t *testing.T) {
+	d := newTestDaemon()
+
+	state := &RunState{
+		CaptureFailCount:   5,
+		NextCaptureRetryAt: time.Now().Add(time.Minute),
+		LastCaptureError:   "some error",
+	}
+
+	d.resetCaptureBackoff(state)
+
+	if state.CaptureFailCount != 0 {
+		t.Errorf("expected CaptureFailCount=0, got %d", state.CaptureFailCount)
+	}
+	if !state.NextCaptureRetryAt.IsZero() {
+		t.Error("expected NextCaptureRetryAt to be reset")
+	}
+	if state.LastCaptureError != "" {
+		t.Error("expected LastCaptureError to be cleared")
+	}
+}
+
+func TestIsConnectionRefused(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		expect bool
+	}{
+		{"nil error", nil, false},
+		{"generic error", &mockError{msg: "some error"}, false},
+		{"connection refused message", &mockError{msg: "connection refused"}, true},
+		{"connect prefix refused", &mockError{msg: "connect: connection refused"}, true},
+		{"other network error", &mockError{msg: "timeout"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isConnectionRefused(tt.err)
+			if got != tt.expect {
+				t.Errorf("isConnectionRefused(%v) = %v, want %v", tt.err, got, tt.expect)
+			}
+		})
+	}
+}
+
+type mockError struct {
+	msg string
+}
+
+func (e *mockError) Error() string {
+	return e.msg
+}


### PR DESCRIPTION
## Summary

- Implement per-run exponential backoff (10s → 60s cap) for message capture failures against dead OpenCode server endpoints
- Apply stricter backoff (2x multiplier) for ECONNREFUSED errors specifically 
- Rate-limit and deduplicate log messages to avoid spam

## Motivation

Connection refused errors from stale OpenCode server ports created high-volume log noise and unnecessary retry load when daemon monitoring attempted message capture against older runs whose servers had stopped.

## Changes

### `internal/daemon/daemon.go`
- Extended `RunState` struct with capture backoff state fields:
  - `CaptureFailCount` - tracks consecutive failures
  - `LastCaptureFailAt` - when last failure occurred
  - `NextCaptureRetryAt` - backoff deadline
  - `LastCaptureError` - for log deduplication

### `internal/daemon/monitor.go`
- Added backoff constants: initial=10s, max=60s, factor=2x
- `shouldSkipCapture()` - skips capture during backoff period
- `handleCaptureError()` - sets backoff and logs first/new errors only
- `resetCaptureBackoff()` - clears state on successful capture
- `calculateCaptureBackoff()` - exponential backoff with ECONNREFUSED boost
- `isConnectionRefused()` - detects connection refused via net.OpError or string

### `internal/daemon/monitor_test.go`
- Tests for `shouldSkipCapture`, `calculateCaptureBackoff`, `handleCaptureError`, `resetCaptureBackoff`, `isConnectionRefused`

## Acceptance Criteria Evidence

| Criterion | Evidence |
|-----------|----------|
| Connection-refused spam reduced to bounded, periodic logs | First error logged, then debug-level only for repeats. Backoff caps at 60s. |
| Capture loop avoids tight retries | `shouldSkipCapture()` enforces `NextCaptureRetryAt` deadline. |
| Normal live OpenCode capture still works | `resetCaptureBackoff()` clears state on success; no changes to successful path. |
| Tests cover retry/backoff behavior | 5 new test functions with subtests covering all backoff scenarios. |

```
=== RUN   TestShouldSkipCapture
=== RUN   TestShouldSkipCapture/no_backoff_state_allows_capture
=== RUN   TestShouldSkipCapture/future_NextCaptureRetryAt_skips_capture
=== RUN   TestShouldSkipCapture/past_NextCaptureRetryAt_allows_capture
--- PASS: TestShouldSkipCapture (0.00s)
=== RUN   TestCalculateCaptureBackoff
=== RUN   TestCalculateCaptureBackoff/first_failure_uses_initial_backoff
=== RUN   TestCalculateCaptureBackoff/exponential_backoff_increases
=== RUN   TestCalculateCaptureBackoff/backoff_caps_at_max
--- PASS: TestCalculateCaptureBackoff (0.00s)
=== RUN   TestHandleCaptureError
=== RUN   TestHandleCaptureError/first_error_sets_backoff_state
=== RUN   TestHandleCaptureError/consecutive_errors_increase_fail_count
--- PASS: TestHandleCaptureError (0.00s)
=== RUN   TestResetCaptureBackoff
--- PASS: TestResetCaptureBackoff (0.00s)
=== RUN   TestIsConnectionRefused
--- PASS: TestIsConnectionRefused (0.00s)
```

Fixes: orch-427