### PR TITLE
Fix opencode server registry identity to use main repo root

### DIFF
--- a/.semgrep/architecture.yaml
+++ b/.semgrep/architecture.yaml
@@ -697,6 +697,29 @@ rules:
       category: architecture
       violation: identity-leakage
 
+  - id: daemon-no-worktree-path-to-ensure-server
+    patterns:
+      - pattern-either:
+          - pattern: $S.ensureOpenCodeServerRunning($RESULT.WorktreePath)
+          - pattern: $S.ensureOpenCodeServerRunning(worktreePath)
+    paths:
+      include:
+        - /internal/daemon/
+      exclude:
+        - /internal/daemon/*_test.go
+    message: >
+      Do not pass worktree paths to ensureOpenCodeServerRunning().
+      This function uses the path as a registry key - worktree paths create
+      duplicate servers for the same repo. Pass the main repo root
+      (req.ProjectRoot or resolve via git.FindMainRepoRoot).
+      Note: ensureOpenCodeServerRunning also self-normalizes as defense-in-depth,
+      but call sites should pass the correct value.
+    severity: ERROR
+    languages: [go]
+    metadata:
+      category: architecture
+      violation: server-identity
+
   # ---------------------------------------------------------------------------
   # 7. Transport contract fidelity: prevent Message field overloading
   # ---------------------------------------------------------------------------

--- a/internal/daemon/managed_servers_db.go
+++ b/internal/daemon/managed_servers_db.go
@@ -261,8 +261,10 @@ func (s *SocketServer) persistManagedServerStart(srv *managedServer) error {
 		return nil
 	}
 
+	projectRoot := s.normalizeProjectRoot(srv.ProjectRoot)
+
 	record := managedServerRecord{
-		ProjectRoot: srv.ProjectRoot,
+		ProjectRoot: projectRoot,
 		PID:         serverPID(srv),
 		Port:        srv.Port,
 		LogPath:     srv.LogPath,
@@ -277,8 +279,18 @@ func (s *SocketServer) deleteManagedServerRecord(projectRoot string) {
 		return
 	}
 
-	if err := s.managedServerStore.Delete(projectRoot); err != nil && s.logger != nil {
-		s.logger.Printf("warning: failed to delete managed server record for %s: %v", projectRoot, err)
+	normalizedProjectRoot := s.normalizeProjectRoot(projectRoot)
+	if normalizedProjectRoot != "" {
+		if err := s.managedServerStore.Delete(normalizedProjectRoot); err != nil && s.logger != nil {
+			s.logger.Printf("warning: failed to delete managed server record for %s: %v", normalizedProjectRoot, err)
+		}
+	}
+
+	// Delete legacy pre-normalized keys as best-effort cleanup.
+	if normalizedProjectRoot != projectRoot {
+		if err := s.managedServerStore.Delete(projectRoot); err != nil && s.logger != nil {
+			s.logger.Printf("warning: failed to delete legacy managed server record for %s: %v", projectRoot, err)
+		}
 	}
 }
 
@@ -287,6 +299,7 @@ func (s *SocketServer) updateManagedServerHealth(projectRoot string, at time.Tim
 		return
 	}
 
+	projectRoot = s.normalizeProjectRoot(projectRoot)
 	if err := s.managedServerStore.UpdateLastHealthy(projectRoot, at); err != nil && s.logger != nil {
 		s.logger.Printf("warning: failed to update managed server health for %s: %v", projectRoot, err)
 	}
@@ -314,8 +327,25 @@ func (s *SocketServer) reconcileManagedServersOnStartup() error {
 }
 
 func (s *SocketServer) reconcileManagedServerRecord(record managedServerRecord, adoptedPorts map[int]string) {
+	legacyProjectRoot := record.ProjectRoot
+	record.ProjectRoot = s.normalizeProjectRoot(record.ProjectRoot)
+	if record.ProjectRoot == "" {
+		record.ProjectRoot = legacyProjectRoot
+	}
+
+	// Migrate legacy worktree-path keys to normalized repo-root keys.
+	if legacyProjectRoot != "" && legacyProjectRoot != record.ProjectRoot && s.managedServerStore != nil {
+		if err := s.managedServerStore.Upsert(record); err != nil {
+			if s.logger != nil {
+				s.logger.Printf("warning: failed to migrate managed server record from %s to %s: %v", legacyProjectRoot, record.ProjectRoot, err)
+			}
+		} else if err := s.managedServerStore.Delete(legacyProjectRoot); err != nil && s.logger != nil {
+			s.logger.Printf("warning: failed to remove legacy managed server record for %s: %v", legacyProjectRoot, err)
+		}
+	}
+
 	if record.ProjectRoot == "" || record.PID <= 0 || record.Port <= 0 {
-		s.deleteManagedServerRecord(record.ProjectRoot)
+		s.deleteManagedServerRecord(legacyProjectRoot)
 		return
 	}
 

--- a/internal/daemon/managed_servers_db_test.go
+++ b/internal/daemon/managed_servers_db_test.go
@@ -93,6 +93,66 @@ func TestManagedServerStoreCRUD(t *testing.T) {
 	}
 }
 
+func TestPersistManagedServerStartNormalizesProjectRoot(t *testing.T) {
+	setupManagedServerDBEnv(t)
+
+	repoRoot, worktreePath, _ := createMainRepoWithTwoWorktrees(t)
+
+	store, err := newManagedServerStore(xdg.DaemonDBPath())
+	if err != nil {
+		t.Fatalf("newManagedServerStore() error = %v", err)
+	}
+	defer store.Close()
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	server.managedServerStore = store
+	expectedProjectRoot := server.normalizeProjectRoot(repoRoot)
+
+	if err := server.persistManagedServerStart(&managedServer{
+		ProjectRoot: worktreePath,
+		PID:         12345,
+		Port:        4101,
+		LogPath:     "/tmp/opencode-normalized.log",
+		StartTime:   time.Now().Add(-5 * time.Second),
+	}); err != nil {
+		t.Fatalf("persistManagedServerStart() error = %v", err)
+	}
+
+	rows, err := store.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].ProjectRoot != expectedProjectRoot {
+		t.Fatalf("expected normalized project_root %q, got %q", expectedProjectRoot, rows[0].ProjectRoot)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	server.updateManagedServerHealth(worktreePath, now)
+
+	rows, err = store.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row after health update, got %d", len(rows))
+	}
+	if rows[0].LastHealthy.IsZero() {
+		t.Fatal("expected non-zero last_healthy after normalized update")
+	}
+
+	server.deleteManagedServerRecord(worktreePath)
+	rows, err = store.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected row deleted via normalized key, got %d rows", len(rows))
+	}
+}
+
 func TestReconcileManagedServersOnStartupAdoptsHealthyServer(t *testing.T) {
 	setupManagedServerDBEnv(t)
 

--- a/internal/daemon/opencode_server_project_root_test.go
+++ b/internal/daemon/opencode_server_project_root_test.go
@@ -1,0 +1,66 @@
+package daemon
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEnsureOpenCodeServerRunningNormalizesWorktreePath(t *testing.T) {
+	repoRoot, worktreeA, worktreeB := createMainRepoWithTwoWorktrees(t)
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+
+	normalizedRepoRoot := server.normalizeProjectRoot(repoRoot)
+	if normalizedRepoRoot == "" {
+		t.Fatal("expected normalized repo root to be non-empty")
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/global/health":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"healthy":true,"version":"test"}`)
+		case "/project/current":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, fmt.Sprintf(`{"id":"proj","worktree":%q,"sandboxes":[]}`, normalizedRepoRoot))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	port := getPortFromURL(t, ts.URL)
+
+	server.openCodeServers[normalizedRepoRoot] = &managedServer{
+		ProjectRoot: normalizedRepoRoot,
+		Port:        port,
+		WaitResult:  make(chan error),
+	}
+
+	gotA, err := server.ensureOpenCodeServerRunning(worktreeA)
+	if err != nil {
+		t.Fatalf("ensureOpenCodeServerRunning(worktreeA) error = %v", err)
+	}
+	gotB, err := server.ensureOpenCodeServerRunning(worktreeB)
+	if err != nil {
+		t.Fatalf("ensureOpenCodeServerRunning(worktreeB) error = %v", err)
+	}
+
+	if gotA != port || gotB != port {
+		t.Fatalf("expected both worktrees to resolve to port %d, got %d and %d", port, gotA, gotB)
+	}
+	if len(server.openCodeServers) != 1 {
+		t.Fatalf("expected one server entry, got %d", len(server.openCodeServers))
+	}
+	if _, ok := server.openCodeServers[normalizedRepoRoot]; !ok {
+		t.Fatalf("expected server map entry keyed by repo root %q", normalizedRepoRoot)
+	}
+
+	gotPort := server.getOpenCodeServerPort(worktreeB)
+	if gotPort != port {
+		t.Fatalf("getOpenCodeServerPort(worktreeB) = %d, want %d", gotPort, port)
+	}
+}

--- a/internal/daemon/project_root_test_helpers_test.go
+++ b/internal/daemon/project_root_test_helpers_test.go
@@ -1,0 +1,48 @@
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func createMainRepoWithTwoWorktrees(t *testing.T) (repoRoot string, worktreeA string, worktreeB string) {
+	t.Helper()
+
+	baseDir := t.TempDir()
+	repoRoot = filepath.Join(baseDir, "repo")
+	if err := os.MkdirAll(repoRoot, 0755); err != nil {
+		t.Fatalf("failed to create repo dir: %v", err)
+	}
+
+	runGit(t, repoRoot, "init")
+	runGit(t, repoRoot, "config", "user.email", "orch-tests@example.com")
+	runGit(t, repoRoot, "config", "user.name", "Orch Tests")
+
+	readmePath := filepath.Join(repoRoot, "README.md")
+	if err := os.WriteFile(readmePath, []byte("test\n"), 0644); err != nil {
+		t.Fatalf("failed to write README.md: %v", err)
+	}
+	runGit(t, repoRoot, "add", "README.md")
+	runGit(t, repoRoot, "commit", "-m", "initial commit")
+
+	worktreeA = filepath.Join(baseDir, "worktree-a")
+	worktreeB = filepath.Join(baseDir, "worktree-b")
+	runGit(t, repoRoot, "worktree", "add", "-b", "feature-a", worktreeA, "HEAD")
+	runGit(t, repoRoot, "worktree", "add", "-b", "feature-b", worktreeB, "HEAD")
+
+	return repoRoot, worktreeA, worktreeB
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, string(out))
+	}
+}

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -1400,8 +1400,10 @@ func (s *SocketServer) handleProtoEnsureOpenCodeServer(req *orchpb.EnsureOpenCod
 		return errorResponse(fmt.Sprintf("failed to ensure opencode server: %v", err))
 	}
 
+	projectRoot := s.normalizeProjectRoot(req.ProjectRoot)
+
 	s.openCodeServersMu.RLock()
-	srv, exists := s.openCodeServers[req.ProjectRoot]
+	srv, exists := s.openCodeServers[projectRoot]
 	alreadyRunning := exists && srv != nil
 	s.openCodeServersMu.RUnlock()
 

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -831,7 +831,35 @@ func (s *SocketServer) handleEnsureOpenCodeServer(req SendRequest, encoder *json
 	})
 }
 
+func (s *SocketServer) normalizeProjectRoot(projectRoot string) string {
+	if projectRoot == "" {
+		return ""
+	}
+
+	normalized := projectRoot
+	if info, statErr := os.Stat(projectRoot); statErr == nil && info.IsDir() {
+		mainRoot, err := git.FindMainRepoRoot(projectRoot)
+		if err == nil && mainRoot != "" {
+			normalized = mainRoot
+		}
+	}
+
+	normalized = filepath.Clean(normalized)
+	if !filepath.IsAbs(normalized) {
+		if abs, absErr := filepath.Abs(normalized); absErr == nil {
+			normalized = abs
+		}
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(normalized); resolveErr == nil && resolved != "" {
+		normalized = resolved
+	}
+
+	return normalized
+}
+
 func (s *SocketServer) ensureOpenCodeServerRunning(projectRoot string) (int, error) {
+	projectRoot = s.normalizeProjectRoot(projectRoot)
+
 	s.openCodeServersMu.Lock()
 	defer s.openCodeServersMu.Unlock()
 
@@ -840,7 +868,7 @@ func (s *SocketServer) ensureOpenCodeServerRunning(projectRoot string) (int, err
 			client := agent.NewOpenCodeClient(srv.Port)
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
-			if client.IsServerRunning(ctx) {
+			if client.IsServerRunningForWorktree(ctx, projectRoot) {
 				srv.LastHealthy = time.Now()
 				s.updateManagedServerHealth(projectRoot, srv.LastHealthy)
 				s.logger.Printf("opencode server healthy on port %d for %s", srv.Port, projectRoot)
@@ -872,7 +900,9 @@ func (s *SocketServer) ensureOpenCodeServerRunning(projectRoot string) (int, err
 	}
 
 	client := agent.NewOpenCodeClient(port)
-	if err := s.procManager.WaitForHealthy(srv, 30*time.Second, client.IsServerRunning); err != nil {
+	if err := s.procManager.WaitForHealthy(srv, 30*time.Second, func(ctx context.Context) bool {
+		return client.IsServerRunningForWorktree(ctx, projectRoot)
+	}); err != nil {
 		s.procManager.StopServerLocked(srv)
 		return 0, fmt.Errorf("server started but failed health check (logs: %s): %w", srv.LogPath, err)
 	}
@@ -1092,7 +1122,7 @@ func (s *SocketServer) checkOpenCodeServerHealth() {
 
 		client := agent.NewOpenCodeClient(srv.Port)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		if client.IsServerRunning(ctx) {
+		if client.IsServerRunningForWorktree(ctx, projectRoot) {
 			srv.LastHealthy = time.Now()
 			s.updateManagedServerHealth(projectRoot, srv.LastHealthy)
 		} else {
@@ -1118,6 +1148,8 @@ func (s *SocketServer) StopAllOpenCodeServers() {
 }
 
 func (s *SocketServer) getOpenCodeServerPort(projectRoot string) int {
+	projectRoot = s.normalizeProjectRoot(projectRoot)
+
 	s.openCodeServersMu.RLock()
 	defer s.openCodeServersMu.RUnlock()
 
@@ -2496,7 +2528,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 
 	serverAlreadyRunning := false
 	if adapter.PromptInjection() == agent.InjectionHTTP {
-		resp, err := s.ensureOpenCodeServerRunning(worktreeResult.WorktreePath)
+		resp, err := s.ensureOpenCodeServerRunning(repoRoot)
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
 			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
@@ -2775,7 +2807,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 
 	serverAlreadyRunning := false
 	if adapter.PromptInjection() == agent.InjectionHTTP {
-		resp, err := s.ensureOpenCodeServerRunning(worktreeResult.WorktreePath)
+		resp, err := s.ensureOpenCodeServerRunning(projectRoot)
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
 			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
@@ -3129,7 +3161,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 
 	serverAlreadyRunning := false
 	if adapter.PromptInjection() == agent.InjectionHTTP {
-		resp, err := s.ensureOpenCodeServerRunning(worktreePath)
+		resp, err := s.ensureOpenCodeServerRunning(projectRoot)
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
 			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
@@ -3511,7 +3543,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 
 	serverAlreadyRunning := false
 	if adapter.PromptInjection() == agent.InjectionHTTP {
-		resp, err := s.ensureOpenCodeServerRunning(worktreePath)
+		resp, err := s.ensureOpenCodeServerRunning(s.normalizeProjectRoot(worktreePath))
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
 			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"math/rand"
@@ -335,12 +336,19 @@ func TestProcessSendOpenCodeReturnsAfterAck(t *testing.T) {
 		t.Fatalf("failed to find repo root: %v", err)
 	}
 
+	logger := log.New(io.Discard, "", 0)
+	server := NewSocketServer(nil, logger)
+	normalizedRoot := server.normalizeProjectRoot(projectRoot)
+
 	const bodyDelay = 600 * time.Millisecond
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/global/health":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"healthy":true,"version":"test"}`)
+		case r.URL.Path == "/project/current":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, fmt.Sprintf(`{"id":"proj","worktree":%q,"sandboxes":[]}`, normalizedRoot))
 		case strings.HasSuffix(r.URL.Path, "/message"):
 			w.WriteHeader(http.StatusAccepted)
 			if flusher, ok := w.(http.Flusher); ok {
@@ -354,10 +362,8 @@ func TestProcessSendOpenCodeReturnsAfterAck(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	logger := log.New(io.Discard, "", 0)
-	server := NewSocketServer(nil, logger)
-	server.openCodeServers[projectRoot] = &managedServer{
-		ProjectRoot: projectRoot,
+	server.openCodeServers[normalizedRoot] = &managedServer{
+		ProjectRoot: normalizedRoot,
 		Port:        getPortFromURL(t, testServer.URL),
 		WaitResult:  make(chan error, 1),
 	}
@@ -395,12 +401,19 @@ func TestProcessSendOpenCodeTimesOutPromptlyWithoutAck(t *testing.T) {
 		t.Fatalf("failed to find repo root: %v", err)
 	}
 
+	logger := log.New(io.Discard, "", 0)
+	server := NewSocketServer(nil, logger)
+	normalizedRoot := server.normalizeProjectRoot(projectRoot)
+
 	const ackDelay = 300 * time.Millisecond
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/global/health":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"healthy":true,"version":"test"}`)
+		case r.URL.Path == "/project/current":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, fmt.Sprintf(`{"id":"proj","worktree":%q,"sandboxes":[]}`, normalizedRoot))
 		case strings.HasSuffix(r.URL.Path, "/message"):
 			time.Sleep(ackDelay)
 			w.WriteHeader(http.StatusAccepted)
@@ -411,10 +424,8 @@ func TestProcessSendOpenCodeTimesOutPromptlyWithoutAck(t *testing.T) {
 	}))
 	defer testServer.Close()
 
-	logger := log.New(io.Discard, "", 0)
-	server := NewSocketServer(nil, logger)
-	server.openCodeServers[projectRoot] = &managedServer{
-		ProjectRoot: projectRoot,
+	server.openCodeServers[normalizedRoot] = &managedServer{
+		ProjectRoot: normalizedRoot,
 		Port:        getPortFromURL(t, testServer.URL),
 		WaitResult:  make(chan error, 1),
 	}


### PR DESCRIPTION
## Summary
- Normalize opencode server identity paths in daemon so worktree paths and main repo paths resolve to the same registry key.
- Add project-identity health checks (`IsServerRunningForWorktree`) in server ensure/health paths.
- Normalize persisted managed-server DB keys and add legacy-key migration/cleanup behavior.
- Add architecture semgrep guardrail to prevent passing worktree paths to `ensureOpenCodeServerRunning`.
- Add regression tests for worktree-path normalization and DB-key normalization.

## Acceptance Criteria Evidence

### 1) `ensureOpenCodeServerRunning` resolves worktree paths to main repo root
- Implemented at `internal/daemon/socket.go:834` (`normalizeProjectRoot`) and `internal/daemon/socket.go:860` (`ensureOpenCodeServerRunning` entry normalization).

### 2) `getOpenCodeServerPort` does the same normalization
- Implemented at `internal/daemon/socket.go:1150`.

### 3) Only one opencode server is used per repo across worktrees
- Added regression test: `internal/daemon/opencode_server_project_root_test.go:12`.
- Test command:
  - `go test ./internal/daemon -run "TestEnsureOpenCodeServerRunningNormalizesWorktreePath|TestPersistManagedServerStartNormalizesProjectRoot" -count=1`
  - Output: `ok   github.com/s22625/orch/internal/daemon  0.934s`

### 4) `managed_servers` SQLite key uses normalized repo root
- Normalization added in persistence/update/delete paths:
  - `internal/daemon/managed_servers_db.go:264`
  - `internal/daemon/managed_servers_db.go:282`
  - `internal/daemon/managed_servers_db.go:302`
  - startup migration in `internal/daemon/managed_servers_db.go:331`
- Regression test: `internal/daemon/managed_servers_db_test.go:96` (`TestPersistManagedServerStartNormalizesProjectRoot`).

### 5) Semgrep rule prevents worktree paths passed to `ensureOpenCodeServerRunning`
- Added rule: `.semgrep/architecture.yaml:700` (`daemon-no-worktree-path-to-ensure-server`).
- Updated daemon call sites to pass repo-root variables.

### 6) `make lint` passes with no new violations
- Command: `make lint`
- Output excerpt: `Scan completed successfully. Findings: 0 (0 blocking)`

### 7) Existing tests pass; add test for two worktrees same port
- Added tests:
  - `internal/daemon/opencode_server_project_root_test.go:12`
  - `internal/daemon/managed_servers_db_test.go:96`
- Daemon package tests pass:
  - `go test ./internal/daemon -count=1`
  - Output: `ok   github.com/s22625/orch/internal/daemon  5.220s`
- Full repo tests currently have pre-existing failures outside this change:
  - `go test ./...` fails in `internal/cli` (`TestApplyConfigDefaultsFallbacks`) and `test/integration` (opencode integration startup), while `internal/daemon` passes.

### 8) `go build ./...` passes
- Command: `go build ./...`
- Result: success (exit 0).

## Issue
- References: `orch-445`
