### PR TITLE
orch-431: omit empty opencode assistant lines and summarize tool uses

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -275,14 +276,28 @@ func FormatOpenCodeMessages(messages []Message, maxLines int) string {
 			role = "UNKNOWN"
 		}
 
-		allLines = append(allLines, "--- ["+role+"] ---")
+		var textLines []string
+		toolUseCount := 0
 
 		for _, part := range msg.Parts {
+			if part.Type == "tool_use" {
+				toolUseCount++
+			}
 			if part.Type != "text" || part.Text == "" {
 				continue
 			}
 			partLines := strings.Split(part.Text, "\n")
-			allLines = append(allLines, partLines...)
+			textLines = append(textLines, partLines...)
+		}
+
+		if len(textLines) > 0 {
+			allLines = append(allLines, "--- ["+role+"] ---")
+			allLines = append(allLines, textLines...)
+			continue
+		}
+
+		if toolUseCount > 0 {
+			allLines = append(allLines, "--- ["+role+"] --- ("+strconv.Itoa(toolUseCount)+" tool uses)")
 		}
 	}
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -707,6 +707,70 @@ func TestFormatOpenCodeMessagesLineLimit(t *testing.T) {
 	}
 }
 
+func TestFormatOpenCodeMessagesSpecialCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		messages []Message
+		maxLines int
+		want     string
+	}{
+		{
+			name: "empty message omitted entirely",
+			messages: []Message{
+				{
+					Info:  MessageInfo{ID: "msg-empty", Role: "assistant"},
+					Parts: []MessagePart{},
+				},
+				{
+					Info:  MessageInfo{ID: "msg-user", Role: "user"},
+					Parts: []MessagePart{{Type: "text", Text: "Visible text"}},
+				},
+			},
+			maxLines: 100,
+			want:     "--- [USER] ---\nVisible text",
+		},
+		{
+			name: "tool-only assistant message shows tool use count",
+			messages: []Message{
+				{
+					Info: MessageInfo{ID: "msg-tools", Role: "assistant"},
+					Parts: []MessagePart{
+						{Type: "tool_use", ToolName: "read_file"},
+						{Type: "tool_result", Text: "result text"},
+						{Type: "thinking", Text: "internal"},
+						{Type: "tool_use", ToolName: "edit_file"},
+					},
+				},
+			},
+			maxLines: 100,
+			want:     "--- [ASSISTANT] --- (2 tool uses)",
+		},
+		{
+			name: "mixed message with text remains unchanged",
+			messages: []Message{
+				{
+					Info: MessageInfo{ID: "msg-mixed", Role: "assistant"},
+					Parts: []MessagePart{
+						{Type: "tool_use", ToolName: "read_file"},
+						{Type: "text", Text: "Final answer"},
+					},
+				},
+			},
+			maxLines: 100,
+			want:     "--- [ASSISTANT] ---\nFinal answer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatOpenCodeMessages(tt.messages, tt.maxLines)
+			if got != tt.want {
+				t.Fatalf("FormatOpenCodeMessages() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatOpenCodeMessagesPartOrdering(t *testing.T) {
 	messages := []Message{
 		{


### PR DESCRIPTION
## Summary
- update `FormatOpenCodeMessages()` to avoid emitting empty role headers
- when a message has no text but includes `tool_use` parts, emit `--- [ROLE] --- (N tool uses)`
- omit messages that have neither text content nor tool uses (including zero-part messages)
- add focused unit tests for empty-message omission, tool-only summary formatting, and mixed message behavior

## Behavior
Before:
```text
--- [ASSISTANT] ---
--- [ASSISTANT] ---
```

After:
```text
--- [ASSISTANT] --- (2 tool uses)
```

## Acceptance Criteria Evidence
- [x] Assistant messages with only `tool_use` parts show `--- [ASSISTANT] --- (N tool uses)`
  - Verified by `TestFormatOpenCodeMessagesSpecialCases/tool-only_assistant_message_shows_tool_use_count`
- [x] Messages with zero parts are omitted entirely
  - Verified by `TestFormatOpenCodeMessagesSpecialCases/empty_message_omitted_entirely`
- [x] Messages with text content continue to display normally
  - Verified by `TestFormatOpenCodeMessagesSpecialCases/mixed_message_with_text_remains_unchanged`
- [x] Tool use count reflects `tool_use` parts only (not `tool_result`/`thinking`)
  - Test case includes `tool_result` and `thinking` but output count remains `2 tool uses`
- [x] Existing tests in `internal/cli/capture_test.go` still pass
  - `go test ./internal/cli -run TestCapture -count=1` -> `ok`
- [x] New test cases cover empty message, tool-only message, mixed message
  - Added `TestFormatOpenCodeMessagesSpecialCases` in `internal/agent/manager_test.go`

## Validation Commands
```bash
go test ./internal/agent -run 'TestFormatOpenCodeMessages|TestFormatOpenCodeMessagesSpecialCases|TestFormatOpenCodeMessagesLineLimit|TestFormatOpenCodeMessagesPartOrdering|TestFormatOpenCodeMessagesMessageOrdering'
go test ./internal/agent -run TestFormatOpenCodeMessagesSpecialCases -v
go test ./internal/cli -run TestCapture -count=1
go test ./...
go build ./...
make lint
```

Issue: orch-431
