### PR TITLE
feat(daemon): add abrupt-exit diagnostics and stale-socket startup recovery

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -94,14 +94,6 @@ func (d *Daemon) debug(format string, v ...interface{}) {
 
 // Run starts the daemon main loop (blocking)
 func (d *Daemon) Run() error {
-	// Acquire global lock (XDG-compliant)
-	lockFile, err := AcquireLock("")
-	if err != nil {
-		return err
-	}
-	d.lockFile = lockFile
-
-	// Ensure state directory exists and open log file
 	if err := xdg.EnsureStateDir(); err != nil {
 		return fmt.Errorf("failed to create state directory: %w", err)
 	}
@@ -113,6 +105,21 @@ func (d *Daemon) Run() error {
 	}
 	defer logFile.Close()
 	d.logger = log.New(logFile, "", log.LstdFlags)
+
+	recoveryResult, err := CheckAndRecoverStaleArtifacts(d.logger)
+	if err != nil {
+		return err
+	}
+	if recoveryResult != nil && (recoveryResult.HadStalePID || recoveryResult.HadStaleSocket || recoveryResult.WasAbruptExit) {
+		d.logger.Printf("LIFECYCLE: startup recovery completed - stalePID=%v, staleSocket=%v, abruptExit=%v",
+			recoveryResult.HadStalePID, recoveryResult.HadStaleSocket, recoveryResult.WasAbruptExit)
+	}
+
+	lockFile, err := AcquireLock("")
+	if err != nil {
+		return err
+	}
+	d.lockFile = lockFile
 
 	if err := d.initBinaryTracking(); err != nil {
 		d.logger.Printf("warning: failed to init binary tracking: %v", err)
@@ -154,7 +161,7 @@ func (d *Daemon) Run() error {
 		d.logger.Printf("warning: failed to register daemon: %v", err)
 	}
 
-	d.logger.Printf("global daemon started (pid=%d, binary=%s)", os.Getpid(), d.executablePath)
+	d.logger.Printf("LIFECYCLE: global daemon started (pid=%d, binary=%s)", os.Getpid(), d.executablePath)
 
 	d.socketServer = NewSocketServer(d.storeFactory, d.logger)
 	d.socketServer.SetGitHubBackend(d.githubBackend)
@@ -182,18 +189,28 @@ func (d *Daemon) Run() error {
 			d.checkBinaryStaleness()
 		case sig := <-sigCh:
 			if sig == syscall.SIGHUP {
-				d.logger.Printf("received SIGHUP, restarting with new binary")
+				d.logger.Printf("LIFECYCLE: received SIGHUP, restarting with new binary")
+				if err := UpdateShutdownReason(ShutdownReasonRestart); err != nil {
+					d.logger.Printf("warning: failed to record shutdown reason: %v", err)
+				}
 				if err := d.restartWithNewBinary(); err != nil {
 					d.logger.Printf("restart failed: %v", err)
 					continue
 				}
 				return nil
 			}
-			d.logger.Printf("received signal %v, shutting down", sig)
+			d.logger.Printf("LIFECYCLE: received signal %v, initiating graceful shutdown", sig)
+			if err := UpdateShutdownReason(ShutdownReasonGraceful); err != nil {
+				d.logger.Printf("warning: failed to record shutdown reason: %v", err)
+			}
 			d.Stop()
+			d.logger.Printf("LIFECYCLE: graceful shutdown completed")
 			return nil
 		case <-d.stopCh:
-			d.logger.Printf("daemon stopped")
+			d.logger.Printf("LIFECYCLE: daemon stopped via API/command")
+			if err := UpdateShutdownReason(ShutdownReasonStopped); err != nil {
+				d.logger.Printf("warning: failed to record shutdown reason: %v", err)
+			}
 			return nil
 		}
 	}
@@ -230,11 +247,13 @@ func (d *Daemon) initBinaryTracking() error {
 
 func (d *Daemon) writeMetadata() error {
 	meta := DaemonMetadata{
-		PID:       os.Getpid(),
-		StartedAt: time.Now(),
-		ExecPath:  d.executablePath,
-		ExecMtime: d.startupMtime,
-		Version:   2, // XDG global daemon version
+		PID:            os.Getpid(),
+		StartedAt:      time.Now(),
+		ExecPath:       d.executablePath,
+		ExecMtime:      d.startupMtime,
+		Version:        2,
+		ShutdownReason: ShutdownReasonUnknown,
+		ShutdownAt:     time.Time{},
 	}
 	data, err := json.Marshal(meta)
 	if err != nil {

--- a/internal/daemon/pid.go
+++ b/internal/daemon/pid.go
@@ -21,13 +21,23 @@ const (
 	lockFile     = "daemon.lock"
 )
 
+// Shutdown reason constants for distinguishing exit types
+const (
+	ShutdownReasonUnknown  = ""         // Not yet shutdown or unknown
+	ShutdownReasonGraceful = "graceful" // Normal signal-based shutdown (SIGINT/SIGTERM)
+	ShutdownReasonRestart  = "restart"  // SIGHUP triggered restart
+	ShutdownReasonStopped  = "stopped"  // Explicit stop via API/command
+)
+
 type DaemonMetadata struct {
-	PID         int       `json:"pid"`
-	StartedAt   time.Time `json:"started_at"`
-	ExecPath    string    `json:"exec_path"`
-	ExecMtime   time.Time `json:"exec_mtime"`
-	ProjectRoot string    `json:"project_root,omitempty"` // Deprecated: for legacy compat
-	Version     int       `json:"version,omitempty"`      // Schema version (2 = XDG global daemon)
+	PID            int       `json:"pid"`
+	StartedAt      time.Time `json:"started_at"`
+	ExecPath       string    `json:"exec_path"`
+	ExecMtime      time.Time `json:"exec_mtime"`
+	ProjectRoot    string    `json:"project_root,omitempty"`    // Deprecated: for legacy compat
+	Version        int       `json:"version,omitempty"`         // Schema version (2 = XDG global daemon)
+	ShutdownReason string    `json:"shutdown_reason,omitempty"` // Reason for last shutdown (empty if still running or abrupt exit)
+	ShutdownAt     time.Time `json:"shutdown_at,omitempty"`     // Time of last shutdown (zero if still running or abrupt exit)
 }
 
 // DaemonInfo contains information about a running daemon for listing
@@ -96,6 +106,140 @@ func ReadMetadata(_ string) (*DaemonMetadata, error) {
 		return nil, err
 	}
 	return &meta, nil
+}
+
+func WriteMetadata(meta *DaemonMetadata) error {
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(xdg.MetadataPath(), data, 0644)
+}
+
+func UpdateShutdownReason(reason string) error {
+	meta, err := ReadMetadata("")
+	if err != nil {
+		return err
+	}
+	meta.ShutdownReason = reason
+	meta.ShutdownAt = time.Now()
+	return WriteMetadata(meta)
+}
+
+type StartupRecoveryResult struct {
+	HadStalePID       bool
+	HadStaleSocket    bool
+	HadStaleMetadata  bool
+	PreviousPID       int
+	PreviousShutdown  string
+	PreviousStartedAt time.Time
+	WasAbruptExit     bool
+}
+
+func CheckAndRecoverStaleArtifacts(logger interface{ Printf(string, ...interface{}) }) (*StartupRecoveryResult, error) {
+	result := &StartupRecoveryResult{}
+
+	meta, metaErr := ReadMetadata("")
+	if metaErr == nil {
+		result.PreviousPID = meta.PID
+		result.PreviousShutdown = meta.ShutdownReason
+		result.PreviousStartedAt = meta.StartedAt
+
+		if meta.PID > 0 && !IsProcessRunning(meta.PID) {
+			result.HadStaleMetadata = true
+			if meta.ShutdownReason == "" || meta.ShutdownAt.IsZero() {
+				result.WasAbruptExit = true
+			}
+		}
+	}
+
+	pid, pidErr := ReadPID("")
+	if pidErr == nil && pid > 0 {
+		if IsProcessRunning(pid) {
+			return nil, fmt.Errorf("daemon already running (pid=%d)", pid)
+		}
+		result.HadStalePID = true
+		result.PreviousPID = pid
+
+		if logger != nil {
+			logger.Printf("STARTUP RECOVERY: found stale PID file (pid=%d, process not running) - removing", pid)
+		}
+		if err := RemovePID(""); err != nil {
+			if logger != nil {
+				logger.Printf("STARTUP RECOVERY: failed to remove stale PID file: %v", err)
+			}
+		}
+	}
+
+	socketPath := xdg.SocketPath()
+	if _, err := os.Stat(socketPath); err == nil {
+		conn, dialErr := dialSocket(socketPath)
+		if dialErr != nil {
+			result.HadStaleSocket = true
+			if logger != nil {
+				logger.Printf("STARTUP RECOVERY: found stale socket file (no daemon responding) - removing")
+			}
+			if err := os.Remove(socketPath); err != nil {
+				if logger != nil {
+					logger.Printf("STARTUP RECOVERY: failed to remove stale socket: %v", err)
+				}
+			}
+		} else {
+			conn.Close()
+			return nil, fmt.Errorf("daemon already running (socket responsive)")
+		}
+	}
+
+	lockPath := xdg.LockPath()
+	if _, err := os.Stat(lockPath); err == nil {
+		f, lockErr := os.OpenFile(lockPath, os.O_RDWR, 0600)
+		if lockErr == nil {
+			err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+			if err == nil {
+				syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+				if logger != nil {
+					logger.Printf("STARTUP RECOVERY: found stale lock file (lock available) - will be reused")
+				}
+			}
+			f.Close()
+		}
+	}
+
+	if logger != nil && (result.HadStalePID || result.HadStaleSocket || result.WasAbruptExit) {
+		if result.WasAbruptExit {
+			logger.Printf("STARTUP RECOVERY: previous daemon (pid=%d, started=%s) exited ABRUPTLY without graceful shutdown",
+				result.PreviousPID, result.PreviousStartedAt.Format(time.RFC3339))
+		} else if result.PreviousShutdown != "" {
+			logger.Printf("STARTUP RECOVERY: previous daemon shutdown was: %s at %s",
+				result.PreviousShutdown, meta.ShutdownAt.Format(time.RFC3339))
+		}
+	}
+
+	return result, nil
+}
+
+func dialSocket(socketPath string) (interface{ Close() error }, error) {
+	conn, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	addr := &syscall.SockaddrUnix{Name: socketPath}
+	err = syscall.Connect(conn, addr)
+	if err != nil {
+		syscall.Close(conn)
+		return nil, err
+	}
+
+	return &socketConn{fd: conn}, nil
+}
+
+type socketConn struct {
+	fd int
+}
+
+func (s *socketConn) Close() error {
+	return syscall.Close(s.fd)
 }
 
 // EnsureOrchDir is kept for backward compatibility but now ensures XDG dirs.

--- a/internal/daemon/pid_test.go
+++ b/internal/daemon/pid_test.go
@@ -1,8 +1,13 @@
 package daemon
 
 import (
+	"bytes"
+	"encoding/json"
+	"log"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/s22625/orch/internal/xdg"
 )
@@ -42,7 +47,6 @@ func TestPIDFileOperations(t *testing.T) {
 }
 
 func TestReadPIDInvalid(t *testing.T) {
-	// Use a temp XDG runtime dir for testing
 	tmpDir := t.TempDir()
 	oldXDG := os.Getenv("XDG_RUNTIME_DIR")
 	os.Setenv("XDG_RUNTIME_DIR", tmpDir)
@@ -58,5 +62,305 @@ func TestReadPIDInvalid(t *testing.T) {
 
 	if _, err := ReadPID(""); err == nil {
 		t.Fatal("expected error for invalid pid")
+	}
+}
+
+func TestShutdownReasonTracking(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldRuntime := os.Getenv("XDG_RUNTIME_DIR")
+	oldState := os.Getenv("XDG_STATE_HOME")
+	os.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	os.Setenv("XDG_STATE_HOME", tmpDir)
+	defer func() {
+		os.Setenv("XDG_RUNTIME_DIR", oldRuntime)
+		os.Setenv("XDG_STATE_HOME", oldState)
+	}()
+
+	if err := xdg.EnsureRuntimeDir(); err != nil {
+		t.Fatalf("EnsureRuntimeDir error: %v", err)
+	}
+	if err := xdg.EnsureStateDir(); err != nil {
+		t.Fatalf("EnsureStateDir error: %v", err)
+	}
+
+	meta := &DaemonMetadata{
+		PID:       os.Getpid(),
+		StartedAt: time.Now(),
+		ExecPath:  "/usr/bin/orch",
+		Version:   2,
+	}
+	if err := WriteMetadata(meta); err != nil {
+		t.Fatalf("WriteMetadata error: %v", err)
+	}
+
+	if err := UpdateShutdownReason(ShutdownReasonGraceful); err != nil {
+		t.Fatalf("UpdateShutdownReason error: %v", err)
+	}
+
+	readMeta, err := ReadMetadata("")
+	if err != nil {
+		t.Fatalf("ReadMetadata error: %v", err)
+	}
+
+	if readMeta.ShutdownReason != ShutdownReasonGraceful {
+		t.Errorf("ShutdownReason = %q, want %q", readMeta.ShutdownReason, ShutdownReasonGraceful)
+	}
+	if readMeta.ShutdownAt.IsZero() {
+		t.Error("ShutdownAt should not be zero")
+	}
+}
+
+func TestCheckAndRecoverStaleArtifacts_NoArtifacts(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldRuntime := os.Getenv("XDG_RUNTIME_DIR")
+	oldState := os.Getenv("XDG_STATE_HOME")
+	os.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	os.Setenv("XDG_STATE_HOME", tmpDir)
+	defer func() {
+		os.Setenv("XDG_RUNTIME_DIR", oldRuntime)
+		os.Setenv("XDG_STATE_HOME", oldState)
+	}()
+
+	if err := xdg.EnsureRuntimeDir(); err != nil {
+		t.Fatalf("EnsureRuntimeDir error: %v", err)
+	}
+
+	result, err := CheckAndRecoverStaleArtifacts(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.HadStalePID || result.HadStaleSocket || result.WasAbruptExit {
+		t.Errorf("expected no stale artifacts, got: stalePID=%v, staleSocket=%v, abruptExit=%v",
+			result.HadStalePID, result.HadStaleSocket, result.WasAbruptExit)
+	}
+}
+
+func TestCheckAndRecoverStaleArtifacts_StalePID(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldRuntime := os.Getenv("XDG_RUNTIME_DIR")
+	oldState := os.Getenv("XDG_STATE_HOME")
+	os.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	os.Setenv("XDG_STATE_HOME", tmpDir)
+	defer func() {
+		os.Setenv("XDG_RUNTIME_DIR", oldRuntime)
+		os.Setenv("XDG_STATE_HOME", oldState)
+	}()
+
+	if err := xdg.EnsureRuntimeDir(); err != nil {
+		t.Fatalf("EnsureRuntimeDir error: %v", err)
+	}
+
+	pidPath := xdg.PIDPath()
+	if err := os.WriteFile(pidPath, []byte("99999999"), 0644); err != nil {
+		t.Fatalf("write pid: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	logger := log.New(&logBuf, "", 0)
+
+	result, err := CheckAndRecoverStaleArtifacts(logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.HadStalePID {
+		t.Error("expected HadStalePID=true")
+	}
+	if result.PreviousPID != 99999999 {
+		t.Errorf("PreviousPID = %d, want 99999999", result.PreviousPID)
+	}
+
+	logOutput := logBuf.String()
+	if !bytes.Contains([]byte(logOutput), []byte("STARTUP RECOVERY")) {
+		t.Errorf("expected STARTUP RECOVERY in log output, got: %s", logOutput)
+	}
+	if !bytes.Contains([]byte(logOutput), []byte("stale PID file")) {
+		t.Errorf("expected 'stale PID file' in log output, got: %s", logOutput)
+	}
+
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Error("expected stale PID file to be removed")
+	}
+}
+
+func TestCheckAndRecoverStaleArtifacts_StaleSocket(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldRuntime := os.Getenv("XDG_RUNTIME_DIR")
+	oldState := os.Getenv("XDG_STATE_HOME")
+	os.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	os.Setenv("XDG_STATE_HOME", tmpDir)
+	defer func() {
+		os.Setenv("XDG_RUNTIME_DIR", oldRuntime)
+		os.Setenv("XDG_STATE_HOME", oldState)
+	}()
+
+	if err := xdg.EnsureRuntimeDir(); err != nil {
+		t.Fatalf("EnsureRuntimeDir error: %v", err)
+	}
+
+	socketPath := xdg.SocketPath()
+	if err := os.WriteFile(socketPath, []byte(""), 0600); err != nil {
+		t.Fatalf("write socket: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	logger := log.New(&logBuf, "", 0)
+
+	result, err := CheckAndRecoverStaleArtifacts(logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.HadStaleSocket {
+		t.Error("expected HadStaleSocket=true")
+	}
+
+	logOutput := logBuf.String()
+	if !bytes.Contains([]byte(logOutput), []byte("stale socket file")) {
+		t.Errorf("expected 'stale socket file' in log output, got: %s", logOutput)
+	}
+
+	if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+		t.Error("expected stale socket file to be removed")
+	}
+}
+
+func TestCheckAndRecoverStaleArtifacts_AbruptExit(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldRuntime := os.Getenv("XDG_RUNTIME_DIR")
+	oldState := os.Getenv("XDG_STATE_HOME")
+	os.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	os.Setenv("XDG_STATE_HOME", tmpDir)
+	defer func() {
+		os.Setenv("XDG_RUNTIME_DIR", oldRuntime)
+		os.Setenv("XDG_STATE_HOME", oldState)
+	}()
+
+	if err := xdg.EnsureRuntimeDir(); err != nil {
+		t.Fatalf("EnsureRuntimeDir error: %v", err)
+	}
+	if err := xdg.EnsureStateDir(); err != nil {
+		t.Fatalf("EnsureStateDir error: %v", err)
+	}
+
+	meta := &DaemonMetadata{
+		PID:            99999999,
+		StartedAt:      time.Now().Add(-1 * time.Hour),
+		ExecPath:       "/usr/bin/orch",
+		Version:        2,
+		ShutdownReason: "",
+		ShutdownAt:     time.Time{},
+	}
+	metaData, _ := json.Marshal(meta)
+	if err := os.WriteFile(xdg.MetadataPath(), metaData, 0644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	logger := log.New(&logBuf, "", 0)
+
+	result, err := CheckAndRecoverStaleArtifacts(logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.WasAbruptExit {
+		t.Error("expected WasAbruptExit=true")
+	}
+	if !result.HadStaleMetadata {
+		t.Error("expected HadStaleMetadata=true")
+	}
+
+	logOutput := logBuf.String()
+	if !bytes.Contains([]byte(logOutput), []byte("exited ABRUPTLY")) {
+		t.Errorf("expected 'exited ABRUPTLY' in log output, got: %s", logOutput)
+	}
+}
+
+func TestCheckAndRecoverStaleArtifacts_ActiveDaemon(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldRuntime := os.Getenv("XDG_RUNTIME_DIR")
+	oldState := os.Getenv("XDG_STATE_HOME")
+	os.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	os.Setenv("XDG_STATE_HOME", tmpDir)
+	defer func() {
+		os.Setenv("XDG_RUNTIME_DIR", oldRuntime)
+		os.Setenv("XDG_STATE_HOME", oldState)
+	}()
+
+	if err := xdg.EnsureRuntimeDir(); err != nil {
+		t.Fatalf("EnsureRuntimeDir error: %v", err)
+	}
+
+	pidPath := xdg.PIDPath()
+	currentPID := os.Getpid()
+	if err := os.WriteFile(pidPath, []byte(filepath.Join(string(rune('0'+currentPID/10000%10)), string(rune('0'+currentPID/1000%10)), string(rune('0'+currentPID/100%10)), string(rune('0'+currentPID/10%10)), string(rune('0'+currentPID%10)))), 0644); err != nil {
+		t.Fatalf("write pid: %v", err)
+	}
+	if err := os.WriteFile(pidPath, []byte(string(rune('0'+currentPID/10000%10))+string(rune('0'+currentPID/1000%10))+string(rune('0'+currentPID/100%10))+string(rune('0'+currentPID/10%10))+string(rune('0'+currentPID%10))), 0644); err != nil {
+		t.Fatalf("write pid: %v", err)
+	}
+
+	pidStr := make([]byte, 0, 10)
+	for n := currentPID; n > 0; n /= 10 {
+		pidStr = append([]byte{byte('0' + n%10)}, pidStr...)
+	}
+	if err := os.WriteFile(pidPath, pidStr, 0644); err != nil {
+		t.Fatalf("write pid: %v", err)
+	}
+
+	_, err := CheckAndRecoverStaleArtifacts(nil)
+	if err == nil {
+		t.Fatal("expected error when active daemon is running")
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("already running")) {
+		t.Errorf("expected 'already running' in error, got: %v", err)
+	}
+}
+
+func TestCheckAndRecoverStaleArtifacts_GracefulShutdownLogged(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldRuntime := os.Getenv("XDG_RUNTIME_DIR")
+	oldState := os.Getenv("XDG_STATE_HOME")
+	os.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	os.Setenv("XDG_STATE_HOME", tmpDir)
+	defer func() {
+		os.Setenv("XDG_RUNTIME_DIR", oldRuntime)
+		os.Setenv("XDG_STATE_HOME", oldState)
+	}()
+
+	if err := xdg.EnsureRuntimeDir(); err != nil {
+		t.Fatalf("EnsureRuntimeDir error: %v", err)
+	}
+	if err := xdg.EnsureStateDir(); err != nil {
+		t.Fatalf("EnsureStateDir error: %v", err)
+	}
+
+	meta := &DaemonMetadata{
+		PID:            99999999,
+		StartedAt:      time.Now().Add(-1 * time.Hour),
+		ExecPath:       "/usr/bin/orch",
+		Version:        2,
+		ShutdownReason: ShutdownReasonGraceful,
+		ShutdownAt:     time.Now().Add(-30 * time.Minute),
+	}
+	metaData, _ := json.Marshal(meta)
+	if err := os.WriteFile(xdg.MetadataPath(), metaData, 0644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	logger := log.New(&logBuf, "", 0)
+
+	result, err := CheckAndRecoverStaleArtifacts(logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.WasAbruptExit {
+		t.Error("expected WasAbruptExit=false for graceful shutdown")
+	}
+	if result.PreviousShutdown != ShutdownReasonGraceful {
+		t.Errorf("PreviousShutdown = %q, want %q", result.PreviousShutdown, ShutdownReasonGraceful)
 	}
 }


### PR DESCRIPTION
## Summary

- Add shutdown reason tracking to daemon metadata for incident triage
- Implement startup recovery for stale PID, socket, and lock files
- Detect and clearly log abrupt exits vs graceful shutdowns

## Changes

### Shutdown Reason Tracking
- Added `ShutdownReason` and `ShutdownAt` fields to `DaemonMetadata`
- Constants for shutdown reasons: `graceful`, `restart`, `stopped`
- Shutdown reason recorded before daemon exit (signal-based or API/command)
- Empty shutdown reason indicates abrupt exit (crash, OOM, etc.)

### Startup Recovery
- `CheckAndRecoverStaleArtifacts()` function detects and cleans up:
  - Stale PID file (process not running)
  - Stale socket file (no daemon responding)
  - Stale lock file (lock available)
- Safe recovery: returns error if active daemon detected (protects healthy daemons)
- Analyzes previous daemon's shutdown reason for incident triage

### Lifecycle Logging
All lifecycle events now use `LIFECYCLE:` prefix for easy grep:
```
LIFECYCLE: global daemon started (pid=12345, binary=/usr/bin/orch)
LIFECYCLE: received signal SIGTERM, initiating graceful shutdown
LIFECYCLE: graceful shutdown completed
STARTUP RECOVERY: found stale PID file (pid=12344, process not running) - removing
STARTUP RECOVERY: previous daemon (pid=12344, started=...) exited ABRUPTLY without graceful shutdown
```

## Acceptance Criteria Verification

- [x] **Startup logs clearly indicate when stale runtime state was detected and repaired**
  - `STARTUP RECOVERY:` prefixed log messages show exactly what was found and cleaned up
  
- [x] **Recovery does not kill/override a healthy active daemon**
  - `CheckAndRecoverStaleArtifacts` returns error if PID file refers to running process
  - Socket connectivity test before cleanup
  
- [x] **Incident triage can distinguish graceful stop from abrupt disappearance using logs**
  - Graceful: `LIFECYCLE: graceful shutdown completed`
  - Abrupt: `STARTUP RECOVERY: ... exited ABRUPTLY without graceful shutdown`
  
- [x] **Added test coverage for stale artifact recovery path**
  - 7 new tests covering all scenarios:
    - `TestShutdownReasonTracking`
    - `TestCheckAndRecoverStaleArtifacts_NoArtifacts`
    - `TestCheckAndRecoverStaleArtifacts_StalePID`
    - `TestCheckAndRecoverStaleArtifacts_StaleSocket`
    - `TestCheckAndRecoverStaleArtifacts_AbruptExit`
    - `TestCheckAndRecoverStaleArtifacts_ActiveDaemon`
    - `TestCheckAndRecoverStaleArtifacts_GracefulShutdownLogged`

## Test Results

```
=== RUN   TestShutdownReasonTracking
--- PASS: TestShutdownReasonTracking (0.00s)
=== RUN   TestCheckAndRecoverStaleArtifacts_NoArtifacts
--- PASS: TestCheckAndRecoverStaleArtifacts_NoArtifacts (0.00s)
=== RUN   TestCheckAndRecoverStaleArtifacts_StalePID
--- PASS: TestCheckAndRecoverStaleArtifacts_StalePID (0.00s)
=== RUN   TestCheckAndRecoverStaleArtifacts_StaleSocket
--- PASS: TestCheckAndRecoverStaleArtifacts_StaleSocket (0.00s)
=== RUN   TestCheckAndRecoverStaleArtifacts_AbruptExit
--- PASS: TestCheckAndRecoverStaleArtifacts_AbruptExit (0.00s)
=== RUN   TestCheckAndRecoverStaleArtifacts_ActiveDaemon
--- PASS: TestCheckAndRecoverStaleArtifacts_ActiveDaemon (0.00s)
=== RUN   TestCheckAndRecoverStaleArtifacts_GracefulShutdownLogged
--- PASS: TestCheckAndRecoverStaleArtifacts_GracefulShutdownLogged (0.00s)
PASS
```

Fixes: orch-428