### PR TITLE
fix(daemon): throttle opencode capture retries for dead endpoints

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -64,6 +64,13 @@ type RunState struct {
 	PRRecorded     bool
 	WasAlive       bool
 	DeadCheckCount int
+
+	CaptureEndpoint       string
+	CaptureFailureCount   int
+	CaptureRetryAt        time.Time
+	CaptureErrorKey       string
+	CaptureErrorLogAt     time.Time
+	SuppressedCaptureLogs int
 }
 
 func New(factory StoreFactory) *Daemon {

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +16,15 @@ import (
 )
 
 const deadChecksBeforeFailed = 3
+
+const (
+	captureErrorLogInterval        = 60 * time.Second
+	captureBackoffInitial          = 5 * time.Second
+	captureBackoffMax              = 60 * time.Second
+	captureRefusedBackoffInitial   = 10 * time.Second
+	captureRefusedBackoffMax       = 5 * time.Minute
+	captureRefusedNegativeCacheTTL = 30 * time.Second
+)
 
 func (d *Daemon) monitorRun(run *model.Run, st store.Store) error {
 	if run.Status == model.StatusCanceled {
@@ -93,11 +103,29 @@ func (d *Daemon) monitorRun(run *model.Run, st store.Store) error {
 		return d.updateStatus(run, model.StatusFailed, st)
 	}
 
-	output, err := mgr.CaptureOutput(run)
-	if err != nil {
-		d.logger.Printf("%s#%s: failed to capture output: %v", run.IssueID, run.RunID, err)
+	now := time.Now()
+	captureEndpoint := captureEndpointKey(run, mgr)
+	if state.shouldSkipCapture(captureEndpoint, now) {
 		return nil
 	}
+
+	output, err := mgr.CaptureOutput(run)
+	if err != nil {
+		retryAt, shouldLog, suppressed := state.recordCaptureFailure(captureEndpoint, err, now)
+		if shouldLog {
+			retryIn := retryAt.Sub(now).Round(time.Second)
+			if retryIn < time.Second {
+				retryIn = time.Second
+			}
+			if suppressed > 0 {
+				d.logger.Printf("%s#%s: failed to capture output from %s: %v (next retry in %s, suppressed %d similar errors)", run.IssueID, run.RunID, captureEndpoint, err, retryIn, suppressed)
+			} else {
+				d.logger.Printf("%s#%s: failed to capture output from %s: %v (next retry in %s)", run.IssueID, run.RunID, captureEndpoint, err, retryIn)
+			}
+		}
+		return nil
+	}
+	state.resetCaptureFailure()
 
 	contentHash := hashContent(output)
 	outputChanged := contentHash != state.OutputHash
@@ -142,6 +170,133 @@ func (d *Daemon) monitorRun(run *model.Run, st store.Store) error {
 	}
 
 	return nil
+}
+
+func captureEndpointKey(run *model.Run, mgr agent.AgentManager) string {
+	if run.Agent == string(agent.AgentOpenCode) {
+		if opencodeMgr, ok := mgr.(*agent.OpenCodeManager); ok && opencodeMgr.Port > 0 {
+			return "opencode:" + strconv.Itoa(opencodeMgr.Port)
+		}
+		if run.ServerPort > 0 {
+			return "opencode:" + strconv.Itoa(run.ServerPort)
+		}
+		return "opencode:unknown"
+	}
+
+	sessionName := run.SessionName
+	if sessionName == "" {
+		sessionName = model.GenerateSessionName(run.IssueID, run.RunID)
+	}
+	agentName := run.Agent
+	if agentName == "" {
+		agentName = "unknown"
+	}
+	return agentName + ":" + sessionName
+}
+
+func (s *RunState) shouldSkipCapture(endpoint string, now time.Time) bool {
+	if endpoint == "" {
+		return false
+	}
+
+	if s.CaptureEndpoint != endpoint {
+		s.resetCaptureFailure()
+		s.CaptureEndpoint = endpoint
+		return false
+	}
+
+	if s.CaptureRetryAt.IsZero() {
+		return false
+	}
+
+	return now.Before(s.CaptureRetryAt)
+}
+
+func (s *RunState) recordCaptureFailure(endpoint string, err error, now time.Time) (time.Time, bool, int) {
+	if endpoint == "" {
+		endpoint = "unknown"
+	}
+	if s.CaptureEndpoint != endpoint {
+		s.resetCaptureFailure()
+		s.CaptureEndpoint = endpoint
+	}
+
+	s.CaptureFailureCount++
+	backoff := captureBackoffDuration(err, s.CaptureFailureCount)
+	s.CaptureRetryAt = now.Add(backoff)
+
+	errorKey := captureErrorKey(endpoint, err)
+	if s.CaptureErrorKey == errorKey && !s.CaptureErrorLogAt.IsZero() && now.Sub(s.CaptureErrorLogAt) < captureErrorLogInterval {
+		s.SuppressedCaptureLogs++
+		return s.CaptureRetryAt, false, 0
+	}
+
+	suppressed := s.SuppressedCaptureLogs
+	s.SuppressedCaptureLogs = 0
+	s.CaptureErrorKey = errorKey
+	s.CaptureErrorLogAt = now
+	return s.CaptureRetryAt, true, suppressed
+}
+
+func (s *RunState) resetCaptureFailure() {
+	s.CaptureEndpoint = ""
+	s.CaptureFailureCount = 0
+	s.CaptureRetryAt = time.Time{}
+	s.CaptureErrorKey = ""
+	s.CaptureErrorLogAt = time.Time{}
+	s.SuppressedCaptureLogs = 0
+}
+
+func captureBackoffDuration(err error, failures int) time.Duration {
+	if failures < 1 {
+		failures = 1
+	}
+
+	if isConnectionRefusedError(err) {
+		backoff := exponentialBackoff(captureRefusedBackoffInitial, captureRefusedBackoffMax, failures)
+		if backoff < captureRefusedNegativeCacheTTL {
+			backoff = captureRefusedNegativeCacheTTL
+		}
+		return backoff
+	}
+
+	return exponentialBackoff(captureBackoffInitial, captureBackoffMax, failures)
+}
+
+func exponentialBackoff(initial, max time.Duration, failures int) time.Duration {
+	if failures <= 1 {
+		return initial
+	}
+
+	backoff := initial
+	for i := 1; i < failures; i++ {
+		if backoff >= max/2 {
+			return max
+		}
+		backoff *= 2
+	}
+	if backoff > max {
+		return max
+	}
+	return backoff
+}
+
+func captureErrorKey(endpoint string, err error) string {
+	if isConnectionRefusedError(err) {
+		return endpoint + "|connection-refused"
+	}
+	if err == nil {
+		return endpoint + "|none"
+	}
+	return endpoint + "|" + err.Error()
+}
+
+func isConnectionRefusedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "connection refused") || strings.Contains(msg, "econnrefused")
 }
 
 func (d *Daemon) updateStatus(run *model.Run, status model.Status, st store.Store) error {

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -1,8 +1,13 @@
 package daemon
 
 import (
+	"errors"
 	"io"
 	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -288,4 +293,150 @@ func TestCheckPRMergedWithURLReturnsURLWhenFound(t *testing.T) {
 		t.Error("expected non-empty URL when merged PR is found")
 	}
 	_ = merged
+}
+
+func TestCaptureFailureBackoffConnectionRefused(t *testing.T) {
+	state := &RunState{}
+	endpoint := "opencode:4097"
+	now := time.Now()
+
+	if state.shouldSkipCapture(endpoint, now) {
+		t.Fatal("expected first capture attempt not to be skipped")
+	}
+
+	err := errors.New("dial tcp 127.0.0.1:4097: connect: connection refused")
+	retryAt, shouldLog, suppressed := state.recordCaptureFailure(endpoint, err, now)
+
+	if !shouldLog {
+		t.Fatal("expected first failure to be logged")
+	}
+	if suppressed != 0 {
+		t.Fatalf("expected no suppressed logs on first failure, got %d", suppressed)
+	}
+	if got := retryAt.Sub(now); got < captureRefusedNegativeCacheTTL {
+		t.Fatalf("expected retry delay >= %s, got %s", captureRefusedNegativeCacheTTL, got)
+	}
+
+	if !state.shouldSkipCapture(endpoint, now.Add(5*time.Second)) {
+		t.Fatal("expected capture attempt to be throttled during backoff")
+	}
+	if state.shouldSkipCapture(endpoint, retryAt.Add(time.Millisecond)) {
+		t.Fatal("expected capture attempt to resume after backoff")
+	}
+}
+
+func TestCaptureFailureLogDeduplication(t *testing.T) {
+	state := &RunState{}
+	endpoint := "opencode:4098"
+	err := errors.New("dial tcp 127.0.0.1:4098: connect: connection refused")
+	now := time.Now()
+
+	_, shouldLog, _ := state.recordCaptureFailure(endpoint, err, now)
+	if !shouldLog {
+		t.Fatal("expected first failure to be logged")
+	}
+
+	_, shouldLog, _ = state.recordCaptureFailure(endpoint, err, now.Add(5*time.Second))
+	if shouldLog {
+		t.Fatal("expected duplicate failure log to be suppressed inside log interval")
+	}
+
+	_, shouldLog, suppressed := state.recordCaptureFailure(endpoint, err, now.Add(captureErrorLogInterval+time.Second))
+	if !shouldLog {
+		t.Fatal("expected failure log after interval")
+	}
+	if suppressed != 1 {
+		t.Fatalf("expected one suppressed log to be reported, got %d", suppressed)
+	}
+}
+
+func TestCaptureFailureEndpointChangeResetsBackoff(t *testing.T) {
+	state := &RunState{}
+	now := time.Now()
+
+	_, _, _ = state.recordCaptureFailure("opencode:4097", errors.New("dial tcp 127.0.0.1:4097: connect: connection refused"), now)
+
+	if !state.shouldSkipCapture("opencode:4097", now.Add(2*time.Second)) {
+		t.Fatal("expected original endpoint to remain throttled")
+	}
+	if state.shouldSkipCapture("opencode:4099", now.Add(2*time.Second)) {
+		t.Fatal("expected new endpoint to bypass old endpoint backoff")
+	}
+}
+
+func TestMonitorRunOpenCodeCaptureSuccessResetsFailureState(t *testing.T) {
+	worktreePath := "/tmp/orch-opencode-live"
+	sessionID := "ses_live"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/global/health":
+			_, _ = io.WriteString(w, `{"healthy":true,"version":"test"}`)
+		case "/project/current":
+			_, _ = io.WriteString(w, `{"id":"proj_test","worktree":"`+worktreePath+`"}`)
+		case "/session/" + sessionID + "/message":
+			_, _ = io.WriteString(w, `[{"info":{"id":"msg_1","sessionID":"`+sessionID+`","role":"assistant","createdAt":"2026-02-09T00:00:00Z"},"parts":[{"type":"text","text":"capture alive"}]}]`)
+		case "/session/status":
+			_, _ = io.WriteString(w, `{"`+sessionID+`":"busy"}`)
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	port := testPortFromURL(t, server.URL)
+
+	d := newTestDaemon()
+	run := &model.Run{
+		IssueID:           "orch-427",
+		RunID:             "run-live",
+		Agent:             "opencode",
+		Status:            model.StatusRunning,
+		WorktreePath:      worktreePath,
+		ServerPort:        port,
+		OpenCodeSessionID: sessionID,
+	}
+	state := d.getOrCreateState(run)
+	state.CaptureEndpoint = "opencode:" + strconv.Itoa(port)
+	state.CaptureFailureCount = 3
+	state.CaptureRetryAt = time.Now().Add(-time.Second)
+	state.CaptureErrorKey = "opencode:old|connection-refused"
+	state.CaptureErrorLogAt = time.Now().Add(-2 * time.Minute)
+	state.SuppressedCaptureLogs = 5
+
+	st := &mockStoreForUpdate{issue: &model.Issue{ID: "orch-427", Status: model.IssueStatusOpen}}
+	if err := d.monitorRun(run, st); err != nil {
+		t.Fatalf("monitorRun() error = %v", err)
+	}
+
+	if state.CaptureFailureCount != 0 {
+		t.Fatalf("expected capture failure count reset, got %d", state.CaptureFailureCount)
+	}
+	if !state.CaptureRetryAt.IsZero() {
+		t.Fatalf("expected capture retry time reset, got %s", state.CaptureRetryAt)
+	}
+	if state.CaptureEndpoint != "" {
+		t.Fatalf("expected capture endpoint reset, got %q", state.CaptureEndpoint)
+	}
+	if state.SuppressedCaptureLogs != 0 {
+		t.Fatalf("expected suppressed log counter reset, got %d", state.SuppressedCaptureLogs)
+	}
+	if state.LastOutput == "" {
+		t.Fatal("expected successful capture to update last output")
+	}
+}
+
+func testPortFromURL(t *testing.T, rawURL string) int {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+	return port
 }


### PR DESCRIPTION
## Summary
- add per-run/per-endpoint capture failure state in the daemon to track retry windows and deduplicated error logging
- throttle capture retries with exponential backoff and a connection-refused negative-cache TTL so dead ports are not retried every monitor cycle
- keep successful capture behavior intact by resetting failure state after a successful capture and add focused tests for backoff/dedup/live capture paths

## Acceptance Criteria Evidence
- Connection-refused spam is reduced to bounded, periodic logs.
  - `recordCaptureFailure` now deduplicates identical capture errors within a 60s log window and reports suppressed-count when logging resumes.
  - Verified by: `go test ./internal/daemon -run 'TestCaptureFailureLogDeduplication'`
- Capture loop avoids tight retries against known-dead endpoints.
  - `shouldSkipCapture` + endpoint-scoped `CaptureRetryAt` + `captureRefusedNegativeCacheTTL` (30s minimum) prevent per-cycle retries against refused endpoints.
  - Verified by: `go test ./internal/daemon -run 'TestCaptureFailureBackoffConnectionRefused|TestCaptureFailureEndpointChangeResetsBackoff'`
- Normal live OpenCode capture still works.
  - `TestMonitorRunOpenCodeCaptureSuccessResetsFailureState` exercises monitor flow against a live `httptest` OpenCode server and confirms capture success + failure-state reset.
  - Verified by: `go test ./internal/daemon -run 'TestMonitorRunOpenCodeCaptureSuccessResetsFailureState'`
- Tests cover retry/backoff behavior for dead endpoints.
  - Added tests in `internal/daemon/monitor_test.go`:
    - `TestCaptureFailureBackoffConnectionRefused`
    - `TestCaptureFailureLogDeduplication`
    - `TestCaptureFailureEndpointChangeResetsBackoff`
    - `TestMonitorRunOpenCodeCaptureSuccessResetsFailureState`
  - Verified by: `go test ./internal/daemon -run 'TestCaptureFailureBackoffConnectionRefused|TestCaptureFailureLogDeduplication|TestCaptureFailureEndpointChangeResetsBackoff|TestMonitorRunOpenCodeCaptureSuccessResetsFailureState'`
  - Output: `ok github.com/s22625/orch/internal/daemon 0.257s`

## Additional Verification
- `go test ./internal/daemon`
- `go test ./... && go build ./...`

Refs: orch-427