### PR TITLE
Fix OpenCode server key normalization across worktrees

### DIFF
--- a/.semgrep/architecture.yaml
+++ b/.semgrep/architecture.yaml
@@ -697,6 +697,29 @@ rules:
       category: architecture
       violation: identity-leakage
 
+  - id: daemon-no-worktree-path-to-ensure-server
+    patterns:
+      - pattern-either:
+          - pattern: $S.ensureOpenCodeServerRunning($RESULT.WorktreePath)
+          - pattern: $S.ensureOpenCodeServerRunning(worktreePath)
+    paths:
+      include:
+        - /internal/daemon/
+      exclude:
+        - /internal/daemon/*_test.go
+    message: >
+      Do not pass worktree paths to ensureOpenCodeServerRunning().
+      This function uses the path as a registry key; worktree paths create
+      duplicate servers for the same repo. Pass the main repo root
+      (req.ProjectRoot or resolve via git.FindMainRepoRoot).
+      Note: ensureOpenCodeServerRunning also self-normalizes as defense-in-depth,
+      but call sites should pass the correct value.
+    severity: ERROR
+    languages: [go]
+    metadata:
+      category: architecture
+      violation: server-identity
+
   # ---------------------------------------------------------------------------
   # 7. Transport contract fidelity: prevent Message field overloading
   # ---------------------------------------------------------------------------

--- a/internal/daemon/managed_servers_db.go
+++ b/internal/daemon/managed_servers_db.go
@@ -261,15 +261,31 @@ func (s *SocketServer) persistManagedServerStart(srv *managedServer) error {
 		return nil
 	}
 
+	persistedProjectRoot := srv.ProjectRoot
+	normalizedProjectRoot := normalizeOpenCodeServerProjectRoot(persistedProjectRoot)
+	if normalizedProjectRoot == "" {
+		normalizedProjectRoot = persistedProjectRoot
+	}
+
 	record := managedServerRecord{
-		ProjectRoot: srv.ProjectRoot,
+		ProjectRoot: normalizedProjectRoot,
 		PID:         serverPID(srv),
 		Port:        srv.Port,
 		LogPath:     srv.LogPath,
 		StartedAt:   srv.StartTime,
 		LastHealthy: srv.LastHealthy,
 	}
-	return s.managedServerStore.Upsert(record)
+	if err := s.managedServerStore.Upsert(record); err != nil {
+		return err
+	}
+
+	if persistedProjectRoot != "" && persistedProjectRoot != normalizedProjectRoot {
+		if err := s.managedServerStore.Delete(persistedProjectRoot); err != nil && s.logger != nil {
+			s.logger.Printf("warning: failed to remove legacy managed server key %s after normalization to %s: %v", persistedProjectRoot, normalizedProjectRoot, err)
+		}
+	}
+
+	return nil
 }
 
 func (s *SocketServer) deleteManagedServerRecord(projectRoot string) {
@@ -314,8 +330,13 @@ func (s *SocketServer) reconcileManagedServersOnStartup() error {
 }
 
 func (s *SocketServer) reconcileManagedServerRecord(record managedServerRecord, adoptedPorts map[int]string) {
+	persistedProjectRoot := record.ProjectRoot
+	if normalizedProjectRoot := normalizeOpenCodeServerProjectRoot(record.ProjectRoot); normalizedProjectRoot != "" {
+		record.ProjectRoot = normalizedProjectRoot
+	}
+
 	if record.ProjectRoot == "" || record.PID <= 0 || record.Port <= 0 {
-		s.deleteManagedServerRecord(record.ProjectRoot)
+		s.deleteManagedServerRecord(persistedProjectRoot)
 		return
 	}
 
@@ -326,7 +347,20 @@ func (s *SocketServer) reconcileManagedServerRecord(record managedServerRecord, 
 		if err := s.terminateServerProcessByPID(record.PID, 5*time.Second); err != nil && s.logger != nil {
 			s.logger.Printf("warning: failed to terminate duplicate server process pid=%d for %s: %v", record.PID, record.ProjectRoot, err)
 		}
-		s.deleteManagedServerRecord(record.ProjectRoot)
+		s.deleteManagedServerRecord(persistedProjectRoot)
+		return
+	}
+
+	if existingSrv, exists := s.openCodeServers[record.ProjectRoot]; exists {
+		if s.logger != nil {
+			s.logger.Printf("startup recovery: server already adopted for %s on port %d; removing duplicate record (pid=%d, port=%d)", record.ProjectRoot, existingSrv.Port, record.PID, record.Port)
+		}
+		if existingSrv.PID != record.PID {
+			if err := s.terminateServerProcessByPID(record.PID, 5*time.Second); err != nil && s.logger != nil {
+				s.logger.Printf("warning: failed to terminate duplicate server process pid=%d for %s: %v", record.PID, record.ProjectRoot, err)
+			}
+		}
+		s.deleteManagedServerRecord(persistedProjectRoot)
 		return
 	}
 
@@ -334,7 +368,7 @@ func (s *SocketServer) reconcileManagedServerRecord(record managedServerRecord, 
 		if s.logger != nil {
 			s.logger.Printf("startup recovery: removing stale managed server record for %s (pid=%d dead)", record.ProjectRoot, record.PID)
 		}
-		s.deleteManagedServerRecord(record.ProjectRoot)
+		s.deleteManagedServerRecord(persistedProjectRoot)
 		return
 	}
 
@@ -353,7 +387,7 @@ func (s *SocketServer) reconcileManagedServerRecord(record managedServerRecord, 
 			}
 			return
 		}
-		s.deleteManagedServerRecord(record.ProjectRoot)
+		s.deleteManagedServerRecord(persistedProjectRoot)
 		return
 	}
 
@@ -362,7 +396,7 @@ func (s *SocketServer) reconcileManagedServerRecord(record managedServerRecord, 
 		lastHealthy = time.Now()
 	}
 
-	s.openCodeServers[record.ProjectRoot] = &managedServer{
+	srv := &managedServer{
 		ProjectRoot: record.ProjectRoot,
 		Port:        record.Port,
 		PID:         record.PID,
@@ -371,7 +405,16 @@ func (s *SocketServer) reconcileManagedServerRecord(record managedServerRecord, 
 		LogPath:     record.LogPath,
 		Adopted:     true,
 	}
+	s.openCodeServers[record.ProjectRoot] = srv
 	adoptedPorts[record.Port] = record.ProjectRoot
+
+	if persistedProjectRoot != "" && persistedProjectRoot != record.ProjectRoot {
+		s.deleteManagedServerRecord(persistedProjectRoot)
+		if err := s.persistManagedServerStart(srv); err != nil && s.logger != nil {
+			s.logger.Printf("warning: failed to persist normalized managed server key for %s: %v", record.ProjectRoot, err)
+		}
+	}
+
 	s.updateManagedServerHealth(record.ProjectRoot, lastHealthy)
 
 	if s.logger != nil {

--- a/internal/daemon/managed_servers_db_test.go
+++ b/internal/daemon/managed_servers_db_test.go
@@ -93,6 +93,56 @@ func TestManagedServerStoreCRUD(t *testing.T) {
 	}
 }
 
+func TestPersistManagedServerStartNormalizesProjectRootKey(t *testing.T) {
+	setupManagedServerDBEnv(t)
+
+	repoRoot := filepath.Join(os.TempDir(), "orch-main-repo")
+	worktreePath := filepath.Join(repoRoot, ".git-worktrees", "run-a")
+
+	prevFindMainRepoRoot := findMainRepoRoot
+	findMainRepoRoot = func(startDir string) (string, error) {
+		switch startDir {
+		case repoRoot, worktreePath:
+			return repoRoot, nil
+		default:
+			return "", os.ErrNotExist
+		}
+	}
+	defer func() { findMainRepoRoot = prevFindMainRepoRoot }()
+
+	store, err := newManagedServerStore(xdg.DaemonDBPath())
+	if err != nil {
+		t.Fatalf("newManagedServerStore() error = %v", err)
+	}
+	defer store.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	server.managedServerStore = store
+
+	err = server.persistManagedServerStart(&managedServer{
+		ProjectRoot: worktreePath,
+		PID:         23456,
+		Port:        4097,
+		LogPath:     "/tmp/opencode-normalized.log",
+		StartTime:   time.Now().Add(-15 * time.Second),
+		LastHealthy: time.Now().Add(-5 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("persistManagedServerStart() error = %v", err)
+	}
+
+	rows, err := store.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].ProjectRoot != repoRoot {
+		t.Fatalf("expected normalized project_root %q, got %q", repoRoot, rows[0].ProjectRoot)
+	}
+}
+
 func TestReconcileManagedServersOnStartupAdoptsHealthyServer(t *testing.T) {
 	setupManagedServerDBEnv(t)
 

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -1394,8 +1394,9 @@ func (s *SocketServer) handleProtoEnsureOpenCodeServer(req *orchpb.EnsureOpenCod
 		return errorResponse(fmt.Sprintf("failed to ensure opencode server: %v", err))
 	}
 
+	serverKey := normalizeOpenCodeServerProjectRoot(req.ProjectRoot)
 	s.openCodeServersMu.RLock()
-	srv, exists := s.openCodeServers[req.ProjectRoot]
+	srv, exists := s.openCodeServers[serverKey]
 	alreadyRunning := exists && srv != nil
 	s.openCodeServersMu.RUnlock()
 

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -39,6 +39,7 @@ var (
 	// the server accepts the message.
 	openCodeSendAckTimeout = 10 * time.Second
 	codexTmuxSubmitDelay   = 250 * time.Millisecond
+	findMainRepoRoot       = git.FindMainRepoRoot
 
 	getSendMultiplexer = func() sendMultiplexer {
 		return multiplexer.GetDefault()
@@ -826,7 +827,32 @@ func (s *SocketServer) handleEnsureOpenCodeServer(req SendRequest, encoder *json
 	})
 }
 
+func normalizeOpenCodeServerProjectRoot(projectRoot string) string {
+	projectRoot = strings.TrimSpace(projectRoot)
+	if projectRoot == "" {
+		return ""
+	}
+
+	keyRoot := projectRoot
+	if mainRoot, err := findMainRepoRoot(projectRoot); err == nil {
+		if trimmed := strings.TrimSpace(mainRoot); trimmed != "" {
+			keyRoot = trimmed
+		}
+	}
+
+	absRoot, err := filepath.Abs(keyRoot)
+	if err == nil {
+		return filepath.Clean(absRoot)
+	}
+	return filepath.Clean(keyRoot)
+}
+
 func (s *SocketServer) ensureOpenCodeServerRunning(projectRoot string) (int, error) {
+	projectRoot = normalizeOpenCodeServerProjectRoot(projectRoot)
+	if projectRoot == "" {
+		return 0, fmt.Errorf("project root required")
+	}
+
 	s.openCodeServersMu.Lock()
 	defer s.openCodeServersMu.Unlock()
 
@@ -1113,6 +1139,11 @@ func (s *SocketServer) StopAllOpenCodeServers() {
 }
 
 func (s *SocketServer) getOpenCodeServerPort(projectRoot string) int {
+	projectRoot = normalizeOpenCodeServerProjectRoot(projectRoot)
+	if projectRoot == "" {
+		return 0
+	}
+
 	s.openCodeServersMu.RLock()
 	defer s.openCodeServersMu.RUnlock()
 
@@ -2494,7 +2525,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 
 	serverAlreadyRunning := false
 	if adapter.PromptInjection() == agent.InjectionHTTP {
-		resp, err := s.ensureOpenCodeServerRunning(worktreeResult.WorktreePath)
+		resp, err := s.ensureOpenCodeServerRunning(repoRoot)
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
 			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
@@ -2773,7 +2804,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 
 	serverAlreadyRunning := false
 	if adapter.PromptInjection() == agent.InjectionHTTP {
-		resp, err := s.ensureOpenCodeServerRunning(worktreeResult.WorktreePath)
+		resp, err := s.ensureOpenCodeServerRunning(projectRoot)
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
 			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
@@ -3127,7 +3158,12 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 
 	serverAlreadyRunning := false
 	if adapter.PromptInjection() == agent.InjectionHTTP {
-		resp, err := s.ensureOpenCodeServerRunning(worktreePath)
+		serverProjectRoot := projectRoot
+		if serverProjectRoot == "" {
+			serverProjectRoot = worktreePath
+		}
+
+		resp, err := s.ensureOpenCodeServerRunning(serverProjectRoot)
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
 			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
@@ -3509,7 +3545,12 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 
 	serverAlreadyRunning := false
 	if adapter.PromptInjection() == agent.InjectionHTTP {
-		resp, err := s.ensureOpenCodeServerRunning(worktreePath)
+		serverProjectRoot := s.resolveProjectRoot(req)
+		if serverProjectRoot == "" {
+			serverProjectRoot = worktreePath
+		}
+
+		resp, err := s.ensureOpenCodeServerRunning(serverProjectRoot)
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
 			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -356,7 +356,8 @@ func TestProcessSendOpenCodeReturnsAfterAck(t *testing.T) {
 
 	logger := log.New(io.Discard, "", 0)
 	server := NewSocketServer(nil, logger)
-	server.openCodeServers[projectRoot] = &managedServer{
+	serverKey := normalizeOpenCodeServerProjectRoot(projectRoot)
+	server.openCodeServers[serverKey] = &managedServer{
 		ProjectRoot: projectRoot,
 		Port:        getPortFromURL(t, testServer.URL),
 		WaitResult:  make(chan error, 1),
@@ -413,7 +414,8 @@ func TestProcessSendOpenCodeTimesOutPromptlyWithoutAck(t *testing.T) {
 
 	logger := log.New(io.Discard, "", 0)
 	server := NewSocketServer(nil, logger)
-	server.openCodeServers[projectRoot] = &managedServer{
+	serverKey := normalizeOpenCodeServerProjectRoot(projectRoot)
+	server.openCodeServers[serverKey] = &managedServer{
 		ProjectRoot: projectRoot,
 		Port:        getPortFromURL(t, testServer.URL),
 		WaitResult:  make(chan error, 1),
@@ -1555,6 +1557,59 @@ func TestWaitForOpenCodeServerHealthy(t *testing.T) {
 		}
 		close(waitResult)
 	})
+}
+
+func TestEnsureOpenCodeServerRunningNormalizesWorktreeServerKey(t *testing.T) {
+	repoRoot := filepath.Join(os.TempDir(), "orch-main-repo")
+	worktreeA := filepath.Join(repoRoot, ".git-worktrees", "run-a")
+	worktreeB := filepath.Join(repoRoot, ".git-worktrees", "run-b")
+
+	port, shutdown := startFakeOpenCodeServer(t, repoRoot)
+	defer shutdown()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	server.openCodeServers[repoRoot] = &managedServer{
+		ProjectRoot: repoRoot,
+		Port:        port,
+		WaitResult:  make(chan error, 1),
+		LastHealthy: time.Now(),
+	}
+
+	prevFindMainRepoRoot := findMainRepoRoot
+	findMainRepoRoot = func(startDir string) (string, error) {
+		switch startDir {
+		case repoRoot, worktreeA, worktreeB:
+			return repoRoot, nil
+		default:
+			return "", os.ErrNotExist
+		}
+	}
+	defer func() { findMainRepoRoot = prevFindMainRepoRoot }()
+
+	portA, err := server.ensureOpenCodeServerRunning(worktreeA)
+	if err != nil {
+		t.Fatalf("ensureOpenCodeServerRunning(worktreeA) error = %v", err)
+	}
+	portB, err := server.ensureOpenCodeServerRunning(worktreeB)
+	if err != nil {
+		t.Fatalf("ensureOpenCodeServerRunning(worktreeB) error = %v", err)
+	}
+
+	if portA != port || portB != port {
+		t.Fatalf("expected both worktrees to resolve to port %d, got portA=%d portB=%d", port, portA, portB)
+	}
+	if got := server.getOpenCodeServerPort(worktreeA); got != port {
+		t.Fatalf("getOpenCodeServerPort(worktreeA) = %d, want %d", got, port)
+	}
+	if got := server.getOpenCodeServerPort(worktreeB); got != port {
+		t.Fatalf("getOpenCodeServerPort(worktreeB) = %d, want %d", got, port)
+	}
+	if len(server.openCodeServers) != 1 {
+		t.Fatalf("expected a single server entry keyed by main repo root, got %d entries", len(server.openCodeServers))
+	}
+	if _, ok := server.openCodeServers[repoRoot]; !ok {
+		t.Fatalf("expected server map key %q", repoRoot)
+	}
 }
 
 func TestOpenCodeServerLogPathIsPerProjectRoot(t *testing.T) {


### PR DESCRIPTION
## Summary
- Normalize OpenCode server identity to the main repo root in `ensureOpenCodeServerRunning` and `getOpenCodeServerPort`, so worktree paths cannot create duplicate server registry entries.
- Update daemon OpenCode launch/continue call sites to pass repo roots, and normalize managed server persistence/reconciliation keys in SQLite startup recovery.
- Add architecture lint protection and regression tests for worktree-path normalization in both in-memory server registry and persisted `managed_servers` records.

## Acceptance Criteria Evidence
- [x] `ensureOpenCodeServerRunning` resolves worktree paths to main repo root before registry lookup (`internal/daemon/socket.go`).
- [x] `getOpenCodeServerPort` resolves worktree paths to main repo root before lookup (`internal/daemon/socket.go`).
- [x] One OpenCode server per repo across worktrees: `go test ./internal/daemon -run TestEnsureOpenCodeServerRunningNormalizesWorktreeServerKey -v` passes.
- [x] `managed_servers` SQLite key normalization: `go test ./internal/daemon -run TestPersistManagedServerStartNormalizesProjectRootKey -v` passes.
- [x] Semgrep rule added: `daemon-no-worktree-path-to-ensure-server` in `.semgrep/architecture.yaml`.
- [x] `make lint` passes with no new violations.
- [x] `go build ./...` passes.
- [ ] `go test ./...` currently fails in an unrelated pre-existing test: `internal/cli TestApplyConfigDefaultsFallbacks` (`invalid config schema ... EOF`). Daemon package tests pass (`go test ./internal/daemon`).

Issue: orch-445