### PR TITLE
fix: reuse opencode control session across orch-monitor --new

### DIFF
--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -32,6 +32,11 @@ const (
 	socketFile                  = "daemon.sock"
 	openCodeControlSessionTitle = "orch-control"
 	tmuxSubmitKeyEnter          = "Enter"
+
+	openCodeControlSessionLookupAttempts      = 3
+	openCodeControlSessionLookupTimeout       = 5 * time.Second
+	openCodeControlSessionLookupRetryBackoff  = 250 * time.Millisecond
+	openCodeControlSessionRecoveryListTimeout = 5 * time.Second
 )
 
 var (
@@ -1139,10 +1144,8 @@ func (s *SocketServer) getOrCreateOpenCodeControlSession(projectRoot string, por
 			modelMatches := storedModel == resolvedModel && storedVariant == resolvedVariant
 			if modelMatches {
 				client := agent.NewOpenCodeClient(port)
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
 
-				if session, err := client.GetSession(ctx, stored.SessionID, projectRoot); err == nil && session != nil {
+				if session, err := s.getOpenCodeControlSessionWithRetry(client, stored.SessionID, projectRoot); err == nil && session != nil {
 					s.logger.Printf("reusing existing opencode control session: %s", stored.SessionID)
 					if stored.Port != port {
 						if err := s.saveOpenCodeControlSession(projectRoot, stored.SessionID, port, resolvedModel, resolvedVariant); err != nil {
@@ -1150,16 +1153,16 @@ func (s *SocketServer) getOrCreateOpenCodeControlSession(projectRoot string, por
 						}
 					}
 					return stored.SessionID, nil
-				} else if err != nil && strings.Contains(err.Error(), "session not found") {
-					// opencode may reassign session IDs when the server restarts; recover by directory.
-					sessions, listErr := client.GetSessionsForDirectory(ctx, projectRoot)
-					if listErr != nil {
-						s.logger.Printf("failed to list opencode sessions for recovery: %v", listErr)
-					} else if recovered := findBestOpenCodeControlSession(projectRoot, sessions); recovered != nil {
+				} else {
+					s.logger.Printf("failed to reuse stored opencode control session %s: %v", stored.SessionID, err)
+
+					if recovered, recoverySource, recoverErr := s.recoverOpenCodeControlSession(client, projectRoot); recoverErr != nil {
+						s.logger.Printf("failed to recover opencode control session after reuse failure for project %q: %v", projectRoot, recoverErr)
+					} else if recovered != nil {
 						if err := s.saveOpenCodeControlSession(projectRoot, recovered.ID, port, resolvedModel, resolvedVariant); err != nil {
 							s.logger.Printf("warning: failed to save recovered control session: %v", err)
 						}
-						s.logger.Printf("recovered opencode control session after ID mismatch: %s", recovered.ID)
+						s.logger.Printf("recovered opencode control session after reuse failure via %s: %s", recoverySource, recovered.ID)
 						return recovered.ID, nil
 					}
 				}
@@ -1207,13 +1210,93 @@ func (s *SocketServer) getOrCreateOpenCodeControlSession(projectRoot string, por
 	return session.ID, nil
 }
 
+func (s *SocketServer) getOpenCodeControlSessionWithRetry(client *agent.OpenCodeClient, sessionID, projectRoot string) (*agent.Session, error) {
+	var lastErr error
+
+	for attempt := 1; attempt <= openCodeControlSessionLookupAttempts; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), openCodeControlSessionLookupTimeout)
+		session, err := client.GetSession(ctx, sessionID, projectRoot)
+		cancel()
+
+		if err == nil && session != nil {
+			return session, nil
+		}
+
+		if err == nil {
+			lastErr = fmt.Errorf("session lookup returned empty response for %s", sessionID)
+		} else {
+			lastErr = err
+		}
+
+		if attempt < openCodeControlSessionLookupAttempts {
+			backoff := time.Duration(attempt) * openCodeControlSessionLookupRetryBackoff
+			s.logger.Printf(
+				"opencode control session lookup attempt %d/%d failed for %s: %v (retrying in %s)",
+				attempt,
+				openCodeControlSessionLookupAttempts,
+				sessionID,
+				lastErr,
+				backoff,
+			)
+			time.Sleep(backoff)
+		}
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("session lookup failed for %s", sessionID)
+	}
+
+	return nil, lastErr
+}
+
+func (s *SocketServer) recoverOpenCodeControlSession(client *agent.OpenCodeClient, projectRoot string) (*agent.Session, string, error) {
+	dirCtx, dirCancel := context.WithTimeout(context.Background(), openCodeControlSessionRecoveryListTimeout)
+	sessions, listErr := client.GetSessionsForDirectory(dirCtx, projectRoot)
+	dirCancel()
+	if listErr != nil {
+		s.logger.Printf("failed to list opencode sessions for directory-scoped recovery (project=%q): %v", projectRoot, listErr)
+	} else if recovered := findBestOpenCodeControlSession(projectRoot, sessions); recovered != nil {
+		return recovered, "directory-scoped session list", nil
+	} else {
+		s.logger.Printf("directory-scoped session recovery found no candidate for project %q", projectRoot)
+	}
+
+	allCtx, allCancel := context.WithTimeout(context.Background(), openCodeControlSessionRecoveryListTimeout)
+	allSessions, allErr := client.GetSessions(allCtx)
+	allCancel()
+	if allErr != nil {
+		return nil, "", fmt.Errorf("listing all opencode sessions for recovery: %w", allErr)
+	}
+
+	if recovered := findBestOpenCodeControlSession(projectRoot, allSessions); recovered != nil {
+		return recovered, "global session list", nil
+	}
+
+	return nil, "", fmt.Errorf("no recoverable opencode control session found")
+}
+
 func findBestOpenCodeControlSession(projectRoot string, sessions []agent.Session) *agent.Session {
+	normalizedProjectRoot := normalizeOpenCodeSessionDirectory(projectRoot)
+
 	var bestPreferred *agent.Session
 	var bestFallback *agent.Session
+	var bestTitleFallback *agent.Session
 
 	for i := range sessions {
 		session := sessions[i]
-		if projectRoot != "" && session.Directory != projectRoot {
+
+		if session.Title == openCodeControlSessionTitle {
+			if bestTitleFallback == nil || session.UpdatedAt().After(bestTitleFallback.UpdatedAt()) {
+				copy := session
+				bestTitleFallback = &copy
+			}
+		}
+
+		directoryMatches := normalizedProjectRoot == ""
+		if !directoryMatches {
+			directoryMatches = normalizeOpenCodeSessionDirectory(session.Directory) == normalizedProjectRoot
+		}
+		if !directoryMatches {
 			continue
 		}
 
@@ -1235,7 +1318,24 @@ func findBestOpenCodeControlSession(projectRoot string, sessions []agent.Session
 	if bestPreferred != nil {
 		return bestPreferred
 	}
-	return bestFallback
+	if bestFallback != nil {
+		return bestFallback
+	}
+	return bestTitleFallback
+}
+
+func normalizeOpenCodeSessionDirectory(path string) string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return ""
+	}
+
+	cleaned := filepath.Clean(trimmed)
+	if resolved, err := filepath.EvalSymlinks(cleaned); err == nil && resolved != "" {
+		cleaned = filepath.Clean(resolved)
+	}
+
+	return cleaned
 }
 
 func getControlPromptInstruction() string {

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/binary"
@@ -1690,6 +1691,158 @@ func TestGetOrCreateOpenCodeControlSessionReusesExisting(t *testing.T) {
 	}
 }
 
+func TestGetOrCreateOpenCodeControlSessionCreatesNewWhenNoStoredSession(t *testing.T) {
+	projectRoot := t.TempDir()
+	modelName := "openai/gpt-5.3-codex"
+	modelVariant := "xhigh"
+
+	var mu sync.Mutex
+	getCalls := 0
+	listCalls := 0
+	createCalls := 0
+	promptReqCh := make(chan struct{}, 1)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/session/"):
+			mu.Lock()
+			getCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == "GET" && r.URL.Path == "/session":
+			mu.Lock()
+			listCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == "POST" && r.URL.Path == "/session":
+			mu.Lock()
+			createCalls++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":        "ses_fresh_no_stored",
+				"title":     openCodeControlSessionTitle,
+				"directory": projectRoot,
+				"time": map[string]int64{
+					"created": 1000,
+					"updated": 1000,
+				},
+			})
+		case r.Method == "POST" && r.URL.Path == "/session/ses_fresh_no_stored/message":
+			select {
+			case promptReqCh <- struct{}{}:
+			default:
+			}
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	port := getPortFromURL(t, ts.URL)
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, port, modelName, modelVariant)
+	if err != nil {
+		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
+	}
+	if sessionID != "ses_fresh_no_stored" {
+		t.Fatalf("expected new session ID %q, got %q", "ses_fresh_no_stored", sessionID)
+	}
+
+	select {
+	case <-promptReqCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for initial prompt on newly created session")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if getCalls != 0 {
+		t.Fatalf("expected no GET by session ID when no stored session, got %d", getCalls)
+	}
+	if listCalls != 0 {
+		t.Fatalf("expected no list call when no stored session, got %d", listCalls)
+	}
+	if createCalls != 1 {
+		t.Fatalf("expected one create call when no stored session, got %d", createCalls)
+	}
+}
+
+func TestGetOrCreateOpenCodeControlSessionRetriesLookupBeforeReuse(t *testing.T) {
+	projectRoot := t.TempDir()
+	modelName := "openai/gpt-5.3-codex"
+	modelVariant := "xhigh"
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_existing", modelName, modelVariant)
+
+	var mu sync.Mutex
+	getCalls := 0
+	listCalls := 0
+	createCalls := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/session/ses_existing":
+			mu.Lock()
+			getCalls++
+			callNum := getCalls
+			mu.Unlock()
+
+			if callNum < openCodeControlSessionLookupAttempts {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error":"not found"}`))
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":        "ses_existing",
+				"title":     openCodeControlSessionTitle,
+				"directory": projectRoot,
+				"time": map[string]int64{
+					"created": 1000,
+					"updated": 2000,
+				},
+			})
+		case r.Method == "GET" && r.URL.Path == "/session":
+			mu.Lock()
+			listCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == "POST" && r.URL.Path == "/session":
+			mu.Lock()
+			createCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	port := getPortFromURL(t, ts.URL)
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, port, modelName, modelVariant)
+	if err != nil {
+		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
+	}
+	if sessionID != "ses_existing" {
+		t.Fatalf("expected existing session to be reused after retries, got %q", sessionID)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if getCalls != openCodeControlSessionLookupAttempts {
+		t.Fatalf("expected %d GET attempts before reuse, got %d", openCodeControlSessionLookupAttempts, getCalls)
+	}
+	if listCalls != 0 {
+		t.Fatalf("expected no fallback list call after successful retry, got %d", listCalls)
+	}
+	if createCalls != 0 {
+		t.Fatalf("expected no create call after successful retry, got %d", createCalls)
+	}
+}
+
 func TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart(t *testing.T) {
 	projectRoot := t.TempDir()
 	modelName := "openai/gpt-5.3-codex"
@@ -1779,8 +1932,8 @@ func TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart(t *testing.
 
 	mu.Lock()
 	defer mu.Unlock()
-	if getCalls != 1 {
-		t.Fatalf("expected one GET by stale session ID, got %d", getCalls)
+	if getCalls != openCodeControlSessionLookupAttempts {
+		t.Fatalf("expected %d GET retries by stale session ID, got %d", openCodeControlSessionLookupAttempts, getCalls)
 	}
 	if listCalls != 1 {
 		t.Fatalf("expected one fallback list call, got %d", listCalls)
@@ -1793,7 +1946,7 @@ func TestGetOrCreateOpenCodeControlSessionRecoversAfterServerRestart(t *testing.
 	}
 }
 
-func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *testing.T) {
+func TestGetOrCreateOpenCodeControlSessionRecoversFromGlobalListWhenDirectoryLookupEmpty(t *testing.T) {
 	projectRoot := t.TempDir()
 	modelName := "openai/gpt-5.3-codex"
 	modelVariant := "xhigh"
@@ -1802,13 +1955,9 @@ func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *t
 	var mu sync.Mutex
 	getCalls := 0
 	listCalls := 0
+	directoryScopedListCalls := 0
+	globalListCalls := 0
 	createCalls := 0
-	createDirectory := ""
-	createTitle := ""
-	createDecodeErr := ""
-	promptReqCh := make(chan agent.PromptRequest, 1)
-	promptDecodeErr := ""
-	promptDirectory := ""
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -1821,6 +1970,157 @@ func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *t
 		case r.Method == "GET" && r.URL.Path == "/session":
 			mu.Lock()
 			listCalls++
+			directory := r.Header.Get("X-OpenCode-Directory")
+			mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			if directory != "" {
+				mu.Lock()
+				directoryScopedListCalls++
+				mu.Unlock()
+				_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+				return
+			}
+
+			mu.Lock()
+			globalListCalls++
+			mu.Unlock()
+
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+				{
+					"id":        "ses_chat_latest",
+					"title":     "chat",
+					"directory": "/other/project",
+					"time":      map[string]int64{"created": 1000, "updated": 9000},
+				},
+				{
+					"id":        "ses_control_global",
+					"title":     openCodeControlSessionTitle,
+					"directory": "/resolved/project/path",
+					"time":      map[string]int64{"created": 1000, "updated": 5000},
+				},
+			})
+		case r.Method == "POST" && r.URL.Path == "/session":
+			mu.Lock()
+			createCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	port := getPortFromURL(t, ts.URL)
+	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, port, modelName, modelVariant)
+	if err != nil {
+		t.Fatalf("getOrCreateOpenCodeControlSession() error = %v", err)
+	}
+	if sessionID != "ses_control_global" {
+		t.Fatalf("expected global fallback control session %q, got %q", "ses_control_global", sessionID)
+	}
+
+	stored := readStoredOpenCodeControlSession(t, projectRoot)
+	if stored.SessionID != "ses_control_global" {
+		t.Fatalf("expected stored session ID to be updated to global fallback ID, got %q", stored.SessionID)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if getCalls != openCodeControlSessionLookupAttempts {
+		t.Fatalf("expected %d GET retries by stale session ID, got %d", openCodeControlSessionLookupAttempts, getCalls)
+	}
+	if listCalls != 2 {
+		t.Fatalf("expected two list calls (directory + global), got %d", listCalls)
+	}
+	if directoryScopedListCalls != 1 {
+		t.Fatalf("expected one directory-scoped list call, got %d", directoryScopedListCalls)
+	}
+	if globalListCalls != 1 {
+		t.Fatalf("expected one global list call, got %d", globalListCalls)
+	}
+	if createCalls != 0 {
+		t.Fatalf("expected no new session creation during global fallback recovery, got %d", createCalls)
+	}
+}
+
+func TestFindBestOpenCodeControlSessionNormalizesProjectRootPath(t *testing.T) {
+	realProjectRoot := t.TempDir()
+	symlinkParent := t.TempDir()
+	symlinkProjectRoot := filepath.Join(symlinkParent, "project-link")
+	if err := os.Symlink(realProjectRoot, symlinkProjectRoot); err != nil {
+		t.Skipf("symlink not supported in test environment: %v", err)
+	}
+
+	otherProjectRoot := t.TempDir()
+
+	sessions := []agent.Session{
+		{
+			ID:        "ses_control_other",
+			Title:     openCodeControlSessionTitle,
+			Directory: otherProjectRoot,
+			Time:      agent.SessionTimeMillis{Created: 1000, Updated: 9000},
+		},
+		{
+			ID:        "ses_control_match",
+			Title:     openCodeControlSessionTitle,
+			Directory: realProjectRoot,
+			Time:      agent.SessionTimeMillis{Created: 1000, Updated: 5000},
+		},
+		{
+			ID:        "ses_chat_match",
+			Title:     "chat",
+			Directory: realProjectRoot,
+			Time:      agent.SessionTimeMillis{Created: 1000, Updated: 8000},
+		},
+	}
+
+	recovered := findBestOpenCodeControlSession(symlinkProjectRoot+string(os.PathSeparator), sessions)
+	if recovered == nil {
+		t.Fatal("expected normalized path recovery to return a session")
+	}
+	if recovered.ID != "ses_control_match" {
+		t.Fatalf("expected normalized path recovery to prefer %q, got %q", "ses_control_match", recovered.ID)
+	}
+}
+
+func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *testing.T) {
+	projectRoot := t.TempDir()
+	modelName := "openai/gpt-5.3-codex"
+	modelVariant := "xhigh"
+	writeStoredOpenCodeControlSession(t, projectRoot, "ses_stale", modelName, modelVariant)
+
+	var mu sync.Mutex
+	getCalls := 0
+	listCalls := 0
+	directoryScopedListCalls := 0
+	globalListCalls := 0
+	createCalls := 0
+	createDirectory := ""
+	createTitle := ""
+	createDecodeErr := ""
+	promptReqCh := make(chan agent.PromptRequest, 1)
+	promptDecodeErr := ""
+	promptDirectory := ""
+	var logBuf bytes.Buffer
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/session/ses_stale":
+			mu.Lock()
+			getCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+		case r.Method == "GET" && r.URL.Path == "/session":
+			mu.Lock()
+			listCalls++
+			if r.Header.Get("X-OpenCode-Directory") == "" {
+				globalListCalls++
+			} else {
+				directoryScopedListCalls++
+			}
 			mu.Unlock()
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
@@ -1876,7 +2176,7 @@ func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *t
 	}))
 	defer ts.Close()
 
