### PR TITLE
Recover opencode control session after daemon restart

### DIFF
--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	socketFile = "daemon.sock"
+	socketFile                  = "daemon.sock"
+	openCodeControlSessionTitle = "orch-control"
 )
 
 func readAll(conn net.Conn) ([]byte, error) {
@@ -1103,6 +1104,18 @@ func (s *SocketServer) getOrCreateOpenCodeControlSession(projectRoot string, por
 					s.saveControlSession(projectRoot, stored.SessionID, "opencode")
 				}
 				return stored.SessionID, nil
+			} else if err != nil && strings.Contains(err.Error(), "session not found") {
+				// opencode may reassign session IDs when the server restarts; recover by directory.
+				sessions, listErr := client.GetSessionsForDirectory(ctx, projectRoot)
+				if listErr != nil {
+					s.logger.Printf("failed to list opencode sessions for recovery: %v", listErr)
+				} else if recovered := findBestOpenCodeControlSession(projectRoot, sessions); recovered != nil {
+					if err := s.saveControlSession(projectRoot, recovered.ID, "opencode"); err != nil {
+						s.logger.Printf("warning: failed to save recovered control session: %v", err)
+					}
+					s.logger.Printf("recovered opencode control session after ID mismatch: %s", recovered.ID)
+					return recovered.ID, nil
+				}
 			}
 		}
 	}
