### PR TITLE
Fix codex orch send submission by using C-m

### DIFF
--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -31,6 +31,8 @@ import (
 const (
 	socketFile                  = "daemon.sock"
 	openCodeControlSessionTitle = "orch-control"
+	tmuxSubmitKeyDefault        = "Enter"
+	tmuxSubmitKeyCodex          = "C-m"
 )
 
 func readAll(conn net.Conn) ([]byte, error) {
@@ -1846,18 +1848,26 @@ func (s *SocketServer) processSendTmux(run *model.Run, message string, noEnter b
 		return &agent.SessionNotFoundError{SessionName: sessionName}
 	}
 
-	var err error
-	if noEnter {
-		err = mux.SendKeysLiteral(sessionName, message)
-	} else {
-		err = mux.SendKeys(sessionName, message)
-	}
-	if err != nil {
+	if err := mux.SendKeysLiteral(sessionName, message); err != nil {
 		return fmt.Errorf("failed to send keys: %w", err)
+	}
+
+	if !noEnter {
+		submitKey := tmuxSubmitKeyForAgent(run.Agent)
+		if err := mux.SendText(sessionName, submitKey); err != nil {
+			return fmt.Errorf("failed to send submit key: %w", err)
+		}
 	}
 
 	s.logger.Printf("message sent successfully to tmux session %s", sessionName)
 	return nil
+}
+
+func tmuxSubmitKeyForAgent(agentName string) string {
+	if strings.EqualFold(agentName, string(agent.AgentCodex)) {
+		return tmuxSubmitKeyCodex
+	}
+	return tmuxSubmitKeyDefault
 }
 
 func (s *SocketServer) processSendMessage(st store.Store, params *SendMessageParams) error {

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -2400,3 +2400,41 @@ func TestProcessSendMessageValidation(t *testing.T) {
 		}
 	})
 }
+
+func TestTmuxSubmitKeyForAgent(t *testing.T) {
+	tests := []struct {
+		name    string
+		agent   string
+		wantKey string
+	}{
+		{
+			name:    "codex uses carriage return submit key",
+			agent:   "codex",
+			wantKey: "C-m",
+		},
+		{
+			name:    "codex matching is case insensitive",
+			agent:   "CODEX",
+			wantKey: "C-m",
+		},
+		{
+			name:    "claude keeps default enter key",
+			agent:   "claude",
+			wantKey: "Enter",
+		},
+		{
+			name:    "unknown agents keep default enter key",
+			agent:   "custom-agent",
+			wantKey: "Enter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tmuxSubmitKeyForAgent(tt.agent)
+			if got != tt.wantKey {
+				t.Fatalf("tmuxSubmitKeyForAgent(%q) = %q, want %q", tt.agent, got, tt.wantKey)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `orch send` for codex tmux runs by using agent-specific submit key handling.
- Keep send flow as: literal message first, then submit key.
- Use `C-m` (carriage return) for codex; keep `Enter` for all other agents.
- Add unit coverage for submit-key selection.

## Changes
- `internal/daemon/socket.go`
  - `processSendTmux` now always calls `SendKeysLiteral` first.
  - Submit key is chosen by new helper `tmuxSubmitKeyForAgent(agentName)`.
  - Codex => `C-m`; others => `Enter`.
- `internal/daemon/socket_test.go`
  - Added `TestTmuxSubmitKeyForAgent` with codex/case-insensitive/non-codex cases.

## Acceptance Criteria Evidence

### 1) `orch send` for codex submits the message
Executed from this branch binary with isolated daemon runtime + tmux wrapper:

```bash
go run ./cmd/orch send 61eb36 "ACPT-CODEX-SEND-1770743845"
# Sent message to orch-432#20260211-011850
```

Wrapper-captured tmux args from daemon:
```text
send-keys -t run-orch-432-20260211-011850 -l ACPT-CODEX-SEND-1770743845
send-keys -t run-orch-432-20260211-011850 C-m
```

Pane capture shows the marker was actually submitted and answered:
```text
› ACPT-CODEX-SEND-1770743845
• ACPT-CODEX-SEND-1770743845
```

### 2) Verified codex submit key sequence
Live codex pane test on tmux session:

After `Enter`:
```text
› ACPT-KEYSEQ-1770743925
```
(message remains in input)

After `C-m`:
```text
› ACPT-KEYSEQ-1770743925
• ACPT-KEYSEQ-1770743925
```
(submitted and processed)

### 3) Non-codex tmux agents unchanged
- Unit test asserts fallback remains `Enter` for non-codex:
  - `go test ./internal/daemon -run TestTmuxSubmitKeyForAgent`
- Existing tmux default behavior still validated:
  - `go test ./internal/multiplexer -run TestTmuxMultiplexer_SendKeys`

### 4) Added test
- Added `TestTmuxSubmitKeyForAgent` in `internal/daemon/socket_test.go`.

## Validation Run
- `go build ./...` ✅
- `go test ./...` ❌ (pre-existing unrelated failure)
  - `internal/cli/run_test.go:344 TestApplyConfigDefaultsFallbacks`
  - `invalid config schema ... EOF`
- `make lint` ✅

Refs: orch-436