### PR TITLE
fix(monitor): actively probe daemon health in monitor client

### DIFF
--- a/orch-monitor-tui/orch_monitor/daemon_api.py
+++ b/orch-monitor-tui/orch_monitor/daemon_api.py
@@ -23,8 +23,12 @@ from .types import (
     IssueFilters as ProtoIssueFilters,
     ListIssuesResponse as ProtoListIssuesResponse,
     ListRunsResponse as ProtoListRunsResponse,
+    ProtoDaemonConnectionRefusedError,
     ProtoDaemonError,
     ProtoDaemonNotRunningError,
+    ProtoDaemonPermissionError,
+    ProtoDaemonSocketMissingError,
+    ProtoDaemonTimeoutError,
     RunFilters as ProtoRunFilters,
 )
 from .models import Issue as ModelIssue
@@ -54,25 +58,36 @@ from .orch_api import DaemonNotRunningError as ApiDaemonNotRunningError
 _logger = logging.getLogger("orch_monitor.daemon_api")
 
 
+def _map_proto_error(err: Exception) -> Failure:
+    """Map typed proto errors to API-level errors while preserving cause text."""
+    if isinstance(err, ProtoDaemonSocketMissingError):
+        return Failure(ApiDaemonNotRunningError(str(err)))
+    if isinstance(err, ProtoDaemonConnectionRefusedError):
+        return Failure(ApiDaemonNotRunningError(str(err)))
+    if isinstance(err, ProtoDaemonNotRunningError):
+        return Failure(ApiDaemonNotRunningError(str(err) or "Daemon not running"))
+    if isinstance(err, ProtoDaemonTimeoutError):
+        return Failure(OrchError(str(err)))
+    if isinstance(err, ProtoDaemonPermissionError):
+        return Failure(OrchError(str(err)))
+    if isinstance(err, ProtoDaemonError):
+        return Failure(OrchError(str(err)))
+    err_type = type(err).__name__
+    return Failure(OrchError(f"{err_type}: {err}"))
+
+
 def _log_and_map_error(operation: str, err: Exception) -> Failure:
     """Log error with full context and map to appropriate API error type."""
     import traceback
 
     err_type = type(err).__name__
     _logger.error(f"{operation}: {err_type}: {err}\n{traceback.format_exc()}")
-
-    if isinstance(err, ProtoDaemonNotRunningError):
-        return Failure(ApiDaemonNotRunningError("Daemon not running"))
-    if isinstance(err, ProtoDaemonError):
-        return Failure(OrchError(str(err)))
-    return Failure(OrchError(f"{err_type}: {err}"))
+    return _map_proto_error(err)
 
 
 def _map_daemon_error(err: ProtoDaemonError) -> Failure:
     """Map ProtoDaemonError to appropriate API error type (legacy, use _log_and_map_error)."""
-    if isinstance(err, ProtoDaemonNotRunningError):
-        return Failure(ApiDaemonNotRunningError("Daemon not running"))
-    return Failure(OrchError(str(err)))
+    return _map_proto_error(err)
 
 
 def _model_status_to_api(status: ModelStatus) -> RunStatus:

--- a/orch-monitor-tui/orch_monitor/issues_dashboard.hy
+++ b/orch-monitor-tui/orch_monitor/issues_dashboard.hy
@@ -223,7 +223,7 @@
       (setv self.title f"{self._base_title} | Disconnected")
       (setv log-path (_log-error "list_issues" error self.config.project_root
                        :socket-path self.config.socket_path))
-      (.notify self f"Daemon unavailable: {error}\nSee {log-path}"
+      (.notify self f"Daemon state: {error}\nAuto-retrying...\nSee {log-path}"
                :severity "warning" :timeout 5)
       (return))
     (setv self._daemon_error None)

--- a/orch-monitor-tui/orch_monitor/macros.hy
+++ b/orch-monitor-tui/orch_monitor/macros.hy
@@ -499,30 +499,43 @@
        (send-and-receive sock))
    
    Catches:
