### PR TITLE
Capture: omit empty assistant lines or show (N tool uses) for opencode

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -270,19 +271,39 @@ func FormatOpenCodeMessages(messages []Message, maxLines int) string {
 	var allLines []string
 
 	for _, msg := range messages {
+		if len(msg.Parts) == 0 {
+			continue
+		}
+
 		role := strings.ToUpper(msg.Info.Role)
 		if role == "" {
 			role = "UNKNOWN"
 		}
 
-		allLines = append(allLines, "--- ["+role+"] ---")
+		header := "--- [" + role + "] ---"
+		var textLines []string
+		toolUseCount := 0
 
 		for _, part := range msg.Parts {
+			if part.Type == "tool_use" {
+				toolUseCount++
+			}
+
 			if part.Type != "text" || part.Text == "" {
 				continue
 			}
 			partLines := strings.Split(part.Text, "\n")
-			allLines = append(allLines, partLines...)
+			textLines = append(textLines, partLines...)
+		}
+
+		if len(textLines) > 0 {
+			allLines = append(allLines, header)
+			allLines = append(allLines, textLines...)
+			continue
+		}
+
+		if toolUseCount > 0 {
+			allLines = append(allLines, header+" ("+strconv.Itoa(toolUseCount)+" tool uses)")
 		}
 	}
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -623,13 +623,13 @@ func TestFormatOpenCodeMessages(t *testing.T) {
 		name     string
 		messages []Message
 		maxLines int
-		wantLen  int
+		want     string
 	}{
 		{
 			name:     "empty messages",
 			messages: []Message{},
 			maxLines: 10,
-			wantLen:  0,
+			want:     "",
 		},
 		{
 			name: "single message",
@@ -640,7 +640,7 @@ func TestFormatOpenCodeMessages(t *testing.T) {
 				},
 			},
 			maxLines: 10,
-			wantLen:  2,
+			want:     "--- [USER] ---\nHello world",
 		},
 		{
 			name: "multiple messages",
@@ -655,7 +655,7 @@ func TestFormatOpenCodeMessages(t *testing.T) {
 				},
 			},
 			maxLines: 10,
-			wantLen:  4,
+			want:     "--- [USER] ---\nHello\n--- [ASSISTANT] ---\nHi there!",
 		},
 		{
 			name: "non-text parts ignored",
@@ -669,23 +669,72 @@ func TestFormatOpenCodeMessages(t *testing.T) {
 				},
 			},
 			maxLines: 10,
-			wantLen:  2,
+			want:     "--- [ASSISTANT] ---\nOnly this text",
+		},
+		{
+			name: "message with zero parts omitted",
+			messages: []Message{
+				{
+					Info:  MessageInfo{ID: "msg1", Role: "assistant"},
+					Parts: []MessagePart{},
+				},
+			},
+			maxLines: 10,
+			want:     "",
+		},
+		{
+			name: "tool-only message shows tool use count",
+			messages: []Message{
+				{
+					Info: MessageInfo{ID: "msg1", Role: "assistant"},
+					Parts: []MessagePart{
+						{Type: "tool_use", ToolName: "bash"},
+						{Type: "tool_use", ToolName: "read"},
+						{Type: "tool_use", ToolName: "write"},
+					},
+				},
+			},
+			maxLines: 10,
+			want:     "--- [ASSISTANT] --- (3 tool uses)",
+		},
+		{
+			name: "tool summary counts tool_use only",
+			messages: []Message{
+				{
+					Info: MessageInfo{ID: "msg1", Role: "assistant"},
+					Parts: []MessagePart{
+						{Type: "tool_use", ToolName: "bash"},
+						{Type: "tool_result", Text: "ok"},
+						{Type: "thinking", Text: "thinking"},
+						{Type: "tool_use", ToolName: "read"},
+					},
+				},
+			},
+			maxLines: 10,
+			want:     "--- [ASSISTANT] --- (2 tool uses)",
+		},
+		{
+			name: "mixed text and tool parts keeps normal text display",
+			messages: []Message{
+				{
+					Info: MessageInfo{ID: "msg1", Role: "assistant"},
+					Parts: []MessagePart{
+						{Type: "tool_use", ToolName: "bash"},
+						{Type: "text", Text: "Done"},
+						{Type: "tool_result", Text: "ok"},
+					},
+				},
+			},
+			maxLines: 10,
+			want:     "--- [ASSISTANT] ---\nDone",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := FormatOpenCodeMessages(tt.messages, tt.maxLines)
-
-			if len(tt.messages) == 0 {
-				if result != "" {
-					t.Errorf("expected empty string for empty messages, got %q", result)
-				}
-				return
-			}
-
-			if result == "" && tt.wantLen > 0 {
-				t.Errorf("expected non-empty result")
+			if result != tt.want {
+				t.Errorf("FormatOpenCodeMessages() = %q, want %q", result, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Updated `FormatOpenCodeMessages()` to omit messages with zero parts, and to show `--- [ASSISTANT] --- (N tool uses)` when a message has no text but contains `tool_use` parts.
- Preserved existing behavior for text messages: headers plus text content render unchanged.
- Added explicit formatter tests for empty message omission, tool-only summary formatting, tool-use-only counting, and mixed text/tool messages.

## Acceptance Criteria Evidence (orch-431)

- [x] Assistant messages with only `tool_use` parts show `--- [ASSISTANT] --- (N tool uses)`
  - Verified by `go test ./internal/agent -run TestFormatOpenCodeMessages -count=1 -v`
  - Includes passing subtest: `tool-only_message_shows_tool_use_count`

- [x] Messages with zero parts are omitted entirely
  - Verified by same command above
  - Includes passing subtest: `message_with_zero_parts_omitted`

- [x] Messages with text content continue to display normally
  - Verified by same command above
  - Includes passing subtest: `mixed_text_and_tool_parts_keeps_normal_text_display`

- [x] Tool use count reflects `tool_use` parts only
  - Verified by same command above
  - Includes passing subtest: `tool_summary_counts_tool_use_only`

- [x] Existing tests in `internal/cli/capture_test.go` still pass
  - Verified by `go test ./internal/cli -run TestCapture -count=1 -v`

- [x] New test cases cover empty message, tool-only message, mixed message
  - Added in `internal/agent/manager_test.go` under `TestFormatOpenCodeMessages`.

## Validation
- `go test ./internal/agent -run TestFormatOpenCodeMessages -count=1 -v` ✅
- `go test ./internal/cli -run TestCapture -count=1 -v` ✅
- `go build ./...` ✅
- `make lint` ✅
- `go test ./... -count=1` ❌ (existing unrelated failure in `internal/cli`: `TestApplyConfigDefaultsFallbacks` reports `invalid config schema ... EOF`)

## Issue
- Closes orch-431
