### PR TITLE
Fix opencode send timeout despite ACKed delivery

### DIFF
--- a/internal/agent/opencode_client.go
+++ b/internal/agent/opencode_client.go
@@ -455,7 +455,10 @@ func (c *OpenCodeClient) sendMessagePromptOnce(ctx context.Context, sessionID, t
 	}
 	c.logDebug("  Prompt length: %d bytes", len(text))
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	reqCtx, cancelReq := context.WithCancel(ctx)
+	defer cancelReq()
+
+	req, err := http.NewRequestWithContext(reqCtx, "POST", url, bytes.NewReader(jsonBody))
 	if err != nil {
 		return fmt.Errorf("creating prompt request: %w", err)
 	}
@@ -464,18 +467,24 @@ func (c *OpenCodeClient) sendMessagePromptOnce(ctx context.Context, sessionID, t
 		req.Header.Set("X-OpenCode-Directory", directory)
 	}
 
+	sendStartedAt := time.Now()
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("sending prompt: %w", err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
 		return fmt.Errorf("send prompt returned status %d: %s", resp.StatusCode, string(body))
 	}
 
-	c.logDebug("Prompt sent: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	// We only need the ACK status code. Cancel and close immediately so this
+	// call does not wait on response body streaming/drain behavior.
+	cancelReq()
+	_ = resp.Body.Close()
+
+	c.logDebug("Prompt sent: %d %s (ack in %s)", resp.StatusCode, http.StatusText(resp.StatusCode), time.Since(sendStartedAt))
 	return nil
 }
 

--- a/internal/agent/opencode_client_test.go
+++ b/internal/agent/opencode_client_test.go
@@ -418,6 +418,69 @@ func TestSendMessagePromptWithoutModel(t *testing.T) {
 	}
 }
 