-	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	server := NewSocketServer(nil, log.New(&logBuf, "", 0))
 	port := getPortFromURL(t, ts.URL)
 	sessionID, err := server.getOrCreateOpenCodeControlSession(projectRoot, port, modelName, modelVariant)
 	if err != nil {
@@ -1919,11 +2219,17 @@ func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *t
 
 	mu.Lock()
 	defer mu.Unlock()
-	if getCalls != 1 {
-		t.Fatalf("expected one GET by stale session ID, got %d", getCalls)
+	if getCalls != openCodeControlSessionLookupAttempts {
+		t.Fatalf("expected %d GET retries by stale session ID, got %d", openCodeControlSessionLookupAttempts, getCalls)
 	}
-	if listCalls != 1 {
-		t.Fatalf("expected one fallback list call, got %d", listCalls)
+	if listCalls != 2 {
+		t.Fatalf("expected two list calls (directory + global), got %d", listCalls)
+	}
+	if directoryScopedListCalls != 1 {
+		t.Fatalf("expected one directory-scoped list call, got %d", directoryScopedListCalls)
+	}
+	if globalListCalls != 1 {
+		t.Fatalf("expected one global list call, got %d", globalListCalls)
 	}
 	if createCalls != 1 {
 		t.Fatalf("expected one create call, got %d", createCalls)
@@ -1942,6 +2248,17 @@ func TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession(t *t
 	}
 	if promptDirectory != projectRoot {
 		t.Fatalf("expected prompt directory header %q, got %q", projectRoot, promptDirectory)
+	}
+
+	logs := logBuf.String()
+	if !strings.Contains(logs, "failed to reuse stored opencode control session ses_stale") {
+		t.Fatalf("expected reuse failure log to include stored session ID, logs: %s", logs)
+	}
+	if !strings.Contains(logs, "failed to recover opencode control session after reuse failure") {
+		t.Fatalf("expected recovery failure log message, logs: %s", logs)
+	}
+	if !strings.Contains(logs, "no recoverable opencode control session found") {
+		t.Fatalf("expected recovery failure reason in logs, logs: %s", logs)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add retry/backoff session lookup in `getOrCreateOpenCodeControlSession()` so transient opencode server restarts during `orch-monitor --new` do not immediately force a new control session.
- Make recovery more robust by normalizing directories (clean + symlink resolution) and adding a global title-based fallback (`orch-control`) when directory-scoped lookup cannot recover.
- Add explicit daemon log reasons for reuse/recovery failures and extend daemon tests for retry behavior, global fallback recovery, path normalization, and fresh-session creation.

## Testing
- `go test -v ./internal/daemon -run "TestGetOrCreateOpenCodeControlSession(ReusesExisting|CreatesNewWhenNoStoredSession|RetriesLookupBeforeReuse|RecoversAfterServerRestart|RecoversFromGlobalListWhenDirectoryLookupEmpty|CreatesWhenRecoveryFindsNoSession)|TestFindBestOpenCodeControlSessionNormalizesProjectRootPath" -count=1`
- `go test ./internal/daemon -count=1`
- `go build ./...`

## Acceptance Criteria Evidence
- [x] `orch-monitor --new` preserves control session history when opencode server is still running
  - Verified by `TestGetOrCreateOpenCodeControlSessionReusesExisting`
  - Verified by `TestGetOrCreateOpenCodeControlSessionRetriesLookupBeforeReuse` (transient not-found before successful reuse)
- [x] Session reuse works even if paths differ by trailing slash or symlink resolution
  - Verified by `TestFindBestOpenCodeControlSessionNormalizesProjectRootPath` (symlink root + trailing slash)
- [x] `--new-control-agent` still correctly creates a fresh session
  - Verified by `TestGetOrCreateOpenCodeControlSessionCreatesNewWhenNoStoredSession` (no stored session => direct fresh create path)
- [x] Add daemon log messages when session reuse fails (with reason) for debuggability
  - Verified by `TestGetOrCreateOpenCodeControlSessionCreatesWhenRecoveryFindsNoSession` (asserts failure-reason log output)
- [x] Add test for path normalization in `findBestOpenCodeControlSession()`
  - Added `TestFindBestOpenCodeControlSessionNormalizesProjectRootPath`

Refs: orch-440