### PR TITLE
Fix opencode control-session reuse for monitor layout restarts

### DIFF
--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -37,8 +37,14 @@ const (
 var (
 	// Keep opencode send ACK timeout short so `orch send` returns quickly after
 	// the server accepts the message.
-	openCodeSendAckTimeout = 10 * time.Second
-	codexTmuxSubmitDelay   = 250 * time.Millisecond
+	openCodeSendAckTimeout              = 10 * time.Second
+	codexTmuxSubmitDelay                = 250 * time.Millisecond
+	openCodeControlSessionLookupBackoff = []time.Duration{
+		0,
+		250 * time.Millisecond,
+		500 * time.Millisecond,
+	}
+	openCodeControlSessionLookupTimeout = 5 * time.Second
 
 	getSendMultiplexer = func() sendMultiplexer {
 		return multiplexer.GetDefault()
@@ -1139,10 +1145,7 @@ func (s *SocketServer) getOrCreateOpenCodeControlSession(projectRoot string, por
 			modelMatches := storedModel == resolvedModel && storedVariant == resolvedVariant
 			if modelMatches {
 				client := agent.NewOpenCodeClient(port)
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-
-				if session, err := client.GetSession(ctx, stored.SessionID, projectRoot); err == nil && session != nil {
+				if session, err := s.getOpenCodeSessionWithRetry(client, stored.SessionID, projectRoot); err == nil && session != nil {
 					s.logger.Printf("reusing existing opencode control session: %s", stored.SessionID)
 					if stored.Port != port {
 						if err := s.saveOpenCodeControlSession(projectRoot, stored.SessionID, port, resolvedModel, resolvedVariant); err != nil {
@@ -1150,17 +1153,20 @@ func (s *SocketServer) getOrCreateOpenCodeControlSession(projectRoot string, por
 						}
 					}
 					return stored.SessionID, nil
-				} else if err != nil && strings.Contains(err.Error(), "session not found") {
-					// opencode may reassign session IDs when the server restarts; recover by directory.
-					sessions, listErr := client.GetSessionsForDirectory(ctx, projectRoot)
-					if listErr != nil {
-						s.logger.Printf("failed to list opencode sessions for recovery: %v", listErr)
-					} else if recovered := findBestOpenCodeControlSession(projectRoot, sessions); recovered != nil {
+				} else {
+					s.logger.Printf("failed to reuse stored opencode control session %q: %v", stored.SessionID, err)
+					if recovered := s.recoverOpenCodeControlSession(client, projectRoot); recovered != nil {
 						if err := s.saveOpenCodeControlSession(projectRoot, recovered.ID, port, resolvedModel, resolvedVariant); err != nil {
 							s.logger.Printf("warning: failed to save recovered control session: %v", err)
 						}
 						s.logger.Printf("recovered opencode control session after ID mismatch: %s", recovered.ID)
 						return recovered.ID, nil
+					}
+
+					if isOpenCodeSessionNotFoundError(err) {
+						s.logger.Printf("stored opencode control session %q was not found; creating a new control session", stored.SessionID)
+					} else {
+						s.logger.Printf("unable to recover stored opencode control session %q; creating a new control session", stored.SessionID)
 					}
 				}
 			} else {
@@ -1207,35 +1213,169 @@ func (s *SocketServer) getOrCreateOpenCodeControlSession(projectRoot string, por
 	return session.ID, nil
 }
 
+func (s *SocketServer) getOpenCodeSessionWithRetry(client *agent.OpenCodeClient, sessionID, projectRoot string) (*agent.Session, error) {
+	var lastErr error
+
+	for attempt, backoff := range openCodeControlSessionLookupBackoff {
+		if backoff > 0 {
+			time.Sleep(backoff)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), openCodeControlSessionLookupTimeout)
+		session, err := client.GetSession(ctx, sessionID, projectRoot)
+		cancel()
+		if err == nil && session != nil {
+			if attempt > 0 {
+				s.logger.Printf("reused opencode control session %s after %d lookup retries", sessionID, attempt)
+			}
+			return session, nil
+		}
+
+		if err == nil {
+			lastErr = fmt.Errorf("session lookup returned empty response")
+		} else {
+			lastErr = err
+		}
+
+		if attempt == len(openCodeControlSessionLookupBackoff)-1 {
+			break
+		}
+		if !shouldRetryOpenCodeSessionLookup(lastErr) {
+			break
+		}
+
+		s.logger.Printf("retrying opencode control session lookup for %s (%d/%d): %v",
+			sessionID, attempt+1, len(openCodeControlSessionLookupBackoff)-1, lastErr)
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("session lookup failed")
+	}
+	return nil, lastErr
+}
+
+func shouldRetryOpenCodeSessionLookup(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isOpenCodeSessionNotFoundError(err) {
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "unexpected eof") ||
+		strings.Contains(msg, "status 5")
+}
+
+func isOpenCodeSessionNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "session not found")
+}
+
+func (s *SocketServer) recoverOpenCodeControlSession(client *agent.OpenCodeClient, projectRoot string) *agent.Session {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	sessions, listErr := client.GetSessionsForDirectory(ctx, projectRoot)
+	cancel()
+	if listErr != nil {
+		s.logger.Printf("failed to list opencode sessions for recovery in %q: %v", projectRoot, listErr)
+	} else if recovered := findBestOpenCodeControlSession(projectRoot, sessions); recovered != nil {
+		return recovered
+	} else {
+		s.logger.Printf("no reusable opencode control session found in project-scoped session list for %q", projectRoot)
+	}
+
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	allSessions, listAllErr := client.GetSessionsForDirectory(ctx, "")
+	cancel()
+	if listAllErr != nil {
+		s.logger.Printf("failed to list unscoped opencode sessions for recovery in %q: %v", projectRoot, listAllErr)
+		return nil
+	}
+
+	recovered := findBestOpenCodeControlSession(projectRoot, allSessions)
+	if recovered == nil {
+		s.logger.Printf("no reusable opencode control session found in unscoped session list for %q", projectRoot)
+		return nil
+	}
+
+	if normalizeOpenCodeSessionDirectory(projectRoot) != normalizeOpenCodeSessionDirectory(recovered.Directory) {
+		s.logger.Printf("recovering opencode control session %s by title fallback despite directory mismatch (project=%q session_dir=%q)",
+			recovered.ID, projectRoot, recovered.Directory)
+	}
+	return recovered
+}
+
 func findBestOpenCodeControlSession(projectRoot string, sessions []agent.Session) *agent.Session {
-	var bestPreferred *agent.Session
-	var bestFallback *agent.Session
+	normalizedProjectRoot := normalizeOpenCodeSessionDirectory(projectRoot)
+	var bestPreferredSameProject *agent.Session
+	var bestFallbackSameProject *agent.Session
+	var bestPreferredAnyProject *agent.Session
+	var bestFallbackAnyProject *agent.Session
 
 	for i := range sessions {
 		session := sessions[i]
-		if projectRoot != "" && session.Directory != projectRoot {
-			continue
-		}
+		directoryMatches := normalizedProjectRoot == "" ||
+			normalizeOpenCodeSessionDirectory(session.Directory) == normalizedProjectRoot
 
 		// Prefer explicit control sessions, but keep the most recent general session as fallback.
 		if session.Title == openCodeControlSessionTitle {
-			if bestPreferred == nil || session.UpdatedAt().After(bestPreferred.UpdatedAt()) {
+			if bestPreferredAnyProject == nil || session.UpdatedAt().After(bestPreferredAnyProject.UpdatedAt()) {
 				copy := session
-				bestPreferred = &copy
+				bestPreferredAnyProject = &copy
+			}
+			if directoryMatches && (bestPreferredSameProject == nil || session.UpdatedAt().After(bestPreferredSameProject.UpdatedAt())) {
+				copy := session
+				bestPreferredSameProject = &copy
 			}
 			continue
 		}
 
-		if bestFallback == nil || session.UpdatedAt().After(bestFallback.UpdatedAt()) {
+		if bestFallbackAnyProject == nil || session.UpdatedAt().After(bestFallbackAnyProject.UpdatedAt()) {
 			copy := session
-			bestFallback = &copy
+			bestFallbackAnyProject = &copy
+		}
+		if directoryMatches && (bestFallbackSameProject == nil || session.UpdatedAt().After(bestFallbackSameProject.UpdatedAt())) {
+			copy := session
+			bestFallbackSameProject = &copy
 		}
 	}
 
-	if bestPreferred != nil {
-		return bestPreferred
+	if bestPreferredSameProject != nil {
+		return bestPreferredSameProject
 	}
-	return bestFallback
+	if bestFallbackSameProject != nil {
+		return bestFallbackSameProject
+	}
+	if normalizedProjectRoot != "" {
+		// Recovery mode: allow title-based reuse even if directory strings differ.
+		return bestPreferredAnyProject
+	}
+	if bestPreferredAnyProject != nil {
+		return bestPreferredAnyProject
+	}
+	return bestFallbackAnyProject
+}
+
+func normalizeOpenCodeSessionDirectory(path string) string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return ""
+	}
+
+	cleaned := filepath.Clean(trimmed)
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil || resolved == "" {
+		return cleaned
+	}
+	return filepath.Clean(resolved)
 }
 
 func getControlPromptInstruction() string {

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -1765,12 +1765,12 @@ func TestGetOrCreateOpenCodeControlSessionCreatesWhenNoStoredSession(t *testing.
 		t.Fatalf("expected newly created session %q, got %q", "ses_new_after_clear", sessionID)
 	}
 
-	storedID, storedAgent := readStoredOpenCodeControlSession(t, projectRoot)
-	if storedID != "ses_new_after_clear" {
-		t.Fatalf("expected stored session ID to be updated to created session, got %q", storedID)
+	stored := readStoredOpenCodeControlSession(t, projectRoot)
+	if stored.SessionID != "ses_new_after_clear" {
+		t.Fatalf("expected stored session ID to be updated to created session, got %q", stored.SessionID)
 	}
-	if storedAgent != "opencode" {
-		t.Fatalf("expected stored agent type opencode, got %q", storedAgent)
+	if stored.AgentType != "opencode" {
+		t.Fatalf("expected stored agent type opencode, got %q", stored.AgentType)
 	}
 
 	mu.Lock()
@@ -1796,7 +1796,7 @@ func TestGetOrCreateOpenCodeControlSessionLogsReuseFailureReason(t *testing.T) {
 	setOpenCodeControlSessionLookupBackoffForTest(t, []time.Duration{0})
 
 	projectRoot := t.TempDir()
-	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale")
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale", "", "")
 
 	logs := &bytes.Buffer{}
 	server := NewSocketServer(nil, log.New(logs, "", 0))
@@ -1852,7 +1852,7 @@ func TestGetOrCreateOpenCodeControlSessionRetriesStoredLookup(t *testing.T) {
 	setOpenCodeControlSessionLookupBackoffForTest(t, []time.Duration{0, 0, 0})
 
 	projectRoot := t.TempDir()
-	writeStoredOpenCodeControlSession(t, projectRoot, "ses_existing")
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_existing", "", "")
 
 	var mu sync.Mutex
 	getCalls := 0
@@ -2037,7 +2037,7 @@ func TestGetOrCreateOpenCodeControlSessionRecoversWithNormalizedDirectory(t *tes
 	}
 
 	projectRoot := symlinkRoot + string(os.PathSeparator)
-	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale")
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale", "", "")
 
 	var mu sync.Mutex
 	getCalls := 0
@@ -2102,7 +2102,7 @@ func TestGetOrCreateOpenCodeControlSessionRecoversByTitleWithoutDirectoryFilter(
 	setOpenCodeControlSessionLookupBackoffForTest(t, []time.Duration{0})
 
 	projectRoot := t.TempDir()
-	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale")
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale", "", "")
 
 	var mu sync.Mutex
 	getCalls := 0
@@ -2164,12 +2164,12 @@ func TestGetOrCreateOpenCodeControlSessionRecoversByTitleWithoutDirectoryFilter(
 		t.Fatalf("expected title-based recovered session %q, got %q", "ses_control_title_fallback", sessionID)
 	}
 
-	storedID, storedAgent := readStoredOpenCodeControlSession(t, projectRoot)
-	if storedID != "ses_control_title_fallback" {
-		t.Fatalf("expected stored session ID to be updated to recovered ID, got %q", storedID)
+	stored := readStoredOpenCodeControlSession(t, projectRoot)
+	if stored.SessionID != "ses_control_title_fallback" {
+		t.Fatalf("expected stored session ID to be updated to recovered ID, got %q", stored.SessionID)
 	}
-	if storedAgent != "opencode" {
-		t.Fatalf("expected stored agent type opencode, got %q", storedAgent)
+	if stored.AgentType != "opencode" {
+		t.Fatalf("expected stored agent type opencode, got %q", stored.AgentType)
 	}
 
 	mu.Lock()

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/binary"
@@ -1617,6 +1618,15 @@ func readStoredOpenCodeControlSession(t *testing.T, projectRoot string) controlS
 	return stored
 }
 
+func setOpenCodeControlSessionLookupBackoffForTest(t *testing.T, backoff []time.Duration) {
+	t.Helper()
+	original := append([]time.Duration(nil), openCodeControlSessionLookupBackoff...)
+	openCodeControlSessionLookupBackoff = append([]time.Duration(nil), backoff...)
+	t.Cleanup(func() {
+		openCodeControlSessionLookupBackoff = original
+	})
+}
+
 func TestGetOrCreateOpenCodeControlSessionReusesExisting(t *testing.T) {
 	projectRoot := t.TempDir()
 	modelName := "openai/gpt-5.3-codex"
@@ -1690,7 +1700,230 @@ func TestGetOrCreateOpenCodeControlSessionReusesExisting(t *testing.T) {
 	}
 }
 
+func TestGetOrCreateOpenCodeControlSessionCreatesWhenNoStoredSession(t *testing.T) {
+	projectRoot := t.TempDir()
+
+	var mu sync.Mutex
+	getCalls := 0
+	listCalls := 0
+	createCalls := 0
+	createDirectory := ""
+	createTitle := ""
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/session/"):
+			mu.Lock()
+			getCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == "GET" && r.URL.Path == "/session":
+			mu.Lock()
+			listCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == "POST" && r.URL.Path == "/session":
+			mu.Lock()
+			createCalls++
+			createDirectory = r.Header.Get("X-OpenCode-Directory")
+			mu.Unlock()
+
+			var body map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			mu.Lock()
+			createTitle = body["title"]
+			mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":        "ses_new_after_clear",
+				"title":     openCodeControlSessionTitle,
+				"directory": projectRoot,
+				"time": map[string]int64{
+					"created": 3000,
+					"updated": 3000,
+				},
+			})
+		case r.Method == "POST" && r.URL.Path == "/session/ses_new_after_clear/prompt_async":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, getPortFromURL(t, ts.URL), "", "")
+	if err != nil {
+		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
+	}
+	if sessionID != "ses_new_after_clear" {
+		t.Fatalf("expected newly created session %q, got %q", "ses_new_after_clear", sessionID)
+	}
+
+	storedID, storedAgent := readStoredOpenCodeControlSession(t, projectRoot)
+	if storedID != "ses_new_after_clear" {
+		t.Fatalf("expected stored session ID to be updated to created session, got %q", storedID)
+	}
+	if storedAgent != "opencode" {
+		t.Fatalf("expected stored agent type opencode, got %q", storedAgent)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if getCalls != 0 {
+		t.Fatalf("expected no GET-by-ID calls without stored session, got %d", getCalls)
+	}
+	if listCalls != 0 {
+		t.Fatalf("expected no recovery list calls without stored session, got %d", listCalls)
+	}
+	if createCalls != 1 {
+		t.Fatalf("expected one create call, got %d", createCalls)
+	}
+	if createDirectory != projectRoot {
+		t.Fatalf("expected create session directory header %q, got %q", projectRoot, createDirectory)
+	}
+	if createTitle != openCodeControlSessionTitle {
+		t.Fatalf("expected create session title %q, got %q", openCodeControlSessionTitle, createTitle)
+	}
+}
+
+func TestGetOrCreateOpenCodeControlSessionLogsReuseFailureReason(t *testing.T) {
+	setOpenCodeControlSessionLookupBackoffForTest(t, []time.Duration{0})
+
+	projectRoot := t.TempDir()
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale")
+
+	logs := &bytes.Buffer{}
+	server := NewSocketServer(nil, log.New(logs, "", 0))
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/session/ses_stale":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"server unavailable"}`))
+		case r.Method == "GET" && r.URL.Path == "/session":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"list unavailable"}`))
+		case r.Method == "POST" && r.URL.Path == "/session":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":        "ses_new_after_recovery_failure",
+				"title":     openCodeControlSessionTitle,
+				"directory": projectRoot,
+				"time": map[string]int64{
+					"created": 3000,
+					"updated": 3000,
+				},
+			})
+		case r.Method == "POST" && r.URL.Path == "/session/ses_new_after_recovery_failure/prompt_async":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, getPortFromURL(t, ts.URL), "", "")
+	if err != nil {
+		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
+	}
+	if sessionID != "ses_new_after_recovery_failure" {
+		t.Fatalf("expected new session after failed reuse, got %q", sessionID)
+	}
+
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, `failed to reuse stored opencode control session "ses_stale"`) {
+		t.Fatalf("expected reuse failure log message, got logs:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "failed to list opencode sessions for recovery in") {
+		t.Fatalf("expected project-scoped recovery failure log, got logs:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "failed to list unscoped opencode sessions for recovery") {
+		t.Fatalf("expected unscoped recovery failure log, got logs:\n%s", logOutput)
+	}
+}
+
+func TestGetOrCreateOpenCodeControlSessionRetriesStoredLookup(t *testing.T) {
+	setOpenCodeControlSessionLookupBackoffForTest(t, []time.Duration{0, 0, 0})
+
+	projectRoot := t.TempDir()
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_existing")
+
+	var mu sync.Mutex
+	getCalls := 0
+	listCalls := 0
+	createCalls := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/session/ses_existing":
+			mu.Lock()
+			getCalls++
+			call := getCalls
+			mu.Unlock()
+
+			if call <= 2 {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error":"not found"}`))
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":        "ses_existing",
+				"title":     openCodeControlSessionTitle,
+				"directory": projectRoot,
+				"time": map[string]int64{
+					"created": 1000,
+					"updated": 2000,
+				},
+			})
+		case r.Method == "GET" && r.URL.Path == "/session":
+			mu.Lock()
+			listCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == "POST" && r.URL.Path == "/session":
+			mu.Lock()
+			createCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, getPortFromURL(t, ts.URL), "", "")
+	if err != nil {
+		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
+	}
+	if sessionID != "ses_existing" {
+		t.Fatalf("expected existing session to be reused after retries, got %q", sessionID)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if getCalls != 3 {
+		t.Fatalf("expected three GET attempts for stored session, got %d", getCalls)
+	}
+	if listCalls != 0 {
+		t.Fatalf("expected no fallback list call, got %d", listCalls)
+	}
+	if createCalls != 0 {
+		t.Fatalf("expected no create call, got %d", createCalls)
+	}
+}
+
 func TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart(t *testing.T) {
+	setOpenCodeControlSessionLookupBackoffForTest(t, []time.Duration{0})
+
 	projectRoot := t.TempDir()
 	modelName := "openai/gpt-5.3-codex"
 	modelVariant := "xhigh"
@@ -1793,7 +2026,204 @@ func TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart(t *testing.
 	}
 }
 
+func TestGetOrCreateOpenCodeControlSessionRecoversWithNormalizedDirectory(t *testing.T) {
+	setOpenCodeControlSessionLookupBackoffForTest(t, []time.Duration{0})
+
+	resolvedProjectRoot := t.TempDir()
+	linkParent := t.TempDir()
+	symlinkRoot := filepath.Join(linkParent, "project-link")
+	if err := os.Symlink(resolvedProjectRoot, symlinkRoot); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	projectRoot := symlinkRoot + string(os.PathSeparator)
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale")
+
+	var mu sync.Mutex
+	getCalls := 0
+	listCalls := 0
+	createCalls := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/session/ses_stale":
+			mu.Lock()
+			getCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+		case r.Method == "GET" && r.URL.Path == "/session":
+			mu.Lock()
+			listCalls++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+				{
+					"id":        "ses_control_recovered",
+					"title":     openCodeControlSessionTitle,
+					"directory": resolvedProjectRoot,
+					"time":      map[string]int64{"created": 1000, "updated": 9000},
+				},
+			})
+		case r.Method == "POST" && r.URL.Path == "/session":
+			mu.Lock()
+			createCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, getPortFromURL(t, ts.URL), "", "")
+	if err != nil {
+		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
+	}
+	if sessionID != "ses_control_recovered" {
+		t.Fatalf("expected normalized-path recovery session %q, got %q", "ses_control_recovered", sessionID)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if getCalls != 1 {
+		t.Fatalf("expected one GET by stale session ID, got %d", getCalls)
+	}
+	if listCalls != 1 {
+		t.Fatalf("expected one fallback list call, got %d", listCalls)
+	}
+	if createCalls != 0 {
+		t.Fatalf("expected no create call, got %d", createCalls)
+	}
+}
+
+func TestGetOrCreateOpenCodeControlSessionRecoversByTitleWithoutDirectoryFilter(t *testing.T) {
+	setOpenCodeControlSessionLookupBackoffForTest(t, []time.Duration{0})
+
+	projectRoot := t.TempDir()
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale")
+
+	var mu sync.Mutex
+	getCalls := 0
+	listCalls := 0
+	createCalls := 0
+	var listHeaders []string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/session/ses_stale":
+			mu.Lock()
+			getCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+		case r.Method == "GET" && r.URL.Path == "/session":
+			headerDir := r.Header.Get("X-OpenCode-Directory")
+			mu.Lock()
+			listCalls++
+			listHeaders = append(listHeaders, headerDir)
+			mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			if headerDir != "" {
+				_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+				{
+					"id":        "ses_control_title_fallback",
+					"title":     openCodeControlSessionTitle,
+					"directory": "/canonical/path/that/does/not/match",
+					"time":      map[string]int64{"created": 1000, "updated": 10000},
+				},
+				{
+					"id":        "ses_chat_newer",
+					"title":     "chat",
+					"directory": "/canonical/path/that/does/not/match",
+					"time":      map[string]int64{"created": 1000, "updated": 20000},
+				},
+			})
+		case r.Method == "POST" && r.URL.Path == "/session":
+			mu.Lock()
+			createCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, getPortFromURL(t, ts.URL), "", "")
+	if err != nil {
+		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
+	}
+	if sessionID != "ses_control_title_fallback" {
+		t.Fatalf("expected title-based recovered session %q, got %q", "ses_control_title_fallback", sessionID)
+	}
+
+	storedID, storedAgent := readStoredOpenCodeControlSession(t, projectRoot)
+	if storedID != "ses_control_title_fallback" {
+		t.Fatalf("expected stored session ID to be updated to recovered ID, got %q", storedID)
+	}
+	if storedAgent != "opencode" {
+		t.Fatalf("expected stored agent type opencode, got %q", storedAgent)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if getCalls != 1 {
+		t.Fatalf("expected one GET by stale session ID, got %d", getCalls)
+	}
+	if listCalls != 2 {
+		t.Fatalf("expected two list calls (project scoped and unscoped), got %d", listCalls)
+	}
+	if len(listHeaders) != 2 || listHeaders[0] != projectRoot || listHeaders[1] != "" {
+		t.Fatalf("expected list headers [%q, \"\"], got %v", projectRoot, listHeaders)
+	}
+	if createCalls != 0 {
+		t.Fatalf("expected no create call during title fallback recovery, got %d", createCalls)
+	}
+}
+
+func TestFindBestOpenCodeControlSessionNormalizesPathComparison(t *testing.T) {
+	resolvedProjectRoot := t.TempDir()
+	linkParent := t.TempDir()
+	symlinkRoot := filepath.Join(linkParent, "project-link")
+	if err := os.Symlink(resolvedProjectRoot, symlinkRoot); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	projectRoot := symlinkRoot + string(os.PathSeparator)
+	sessions := []agent.Session{
+		{
+			ID:        "ses_chat",
+			Title:     "chat",
+			Directory: resolvedProjectRoot,
+			Time:      agent.SessionTimeMillis{Created: 1000, Updated: 1500},
+		},
+		{
+			ID:        "ses_control",
+			Title:     openCodeControlSessionTitle,
+			Directory: resolvedProjectRoot,
+			Time:      agent.SessionTimeMillis{Created: 1000, Updated: 2000},
+		},
+	}
+
+	recovered := findBestOpenCodeControlSession(projectRoot, sessions)
+	if recovered == nil {
+		t.Fatal("expected a recovered session for symlink+trailing-slash path")
+	}
+	if recovered.ID != "ses_control" {
+		t.Fatalf("expected control session %q, got %q", "ses_control", recovered.ID)
+	}
+}
+
 func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *testing.T) {
+	setOpenCodeControlSessionLookupBackoffForTest(t, []time.Duration{0})
+
 	projectRoot := t.TempDir()
 	modelName := "openai/gpt-5.3-codex"
 	modelVariant := "xhigh"
@@ -1922,8 +2352,8 @@ func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *t
 	if getCalls != 1 {
 		t.Fatalf("expected one GET by stale session ID, got %d", getCalls)
 	}
-	if listCalls != 1 {
-		t.Fatalf("expected one fallback list call, got %d", listCalls)
+	if listCalls != 2 {
+		t.Fatalf("expected two fallback list calls (project scoped and unscoped), got %d", listCalls)
 	}
 	if createCalls != 1 {
 		t.Fatalf("expected one create call, got %d", createCalls)


### PR DESCRIPTION
## Summary
- harden opencode control-session reuse in daemon by retrying stored-session lookup with backoff before giving up
- normalize directory matching in `findBestOpenCodeControlSession` (clean + symlink resolution fallback) to handle trailing slash/symlink differences
- extend recovery flow to try project-scoped session listing first, then unscoped listing with title-based fallback (`orch-control`)
- add explicit reuse-failure logging paths with concrete reasons for troubleshooting
- add/extend daemon tests to cover retries, normalized-path reuse, title fallback recovery, and fresh-session creation when no stored control session exists

## Acceptance Criteria Evidence
### 1) `orch-monitor --new` preserves control session history when server still running
Verified via daemon reuse and recovery tests:
```bash
go test ./internal/daemon -run "TestGetOrCreateOpenCodeControlSessionReusesExisting|TestGetOrCreateOpenCodeControlSessionRetriesStoredLookup|TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart" -v
```
All pass and show stored session is reused/recovered (no new session creation in those paths).

### 2) Session reuse works with trailing slash/symlink path differences
Verified via normalized path tests:
```bash
go test ./internal/daemon -run "TestGetOrCreateOpenCodeControlSessionRecoversWithNormalizedDirectory|TestFindBestOpenCodeControlSessionNormalizesPathComparison" -v
```
Both pass.

### 3) `--new-control-agent` still creates a fresh session
`--new-control-agent` clears `.orch/control-session.json`; daemon behavior when no stored session now verified by:
```bash
go test ./internal/daemon -run "TestGetOrCreateOpenCodeControlSessionCreatesWhenNoStoredSession" -v
```
Passes and confirms immediate fresh session creation.

### 4) Daemon logs include reuse-failure reasons
Verified via:
```bash
go test ./internal/daemon -run "TestGetOrCreateOpenCodeControlSessionLogsReuseFailureReason" -v
```
Passes and asserts log output includes explicit failure reasons for reuse and recovery listing failures.

### 5) Add test for path normalization in `findBestOpenCodeControlSession`
Added and verified:
```bash
go test ./internal/daemon -run "TestFindBestOpenCodeControlSessionNormalizesPathComparison" -v
```
Passes.

## Validation Run
- `go test ./internal/daemon -run "Test(GetOrCreateOpenCodeControlSession|FindBestOpenCodeControlSession)"` ✅
- `go build ./...` ✅
- `make lint` ✅
- `go test ./...` ❌ (pre-existing unrelated failure in `internal/cli`):
  - `TestApplyConfigDefaultsFallbacks` fails with `invalid config schema ... config.yaml: EOF`

Refs: orch-440