+func TestSendMessagePromptReturnsQuicklyAfterAck(t *testing.T) {
+	const bodyDelay = 600 * time.Millisecond
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(bodyDelay)
+		_, _ = w.Write([]byte(`{"status":"accepted"}`))
+	}))
+	defer server.Close()
+
+	client := &OpenCodeClient{
+		baseURL:    server.URL,
+		httpClient: &http.Client{Timeout: 3 * time.Second},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err := client.SendMessagePrompt(ctx, "ses_quick_ack", "Hello", "/path/to/worktree", nil, "")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("SendMessagePrompt error: %v", err)
+	}
+	if elapsed >= bodyDelay {
+		t.Fatalf("SendMessagePrompt should return before response body completes, elapsed=%s bodyDelay=%s", elapsed, bodyDelay)
+	}
+}
+
+func TestSendMessagePromptRetriesTransientFailures(t *testing.T) {
+	attempts := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("temporary failure"))
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	client := &OpenCodeClient{
+		baseURL:    server.URL,
+		httpClient: &http.Client{Timeout: 2 * time.Second},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err := client.SendMessagePrompt(ctx, "ses_retry", "Hello", "/path/to/worktree", nil, "")
+	if err != nil {
+		t.Fatalf("SendMessagePrompt error: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+}
+
 func TestNewOpenCodeClient(t *testing.T) {
 	client := NewOpenCodeClient(4096)
 	if client.baseURL != "http://127.0.0.1:4096" {

--- a/internal/daemon/proto_client.go
+++ b/internal/daemon/proto_client.go
@@ -18,6 +18,8 @@ type ProtoClient struct {
 	timeout     time.Duration
 }
 
+const protoSendMessageTimeoutBuffer = 5 * time.Second
+
 func NewProtoClient(projectRoot string) *ProtoClient {
 	return &ProtoClient{
 		projectRoot: projectRoot,
@@ -35,6 +37,15 @@ func NewProtoClientWithIssuesRoot(projectRoot, issuesRoot string) *ProtoClient {
 
 func (c *ProtoClient) SetTimeout(timeout time.Duration) {
 	c.timeout = timeout
+}
+
+func (c *ProtoClient) sendMessageTimeout() time.Duration {
+	timeout := c.timeout
+	minTimeout := openCodeSendAckTimeout + protoSendMessageTimeoutBuffer
+	if timeout < minTimeout {
+		return minTimeout
+	}
+	return timeout
 }
 
 func (c *ProtoClient) IsAvailable() bool {
@@ -1613,7 +1624,7 @@ func (c *ProtoClient) SendMessage(issueID, runID, message string) error {
 		},
 	}
 
-	resp, err := c.sendRequest(req)
+	resp, err := c.sendRequestWithTimeout(req, c.sendMessageTimeout())
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/proto_client_test.go
+++ b/internal/daemon/proto_client_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"testing"
+	"time"
 
 	orchpb "github.com/s22625/orch/api/orchpb"
 )
@@ -271,5 +272,21 @@ func TestGetDiffStatsResponseMapping(t *testing.T) {
 				t.Errorf("Files length = %d, want %d", len(got.Files), len(tt.want.Files))
 			}
 		})
+	}
+}
+
+func TestSendMessageTimeoutMaintainsSafetyMargin(t *testing.T) {
+	client := NewProtoClient("/tmp/project")
+
+	minimum := openCodeSendAckTimeout + protoSendMessageTimeoutBuffer
+
+	client.SetTimeout(2 * time.Second)
+	if got := client.sendMessageTimeout(); got != minimum {
+		t.Fatalf("sendMessageTimeout() = %s, want %s", got, minimum)
+	}
+
+	client.SetTimeout(minimum + 2*time.Second)
+	if got := client.sendMessageTimeout(); got != minimum+2*time.Second {
+		t.Fatalf("sendMessageTimeout() = %s, want %s", got, minimum+2*time.Second)
 	}
 }

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -33,6 +33,12 @@ const (
 	openCodeControlSessionTitle = "orch-control"
 )
 
+var (
+	// Keep opencode send ACK timeout short so `orch send` returns quickly after
+	// the server accepts the message.
+	openCodeSendAckTimeout = 10 * time.Second
+)
+
 func readAll(conn net.Conn) ([]byte, error) {
 	var data []byte
 	buf := make([]byte, 4096)
@@ -1812,22 +1818,27 @@ func (s *SocketServer) processSendOpenCode(st store.Store, ref *model.RunRef, ru
 		return fmt.Errorf("failed to find project root for %s: %w", ref.String(), err)
 	}
 
+	ensureStartedAt := time.Now()
 	port, err := s.ensureOpenCodeServerRunning(projectRoot)
 	if err != nil {
+		s.logger.Printf("opencode_send ensure_server_failed run=%s elapsed=%s err=%v", ref.String(), time.Since(ensureStartedAt), err)
 		return fmt.Errorf("failed to ensure opencode server running for %s: %w", ref.String(), err)
 	}
+	s.logger.Printf("opencode_send server_ready run=%s port=%d elapsed=%s", ref.String(), port, time.Since(ensureStartedAt))
 
 	client := agent.NewOpenCodeClient(port)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), openCodeSendAckTimeout)
 	defer cancel()
 
+	sendStartedAt := time.Now()
 	err = client.SendMessagePrompt(ctx, run.OpenCodeSessionID, message, run.WorktreePath, nil, "")
 	if err != nil {
+		s.logger.Printf("opencode_send ack_failed run=%s elapsed=%s timeout=%s err=%v", ref.String(), time.Since(sendStartedAt), openCodeSendAckTimeout, err)
 		return fmt.Errorf("failed to send message: %w", err)
 	}
 
-	s.logger.Printf("message sent successfully to %s", ref.String())
+	s.logger.Printf("opencode_send acknowledged run=%s elapsed=%s", ref.String(), time.Since(sendStartedAt))
 	return nil
 }
 

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/s22625/orch/api/orchpb"
+	"github.com/s22625/orch/internal/agent"
+	"github.com/s22625/orch/internal/git"
 	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/store"
 	"github.com/s22625/orch/internal/xdg"
@@ -323,6 +325,126 @@ func TestSocketServerSendRequestMissingConfig(t *testing.T) {
 	}
 	if resp.Error == "" {
 		t.Error("expected error message explaining what config is missing")
+	}
+}
+
+func TestProcessSendOpenCodeReturnsAfterAck(t *testing.T) {
+	projectRoot, err := git.FindRepoRoot(".")
+	if err != nil {
+		t.Fatalf("failed to find repo root: %v", err)
+	}
+
+	const bodyDelay = 600 * time.Millisecond
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/global/health":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"healthy":true,"version":"test"}`)
+		case strings.HasSuffix(r.URL.Path, "/message"):
+			w.WriteHeader(http.StatusAccepted)
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			time.Sleep(bodyDelay)
+			_, _ = io.WriteString(w, `{"status":"accepted"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer testServer.Close()
+
+	logger := log.New(io.Discard, "", 0)
+	server := NewSocketServer(nil, logger)
+	server.openCodeServers[projectRoot] = &managedServer{
+		ProjectRoot: projectRoot,
+		Port:        getPortFromURL(t, testServer.URL),
+		WaitResult:  make(chan error, 1),
+	}
+
+	originalTimeout := openCodeSendAckTimeout
+	openCodeSendAckTimeout = 2 * time.Second
+	defer func() {
+		openCodeSendAckTimeout = originalTimeout
+	}()
+
+	ref := &model.RunRef{IssueID: "orch-432", RunID: "run-1"}
+	run := &model.Run{
+		IssueID:           ref.IssueID,
+		RunID:             ref.RunID,
+		Agent:             string(agent.AgentOpenCode),
+		OpenCodeSessionID: "ses_fast_ack",
+		WorktreePath:      projectRoot,
+	}
+
+	startedAt := time.Now()
+	err = server.processSendOpenCode(nil, ref, run, "please rebase")
+	elapsed := time.Since(startedAt)
+
+	if err != nil {
+		t.Fatalf("processSendOpenCode() error = %v", err)
+	}
+	if elapsed >= bodyDelay {
+		t.Fatalf("expected send to return before response body completion, elapsed=%s bodyDelay=%s", elapsed, bodyDelay)
+	}
+}
+
+func TestProcessSendOpenCodeTimesOutPromptlyWithoutAck(t *testing.T) {
+	projectRoot, err := git.FindRepoRoot(".")
+	if err != nil {
+		t.Fatalf("failed to find repo root: %v", err)
+	}
+
+	const ackDelay = 300 * time.Millisecond
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/global/health":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"healthy":true,"version":"test"}`)
+		case strings.HasSuffix(r.URL.Path, "/message"):
+			time.Sleep(ackDelay)
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = io.WriteString(w, `{"status":"accepted"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer testServer.Close()
+
+	logger := log.New(io.Discard, "", 0)
+	server := NewSocketServer(nil, logger)
+	server.openCodeServers[projectRoot] = &managedServer{
+		ProjectRoot: projectRoot,
+		Port:        getPortFromURL(t, testServer.URL),
+		WaitResult:  make(chan error, 1),
+	}
+
+	originalTimeout := openCodeSendAckTimeout
+	openCodeSendAckTimeout = 80 * time.Millisecond
+	defer func() {
+		openCodeSendAckTimeout = originalTimeout
+	}()
+
+	ref := &model.RunRef{IssueID: "orch-432", RunID: "run-2"}
+	run := &model.Run{
+		IssueID:           ref.IssueID,
+		RunID:             ref.RunID,
+		Agent:             string(agent.AgentOpenCode),
+		OpenCodeSessionID: "ses_slow_ack",
+		WorktreePath:      projectRoot,
+	}
+
+	startedAt := time.Now()
+	err = server.processSendOpenCode(nil, ref, run, "please retry")
+	elapsed := time.Since(startedAt)
+
+	if err == nil {
+		t.Fatal("expected timeout error when ACK is too slow")
+	}
+	if !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("expected context deadline exceeded error, got: %v", err)
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("expected send to fail promptly, elapsed=%s", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reduce daemon-side opencode send ACK timeout to 10s and add detailed latency logging for server-ensure and ACK phases.
- Make `SendMessagePrompt` return immediately after HTTP ACK status by canceling request context and closing the body without waiting for body streaming/drain completion.
- Ensure proto socket deadline for `SendMessage` always stays above opencode ACK timeout via a safety margin.
- Add regression tests for quick-return-after-ACK, prompt timeout behavior, and retry preservation.

## Issue
- Fixes `orch-432`

## Acceptance Criteria Evidence

### 1) `orch send` for opencode runs returns as soon as server ACKs the message
Implemented in daemon send path and client ACK handling:
- `internal/daemon/socket.go`
- `internal/agent/opencode_client.go`

Verified with tests:
```bash
go test ./internal/daemon -run 'TestProcessSendOpenCodeReturnsAfterAck' -v -count=1
=== RUN   TestProcessSendOpenCodeReturnsAfterAck
--- PASS: TestProcessSendOpenCodeReturnsAfterAck (0.66s)
PASS
```

```bash
go test ./internal/agent -run 'TestSendMessagePromptReturnsQuicklyAfterAck' -v -count=1
=== RUN   TestSendMessagePromptReturnsQuicklyAfterAck
--- PASS: TestSendMessagePromptReturnsQuicklyAfterAck (0.60s)
PASS
```

### 2) No timeout errors when message is successfully delivered
Covered by ACK-fast path regression tests above and ACK/latency logging additions in daemon.

### 3) If opencode server is genuinely unreachable/slow, errors are reported promptly
Verified with daemon timeout regression:
```bash
go test ./internal/daemon -run 'TestProcessSendOpenCodeTimesOutPromptlyWithoutAck' -v -count=1
=== RUN   TestProcessSendOpenCodeTimesOutPromptlyWithoutAck
--- PASS: TestProcessSendOpenCodeTimesOutPromptlyWithoutAck (0.36s)
PASS
```

### 4) Retry logic is preserved for transient network failures
Verified with:
```bash
go test ./internal/agent -run 'TestSendMessagePromptRetriesTransientFailures' -v -count=1
=== RUN   TestSendMessagePromptRetriesTransientFailures
--- PASS: TestSendMessagePromptRetriesTransientFailures (1.51s)
PASS
```

### 5) Existing send behavior for non-opencode agents (tmux) is unchanged
Verified existing daemon send test still passes:
```bash
go test ./internal/daemon -run 'TestSocketServerSendRequest' -v -count=1
=== RUN   TestSocketServerSendRequest
--- PASS: TestSocketServerSendRequest (0.04s)
PASS
```

### 6) Add test that verifies send returns quickly after ACK
Added:
- `internal/daemon/socket_test.go:329`
- `internal/agent/opencode_client_test.go:421`

## Validation
- `go build ./...` ✅
- `make lint` ✅
- `go test ./internal/daemon -run 'Test(SocketServerSendRequest|ProcessSendOpenCodeReturnsAfterAck|ProcessSendOpenCodeTimesOutPromptlyWithoutAck|SendMessageTimeoutMaintainsSafetyMargin)$' -v -count=1` ✅
- `go test ./internal/agent -run 'TestSendMessagePrompt(ReturnsQuicklyAfterAck|RetriesTransientFailures)$' -v -count=1` ✅

Note: `go test ./...` currently fails in unrelated existing CLI test:
- `internal/cli TestApplyConfigDefaultsFallbacks` (config schema EOF)
