### PR TITLE
Fix opencode control agent model/variant propagation

### DIFF
--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -532,6 +532,14 @@ func (s *SocketServer) controlSessionPath(projectRoot string) string {
 	return filepath.Join(projectRoot, ".orch", "control-session.json")
 }
 
+type controlSessionRecord struct {
+	SessionID    string `json:"session_id"`
+	AgentType    string `json:"agent_type"`
+	Port         int    `json:"port,omitempty"`
+	Model        string `json:"model,omitempty"`
+	ModelVariant string `json:"model_variant,omitempty"`
+}
+
 // getControlSessionLock returns a per-project mutex for control session operations.
 // This prevents race conditions when multiple orch-monitor instances start in quick succession.
 func (s *SocketServer) getControlSessionLock(projectRoot string) *sync.Mutex {
@@ -605,15 +613,31 @@ func (s *SocketServer) discoverClaudeSession(projectRoot string) string {
 
 // saveControlSession persists the control session to disk.
 func (s *SocketServer) saveControlSession(projectRoot, sessionID, agentType string) error {
+	return s.writeControlSession(projectRoot, &controlSessionRecord{
+		SessionID: sessionID,
+		AgentType: agentType,
+	})
+}
+
+func (s *SocketServer) saveOpenCodeControlSession(projectRoot, sessionID string, port int, modelName, modelVariant string) error {
+	return s.writeControlSession(projectRoot, &controlSessionRecord{
+		SessionID:    sessionID,
+		AgentType:    string(agent.AgentOpenCode),
+		Port:         port,
+		Model:        strings.TrimSpace(modelName),
+		ModelVariant: strings.TrimSpace(modelVariant),
+	})
+}
+
+func (s *SocketServer) writeControlSession(projectRoot string, sessionData *controlSessionRecord) error {
 	orchDir := filepath.Join(projectRoot, ".orch")
 	if err := os.MkdirAll(orchDir, 0755); err != nil {
 		return fmt.Errorf("failed to create .orch dir: %w", err)
 	}
 
 	sessionPath := s.controlSessionPath(projectRoot)
-	sessionData := map[string]string{
-		"session_id": sessionID,
-		"agent_type": agentType,
+	if sessionData == nil {
+		return fmt.Errorf("control session data is nil")
 	}
 	data, _ := json.MarshalIndent(sessionData, "", "  ")
 	if err := os.WriteFile(sessionPath, data, 0644); err != nil {
@@ -712,25 +736,14 @@ func (s *SocketServer) handleSetControlSession(req SendRequest, encoder *json.En
 	lock.Lock()
 	defer lock.Unlock()
 
-	orchDir := filepath.Join(req.ProjectRoot, ".orch")
-	if err := os.MkdirAll(orchDir, 0755); err != nil {
+	sessionData := &controlSessionRecord{
+		SessionID: req.SessionID,
+		AgentType: req.AgentType,
+	}
+	if err := s.writeControlSession(req.ProjectRoot, sessionData); err != nil {
 		encoder.Encode(map[string]interface{}{
 			"ok":    false,
-			"error": fmt.Sprintf("failed to create .orch dir: %v", err),
-		})
-		return
-	}
-
-	sessionPath := s.controlSessionPath(req.ProjectRoot)
-	sessionData := map[string]string{"session_id": req.SessionID}
-	if req.AgentType != "" {
-		sessionData["agent_type"] = req.AgentType
-	}
-	data, _ := json.MarshalIndent(sessionData, "", "  ")
-	if err := os.WriteFile(sessionPath, data, 0644); err != nil {
-		encoder.Encode(map[string]interface{}{
-			"ok":    false,
-			"error": fmt.Sprintf("failed to write session file: %v", err),
+			"error": fmt.Sprintf("failed to persist session file: %v", err),
 		})
 		return
 	}
@@ -788,7 +801,15 @@ func (s *SocketServer) handleEnsureOpenCodeServer(req SendRequest, encoder *json
 		return
 	}
 
-	sessionID, err := s.getOrCreateOpenCodeControlSession(req.ProjectRoot, port)
+	modelName := ""
+	modelVariant := ""
+	if cfg, cfgErr := loadControlAgentConfig(req.ProjectRoot); cfgErr != nil {
+		s.logger.Printf("warning: failed to load config for ensure_open_code_server: %v", cfgErr)
+	} else {
+		modelName, modelVariant = cfg.ResolveControlModelAndVariant(string(agent.AgentOpenCode))
+	}
+
+	sessionID, err := s.getOrCreateOpenCodeControlSession(req.ProjectRoot, port, modelName, modelVariant)
 	if err != nil {
 		s.logger.Printf("warning: server running but failed to get session: %v", err)
 		encoder.Encode(map[string]interface{}{
@@ -1101,41 +1122,52 @@ func (s *SocketServer) getOpenCodeServerPort(projectRoot string) int {
 	return 0
 }
 
-func (s *SocketServer) getOrCreateOpenCodeControlSession(projectRoot string, port int) (string, error) {
+func (s *SocketServer) getOrCreateOpenCodeControlSession(projectRoot string, port int, modelName, modelVariant string) (string, error) {
 	lock := s.getControlSessionLock(projectRoot)
 	lock.Lock()
 	defer lock.Unlock()
 
+	resolvedModel := strings.TrimSpace(modelName)
+	resolvedVariant := strings.TrimSpace(modelVariant)
+
 	sessionPath := s.controlSessionPath(projectRoot)
 	if data, err := os.ReadFile(sessionPath); err == nil {
-		var stored struct {
-			SessionID string `json:"session_id"`
-			AgentType string `json:"agent_type"`
-			Port      int    `json:"port"`
-		}
+		var stored controlSessionRecord
 		if json.Unmarshal(data, &stored) == nil && stored.SessionID != "" && stored.AgentType == "opencode" {
-			client := agent.NewOpenCodeClient(port)
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
+			storedModel := strings.TrimSpace(stored.Model)
+			storedVariant := strings.TrimSpace(stored.ModelVariant)
+			modelMatches := storedModel == resolvedModel && storedVariant == resolvedVariant
+			if modelMatches {
+				client := agent.NewOpenCodeClient(port)
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
 
-			if session, err := client.GetSession(ctx, stored.SessionID, projectRoot); err == nil && session != nil {
-				s.logger.Printf("reusing existing opencode control session: %s", stored.SessionID)
-				if stored.Port != port {
-					s.saveControlSession(projectRoot, stored.SessionID, "opencode")
-				}
-				return stored.SessionID, nil
-			} else if err != nil && strings.Contains(err.Error(), "session not found") {
-				// opencode may reassign session IDs when the server restarts; recover by directory.
-				sessions, listErr := client.GetSessionsForDirectory(ctx, projectRoot)
-				if listErr != nil {
-					s.logger.Printf("failed to list opencode sessions for recovery: %v", listErr)
-				} else if recovered := findBestOpenCodeControlSession(projectRoot, sessions); recovered != nil {
-					if err := s.saveControlSession(projectRoot, recovered.ID, "opencode"); err != nil {
-						s.logger.Printf("warning: failed to save recovered control session: %v", err)
+				if session, err := client.GetSession(ctx, stored.SessionID, projectRoot); err == nil && session != nil {
+					s.logger.Printf("reusing existing opencode control session: %s", stored.SessionID)
+					if stored.Port != port {
+						if err := s.saveOpenCodeControlSession(projectRoot, stored.SessionID, port, resolvedModel, resolvedVariant); err != nil {
+							s.logger.Printf("warning: failed to update control session metadata for reused session: %v", err)
+						}
 					}
-					s.logger.Printf("recovered opencode control session after ID mismatch: %s", recovered.ID)
-					return recovered.ID, nil
+					return stored.SessionID, nil
+				} else if err != nil && strings.Contains(err.Error(), "session not found") {
+					// opencode may reassign session IDs when the server restarts; recover by directory.
+					sessions, listErr := client.GetSessionsForDirectory(ctx, projectRoot)
+					if listErr != nil {
+						s.logger.Printf("failed to list opencode sessions for recovery: %v", listErr)
+					} else if recovered := findBestOpenCodeControlSession(projectRoot, sessions); recovered != nil {
+						if err := s.saveOpenCodeControlSession(projectRoot, recovered.ID, port, resolvedModel, resolvedVariant); err != nil {
+							s.logger.Printf("warning: failed to save recovered control session: %v", err)
+						}
+						s.logger.Printf("recovered opencode control session after ID mismatch: %s", recovered.ID)
+						return recovered.ID, nil
+					}
 				}
+			} else {
+				s.logger.Printf(
+					"stored opencode control session %s model/variant (%q,%q) does not match resolved (%q,%q); creating new control session",
+					stored.SessionID, storedModel, storedVariant, resolvedModel, resolvedVariant,
+				)
 			}
 		}
 	}
@@ -1149,16 +1181,21 @@ func (s *SocketServer) getOrCreateOpenCodeControlSession(projectRoot string, por
 		return "", fmt.Errorf("failed to create session: %w", err)
 	}
 
-	if err := s.saveControlSession(projectRoot, session.ID, "opencode"); err != nil {
+	if err := s.saveOpenCodeControlSession(projectRoot, session.ID, port, resolvedModel, resolvedVariant); err != nil {
 		s.logger.Printf("warning: failed to save control session: %v", err)
 	}
 
 	prompt := getControlPromptInstruction()
 	if prompt != "" {
+		modelRef := agent.ParseModel(resolvedModel)
+		if resolvedModel != "" && modelRef == nil {
+			s.logger.Printf("warning: control model %q is not in provider/model format; using opencode default for initial prompt", resolvedModel)
+		}
+
 		go func() {
 			sendCtx, sendCancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer sendCancel()
-			if err := client.SendMessagePrompt(sendCtx, session.ID, prompt, projectRoot, nil, ""); err != nil {
+			if err := client.SendMessagePrompt(sendCtx, session.ID, prompt, projectRoot, modelRef, resolvedVariant); err != nil {
 				s.logger.Printf("warning: failed to send initial prompt to control session: %v", err)
 			} else {
 				s.logger.Printf("sent initial prompt to control session %s", session.ID)
@@ -1559,7 +1596,7 @@ func (s *SocketServer) handleGetControlAgentLaunch(req SendRequest, encoder *jso
 		port = serverPort
 
 		// Get or create session
-		session, err := s.getOrCreateOpenCodeControlSession(req.ProjectRoot, port)
+		session, err := s.getOrCreateOpenCodeControlSession(req.ProjectRoot, port, modelName, modelVariant)
 		if err != nil {
 			s.logger.Printf("warning: server running but failed to get session: %v", err)
 			// Still return the command, but without session
@@ -1697,7 +1734,7 @@ func (s *SocketServer) processControlAgentLaunchCore(st store.Store, params *Con
 		}
 		port = serverPort
 
-		session, err := s.getOrCreateOpenCodeControlSession(params.ProjectRoot, port)
+		session, err := s.getOrCreateOpenCodeControlSession(params.ProjectRoot, port, modelName, modelVariant)
 		if err != nil {
 			s.logger.Printf("warning: server running but failed to get session: %v", err)
 			command = fmt.Sprintf("opencode attach http://127.0.0.1:%d --dir %s", port, params.ProjectRoot)

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -1582,38 +1582,46 @@ func TestOpenCodeServerLogPathIsPerProjectRoot(t *testing.T) {
 	}
 }
 
-func writeStoredOpenCodeControlSession(t *testing.T, projectRoot, sessionID string) {
+func writeStoredOpenCodeControlSession(t *testing.T, projectRoot, sessionID, modelName, modelVariant string) {
 	t.Helper()
 	orchDir := filepath.Join(projectRoot, ".orch")
 	if err := os.MkdirAll(orchDir, 0755); err != nil {
 		t.Fatalf("failed to create .orch dir: %v", err)
 	}
-	data := []byte(`{"session_id":"` + sessionID + `","agent_type":"opencode","port":1234}`)
+	data, err := json.Marshal(controlSessionRecord{
+		SessionID:    sessionID,
+		AgentType:    "opencode",
+		Port:         1234,
+		Model:        modelName,
+		ModelVariant: modelVariant,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal stored control session: %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(orchDir, "control-session.json"), data, 0644); err != nil {
 		t.Fatalf("failed to write stored control session: %v", err)
 	}
 }
 
-func readStoredOpenCodeControlSession(t *testing.T, projectRoot string) (string, string) {
+func readStoredOpenCodeControlSession(t *testing.T, projectRoot string) controlSessionRecord {
 	t.Helper()
 	data, err := os.ReadFile(filepath.Join(projectRoot, ".orch", "control-session.json"))
 	if err != nil {
 		t.Fatalf("failed to read stored control session: %v", err)
 	}
 
-	var stored struct {
-		SessionID string `json:"session_id"`
-		AgentType string `json:"agent_type"`
-	}
+	var stored controlSessionRecord
 	if err := json.Unmarshal(data, &stored); err != nil {
 		t.Fatalf("failed to decode stored control session: %v", err)
 	}
-	return stored.SessionID, stored.AgentType
+	return stored
 }
 
 func TestGetOrCreateOpenCodeControlSessionReusesExisting(t *testing.T) {
 	projectRoot := t.TempDir()
-	writeStoredOpenCodeControlSession(t, projectRoot, "ses_existing")
+	modelName := "openai/gpt-5.3-codex"
+	modelVariant := "xhigh"
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_existing", modelName, modelVariant)
 
 	var mu sync.Mutex
 	getCalls := 0
@@ -1653,12 +1661,20 @@ func TestGetOrCreateOpenCodeControlSessionReusesExisting(t *testing.T) {
 	defer ts.Close()
 
 	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
-	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, getPortFromURL(t, ts.URL))
+	port := getPortFromURL(t, ts.URL)
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, port, modelName, modelVariant)
 	if err != nil {
 		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
 	}
 	if sessionID != "ses_existing" {
 		t.Fatalf("expected existing session to be reused, got %q", sessionID)
+	}
+	stored := readStoredOpenCodeControlSession(t, projectRoot)
+	if stored.Port != port {
+		t.Fatalf("expected stored port %d after reuse, got %d", port, stored.Port)
+	}
+	if stored.Model != modelName || stored.ModelVariant != modelVariant {
+		t.Fatalf("expected stored model metadata (%q,%q), got (%q,%q)", modelName, modelVariant, stored.Model, stored.ModelVariant)
 	}
 
 	mu.Lock()
@@ -1676,7 +1692,9 @@ func TestGetOrCreateOpenCodeControlSessionReusesExisting(t *testing.T) {
 
 func TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart(t *testing.T) {
 	projectRoot := t.TempDir()
-	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale")
+	modelName := "openai/gpt-5.3-codex"
+	modelVariant := "xhigh"
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale", modelName, modelVariant)
 
 	var mu sync.Mutex
 	getCalls := 0
@@ -1736,7 +1754,8 @@ func TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart(t *testing.
 	defer ts.Close()
 
 	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
-	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, getPortFromURL(t, ts.URL))
+	port := getPortFromURL(t, ts.URL)
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, port, modelName, modelVariant)
 	if err != nil {
 		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
 	}
@@ -1744,12 +1763,18 @@ func TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart(t *testing.
 		t.Fatalf("expected recovered control session %q, got %q", "ses_control_new", sessionID)
 	}
 
-	storedID, storedAgent := readStoredOpenCodeControlSession(t, projectRoot)
-	if storedID != "ses_control_new" {
-		t.Fatalf("expected stored session ID to be updated to recovered ID, got %q", storedID)
+	stored := readStoredOpenCodeControlSession(t, projectRoot)
+	if stored.SessionID != "ses_control_new" {
+		t.Fatalf("expected stored session ID to be updated to recovered ID, got %q", stored.SessionID)
 	}
-	if storedAgent != "opencode" {
-		t.Fatalf("expected stored agent type opencode, got %q", storedAgent)
+	if stored.AgentType != "opencode" {
+		t.Fatalf("expected stored agent type opencode, got %q", stored.AgentType)
+	}
+	if stored.Port != port {
+		t.Fatalf("expected stored port %d, got %d", port, stored.Port)
+	}
+	if stored.Model != modelName || stored.ModelVariant != modelVariant {
+		t.Fatalf("expected stored model metadata (%q,%q), got (%q,%q)", modelName, modelVariant, stored.Model, stored.ModelVariant)
 	}
 
 	mu.Lock()
@@ -1770,7 +1795,9 @@ func TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart(t *testing.
 
 func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *testing.T) {
 	projectRoot := t.TempDir()
-	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale")
+	modelName := "openai/gpt-5.3-codex"
+	modelVariant := "xhigh"
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale", modelName, modelVariant)
 
 	var mu sync.Mutex
 	getCalls := 0
@@ -1779,6 +1806,9 @@ func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *t
 	createDirectory := ""
 	createTitle := ""
 	createDecodeErr := ""
+	promptReqCh := make(chan agent.PromptRequest, 1)
+	promptDecodeErr := ""
+	promptDirectory := ""
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -1823,8 +1853,23 @@ func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *t
 					"updated": 3000,
 				},
 			})
-		case r.Method == "POST" && r.URL.Path == "/session/ses_brand_new/prompt_async":
-			w.WriteHeader(http.StatusOK)
+		case r.Method == "POST" && r.URL.Path == "/session/ses_brand_new/message":
+			var promptReq agent.PromptRequest
+			if err := json.NewDecoder(r.Body).Decode(&promptReq); err != nil {
+				mu.Lock()
+				promptDecodeErr = err.Error()
+				mu.Unlock()
+			} else {
+				select {
+				case promptReqCh <- promptReq:
+				default:
+				}
+			}
+			mu.Lock()
+			promptDirectory = r.Header.Get("X-OpenCode-Directory")
+			mu.Unlock()
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"status":"accepted"}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -1832,7 +1877,8 @@ func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *t
 	defer ts.Close()
 
 	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
-	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, getPortFromURL(t, ts.URL))
+	port := getPortFromURL(t, ts.URL)
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, port, modelName, modelVariant)
 	if err != nil {
 		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
 	}
@@ -1840,12 +1886,35 @@ func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *t
 		t.Fatalf("expected newly created session ID %q, got %q", "ses_brand_new", sessionID)
 	}
 
-	storedID, storedAgent := readStoredOpenCodeControlSession(t, projectRoot)
-	if storedID != "ses_brand_new" {
-		t.Fatalf("expected stored session ID to be updated to new ID, got %q", storedID)
+	var promptReq agent.PromptRequest
+	select {
+	case promptReq = <-promptReqCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for initial control prompt request")
 	}
-	if storedAgent != "opencode" {
-		t.Fatalf("expected stored agent type opencode, got %q", storedAgent)
+
+	stored := readStoredOpenCodeControlSession(t, projectRoot)
+	if stored.SessionID != "ses_brand_new" {
+		t.Fatalf("expected stored session ID to be updated to new ID, got %q", stored.SessionID)
+	}
+	if stored.AgentType != "opencode" {
+		t.Fatalf("expected stored agent type opencode, got %q", stored.AgentType)
+	}
+	if stored.Port != port {
+		t.Fatalf("expected stored port %d, got %d", port, stored.Port)
+	}
+	if stored.Model != modelName || stored.ModelVariant != modelVariant {
+		t.Fatalf("expected stored model metadata (%q,%q), got (%q,%q)", modelName, modelVariant, stored.Model, stored.ModelVariant)
+	}
+
+	if promptReq.Model == nil {
+		t.Fatal("expected initial prompt request to include model override")
+	}
+	if got := promptReq.Model.ProviderID + "/" + promptReq.Model.ModelID; got != modelName {
+		t.Fatalf("expected initial prompt model %q, got %q", modelName, got)
+	}
+	if promptReq.Variant != modelVariant {
+		t.Fatalf("expected initial prompt variant %q, got %q", modelVariant, promptReq.Variant)
 	}
 
 	mu.Lock()
@@ -1867,6 +1936,179 @@ func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *t
 	}
 	if createDecodeErr != "" {
 		t.Fatalf("unexpected create request decode error: %s", createDecodeErr)
+	}
+	if promptDecodeErr != "" {
+		t.Fatalf("unexpected prompt request decode error: %s", promptDecodeErr)
+	}
+	if promptDirectory != projectRoot {
+		t.Fatalf("expected prompt directory header %q, got %q", projectRoot, promptDirectory)
+	}
+}
+
+func TestGetOrCreateOpenCodeControlSessionCreatesNewWhenStoredModelMismatches(t *testing.T) {
+	projectRoot := t.TempDir()
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_old", "anthropic/claude-opus-4-5", "high")
+
+	modelName := "openai/gpt-5.3-codex"
+	modelVariant := "xhigh"
+
+	var mu sync.Mutex
+	getCalls := 0
+	listCalls := 0
+	createCalls := 0
+	promptReqCh := make(chan struct{}, 1)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/session/ses_old":
+			mu.Lock()
+			getCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == "GET" && r.URL.Path == "/session":
+			mu.Lock()
+			listCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		case r.Method == "POST" && r.URL.Path == "/session":
+			mu.Lock()
+			createCalls++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":        "ses_fresh",
+				"title":     openCodeControlSessionTitle,
+				"directory": projectRoot,
+				"time": map[string]int64{
+					"created": 4000,
+					"updated": 4000,
+				},
+			})
+		case r.Method == "POST" && r.URL.Path == "/session/ses_fresh/message":
+			select {
+			case promptReqCh <- struct{}{}:
+			default:
+			}
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	port := getPortFromURL(t, ts.URL)
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, port, modelName, modelVariant)
+	if err != nil {
+		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
+	}
+	if sessionID != "ses_fresh" {
+		t.Fatalf("expected fresh session ID, got %q", sessionID)
+	}
+
+	select {
+	case <-promptReqCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for initial prompt on newly created session")
+	}
+
+	stored := readStoredOpenCodeControlSession(t, projectRoot)
+	if stored.SessionID != "ses_fresh" {
+		t.Fatalf("expected stored session to be refreshed, got %q", stored.SessionID)
+	}
+	if stored.Model != modelName || stored.ModelVariant != modelVariant {
+		t.Fatalf("expected stored model metadata (%q,%q), got (%q,%q)", modelName, modelVariant, stored.Model, stored.ModelVariant)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if getCalls != 0 {
+		t.Fatalf("expected no GET session reuse call on model mismatch, got %d", getCalls)
+	}
+	if listCalls != 0 {
+		t.Fatalf("expected no recovery list call on model mismatch, got %d", listCalls)
+	}
+	if createCalls != 1 {
+		t.Fatalf("expected exactly one create call on model mismatch, got %d", createCalls)
+	}
+}
+
+func TestResolvedControlModelAndVariantReachOpenCodeInitialPrompt(t *testing.T) {
+	projectRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".orch"), 0755); err != nil {
+		t.Fatalf("failed to create .orch dir: %v", err)
+	}
+
+	configYAML := []byte(`
+control_agent: opencode
+opencode:
+  default_model: openai/gpt-5.3-codex
+  default_variant: xhigh
+`)
+	if err := os.WriteFile(filepath.Join(projectRoot, ".orch", "config.yaml"), configYAML, 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := loadControlAgentConfig(projectRoot)
+	if err != nil {
+		t.Fatalf("loadControlAgentConfig() error = %v", err)
+	}
+	modelName, modelVariant := cfg.ResolveControlModelAndVariant("opencode")
+	if modelName != "openai/gpt-5.3-codex" || modelVariant != "xhigh" {
+		t.Fatalf("unexpected resolved model config: (%q,%q)", modelName, modelVariant)
+	}
+
+	promptReqCh := make(chan agent.PromptRequest, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/session":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":        "ses_from_cfg",
+				"title":     openCodeControlSessionTitle,
+				"directory": projectRoot,
+				"time": map[string]int64{
+					"created": 5000,
+					"updated": 5000,
+				},
+			})
+		case r.Method == "POST" && r.URL.Path == "/session/ses_from_cfg/message":
+			var promptReq agent.PromptRequest
+			if err := json.NewDecoder(r.Body).Decode(&promptReq); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			select {
+			case promptReqCh <- promptReq:
+			default:
+			}
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	_, err = server.getOrCreateOpenCodeControlSession(projectRoot, getPortFromURL(t, ts.URL), modelName, modelVariant)
+	if err != nil {
+		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
+	}
+
+	select {
+	case promptReq := <-promptReqCh:
+		if promptReq.Model == nil {
+			t.Fatal("expected prompt to include model from ResolveControlModelAndVariant")
+		}
+		if got := promptReq.Model.ProviderID + "/" + promptReq.Model.ModelID; got != modelName {
+			t.Fatalf("expected resolved model %q in prompt, got %q", modelName, got)
+		}
+		if promptReq.Variant != modelVariant {
+			t.Fatalf("expected resolved variant %q in prompt, got %q", modelVariant, promptReq.Variant)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for prompt request")
 	}
 }
 


### PR DESCRIPTION
## Summary
- propagate resolved control model/variant into opencode control-session creation flow
- persist opencode control-session metadata (`port`, `model`, `model_variant`) in `.orch/control-session.json`
- enforce model/variant-aware reuse for control sessions; if stored metadata mismatches, create a fresh control session
- add daemon tests proving resolved control model/variant reach `SendMessagePrompt` and metadata is persisted/reused correctly

## Acceptance Criteria Evidence

### 1) Control agent uses `opencode.default_model` and `default_variant` from config
Verified by new test:
- `go test ./internal/daemon -run 'TestResolvedControlModelAndVariantReachOpenCodeInitialPrompt' -count=1`
- Result: `ok   github.com/s22625/orch/internal/daemon`

This test writes project config with:
```yaml
opencode:
  default_model: openai/gpt-5.3-codex
  default_variant: xhigh
```
Then verifies the resolved values are sent in initial `/message` payload.

### 2) Initial prompt to new control session includes configured model/variant
Verified by new/updated tests:
- `go test ./internal/daemon -run 'TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession' -count=1`
- Result: `ok   github.com/s22625/orch/internal/daemon`

The test captures `/session/{id}/message` request and asserts `model=openai/gpt-5.3-codex`, `variant=xhigh`.

### 3) Reused control sessions also respect configured model/variant
Verified by tests:
- `TestGetOrCreateOpenCodeControlSessionReusesExisting`
- `TestGetOrCreateOpenCodeControlSessionCreatesNewWhenStoredModelMismatches`

Command:
- `go test ./internal/daemon -run 'TestGetOrCreateOpenCodeControlSessionReusesExisting|TestGetOrCreateOpenCodeControlSessionCreatesNewWhenStoredModelMismatches' -count=1`
- Result: `ok   github.com/s22625/orch/internal/daemon`

Behavior now:
- stored control-session metadata includes `model` + `model_variant`
- reuse only occurs when stored model metadata matches current resolved config
- mismatch triggers fresh control-session creation with the configured model/variant

### 4) `orch run` continues to correctly pass model/variant (no regression)
Regression checks run:
- `go test ./internal/daemon -run 'TestProtoStartRunFieldMapping|TestProtoContinueRunFieldMapping' -count=1`
- `go test ./internal/agent -run 'TestSendMessagePromptWithDirectoryAndModel' -count=1`
- `go test ./internal/daemon -count=1`
- `go build ./...`

All passed.

### 5) Added test verifying `ResolveControlModelAndVariant` values reach `SendMessagePrompt`
Added:
- `TestResolvedControlModelAndVariantReachOpenCodeInitialPrompt`

It explicitly resolves values via `ResolveControlModelAndVariant("opencode")` and verifies those values are sent in the initial `SendMessagePrompt` payload.

## Additional validation
- `make lint` passed (semgrep architecture lint)

## Issue
- fixes orch-441
