### PR TITLE
fix: orch send submits on codex/tmux without manual Enter

### DIFF
--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -31,15 +31,27 @@ import (
 const (
 	socketFile                  = "daemon.sock"
 	openCodeControlSessionTitle = "orch-control"
-	tmuxSubmitKeyDefault        = "Enter"
-	tmuxSubmitKeyCodex          = "C-m"
+	tmuxSubmitKeyEnter          = "Enter"
 )
 
 var (
 	// Keep opencode send ACK timeout short so `orch send` returns quickly after
 	// the server accepts the message.
 	openCodeSendAckTimeout = 10 * time.Second
+	codexTmuxSubmitDelay   = 250 * time.Millisecond
+
+	getSendMultiplexer = func() sendMultiplexer {
+		return multiplexer.GetDefault()
+	}
 )
+
+type sendMultiplexer interface {
+	Type() multiplexer.Type
+	HasSession(name string) bool
+	SendKeys(session, keys string) error
+	SendKeysLiteral(session, keys string) error
+	SendText(session, text string) error
+}
 
 func readAll(conn net.Conn) ([]byte, error) {
 	var data []byte
@@ -1850,7 +1862,7 @@ func (s *SocketServer) processSendTmux(run *model.Run, message string, noEnter b
 		sessionName = model.GenerateSessionName(run.IssueID, run.RunID)
 	}
 
-	mux := multiplexer.GetDefault()
+	mux := getSendMultiplexer()
 	if mux == nil {
 		return fmt.Errorf("no multiplexer available")
 	}
@@ -1859,14 +1871,21 @@ func (s *SocketServer) processSendTmux(run *model.Run, message string, noEnter b
 		return &agent.SessionNotFoundError{SessionName: sessionName}
 	}
 
-	if err := mux.SendKeysLiteral(sessionName, message); err != nil {
-		return fmt.Errorf("failed to send keys: %w", err)
-	}
-
-	if !noEnter {
-		submitKey := tmuxSubmitKeyForAgent(run.Agent)
-		if err := mux.SendText(sessionName, submitKey); err != nil {
+	if noEnter {
+		if err := mux.SendKeysLiteral(sessionName, message); err != nil {
+			return fmt.Errorf("failed to send keys: %w", err)
+		}
+	} else if useCodexTmuxSubmitDelay(run, mux) {
+		if err := mux.SendKeysLiteral(sessionName, message); err != nil {
+			return fmt.Errorf("failed to send keys: %w", err)
+		}
+		time.Sleep(codexTmuxSubmitDelay)
+		if err := mux.SendText(sessionName, tmuxSubmitKeyEnter); err != nil {
 			return fmt.Errorf("failed to send submit key: %w", err)
+		}
+	} else {
+		if err := mux.SendKeys(sessionName, message); err != nil {
+			return fmt.Errorf("failed to send keys: %w", err)
 		}
 	}
 
@@ -1874,11 +1893,16 @@ func (s *SocketServer) processSendTmux(run *model.Run, message string, noEnter b
 	return nil
 }
 
-func tmuxSubmitKeyForAgent(agentName string) string {
-	if strings.EqualFold(agentName, string(agent.AgentCodex)) {
-		return tmuxSubmitKeyCodex
+func useCodexTmuxSubmitDelay(run *model.Run, mux sendMultiplexer) bool {
+	if run == nil || !strings.EqualFold(run.Agent, string(agent.AgentCodex)) {
+		return false
 	}
-	return tmuxSubmitKeyDefault
+
+	if strings.EqualFold(run.Multiplexer, string(multiplexer.TypeTmux)) {
+		return true
+	}
+
+	return mux != nil && mux.Type() == multiplexer.TypeTmux
 }
 
 func (s *SocketServer) processSendMessage(st store.Store, params *SendMessageParams) error {

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/s22625/orch/internal/agent"
 	"github.com/s22625/orch/internal/git"
 	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/multiplexer"
 	"github.com/s22625/orch/internal/store"
 	"github.com/s22625/orch/internal/xdg"
 	"google.golang.org/protobuf/proto"
@@ -2523,40 +2524,150 @@ func TestProcessSendMessageValidation(t *testing.T) {
 	})
 }
 
-func TestTmuxSubmitKeyForAgent(t *testing.T) {
-	tests := []struct {
-		name    string
-		agent   string
-		wantKey string
-	}{
-		{
-			name:    "codex uses carriage return submit key",
-			agent:   "codex",
-			wantKey: "C-m",
-		},
-		{
-			name:    "codex matching is case insensitive",
-			agent:   "CODEX",
-			wantKey: "C-m",
-		},
-		{
-			name:    "claude keeps default enter key",
-			agent:   "claude",
-			wantKey: "Enter",
-		},
-		{
-			name:    "unknown agents keep default enter key",
-			agent:   "custom-agent",
-			wantKey: "Enter",
-		},
+type sendCall struct {
+	session string
+	keys    string
+}
+
+type mockSendMux struct {
+	hasSession bool
+	sendErr    error
+	muxType    multiplexer.Type
+
+	sendKeysCalls        []sendCall
+	sendKeysLiteralCalls []sendCall
+	sendTextCalls        []sendCall
+}
+
+func (m *mockSendMux) Type() multiplexer.Type {
+	return m.muxType
+}
+
+func (m *mockSendMux) HasSession(name string) bool {
+	return m.hasSession
+}
+
+func (m *mockSendMux) SendKeys(session, keys string) error {
+	m.sendKeysCalls = append(m.sendKeysCalls, sendCall{session: session, keys: keys})
+	return m.sendErr
+}
+
+func (m *mockSendMux) SendKeysLiteral(session, keys string) error {
+	m.sendKeysLiteralCalls = append(m.sendKeysLiteralCalls, sendCall{session: session, keys: keys})
+	return m.sendErr
+}
+
+func (m *mockSendMux) SendText(session, text string) error {
+	m.sendTextCalls = append(m.sendTextCalls, sendCall{session: session, keys: text})
+	return m.sendErr
+}
+
+func TestProcessSendTmuxCodexSendsWithSubmit(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	server := NewSocketServer(nil, logger)
+
+	mockMux := &mockSendMux{hasSession: true, muxType: multiplexer.TypeTmux}
+	prev := getSendMultiplexer
+	prevDelay := codexTmuxSubmitDelay
+	getSendMultiplexer = func() sendMultiplexer { return mockMux }
+	codexTmuxSubmitDelay = 0
+	defer func() {
+		getSendMultiplexer = prev
+		codexTmuxSubmitDelay = prevDelay
+	}()
+
+	run := &model.Run{
+		IssueID:     "issue-1",
+		RunID:       "run-1",
+		SessionName: "run-issue-1-run-1",
+		Agent:       string(agent.AgentCodex),
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tmuxSubmitKeyForAgent(tt.agent)
-			if got != tt.wantKey {
-				t.Fatalf("tmuxSubmitKeyForAgent(%q) = %q, want %q", tt.agent, got, tt.wantKey)
-			}
-		})
+	if err := server.processSendTmux(run, "please continue", false); err != nil {
+		t.Fatalf("processSendTmux() error = %v", err)
+	}
+
+	if len(mockMux.sendKeysLiteralCalls) != 1 {
+		t.Fatalf("SendKeysLiteral calls = %d, want 1", len(mockMux.sendKeysLiteralCalls))
+	}
+	if got := mockMux.sendKeysLiteralCalls[0]; got.session != run.SessionName || got.keys != "please continue" {
+		t.Fatalf("SendKeysLiteral call = (%q, %q), want (%q, %q)", got.session, got.keys, run.SessionName, "please continue")
+	}
+	if len(mockMux.sendTextCalls) != 1 {
+		t.Fatalf("SendText calls = %d, want 1", len(mockMux.sendTextCalls))
+	}
+	if got := mockMux.sendTextCalls[0]; got.session != run.SessionName || got.keys != tmuxSubmitKeyEnter {
+		t.Fatalf("SendText call = (%q, %q), want (%q, %q)", got.session, got.keys, run.SessionName, tmuxSubmitKeyEnter)
+	}
+	if len(mockMux.sendKeysCalls) != 0 {
+		t.Fatalf("SendKeys calls = %d, want 0", len(mockMux.sendKeysCalls))
+	}
+}
+
+func TestProcessSendTmuxNoEnterUsesLiteral(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	server := NewSocketServer(nil, logger)
+
+	mockMux := &mockSendMux{hasSession: true}
+	prev := getSendMultiplexer
+	getSendMultiplexer = func() sendMultiplexer { return mockMux }
+	defer func() { getSendMultiplexer = prev }()
+
+	run := &model.Run{
+		IssueID:     "issue-1",
+		RunID:       "run-1",
+		SessionName: "run-issue-1-run-1",
+		Agent:       string(agent.AgentCodex),
+	}
+
+	if err := server.processSendTmux(run, "partial input", true); err != nil {
+		t.Fatalf("processSendTmux() error = %v", err)
+	}
+
+	if len(mockMux.sendKeysLiteralCalls) != 1 {
+		t.Fatalf("SendKeysLiteral calls = %d, want 1", len(mockMux.sendKeysLiteralCalls))
+	}
+	if got := mockMux.sendKeysLiteralCalls[0]; got.session != run.SessionName || got.keys != "partial input" {
+		t.Fatalf("SendKeysLiteral call = (%q, %q), want (%q, %q)", got.session, got.keys, run.SessionName, "partial input")
+	}
+	if len(mockMux.sendKeysCalls) != 0 {
+		t.Fatalf("SendKeys calls = %d, want 0", len(mockMux.sendKeysCalls))
+	}
+	if len(mockMux.sendTextCalls) != 0 {
+		t.Fatalf("SendText calls = %d, want 0", len(mockMux.sendTextCalls))
+	}
+}
+
+func TestProcessSendTmuxNonCodexUsesSendKeys(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	server := NewSocketServer(nil, logger)
+
+	mockMux := &mockSendMux{hasSession: true, muxType: multiplexer.TypeTmux}
+	prev := getSendMultiplexer
+	getSendMultiplexer = func() sendMultiplexer { return mockMux }
+	defer func() { getSendMultiplexer = prev }()
+
+	run := &model.Run{
+		IssueID:     "issue-1",
+		RunID:       "run-1",
+		SessionName: "run-issue-1-run-1",
+		Agent:       string(agent.AgentClaude),
+	}
+
+	if err := server.processSendTmux(run, "continue", false); err != nil {
+		t.Fatalf("processSendTmux() error = %v", err)
+	}
+
+	if len(mockMux.sendKeysCalls) != 1 {
+		t.Fatalf("SendKeys calls = %d, want 1", len(mockMux.sendKeysCalls))
+	}
+	if got := mockMux.sendKeysCalls[0]; got.session != run.SessionName || got.keys != "continue" {
+		t.Fatalf("SendKeys call = (%q, %q), want (%q, %q)", got.session, got.keys, run.SessionName, "continue")
+	}
+	if len(mockMux.sendKeysLiteralCalls) != 0 {
+		t.Fatalf("SendKeysLiteral calls = %d, want 0", len(mockMux.sendKeysLiteralCalls))
+	}
+	if len(mockMux.sendTextCalls) != 0 {
+		t.Fatalf("SendText calls = %d, want 0", len(mockMux.sendTextCalls))
 	}
 }


### PR DESCRIPTION
## Summary
- Fix `orch send` for codex+tmux runs by adding a 250ms delay before sending Enter
- Verified with live E2E test showing message submits without manual intervention

## Changes
- Added codex+tmux submit delay path in `internal/daemon/socket.go`
- Added regression tests for codex tmux submit behavior

## Acceptance Criteria
- [x] `orch send` submits on codex/tmux without manual Enter
- [x] Regression tests added
- [x] E2E evidence captured

Refs: orch-439