-     socket.timeout       -> ProtoDaemonError
-     ConnectionRefusedError -> ProtoDaemonNotRunningError
-     FileNotFoundError    -> ProtoDaemonNotRunningError
-     Exception            -> ProtoDaemonError
+     socket.timeout / TimeoutError -> ProtoDaemonTimeoutError
+     ConnectionRefusedError        -> ProtoDaemonConnectionRefusedError
+     FileNotFoundError             -> ProtoDaemonSocketMissingError
+     PermissionError               -> ProtoDaemonPermissionError
+     Exception                     -> ProtoDaemonError
    
    All errors are ALWAYS re-raised as typed exceptions (never swallowed).
   "
   `(do
      (import socket)
-     (import orch_monitor.types [ProtoDaemonError ProtoDaemonNotRunningError])
-     (import logging)
-     (try
-       ~@body
-       (except [e socket.timeout]
-         (raise (ProtoDaemonError "Timeout communicating with daemon")))
-       (except [e ConnectionRefusedError]
-         (raise (ProtoDaemonNotRunningError "Daemon is not running")))
-       (except [e FileNotFoundError]
-         (raise (ProtoDaemonNotRunningError
-                  f"Daemon socket not found at {~socket-path}")))
-       (except [e Exception]
-         (setv logger (logging.getLogger "orch_monitor.proto_client"))
-         (setv __err_type__ (. (type e) __name__))
-         (.error logger f"[socket_send] Unexpected: {__err_type__}: {e}")
+      (import orch_monitor.types [ProtoDaemonError
+                                  ProtoDaemonConnectionRefusedError
+                                  ProtoDaemonPermissionError
+                                  ProtoDaemonSocketMissingError
+                                  ProtoDaemonTimeoutError])
+      (import logging)
+      (try
+        ~@body
+        (except [e socket.timeout]
+          (raise (ProtoDaemonTimeoutError
+                   f"Daemon request timed out at {~socket-path}")))
+        (except [e TimeoutError]
+          (raise (ProtoDaemonTimeoutError
+                   f"Daemon request timed out at {~socket-path}")))
+        (except [e ConnectionRefusedError]
+          (raise (ProtoDaemonConnectionRefusedError
+                   f"Daemon connection refused at {~socket-path}")))
+        (except [e FileNotFoundError]
+          (raise (ProtoDaemonSocketMissingError
+                   f"Daemon socket not found at {~socket-path}")))
+        (except [e PermissionError]
+          (raise (ProtoDaemonPermissionError
+                   f"Permission denied accessing daemon socket at {~socket-path}")))
+        (except [e Exception]
+          (setv logger (logging.getLogger "orch_monitor.proto_client"))
+          (setv __err_type__ (. (type e) __name__))
+          (.error logger f"[socket_send] Unexpected: {__err_type__}: {e}")
          (raise (ProtoDaemonError f"Socket error: {e}"))))))
 
 (defn _contains-return? [form]

--- a/orch-monitor-tui/orch_monitor/orch_monitor_app.hy
+++ b/orch-monitor-tui/orch_monitor/orch_monitor_app.hy
@@ -350,7 +350,7 @@
       (setv self.title f"{self._base_title} | Disconnected")
       (setv log-path (_log-error "fetch_all" error self.config.project_root
                        :socket-path self.config.socket_path))
-      (.notify self f"Daemon unavailable: {error}\nSee {log-path}"
+      (.notify self f"Daemon state: {error}\nAuto-retrying...\nSee {log-path}"
                :severity "warning" :timeout 5)
       (return))
     (setv self._daemon_error None)

--- a/orch-monitor-tui/orch_monitor/proto_client.hy
+++ b/orch-monitor-tui/orch_monitor/proto_client.hy
@@ -6,6 +6,7 @@
 (import socket)
 (import struct)
 (import threading)
+(import errno)
 (import datetime [datetime])
 (import pathlib [Path])
 (import logging)
@@ -22,7 +23,11 @@
 ;; Exceptions - Import from Python module for consistency
 ;; ============================================================================
 
-(import orch_monitor.types [ProtoDaemonError ProtoDaemonNotRunningError])
+(import orch_monitor.types [ProtoDaemonError
+                            ProtoDaemonConnectionRefusedError
+                            ProtoDaemonPermissionError
+                            ProtoDaemonSocketMissingError
+                            ProtoDaemonTimeoutError])
 
 
 ;; ============================================================================
@@ -156,6 +161,112 @@
 
 
 ;; ============================================================================
+;; Daemon socket health helpers
+;; ============================================================================
+
+(defn _classify-socket-error [err socket-path [context "daemon communication"]]
+  (setv socket-str (str socket-path))
+  (setv err-no (getattr err "errno" None))
+  (cond
+    (isinstance err ProtoDaemonError)
+      err
+    (or (isinstance err FileNotFoundError)
+        (= err-no errno.ENOENT)
+        (= err-no (getattr errno "ENOTSOCK" None)))
+      (ProtoDaemonSocketMissingError
+        f"Daemon socket not found at {socket-str}")
+    (or (isinstance err ConnectionRefusedError)
+        (= err-no errno.ECONNREFUSED))
+      (ProtoDaemonConnectionRefusedError
+        f"Daemon connection refused at {socket-str}")
+    (or (isinstance err socket.timeout)
+        (isinstance err TimeoutError)
+        (= err-no errno.ETIMEDOUT))
+      (ProtoDaemonTimeoutError
+        f"Daemon request timed out at {socket-str}")
+    (or (isinstance err PermissionError)
+        (= err-no errno.EACCES)
+        (= err-no errno.EPERM))
+      (ProtoDaemonPermissionError
+        f"Permission denied accessing daemon socket at {socket-str}")
+    True
+      (ProtoDaemonError
+        f"{context} failed ({(. (type err) __name__)}): {err}")))
+
+(defn _assert-socket-file [socket-path]
+  "Validate socket path exists and is a unix socket."
+  (import stat)
+  (try
+    (when (not (.exists socket-path))
+      (raise (ProtoDaemonSocketMissingError
+               f"Daemon socket not found at {socket-path}")))
+    (setv mode (. (.stat socket-path) st_mode))
+    (when (not (stat.S_ISSOCK mode))
+      (raise (ProtoDaemonSocketMissingError
+               f"Daemon socket path is not a socket: {socket-path}")))
+    True
+    (except [e Exception]
+      (when (isinstance e ProtoDaemonError)
+        (raise))
+      (raise (_classify-socket-error e socket-path "daemon socket check")))))
+
+(defn _recv-exact [sock size]
+  "Read exactly size bytes or fewer if peer closes."
+  (setv data b"")
+  (while (< (len data) size)
+    (setv chunk (.recv sock (- size (len data))))
+    (when (not chunk)
+      (break))
+    (+= data chunk))
+  data)
+
+(defn _probe-daemon-health [socket-path timeout]
+  "Actively probe daemon with ping request."
+  (setv probe-timeout (if (> timeout 1.0) 1.0 timeout))
+  (when (<= probe-timeout 0)
+    (setv probe-timeout 1.0))
+  (setv sock None)
+  (try
+    (setv sock (socket.socket socket.AF_UNIX socket.SOCK_STREAM))
+    (.settimeout sock probe-timeout)
+    (.connect sock (str socket-path))
+
+    (setv req (pb.Request))
+    (.CopyFrom req.ping (pb.PingRequest))
+
+    (setv payload (.SerializeToString req))
+    (setv length (struct.pack ">I" (len payload)))
+    (.sendall sock (+ length payload))
+
+    (setv len-data (_recv-exact sock 4))
+    (when (< (len len-data) 4)
+      (raise (ProtoDaemonError "Incomplete ping response length")))
+
+    (setv resp-len (get (struct.unpack ">I" len-data) 0))
+    (setv resp-data (_recv-exact sock resp-len))
+    (when (< (len resp-data) resp-len)
+      (raise (ProtoDaemonError "Incomplete ping response payload")))
+
+    (setv response (pb.Response))
+    (.ParseFromString response resp-data)
+    (when (or (not response.ok)
+              (not (.HasField response "ping"))
+              (not response.ping.ok))
+      (raise (ProtoDaemonError
+               (or response.error "Daemon ping failed"))))
+    True
+    (except [e Exception]
+      (when (isinstance e ProtoDaemonError)
+        (raise))
+      (raise (_classify-socket-error e socket-path "daemon health probe")))
+    (finally
+      (when sock
+        (try
+          (.close sock)
+          (except [close-error Exception] None))))))
+
+
+;; ============================================================================
 ;; Proto Daemon Client
 ;; ============================================================================
 
@@ -176,12 +287,22 @@
   
   (defn _project-root-str [self]
     (if self.project-root (str self.project-root) ""))
+
+  (defn check-availability [self]
+    "Active daemon availability check. Returns Result[bool, ProtoDaemonError]."
+    (try
+      (_assert-socket-file self.socket-path)
+      (_probe-daemon-health self.socket-path self._timeout)
+      (Success True)
+      (except [e ProtoDaemonError]
+        (Failure e))
+      (except [e Exception]
+        (Failure (_classify-socket-error e self.socket-path
+                  "daemon availability check")))))
   
   (defn is-available [self]
-    (try-or False
-      (import stat)
-      (setv mode (. (.stat self.socket-path) st_mode))
-      (stat.S_ISSOCK mode)))
+    (setv result (.check-availability self))
+    (isinstance result Success))
   
   ;; =========================================================================
   ;; Connection Management (persistent connection to reduce socket churn)
@@ -244,9 +365,7 @@
   
   (defn _send [self request]
     "Send request using persistent connection. Raises typed ProtoDaemonError on failure."
-    (when (not (.is-available self))
-      (raise (ProtoDaemonNotRunningError 
-               f"Daemon socket not found at {self.socket-path}")))
+    (_assert-socket-file self.socket-path)
     
     (with [_ self._lock]
       (socket-send self.socket-path
@@ -292,8 +411,8 @@
                 (._connect self))
               (when (>= retry max-retries)
                 (.warning _conn_logger (+ "Failed after " (str max-retries) " retries: " (str e)))
-                (raise (ProtoDaemonError f"Connection failed: {e}"))))))
-        
+                (raise (_classify-socket-error e self.socket-path "daemon request"))))))
+         
         response)))
   
   (defn _check [self response [error-msg "Unknown error"]]

--- a/orch-monitor-tui/orch_monitor/runs_dashboard.hy
+++ b/orch-monitor-tui/orch_monitor/runs_dashboard.hy
@@ -314,7 +314,7 @@ DataTable {
       (setv self.title f"{self._base_title} | Disconnected")
       (setv log-path (_log-error "list_runs" error self.config.project_root
                        :socket-path self.config.socket_path))
-      (.notify self f"Daemon unavailable: {error}\nSee {log-path}"
+      (.notify self f"Daemon state: {error}\nAuto-retrying...\nSee {log-path}"
                :severity "warning" :timeout 5)
       (return))
     (setv self._daemon_error None)

--- a/orch-monitor-tui/orch_monitor/types.py
+++ b/orch-monitor-tui/orch_monitor/types.py
@@ -29,6 +29,30 @@ class ProtoDaemonNotRunningError(ProtoDaemonError):
     pass
 
 
+class ProtoDaemonSocketMissingError(ProtoDaemonNotRunningError):
+    """Raised when daemon socket path is missing or invalid."""
+
+    pass
+
+
+class ProtoDaemonConnectionRefusedError(ProtoDaemonNotRunningError):
+    """Raised when daemon socket exists but refuses connections."""
+
+    pass
+
+
+class ProtoDaemonTimeoutError(ProtoDaemonError):
+    """Raised when daemon communication times out."""
+
+    pass
+
+
+class ProtoDaemonPermissionError(ProtoDaemonError):
+    """Raised when daemon socket access is denied by OS permissions."""
+
+    pass
+
+
 # ============================================================================
 # Constants
 # ============================================================================

--- a/orch-monitor-tui/tests/test_daemon_api.py
+++ b/orch-monitor-tui/tests/test_daemon_api.py
@@ -1,0 +1,35 @@
+"""Tests for daemon API error mapping behavior."""
+
+from returns.result import Failure
+
+from orch_monitor.daemon_api import _map_daemon_error
+from orch_monitor.orch_api import DaemonNotRunningError, OrchError
+from orch_monitor.types import (
+    ProtoDaemonConnectionRefusedError,
+    ProtoDaemonTimeoutError,
+)
+
+
+class TestDaemonErrorMapping:
+    def test_connection_refused_error_is_preserved(self):
+        result = _map_daemon_error(
+            ProtoDaemonConnectionRefusedError(
+                "Daemon connection refused at /tmp/orch/daemon.sock"
+            )
+        )
+
+        assert isinstance(result, Failure)
+        err = result.failure()
+        assert isinstance(err, DaemonNotRunningError)
+        assert "connection refused" in str(err).lower()
+
+    def test_timeout_error_is_distinct_from_not_running(self):
+        result = _map_daemon_error(
+            ProtoDaemonTimeoutError("Daemon request timed out at /tmp/orch/daemon.sock")
+        )
+
+        assert isinstance(result, Failure)
+        err = result.failure()
+        assert isinstance(err, OrchError)
+        assert not isinstance(err, DaemonNotRunningError)
+        assert "timed out" in str(err).lower()

--- a/orch-monitor-tui/tests/test_monitor_heartbeat.py
+++ b/orch-monitor-tui/tests/test_monitor_heartbeat.py
@@ -1,0 +1,39 @@
+"""Tests for monitor heartbeat reconnect behavior."""
+
+from unittest.mock import MagicMock
+
+from returns.result import Failure, Success
+
+from orch_monitor.daemon_api import MonitorHeartbeat
+from orch_monitor.types import ProtoDaemonConnectionRefusedError
+
+
+class _FakeStopEvent:
+    def __init__(self, responses: list[bool]):
+        self._responses = iter(responses)
+
+    def wait(self, timeout: float = 0.0) -> bool:
+        return next(self._responses)
+
+
+class TestMonitorHeartbeatReconnect:
+    def test_reconnects_once_daemon_becomes_healthy(self):
+        client = MagicMock()
+        client.is_available.side_effect = [False, True]
+        client.monitor_heartbeat.return_value = Failure(
+            ProtoDaemonConnectionRefusedError(
+                "Daemon connection refused at /tmp/orch/daemon.sock"
+            )
+        )
+        client.register_monitor.return_value = Success("monitor-new")
+
+        heartbeat = MonitorHeartbeat(client, project="test-project", view="runs")
+        heartbeat._monitor_id = "monitor-old"
+        heartbeat._session_name = "orch-monitor-test"
+        heartbeat._stop_event = _FakeStopEvent([False, False, True])
+
+        heartbeat._heartbeat_loop()
+
+        client.monitor_heartbeat.assert_called_once_with("monitor-old")
+        client.register_monitor.assert_called_once()
+        assert heartbeat._monitor_id == "monitor-new"

--- a/orch-monitor-tui/tests/test_proto_client.py
+++ b/orch-monitor-tui/tests/test_proto_client.py
@@ -1,17 +1,30 @@
 """Tests for protobuf client conversion functions."""
 
+import socket
+import threading
+import tempfile
+import shutil
+from pathlib import Path
+
 import pytest
+from returns.result import Failure
 
 import hy  # noqa: F401 - Enable Hy imports
 
 from orch_monitor.api import orch_pb2 as pb
 from orch_monitor.proto_client import (
+    ProtoDaemonClient,
     proto_branch_state_to_str as _proto_branch_state_to_str,
     proto_multiplexer_to_str as _proto_multiplexer_to_str,
     proto_run_to_model as _proto_run_to_model,
     proto_status_to_model as _proto_status_to_model,
 )
 from orch_monitor.models import Status
+from orch_monitor.types import (
+    ProtoDaemonConnectionRefusedError,
+    ProtoDaemonSocketMissingError,
+    ProtoDaemonTimeoutError,
+)
 
 
 class TestProtoBranchStateToStr:
@@ -208,3 +221,84 @@ class TestProtoRunToModel:
         assert run.server_port == 4096
         assert run.opencode_session_id == "sess-abc123"
         assert run.continued_from == "run-000"
+
+
+class TestProtoDaemonAvailability:
+    def _short_socket_path(self) -> tuple[Path, Path]:
+        socket_dir = Path(tempfile.mkdtemp(prefix="orch-sock-", dir="/tmp"))
+        return socket_dir, socket_dir / "daemon.sock"
+
+    def test_missing_socket_reports_typed_error(self):
+        socket_dir, socket_path = self._short_socket_path()
+        client = ProtoDaemonClient(socket_path, None, None, 0.2)
+
+        try:
+            result = client.check_availability()
+
+            assert isinstance(result, Failure)
+            assert isinstance(result.failure(), ProtoDaemonSocketMissingError)
+            assert client.is_available() is False
+        finally:
+            shutil.rmtree(socket_dir, ignore_errors=True)
+
+    def test_stale_socket_reports_connection_refused(self):
+        socket_dir, socket_path = self._short_socket_path()
+        stale_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            stale_socket.bind(str(socket_path))
+            stale_socket.close()
+
+            client = ProtoDaemonClient(socket_path, None, None, 0.2)
+            result = client.check_availability()
+
+            assert isinstance(result, Failure)
+            assert isinstance(result.failure(), ProtoDaemonConnectionRefusedError)
+            assert client.is_available() is False
+        finally:
+            try:
+                stale_socket.close()
+            except OSError:
+                pass
+            if socket_path.exists():
+                socket_path.unlink(missing_ok=True)
+            shutil.rmtree(socket_dir, ignore_errors=True)
+
+    def test_health_probe_timeout_reports_typed_error(self):
+        socket_dir, socket_path = self._short_socket_path()
+        ready = threading.Event()
+        release = threading.Event()
+
+        def _hanging_server():
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                server.bind(str(socket_path))
+                server.listen(1)
+                ready.set()
+                conn, _ = server.accept()
+                try:
+                    conn.recv(4096)
+                    release.wait(timeout=1.0)
+                finally:
+                    conn.close()
+            finally:
+                server.close()
+
+        thread = threading.Thread(target=_hanging_server, daemon=True)
+        thread.start()
+        assert ready.wait(timeout=1.0)
+
+        try:
+            client = ProtoDaemonClient(socket_path, None, None, 0.05)
+            result = client.check_availability()
+            release.set()
+            thread.join(timeout=1.0)
+
+            assert isinstance(result, Failure)
+            assert isinstance(result.failure(), ProtoDaemonTimeoutError)
+            assert "timed out" in str(result.failure()).lower()
+        finally:
+            release.set()
+            thread.join(timeout=1.0)
+            if socket_path.exists():
+                socket_path.unlink(missing_ok=True)
+            shutil.rmtree(socket_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- Replace Python monitor availability checks with an active daemon ping probe (`check-availability`) instead of socket-file stat only.
- Preserve typed daemon failure causes end-to-end (missing socket, connection refused, timeout, permission) and avoid collapsing monitor errors to a single generic message.
- Update monitor disconnect notifications to show precise daemon state and explicit auto-retry behavior.
- Add regression coverage for stale socket handling, timeout/refused distinction, and automatic heartbeat reconnect.

## Verification
- `uv run pytest tests/test_proto_client.py tests/test_daemon_api.py tests/test_monitor_heartbeat.py`
- Result: `31 passed`

## Acceptance Criteria
- [x] Stale socket does not report as healthy (`test_stale_socket_reports_connection_refused`).
- [x] Connection refused and timeout are distinguishable in monitor errors (`test_health_probe_timeout_reports_typed_error`, `test_timeout_error_is_distinct_from_not_running`).
- [x] Monitor reconnect behavior remains automatic once daemon is healthy again (`test_reconnects_once_daemon_becomes_healthy`).
- [x] Added tests in `orch-monitor-tui/tests` covering stale socket + reconnect.

## Issue
- orch-426