### PR TITLE
fix: apply PR cache in daemon hot paths to prevent rate-limit exhaustion

### DIFF
--- a/.semgrep/architecture.yaml
+++ b/.semgrep/architecture.yaml
@@ -1025,10 +1025,6 @@ rules:
         - /internal/daemon/
       exclude:
         - /internal/daemon/*_test.go
-        # Known debt (orch-450) — remove exclusions as each file is fixed
-        - /internal/daemon/monitor.go
-        - /internal/daemon/types.go
-        - /internal/daemon/proto_handler.go
     message: >
       Daemon must not call pr.LookupInfo() or pr.LookupInfoWithClient() directly.
       These bypass the PR cache and shell out to `gh pr list` on every call,
@@ -1050,10 +1046,6 @@ rules:
         - /internal/daemon/
       exclude:
         - /internal/daemon/*_test.go
-        # Known debt (orch-450) — remove exclusions as each file is fixed
-        - /internal/daemon/monitor.go
-        - /internal/daemon/types.go
-        - /internal/daemon/proto_handler.go
     message: >
       Daemon must not call pr.LookupInfoByURL() directly.
       This bypasses the PR cache and shells out to `gh pr view` on every call,

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -403,7 +403,7 @@ func (d *Daemon) checkPRMerged(run *model.Run) bool {
 
 func (d *Daemon) checkPRMergedWithURL(run *model.Run, st store.Store) (merged bool, prURL string) {
 	if run.PRUrl != "" {
-		prInfo, err := pr.LookupInfoByURL(run.PRUrl)
+		prInfo, err := pr.LookupInfoByURLCached(run.PRUrl)
 		if err == nil && prInfo != nil && prInfo.State == "MERGED" {
 			return true, run.PRUrl
 		}
@@ -425,7 +425,7 @@ func (d *Daemon) checkPRMergedWithURL(run *model.Run, st store.Store) (merged bo
 		}
 	}
 
-	prInfo, err := pr.LookupInfo(repoRoot, run.Branch)
+	prInfo, err := pr.LookupInfoCached(repoRoot, run.Branch)
 	if err != nil || prInfo == nil {
 		return false, ""
 	}
@@ -491,7 +491,7 @@ func (d *Daemon) inferStatusFromGitState(run *model.Run, st store.Store, wasAliv
 	}
 
 	d.debug("%s#%s: infer: checking PR for branch %s", run.IssueID, run.RunID, run.Branch)
-	prInfo, err := pr.LookupInfo(repoRoot, run.Branch)
+	prInfo, err := pr.LookupInfoCached(repoRoot, run.Branch)
 	if err == nil && prInfo != nil && prInfo.URL != "" {
 		d.logger.Printf("%s#%s: infer: found PR %s (state=%s)", run.IssueID, run.RunID, prInfo.URL, prInfo.State)
 		if run.PRUrl == "" {
@@ -514,7 +514,7 @@ func (d *Daemon) inferStatusFromGitState(run *model.Run, st store.Store, wasAliv
 	// This handles cases where the local branch was deleted/rebased but PR still exists
 	if run.PRUrl != "" {
 		d.debug("%s#%s: infer: branch lookup failed, checking existing PR URL: %s", run.IssueID, run.RunID, run.PRUrl)
-		prInfo, err := pr.LookupInfoByURL(run.PRUrl)
+		prInfo, err := pr.LookupInfoByURLCached(run.PRUrl)
 		if err == nil && prInfo != nil {
 			d.logger.Printf("%s#%s: infer: PR %s state=%s (via URL lookup)", run.IssueID, run.RunID, prInfo.URL, prInfo.State)
 			if prInfo.State == "MERGED" {

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -515,7 +515,7 @@ func enrichRunsParallel(runs []*model.Run, protoRuns []*orchpb.Run) []*orchpb.Ru
 
 func lookupPRInfoForRun(run *model.Run) (prNumber int, prState string) {
 	if run.PRUrl != "" {
-		prInfo, err := pr.LookupInfoByURL(run.PRUrl)
+		prInfo, err := pr.LookupInfoByURLCached(run.PRUrl)
 		if err == nil && prInfo != nil {
 			return prInfo.Number, strings.ToLower(prInfo.State)
 		}
@@ -537,7 +537,7 @@ func lookupPRInfoForRun(run *model.Run) (prNumber int, prState string) {
 		}
 	}
 
-	prInfo, err := pr.LookupInfo(repoRoot, run.Branch)
+	prInfo, err := pr.LookupInfoCached(repoRoot, run.Branch)
 	if err != nil || prInfo == nil {
 		return 0, ""
 	}

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -742,7 +742,7 @@ type GetDiffStatsResponse struct {
 
 func lookupPRInfo(run *model.Run) (prNumber int, prState string) {
 	if run.PRUrl != "" {
-		prInfo, err := pr.LookupInfoByURL(run.PRUrl)
+		prInfo, err := pr.LookupInfoByURLCached(run.PRUrl)
 		if err == nil && prInfo != nil {
 			return prInfo.Number, strings.ToLower(prInfo.State)
 		}
@@ -764,7 +764,7 @@ func lookupPRInfo(run *model.Run) (prNumber int, prState string) {
 		}
 	}
 
-	prInfo, err := pr.LookupInfo(repoRoot, run.Branch)
+	prInfo, err := pr.LookupInfoCached(repoRoot, run.Branch)
 	if err != nil || prInfo == nil {
 		return 0, ""
 	}

--- a/internal/pr/cache.go
+++ b/internal/pr/cache.go
@@ -46,6 +46,57 @@ type cache struct {
 	Entries   map[string]cacheEntry `json:"entries"`
 }
 
+func cacheKeyForPRURL(prURL string) string {
+	return "url:" + prURL
+}
+
+func cacheEntryTTL(entry cacheEntry) time.Duration {
+	if entry.URL != "" {
+		return cacheHitTTL
+	}
+	return cacheMissTTL
+}
+
+func cacheEntryToInfo(entry cacheEntry) *Info {
+	if entry.URL == "" {
+		return nil
+	}
+	return &Info{
+		URL:    entry.URL,
+		Number: entry.Number,
+		State:  entry.State,
+	}
+}
+
+// lookupCachedEntry returns cached info and whether the cache entry is still fresh.
+// A fresh cached miss returns (nil, true).
+func lookupCachedEntry(c cache, key string, now time.Time) (*Info, bool) {
+	if len(c.Entries) == 0 {
+		return nil, false
+	}
+	entry, ok := c.Entries[key]
+	if !ok {
+		return nil, false
+	}
+	if !entry.CheckedAt.IsZero() && now.Sub(entry.CheckedAt) < cacheEntryTTL(entry) {
+		return cacheEntryToInfo(entry), true
+	}
+	return nil, false
+}
+
+func upsertCacheEntry(c *cache, key string, info *Info, checkedAt time.Time) {
+	if c.Entries == nil {
+		c.Entries = make(map[string]cacheEntry)
+	}
+	entry := cacheEntry{CheckedAt: checkedAt}
+	if info != nil {
+		entry.URL = info.URL
+		entry.Number = info.Number
+		entry.State = info.State
+	}
+	c.Entries[key] = entry
+}
+
 // PopulateRunInfo populates PR URLs and returns PR info for each run's branch.
 func PopulateRunInfo(runs []*model.Run) InfoMap {
 	return PopulateRunInfoWithClient(ghClient, runs)
@@ -100,22 +151,12 @@ func PopulateRunInfoWithClient(client github.Client, runs []*model.Run) InfoMap 
 			continue
 		}
 
-		if entry, ok := c.Entries[r.Branch]; ok {
-			ttl := cacheMissTTL
-			if entry.URL != "" {
-				ttl = cacheHitTTL
+		if info, ok := lookupCachedEntry(c, r.Branch, now); ok {
+			if info != nil {
+				r.PRUrl = info.URL
+				prInfoMap[r.Branch] = info
 			}
-			if !entry.CheckedAt.IsZero() && now.Sub(entry.CheckedAt) < ttl {
-				if entry.URL != "" {
-					r.PRUrl = entry.URL
-					prInfoMap[r.Branch] = &Info{
-						URL:    entry.URL,
-						Number: entry.Number,
-						State:  entry.State,
-					}
-				}
-				continue
-			}
+			continue
 		}
 
 		if fetches >= cacheMaxFetches {
@@ -129,16 +170,11 @@ func PopulateRunInfoWithClient(client github.Client, runs []*model.Run) InfoMap 
 		dirty = true
 
 		if err != nil || info == nil {
-			c.Entries[r.Branch] = cacheEntry{CheckedAt: fetchTime}
+			upsertCacheEntry(&c, r.Branch, nil, fetchTime)
 			continue
 		}
 
-		c.Entries[r.Branch] = cacheEntry{
-			URL:       info.URL,
-			Number:    info.Number,
-			State:     info.State,
-			CheckedAt: fetchTime,
-		}
+		upsertCacheEntry(&c, r.Branch, info, fetchTime)
 		if info.URL != "" {
 			r.PRUrl = info.URL
 			prInfoMap[r.Branch] = info
@@ -159,19 +195,12 @@ func applyCachedInfo(runs []*model.Run, c cache, now time.Time, prInfoMap InfoMa
 		if r.PRUrl != "" || r.Branch == "" {
 			continue
 		}
-		entry, ok := c.Entries[r.Branch]
-		if !ok || entry.URL == "" {
+		info, ok := lookupCachedEntry(c, r.Branch, now)
+		if !ok || info == nil {
 			continue
 		}
-		if !entry.CheckedAt.IsZero() && now.Sub(entry.CheckedAt) > cacheHitTTL {
-			continue
-		}
-		r.PRUrl = entry.URL
-		prInfoMap[r.Branch] = &Info{
-			URL:    entry.URL,
-			Number: entry.Number,
-			State:  entry.State,
-		}
+		r.PRUrl = info.URL
+		prInfoMap[r.Branch] = info
 	}
 }
 
@@ -202,6 +231,39 @@ func lookupInfo(client github.Client, repoRoot, branch string) (*Info, error) {
 	}, nil
 }
 
+func lookupInfoByURL(client github.Client, prURL string) (*Info, error) {
+	if client == nil {
+		client = ghClient
+	}
+	output, err := client.Run("pr", "view", prURL, "--json", "url,number,state")
+	if err != nil {
+		return nil, err
+	}
+
+	var pr struct {
+		URL    string `json:"url"`
+		Number int    `json:"number"`
+		State  string `json:"state"`
+	}
+	if err := json.Unmarshal(output, &pr); err != nil {
+		return nil, err
+	}
+	if pr.URL == "" {
+		pr.URL = prURL
+	}
+
+	return &Info{
+		URL:    pr.URL,
+		Number: pr.Number,
+		State:  pr.State,
+	}, nil
+}
+
+// LookupInfoCached returns cached PR info for a branch.
+func LookupInfoCached(repoRoot, branch string) (*Info, error) {
+	return LookupInfoWithClient(ghClient, repoRoot, branch)
+}
+
 // LookupInfo returns PR info for a branch using the default GitHub client.
 func LookupInfo(repoRoot, branch string) (*Info, error) {
 	return LookupInfoWithClient(ghClient, repoRoot, branch)
@@ -227,47 +289,119 @@ func LookupInfoWithClient(client github.Client, repoRoot, branch string) (*Info,
 			return nil, err
 		}
 	}
-	return lookupInfo(client, repoRoot, branch)
+
+	if info, statErr := os.Stat(repoRoot); statErr != nil || !info.IsDir() {
+		return lookupInfo(client, repoRoot, branch)
+	}
+
+	cachePath, err := getCachePath(repoRoot)
+	if err != nil {
+		return lookupInfo(client, repoRoot, branch)
+	}
+
+	now := time.Now()
+	c := loadCache(cachePath)
+	if c.Entries == nil {
+		c.Entries = make(map[string]cacheEntry)
+	}
+
+	if info, ok := lookupCachedEntry(c, branch, now); ok {
+		return info, nil
+	}
+
+	if !c.LastFetch.IsZero() && now.Sub(c.LastFetch) < cacheMinFetchInterval {
+		if entry, ok := c.Entries[branch]; ok && entry.URL != "" {
+			return cacheEntryToInfo(entry), nil
+		}
+		return nil, nil
+	}
+
+	info, lookupErr := lookupInfo(client, repoRoot, branch)
+	fetchTime := time.Now()
+	c.LastFetch = fetchTime
+	if lookupErr != nil || info == nil {
+		upsertCacheEntry(&c, branch, nil, fetchTime)
+		saveCache(cachePath, c)
+		return nil, lookupErr
+	}
+
+	upsertCacheEntry(&c, branch, info, fetchTime)
+	saveCache(cachePath, c)
+	return info, nil
+}
+
+// LookupInfoByURLCached returns cached PR info by URL.
+func LookupInfoByURLCached(prURL string) (*Info, error) {
+	return LookupInfoByURLWithClient(ghClient, prURL)
 }
 
 // LookupInfoByURL returns PR info by URL using the GitHub CLI.
 // This works even if the local worktree has been deleted.
 // Only GitHub URLs are supported (gh CLI requirement).
 func LookupInfoByURL(prURL string) (*Info, error) {
+	return LookupInfoByURLWithClient(ghClient, prURL)
+}
+
+// LookupInfoByURLWithClient returns PR info by URL using the provided GitHub client.
+func LookupInfoByURLWithClient(client github.Client, prURL string) (*Info, error) {
 	if strings.TrimSpace(prURL) == "" {
 		return nil, fmt.Errorf("PR URL is required")
 	}
 	if !strings.HasPrefix(prURL, "https://github.com/") {
 		return nil, fmt.Errorf("only GitHub URLs are supported: %s", prURL)
 	}
-	if !ghClient.IsAvailable() {
+	if client == nil {
+		client = ghClient
+	}
+	if !client.IsAvailable() {
 		return nil, fmt.Errorf("gh CLI not available")
 	}
-	output, err := ghClient.Run("pr", "view", prURL, "--json", "url,number,state")
+
+	cachePath, err := getCachePath("")
 	if err != nil {
-		return nil, err
+		return lookupInfoByURL(client, prURL)
 	}
 
-	var pr struct {
-		URL    string `json:"url"`
-		Number int    `json:"number"`
-		State  string `json:"state"`
-	}
-	if err := json.Unmarshal(output, &pr); err != nil {
-		return nil, err
+	now := time.Now()
+	key := cacheKeyForPRURL(prURL)
+	c := loadCache(cachePath)
+	if c.Entries == nil {
+		c.Entries = make(map[string]cacheEntry)
 	}
 
-	return &Info{
-		URL:    pr.URL,
-		Number: pr.Number,
-		State:  pr.State,
-	}, nil
+	if info, ok := lookupCachedEntry(c, key, now); ok {
+		return info, nil
+	}
+
+	if !c.LastFetch.IsZero() && now.Sub(c.LastFetch) < cacheMinFetchInterval {
+		if entry, ok := c.Entries[key]; ok && entry.URL != "" {
+			return cacheEntryToInfo(entry), nil
+		}
+		return nil, nil
+	}
+
+	info, lookupErr := lookupInfoByURL(client, prURL)
+	fetchTime := time.Now()
+	c.LastFetch = fetchTime
+	if lookupErr != nil || info == nil {
+		upsertCacheEntry(&c, key, nil, fetchTime)
+		saveCache(cachePath, c)
+		return nil, lookupErr
+	}
+
+	upsertCacheEntry(&c, key, info, fetchTime)
+	saveCache(cachePath, c)
+	return info, nil
 }
 
 func getCachePath(repoRoot string) (string, error) {
-	cacheDir, err := os.UserCacheDir()
-	if err != nil {
-		return "", err
+	cacheDir := strings.TrimSpace(os.Getenv("XDG_CACHE_HOME"))
+	if cacheDir == "" {
+		var err error
+		cacheDir, err = os.UserCacheDir()
+		if err != nil {
+			return "", err
+		}
 	}
 	dir := filepath.Join(cacheDir, "orch")
 	name := "pr_cache_" + hashString(repoRoot) + ".json"


### PR DESCRIPTION
## Summary
- Make `LookupInfoWithClient` and `LookupInfoByURL` cache-aware in `internal/pr/cache.go` by loading/saving cache entries, honoring `cacheHitTTL`/`cacheMissTTL`, and applying `cacheMinFetchInterval`.
- Add cache-first wrappers (`LookupInfoCached`, `LookupInfoByURLCached`) and switch daemon hot paths to them in `internal/daemon/monitor.go`, `internal/daemon/types.go`, and `internal/daemon/proto_handler.go`.
- Remove orch-450 semgrep exclusions for daemon files in `.semgrep/architecture.yaml` section 11 so architecture lint now enforces this path directly.

## Verification
- `go test ./internal/pr/...` ✅
- `go test ./internal/daemon/...` ✅
- `go test -count=1 ./internal/pr/... ./internal/daemon/...` ✅
- `make lint` ✅ (0 findings)

## Acceptance Criteria Evidence
1. **LookupInfo / LookupInfoByURL use cache + TTL/min interval**
   - Implemented in `internal/pr/cache.go` via cache read/write helpers and min-fetch gating.
   - TDD tests now pass:
     - `TestLookupInfoWithClient_MustUseCache`
     - `TestLookupInfoWithClient_CacheHitSkipsAPI`
     - `TestLookupInfoByURL_MustUseCache`
     - `TestLookupInfoByURL_CacheHitSkipsAPI`

2. **checkPRMergedWithURL throttled (not every 5s API call)**
   - `internal/daemon/monitor.go` now calls cached wrappers only.
   - No direct `pr.LookupInfo*` calls remain in daemon package; semgrep architecture rule enforces this.

3. **lookupPRInfo in types.go uses cached data**
   - `internal/daemon/types.go` now routes through `LookupInfoCached` / `LookupInfoByURLCached`.

4. **Consider global rate limiter**
   - Not added in this change; existing daemon hot-loop bypasses are removed and now governed by cache throttling as a safety baseline.

5. **20 active runs under 3000 calls/hr**
   - Worst-case miss path bounded by `cacheMissTTL=30s`: `20 runs * (3600/30) = 2400 calls/hr` (below 3000/hr target).
   - Cache hits are substantially lower.

6. **No regression to existing cache TTL constants / PopulateRunInfo**
   - Existing constants unchanged.
   - `PopulateRunInfo` path still passes regression tests in `internal/pr/cache_test.go`.

7. **All new TDD tests pass**
   - Confirmed by `go test ./internal/pr/...`.

8. **Semgrep exclusions removed**
   - Removed for `monitor.go`, `types.go`, `proto_handler.go` in `.semgrep/architecture.yaml` section 11.
   - Confirmed by `make lint` with 0 findings.

Refs: orch-450