@@ -1111,7 +1124,7 @@ func (s *SocketServer) getOrCreateOpenCodeControlSession(projectRoot string, por
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	session, err := client.CreateSession(ctx, "orch-control", projectRoot)
+	session, err := client.CreateSession(ctx, openCodeControlSessionTitle, projectRoot)
 	if err != nil {
 		return "", fmt.Errorf("failed to create session: %w", err)
 	}
@@ -1135,6 +1148,37 @@ func (s *SocketServer) getOrCreateOpenCodeControlSession(projectRoot string, por
 
 	s.logger.Printf("created new opencode control session: %s", session.ID)
 	return session.ID, nil
+}
+
+func findBestOpenCodeControlSession(projectRoot string, sessions []agent.Session) *agent.Session {
+	var bestPreferred *agent.Session
+	var bestFallback *agent.Session
+
+	for i := range sessions {
+		session := sessions[i]
+		if projectRoot != "" && session.Directory != projectRoot {
+			continue
+		}
+
+		// Prefer explicit control sessions, but keep the most recent general session as fallback.
+		if session.Title == openCodeControlSessionTitle {
+			if bestPreferred == nil || session.UpdatedAt().After(bestPreferred.UpdatedAt()) {
+				copy := session
+				bestPreferred = &copy
+			}
+			continue
+		}
+
+		if bestFallback == nil || session.UpdatedAt().After(bestFallback.UpdatedAt()) {
+			copy := session
+			bestFallback = &copy
+		}
+	}
+
+	if bestPreferred != nil {
+		return bestPreferred
+	}
+	return bestFallback
 }
 
 func getControlPromptInstruction() string {

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/json"
 	"io"
 	"log"
 	"math/rand"
@@ -17,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1367,6 +1369,294 @@ func TestOpenCodeServerLogPathIsPerProjectRoot(t *testing.T) {
 	}
 	if !strings.HasSuffix(pathA1, ".log") {
 		t.Fatalf("expected .log suffix, got %q", pathA1)
+	}
+}
+
+func writeStoredOpenCodeControlSession(t *testing.T, projectRoot, sessionID string) {
+	t.Helper()
+	orchDir := filepath.Join(projectRoot, ".orch")
+	if err := os.MkdirAll(orchDir, 0755); err != nil {
+		t.Fatalf("failed to create .orch dir: %v", err)
+	}
+	data := []byte(`{"session_id":"` + sessionID + `","agent_type":"opencode","port":1234}`)
+	if err := os.WriteFile(filepath.Join(orchDir, "control-session.json"), data, 0644); err != nil {
+		t.Fatalf("failed to write stored control session: %v", err)
+	}
+}
+
+func readStoredOpenCodeControlSession(t *testing.T, projectRoot string) (string, string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(projectRoot, ".orch", "control-session.json"))
+	if err != nil {
+		t.Fatalf("failed to read stored control session: %v", err)
+	}
+
+	var stored struct {
+		SessionID string `json:"session_id"`
+		AgentType string `json:"agent_type"`
+	}
+	if err := json.Unmarshal(data, &stored); err != nil {
+		t.Fatalf("failed to decode stored control session: %v", err)
+	}
+	return stored.SessionID, stored.AgentType
+}
+
+func TestGetOrCreateOpenCodeControlSessionReusesExisting(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_existing")
+
+	var mu sync.Mutex
+	getCalls := 0
+	listCalls := 0
+	createCalls := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/session/ses_existing":
+			mu.Lock()
+			getCalls++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":        "ses_existing",
+				"title":     openCodeControlSessionTitle,
+				"directory": projectRoot,
+				"time": map[string]int64{
+					"created": 1000,
+					"updated": 2000,
+				},
+			})
+		case r.Method == "GET" && r.URL.Path == "/session":
+			mu.Lock()
+			listCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == "POST" && r.URL.Path == "/session":
+			mu.Lock()
+			createCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, getPortFromURL(t, ts.URL))
+	if err != nil {
+		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
+	}
+	if sessionID != "ses_existing" {
+		t.Fatalf("expected existing session to be reused, got %q", sessionID)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if getCalls != 1 {
+		t.Fatalf("expected one GET by session ID, got %d", getCalls)
+	}
+	if listCalls != 0 {
+		t.Fatalf("expected no fallback list call, got %d", listCalls)
+	}
+	if createCalls != 0 {
+		t.Fatalf("expected no create call, got %d", createCalls)
+	}
+}
+
+func TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale")
+
+	var mu sync.Mutex
+	getCalls := 0
+	listCalls := 0
+	createCalls := 0
+	listDirectory := ""
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/session/ses_stale":
+			mu.Lock()
+			getCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+		case r.Method == "GET" && r.URL.Path == "/session":
+			mu.Lock()
+			listCalls++
+			listDirectory = r.Header.Get("X-OpenCode-Directory")
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+				{
+					"id":        "ses_chat_latest",
+					"title":     "chat",
+					"directory": projectRoot,
+					"time":      map[string]int64{"created": 1000, "updated": 9000},
+				},
+				{
+					"id":        "ses_control_old",
+					"title":     openCodeControlSessionTitle,
+					"directory": projectRoot,
+					"time":      map[string]int64{"created": 1000, "updated": 4000},
+				},
+				{
+					"id":        "ses_control_new",
+					"title":     openCodeControlSessionTitle,
+					"directory": projectRoot,
+					"time":      map[string]int64{"created": 1000, "updated": 5000},
+				},
+				{
+					"id":        "ses_other_project",
+					"title":     openCodeControlSessionTitle,
+					"directory": "/other/project",
+					"time":      map[string]int64{"created": 1000, "updated": 20000},
+				},
+			})
+		case r.Method == "POST" && r.URL.Path == "/session":
+			mu.Lock()
+			createCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, getPortFromURL(t, ts.URL))
+	if err != nil {
+		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
+	}
+	if sessionID != "ses_control_new" {
+		t.Fatalf("expected recovered control session %q, got %q", "ses_control_new", sessionID)
+	}
+
+	storedID, storedAgent := readStoredOpenCodeControlSession(t, projectRoot)
+	if storedID != "ses_control_new" {
+		t.Fatalf("expected stored session ID to be updated to recovered ID, got %q", storedID)
+	}
+	if storedAgent != "opencode" {
+		t.Fatalf("expected stored agent type opencode, got %q", storedAgent)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if getCalls != 1 {
+		t.Fatalf("expected one GET by stale session ID, got %d", getCalls)
+	}
+	if listCalls != 1 {
+		t.Fatalf("expected one fallback list call, got %d", listCalls)
+	}
+	if listDirectory != projectRoot {
+		t.Fatalf("expected list directory header %q, got %q", projectRoot, listDirectory)
+	}
+	if createCalls != 0 {
+		t.Fatalf("expected no new session creation during recovery, got %d", createCalls)
+	}
+}
+
+func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale")
+
+	var mu sync.Mutex
+	getCalls := 0
+	listCalls := 0
+	createCalls := 0
+	createDirectory := ""
+	createTitle := ""
+	createDecodeErr := ""
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/session/ses_stale":
+			mu.Lock()
+			getCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+		case r.Method == "GET" && r.URL.Path == "/session":
+			mu.Lock()
+			listCalls++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		case r.Method == "POST" && r.URL.Path == "/session":
+			mu.Lock()
+			createCalls++
+			createDirectory = r.Header.Get("X-OpenCode-Directory")
+			mu.Unlock()
+
+			var body map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				mu.Lock()
+				createDecodeErr = err.Error()
+				mu.Unlock()
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			mu.Lock()
+			createTitle = body["title"]
+			mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":        "ses_brand_new",
+				"title":     openCodeControlSessionTitle,
+				"directory": projectRoot,
+				"time": map[string]int64{
+					"created": 3000,
+					"updated": 3000,
+				},
+			})
+		case r.Method == "POST" && r.URL.Path == "/session/ses_brand_new/prompt_async":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, getPortFromURL(t, ts.URL))
+	if err != nil {
+		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
+	}
+	if sessionID != "ses_brand_new" {
+		t.Fatalf("expected newly created session ID %q, got %q", "ses_brand_new", sessionID)
+	}
+
+	storedID, storedAgent := readStoredOpenCodeControlSession(t, projectRoot)
+	if storedID != "ses_brand_new" {
+		t.Fatalf("expected stored session ID to be updated to new ID, got %q", storedID)
+	}
+	if storedAgent != "opencode" {
+		t.Fatalf("expected stored agent type opencode, got %q", storedAgent)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if getCalls != 1 {
+		t.Fatalf("expected one GET by stale session ID, got %d", getCalls)
+	}
+	if listCalls != 1 {
+		t.Fatalf("expected one fallback list call, got %d", listCalls)
+	}
+	if createCalls != 1 {
+		t.Fatalf("expected one create call, got %d", createCalls)
+	}
+	if createDirectory != projectRoot {
+		t.Fatalf("expected create session directory header %q, got %q", projectRoot, createDirectory)
+	}
+	if createTitle != openCodeControlSessionTitle {
+		t.Fatalf("expected create session title %q, got %q", openCodeControlSessionTitle, createTitle)
+	}
+	if createDecodeErr != "" {
+		t.Fatalf("unexpected create request decode error: %s", createDecodeErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add restart-recovery fallback in `getOrCreateOpenCodeControlSession`.
  - If stored opencode session ID lookup returns `session not found`, daemon now calls `GetSessionsForDirectory(projectRoot)` and selects the best existing session.
  - Selection behavior: filter by directory, prefer `orch-control` title, then choose most recently updated.
- Persist recovered session IDs back to `.orch/control-session.json`.
- Keep existing behavior when no reusable session exists: create a new control session.
- Introduce `openCodeControlSessionTitle` constant so creation and matching use the same title value.
- Add daemon tests covering:
  - existing session reuse unchanged,
  - restart fallback recovery path,
  - fallback miss -> create new session path.

## Acceptance Criteria Evidence
- [x] After daemon restart, fallback finds prior session via directory+title:
  - `go test ./internal/daemon -run "TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart" -count=1 -v`
  - Passes; test asserts stale ID 404 -> directory listing -> recovers `ses_control_new`.
- [x] `.orch/control-session.json` updated with new session ID:
  - Verified in `TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart` and `TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession` by reading and asserting stored session content.
- [x] If no match found, daemon still creates a new session:
  - `go test ./internal/daemon -run "TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession" -count=1 -v`
  - Passes; test asserts fallback list empty and POST `/session` is called once.
- [x] `orch-control` title convention used consistently:
  - Code now uses `openCodeControlSessionTitle` for both matching and create calls.
  - Creation title asserted in `TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession`.
- [x] Added test coverage for fallback path:
  - New tests in `internal/daemon/socket_test.go`:
    - `TestGetOrCreateOpenCodeControlSessionReusesExisting`
    - `TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart`
    - `TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession`
- [x] Existing happy-path reuse remains unchanged:
  - `TestGetOrCreateOpenCodeControlSessionReusesExisting` validates direct reuse with no fallback listing or creation.

## Validation
- `go test ./internal/daemon -run "TestGetOrCreateOpenCodeControlSession" -count=1 -v` ✅
- `go test ./internal/daemon -count=1` ✅
- `go build ./...` ✅
- `make lint` ✅ (0 semgrep findings)
- `go test ./...` ❌ existing failure in `internal/cli`:
  - `TestApplyConfigDefaultsFallbacks`: `invalid config schema .../.orch/config.yaml: EOF`
  - Failure reproduced before/after this change set and is outside modified files.

Refs: orch-435
