### PR TITLE
refactor(cli): rename 'orch continue' to 'orch restart-from' (orch-451)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,10 @@ Existing violations are tracked; do not add new ones.
 
 The opencode server may have stopped while the run shows as "waiting". 
 - Check if the run is actually alive: look at the ALIVE column in `orch ps`
-- If server stopped, use `orch continue <id>` to restart
+- Capture output first: `orch capture <id>`
+- Check multiplexer sessions directly (`tmux list-sessions` / `zellij list-sessions`)
+- If needed, write feedback into `ORCH_PROMPT.md` in the run worktree and use native multiplexer send
+- Do NOT use `orch restart-from` for send failures unless the run is truly `failed`, `canceled`, or `unknown`
 
 ### Proto changes not reflected
 

--- a/claude-plugins/orch-toolset/README.md
+++ b/claude-plugins/orch-toolset/README.md
@@ -88,7 +88,7 @@ Comprehensive command reference including:
 | Category | Commands |
 |----------|----------|
 | Issue Management | `orch issue create`, `orch issue list`, `orch open` |
-| Run Management | `orch run`, `orch continue`, `orch ps`, `orch show`, `orch stop`, `orch resolve` |
+| Run Management | `orch run`, `orch restart-from`, `orch ps`, `orch show`, `orch stop`, `orch resolve` |
 | Monitoring | `orch monitor`, `orch attach`, `orch capture` |
 | Agent Communication | `orch send`, `orch exec` |
 | Maintenance | `orch repair`, `orch tick` |

--- a/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
+++ b/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
@@ -45,9 +45,9 @@ Orch is a non-interactive orchestrator for managing multiple LLM CLI agents (Cla
 
 ### Run Management
 - `orch run <ISSUE_ID>`: Start new run (creates worktree, launches agent in tmux)
-- `orch continue <RUN_REF>`: Resume from existing worktree/branch (failed/canceled runs ONLY)
-  - Pass a failed/canceled run's short ID to retry: `orch continue 33632a`
-  - Use `--agent` to change agent type: `orch continue 33632a --agent codex`
+- `orch restart-from <RUN_REF>`: Restart from existing worktree/branch (failed/canceled/unknown runs ONLY)
+  - Pass a failed/canceled run's short ID to retry: `orch restart-from 33632a`
+  - Use `--agent` to change agent type: `orch restart-from 33632a --agent codex`
   - **NEVER use on `blocked` runs** — blocked means the agent is waiting for user input, not stuck. Use `orch send` to answer the agent's question instead.
 - `orch ps`: List runs with status filtering
 - `orch show <RUN_REF>`: Inspect run details and events
@@ -80,7 +80,7 @@ State meanings:
 - `queued`: Run created, waiting to start
 - `booting`: Agent starting up
 - `running`: Agent actively working
-- `blocked`: Agent is waiting for user input (asked a question via CLI prompt). This is NOT an error state — the agent is alive and has full context. Use `orch send <RUN_REF> "your answer"` to respond and unblock it. Do NOT use `orch stop` + `orch continue` — that kills the session, loses context, and starts a fresh agent.
+- `blocked`: Agent is waiting for user input (asked a question via CLI prompt). This is NOT an error state — the agent is alive and has full context. Use `orch send <RUN_REF> "your answer"` to respond and unblock it. Do NOT use `orch stop` + `orch restart-from` — that kills the session, loses context, and starts a fresh agent.
 - `blocked_api`: API rate limit hit
 - `pr_open`: PR created, awaiting review
 - `done`: Work completed successfully
@@ -92,7 +92,7 @@ State meanings:
 
 ### Issue/Run Design
 - Keep each issue focused; split large work into separate issues
-- One run per attempt; use `orch continue` for retries from same branch
+- One run per attempt; use `orch restart-from` for retries from same branch
 - Use issue status (open/resolved) separately from run status
 
 ### Monitoring Strategy
@@ -108,8 +108,8 @@ State meanings:
 ### Workflow Tips
 - Stop idle/stale runs before starting new ones
 - Use short IDs (2-6 hex chars) for speed: `orch attach a3b4c5`
-- Continue failed/canceled runs instead of starting fresh: `orch continue <failed-run-id> --agent codex`
-- Unblock blocked runs with `orch send`, never with `orch stop` + `orch continue`
+- Continue failed/canceled runs instead of starting fresh: `orch restart-from <failed-run-id> --agent codex`
+- Unblock blocked runs with `orch send`, never with `orch stop` + `orch restart-from`
 - Keep issue queue clean: resolve completed, close duplicates
 - Use `orch exec -- <test>` for isolated testing without tmux
 
@@ -175,7 +175,7 @@ Benefits of external worktrees:
 |------|---------|
 | Create issue | `orch issue create <ID> --title "..." --tag <tag>` |
 | Start run | `orch run <ISSUE>` |
-| Continue failed run | `orch continue <RUN_ID> --agent codex` |
+| Continue failed run | `orch restart-from <RUN_ID> --agent codex` |
 | List active | `orch ps --status running,blocked` |
 | Inspect run | `orch show <RUN>` |
 | Watch agent | `orch attach <RUN>` |

--- a/claude-plugins/orch-toolset/skills/orch-toolset/reference.md
+++ b/claude-plugins/orch-toolset/skills/orch-toolset/reference.md
@@ -192,22 +192,22 @@ orch run orch-055 --agent claude --profile my-profile
 - Worktree: `<worktree_dir>/<ISSUE_ID>/<SHORT_ID>_<AGENT>_<RUN_ID>`
 - Tmux session: `run-<ISSUE_ID>-<RUN_ID>`
 
-### orch continue RUN_REF|ISSUE_ID
+### orch restart-from RUN_REF|ISSUE_ID
 
-Resume from existing worktree/branch with a new run. **For failed/canceled runs ONLY.** Never use on `blocked` runs — those are waiting for user input via `orch send`, not stuck.
+Resume from existing worktree/branch with a new run. **For failed/canceled/unknown runs ONLY.** Never use on `blocked` runs — those are waiting for user input via `orch send`, not stuck.
 
 ```bash
-# Continue latest run for issue
-orch continue orch-055
+# Restart latest run for issue
+orch restart-from orch-055
 
-# Continue specific run
-orch continue orch-055#20251223-165605
+# Restart specific run
+orch restart-from orch-055#20251223-165605
 
-# Continue with different agent
-orch continue orch-055 --agent codex
+# Restart with different agent
+orch restart-from orch-055 --agent codex
 
-# Continue from specific branch
-orch continue --branch "issue/orch-055/run-20251223" --issue orch-055
+# Restart from specific branch
+orch restart-from --branch "issue/orch-055/run-20251223" --issue orch-055
 ```
 
 **Flags:**
@@ -216,13 +216,13 @@ orch continue --branch "issue/orch-055/run-20251223" --issue orch-055
 | `--agent` | Agent (default: previous run's agent) |
 | `--agent-cmd` | Custom agent command |
 | `--profile` | Agent profile |
-| `--branch` | Specific branch to continue from |
+| `--branch` | Specific branch to restart from |
 | `--issue` | Issue ID when using --branch |
 | `--tmux / --no-tmux` | Enable/disable tmux |
 | `--no-pr` | Skip PR instructions |
 
 **Behavior:**
-- Fails if target run is still active (use `orch stop` first)
+- Fails if target run is still active (use `orch send` / `orch capture` to interact)
 - Reuses existing worktree and branch
 - Creates new run doc with `continued_from` reference
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -133,7 +133,7 @@ A **git worktree** created for each run.
 - Each run works on its own copy of the codebase
 - Located in `~/.orch/worktrees/<issue>/<run>/` by default
 - Automatically created by `orch run`
-- Can be reused with `orch continue`
+- Can be reused with `orch restart-from`
 
 **Why worktrees?**
 - Multiple agents can work on different issues simultaneously

--- a/docs/daily-workflow.md
+++ b/docs/daily-workflow.md
@@ -185,11 +185,17 @@ orch exec fix-login-timeout -- make lint
 
 ### 4. Request changes if needed
 
-If the PR needs work, you can continue the run:
+If the PR needs work and the run is still waiting/alive, send feedback first:
 
 ```bash
-# Continue work with the same agent
-orch continue fix-login-timeout
+orch send fix-login-timeout "Please fix the edge case in session.ts"
+```
+
+If a run actually failed/canceled/unknown, restart it:
+
+```bash
+# Restart from the last failed run with the same agent
+orch restart-from fix-login-timeout#20260120-163045
 
 # Or attach and provide feedback
 orch attach fix-login-timeout

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -164,12 +164,13 @@ orch run --preset thorough my-issue
 
 ---
 
-## orch continue
+## orch restart-from
 
-Continue work from an existing run, reusing its worktree and branch.
+Restart work from an existing run, reusing its worktree and branch.
+Use this recovery command only for failed/canceled/unknown runs.
 
 ```bash
-orch continue RUN_REF|ISSUE_ID [flags]
+orch restart-from RUN_REF|ISSUE_ID [flags]
 ```
 
 ### Flags
@@ -178,7 +179,7 @@ orch continue RUN_REF|ISSUE_ID [flags]
 |------|-------------|
 | `--agent <type>` | Agent type |
 | `--agent-cmd <cmd>` | Custom agent command |
-| `--branch <name>` | Continue from existing branch |
+| `--branch <name>` | Restart from existing branch |
 | `--issue <id>` | Issue ID (with `--branch`) |
 | `--no-pr` | Skip PR creation instructions |
 | `--profile <name>` | Agent profile |
@@ -191,14 +192,14 @@ orch continue RUN_REF|ISSUE_ID [flags]
 ### Examples
 
 ```bash
-# Continue latest run for an issue
-orch continue my-issue
+# Restart specific run
+orch restart-from my-issue#20260120-163045
 
-# Continue specific run
-orch continue my-issue#20260120-163045
+# Restart using short run ID
+orch restart-from a3b4c5
 
-# Continue from existing branch
-orch continue --branch feature/my-work --issue my-issue
+# Restart from existing branch
+orch restart-from --branch feature/my-work --issue my-issue
 ```
 
 ---
@@ -334,7 +335,17 @@ orch stop --all
 
 ## orch send
 
-Send a message to a running agent.
+Send a message to a running/waiting agent.
+This is the primary way to interact with waiting runs.
+
+If `orch send` fails, do not assume the run is dead:
+1. `orch capture <RUN_REF>`
+2. `orch ps`
+3. Check multiplexer sessions (`tmux list-sessions` / `zellij list-sessions`)
+4. Write feedback into `ORCH_PROMPT.md` in the run worktree
+5. Use native multiplexer send (`tmux send-keys` / `zellij action write-chars`)
+
+Do NOT use `orch restart-from` for send failures - the run is likely still alive.
 
 ```bash
 orch send RUN_REF MESSAGE [flags]

--- a/docs/reference/statuses.md
+++ b/docs/reference/statuses.md
@@ -270,7 +270,7 @@ slack:
 1. Check daemon logs: `tail .orch/daemon.log`
 2. Attach to see error: `orch attach run-ref`
 3. Check if issue is retriable
-4. Use `orch continue` to retry from last state
+4. Use `orch restart-from` to retry from last state
 
 ### Monitoring active runs
 

--- a/internal/cli/continue.go
+++ b/internal/cli/continue.go
@@ -49,17 +49,19 @@ func defaultContinueDeps() *continueDeps {
 	return &continueDeps{getAPI: getAPI}
 }
 
-func newContinueCmd() *cobra.Command {
+func newRestartFromCmd() *cobra.Command {
 	opts := &continueOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "continue [RUN_REF|ISSUE_ID]",
-		Short: "Continue work from an existing run",
-		Long: `Continue work from an existing run by reusing its worktree and branch.
+		Use:   "restart-from [RUN_REF|ISSUE_ID]",
+		Short: "Restart work from an existing run",
+		Long: `Restart work from an existing run by reusing its worktree and branch.
 
 This creates a new run record that references the original run.
 
-Use --branch with an issue ID to continue from an untracked branch.`,
+Use this for failed, canceled, or unknown runs.
+
+Use --branch with an issue ID to restart from an untracked branch.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ref := ""
@@ -78,7 +80,7 @@ Use --branch with an issue ID to continue from an untracked branch.`,
 	cmd.Flags().StringVar(&opts.Multiplexer, "multiplexer", "", "Terminal multiplexer (tmux|zellij)")
 	cmd.Flags().BoolVar(&opts.NoPR, "no-pr", false, "Skip PR creation instructions in agent prompt")
 	cmd.Flags().StringVar(&opts.PromptTemplate, "prompt-template", "", "Custom prompt template file")
-	cmd.Flags().StringVar(&opts.Branch, "branch", "", "Existing branch to continue from")
+	cmd.Flags().StringVar(&opts.Branch, "branch", "", "Existing branch to restart from")
 	cmd.Flags().StringVar(&opts.IssueID, "issue", "", "Issue ID (required with --branch when no RUN_REF)")
 	cmd.Flags().StringVar(&opts.WorktreeDir, "worktree-dir", "", "Directory for worktrees (default: ~/.orch/worktrees)")
 	cmd.Flags().StringVar(&opts.RepoRoot, "repo-root", "", "Git repository root (default: auto-detect)")
@@ -175,8 +177,8 @@ func runContinueWithDeps(ctx context.Context, refStr string, opts *continueOptio
 	}
 
 	if !globalOpts.Quiet {
-		fmt.Printf("Run continued: %s#%s\n", resp.IssueID, resp.RunID)
-		fmt.Printf("  Continued from: %s\n", resp.ContinuedFrom)
+		fmt.Printf("Run restarted: %s#%s\n", resp.IssueID, resp.RunID)
+		fmt.Printf("  Restarted from: %s\n", resp.ContinuedFrom)
 		fmt.Printf("  Branch:         %s\n", resp.Branch)
 		fmt.Printf("  Worktree:       %s\n", resp.WorktreePath)
 		if resp.SessionName != "" {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -100,7 +100,7 @@ func init() {
 	rootCmd.AddCommand(newIssueCmd())
 	rootCmd.AddCommand(newPsCmd())
 	rootCmd.AddCommand(newRunCmd())
-	rootCmd.AddCommand(newContinueCmd())
+	rootCmd.AddCommand(newRestartFromCmd())
 	rootCmd.AddCommand(newShowCmd())
 	rootCmd.AddCommand(newDiffCmd())
 	rootCmd.AddCommand(newAttachCmd())

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/s22625/orch/internal/agent"
@@ -25,11 +26,23 @@ func newSendCmd() *cobra.Command {
 		Short: "Send a message to a running agent",
 		Long: `Send a message to a running agent.
 
+This is the primary way to interact with waiting runs.
+Capture the latest output with orch capture first, then reply with orch send.
+
 For tmux-based agents (claude, codex, gemini), the message is sent via send-keys.
 For opencode agents, the message is sent via HTTP API.
 
 By default, Enter is pressed after the message for tmux agents.
 The --no-enter flag is ignored for opencode agents.
+
+If sending fails, treat it as an infrastructure issue first:
+  1. orch capture <RUN_REF>
+  2. orch ps
+  3. Check the multiplexer directly (tmux list-sessions / zellij list-sessions)
+  4. Write feedback into ORCH_PROMPT.md in the run worktree
+  5. Use native multiplexer send (tmux send-keys / zellij action write-chars)
+
+Do NOT use orch restart-from unless the run is failed, canceled, or unknown.
 
 Examples:
   # Send a message to an agent
@@ -86,6 +99,7 @@ func runSend(refStr, message string, opts *sendOptions) error {
 	ref := orchapi.RunRef{IssueID: run.IssueID, RunID: run.RunID}
 	err = api.SendMessage(ctx, ref, message)
 	if err != nil {
+		formattedErr := formatSendFailureMessage(err, run)
 		exitCode := ExitAgentError
 		if strings.Contains(err.Error(), "has ended") {
 			exitCode = ExitRunEnded
@@ -97,13 +111,13 @@ func runSend(refStr, message string, opts *sendOptions) error {
 		if globalOpts.JSON {
 			result := map[string]interface{}{
 				"ok":    false,
-				"error": err.Error(),
+				"error": formattedErr,
 			}
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
 			enc.Encode(result)
 		} else {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			fmt.Fprintf(os.Stderr, "error: %s\n", formattedErr)
 		}
 		os.Exit(exitCode)
 		return err
@@ -127,6 +141,27 @@ func runSend(refStr, message string, opts *sendOptions) error {
 	}
 
 	return nil
+}
+
+func formatSendFailureMessage(err error, run *orchapi.Run) string {
+	if err == nil {
+		return ""
+	}
+
+	runRef := "<RUN_REF>"
+	promptPath := "ORCH_PROMPT.md"
+	if run != nil {
+		if run.IssueID != "" && run.RunID != "" {
+			runRef = run.IssueID + "#" + run.RunID
+		} else if run.IssueID != "" {
+			runRef = run.IssueID
+		}
+		if run.WorktreePath != "" {
+			promptPath = filepath.Join(run.WorktreePath, "ORCH_PROMPT.md")
+		}
+	}
+
+	return fmt.Sprintf("%s\n\nSend failed. Try this escalation path before assuming the run is broken:\n  1. orch capture %s\n  2. orch ps\n  3. Check the multiplexer directly (tmux list-sessions / zellij list-sessions)\n  4. Write feedback into %s\n  5. Use native multiplexer send (tmux send-keys / zellij action write-chars)\n\nDo NOT use orch restart-from - the run is likely still alive.", err.Error(), runRef, promptPath)
 }
 
 func validateSendConfig(run *orchapi.Run, isOpenCode bool) error {

--- a/internal/cli/send_test.go
+++ b/internal/cli/send_test.go
@@ -1,7 +1,11 @@
 package cli
 
 import (
+	"errors"
+	"strings"
 	"testing"
+
+	"github.com/s22625/orch/internal/orchapi"
 )
 
 func TestNewSendCmd(t *testing.T) {
@@ -54,5 +58,44 @@ func TestSendCmdDryRunFlag(t *testing.T) {
 
 	if dryRunFlag.DefValue != "false" {
 		t.Errorf("expected --dry-run default to be false, got %s", dryRunFlag.DefValue)
+	}
+}
+
+func TestSendCmdLongDescriptionGuidance(t *testing.T) {
+	cmd := newSendCmd()
+
+	if !strings.Contains(cmd.Long, "primary way to interact with waiting runs") {
+		t.Fatalf("expected send command help to emphasize waiting-run interaction")
+	}
+	if !strings.Contains(cmd.Long, "Do NOT use orch restart-from") {
+		t.Fatalf("expected send command help to warn against orch restart-from")
+	}
+}
+
+func TestFormatSendFailureMessageIncludesEscalationPath(t *testing.T) {
+	run := &orchapi.Run{
+		IssueID:      "orch-451",
+		RunID:        "20260226-123456",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	msg := formatSendFailureMessage(errors.New("daemon error: session not found"), run)
+
+	checks := []string{
+		"daemon error: session not found",
+		"orch capture orch-451#20260226-123456",
+		"orch ps",
+		"tmux list-sessions",
+		"zellij list-sessions",
+		"/tmp/worktree/ORCH_PROMPT.md",
+		"tmux send-keys",
+		"zellij action write-chars",
+		"Do NOT use orch restart-from - the run is likely still alive.",
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(msg, check) {
+			t.Fatalf("expected message to contain %q, got: %s", check, msg)
+		}
 	}
 }

--- a/internal/cli/tutorial.go
+++ b/internal/cli/tutorial.go
@@ -118,7 +118,7 @@ Interact with the agent:
     orch send <run> "msg"   Send message to running agent
     orch monitor            TUI dashboard for all runs
     orch show <issue>       Show issue details
-    orch continue <run>     Resume a paused or waiting run
+	orch restart-from <run> Restart from a failed/canceled/unknown run
     orch capture <run>      Capture agent session to markdown
 
 --------------------------------------------------------------------------------

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -1413,9 +1413,9 @@ When a run shows "waiting" status:
 2. Send feedback: `+"`orch send <issue-id> \"<message>\"`"+` to provide input
 3. The agent will resume automatically after receiving input
 
-### Continuing Work
-- From a branch: `+"`orch continue <issue> --branch <branch-name>`"+`
-- From a run: `+"`orch continue <issue>#<run-id>`"+`
+### Restarting Work
+- From a branch: `+"`orch restart-from <issue> --branch <branch-name>`"+`
+- From a run: `+"`orch restart-from <issue>#<run-id>`"+`
 
 ## Available Orch Commands
 
@@ -1428,7 +1428,7 @@ Run these commands directly using bash (do not use any special protocol):
 
 ### Run Management
 - Start a run: `+"`orch run <issue-id>`"+`
-- Continue from branch: `+"`orch continue <issue> --branch <branch>`"+`
+- Restart from branch: `+"`orch restart-from <issue> --branch <branch>`"+`
 - List runs: `+"`orch ps`"+` (use `+"`--status running,waiting`"+` to filter)
 - Stop a run: `+"`orch stop <issue-id>#<run-id>`"+`
 - Resolve a run: `+"`orch resolve <issue-id>#<run-id>`"+`
@@ -2806,8 +2806,8 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 			return nil, fmt.Errorf("run reference required (issue_id+run_id, short_id, or branch)")
 		}
 
-		if isActiveForContinue(fromRun.Status) {
-			return nil, fmt.Errorf("run %s#%s is %s; stop it before continuing", fromRun.IssueID, fromRun.RunID, fromRun.Status)
+		if err := validateRestartFromStatus(fromRun); err != nil {
+			return nil, err
 		}
 
 		if fromRun.WorktreePath == "" {
@@ -3173,8 +3173,8 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 			return
 		}
 
-		if isActiveForContinue(fromRun.Status) {
-			encoder.Encode(ContinueRunResponse{OK: false, Error: fmt.Sprintf("run %s#%s is %s; stop it before continuing", fromRun.IssueID, fromRun.RunID, fromRun.Status)})
+		if err := validateRestartFromStatus(fromRun); err != nil {
+			encoder.Encode(ContinueRunResponse{OK: false, Error: err.Error()})
 			return
 		}
 
@@ -3428,13 +3428,48 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 	})
 }
 
-func isActiveForContinue(status model.Status) bool {
+func canRestartFromStatus(status model.Status) bool {
+	switch status {
+	case model.StatusFailed, model.StatusCanceled, model.StatusUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func isLiveRestartableStatus(status model.Status) bool {
 	switch status {
 	case model.StatusRunning, model.StatusWaiting, model.StatusRateLimited, model.StatusBooting, model.StatusQueued, model.StatusPROpen:
 		return true
 	default:
 		return false
 	}
+}
+
+func restartFromStatusDisplay(status model.Status) string {
+	switch status {
+	case model.StatusWaiting:
+		return "wait"
+	case model.StatusRateLimited:
+		return "blocked"
+	default:
+		return string(status)
+	}
+}
+
+func validateRestartFromStatus(run *model.Run) error {
+	status := model.NormalizeStatus(string(run.Status))
+	if canRestartFromStatus(status) {
+		return nil
+	}
+
+	ref := fmt.Sprintf("%s#%s", run.IssueID, run.RunID)
+	if isLiveRestartableStatus(status) {
+		statusText := restartFromStatusDisplay(status)
+		return fmt.Errorf("Run %s is alive (status: %s).\n\n  To send feedback:  orch send %s \"your message\"\n  To check output:   orch capture %s\n\n'orch restart-from' is for recovering from failed/canceled/unknown runs only.", ref, statusText, ref, ref)
+	}
+
+	return fmt.Errorf("run %s is %s; 'orch restart-from' only supports failed, canceled, or unknown runs", ref, status)
 }
 
 func (s *SocketServer) buildRunPrompt(issue *model.Issue, issuesRoot string, noPR bool, promptTemplate string, prTargetBranch string) string {

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -2696,6 +2696,59 @@ func TestProcessContinueRunCoreValidation(t *testing.T) {
 			t.Errorf("expected 'run not found' error, got: %v", err)
 		}
 	})
+
+	t.Run("live run returns safe send/capture guidance", func(t *testing.T) {
+		st.runs["orch-451#run-live"] = &model.Run{
+			IssueID: "orch-451",
+			RunID:   "run-live",
+			Status:  model.StatusWaiting,
+		}
+
+		opts := &ContinueRunOptions{
+			IssueID: "orch-451",
+			RunID:   "run-live",
+		}
+
+		_, err := server.processContinueRunCore(st, "/project", opts)
+		if err == nil {
+			t.Fatal("expected error for live run")
+		}
+
+		msg := err.Error()
+		if !strings.Contains(msg, "Run orch-451#run-live is alive (status: wait).") {
+			t.Fatalf("expected alive status guidance, got: %s", msg)
+		}
+		if !strings.Contains(msg, "orch send orch-451#run-live \"your message\"") {
+			t.Fatalf("expected orch send guidance, got: %s", msg)
+		}
+		if !strings.Contains(msg, "orch capture orch-451#run-live") {
+			t.Fatalf("expected orch capture guidance, got: %s", msg)
+		}
+		if strings.Contains(msg, "orch stop") {
+			t.Fatalf("expected no orch stop guidance, got: %s", msg)
+		}
+	})
+
+	t.Run("done run is rejected", func(t *testing.T) {
+		st.runs["orch-451#run-done"] = &model.Run{
+			IssueID: "orch-451",
+			RunID:   "run-done",
+			Status:  model.StatusDone,
+		}
+
+		opts := &ContinueRunOptions{
+			IssueID: "orch-451",
+			RunID:   "run-done",
+		}
+
+		_, err := server.processContinueRunCore(st, "/project", opts)
+		if err == nil {
+			t.Fatal("expected error for done run")
+		}
+		if !strings.Contains(err.Error(), "'orch restart-from' only supports failed, canceled, or unknown runs") {
+			t.Fatalf("expected restart-from terminal-state guidance, got: %s", err.Error())
+		}
+	})
 }
 
 func TestProcessCreateIssueCoreValidation(t *testing.T) {

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -63,7 +63,7 @@ func (s Status) IsActive() bool {
 type EventSource string
 
 const (
-	EventSourceUser   EventSource = "user"   // CLI commands (stop, continue, resolve)
+	EventSourceUser   EventSource = "user"   // CLI commands (stop, restart-from, resolve)
 	EventSourceDaemon EventSource = "daemon" // Daemon inferences (PR merged, agent dead)
 	EventSourceAgent  EventSource = "agent"  // Agent self-reported status
 )

--- a/internal/monitor/agent_prompt.go
+++ b/internal/monitor/agent_prompt.go
@@ -90,9 +90,9 @@ When a run shows "waiting" status:
 2. Send feedback: ` + "`orch send <issue-id> \"<message>\"`" + ` to provide input
 3. The agent will resume automatically after receiving input
 
-### Continuing Work
-- From a branch: ` + "`orch continue <issue> --branch <branch-name>`" + `
-- From a run: ` + "`orch continue <issue>#<run-id>`" + `
+### Restarting Work
+- From a branch: ` + "`orch restart-from <issue> --branch <branch-name>`" + `
+- From a run: ` + "`orch restart-from <issue>#<run-id>`" + `
 
 ## Available Orch Commands
 
@@ -105,7 +105,7 @@ Run these commands directly using bash (do not use any special protocol):
 
 ### Run Management
 - Start a run: ` + "`orch run <issue-id>`" + `
-- Continue from branch: ` + "`orch continue <issue> --branch <branch>`" + `
+- Restart from branch: ` + "`orch restart-from <issue> --branch <branch>`" + `
 - List runs: ` + "`orch ps`" + ` (use ` + "`--status running,waiting`" + ` to filter)
 - Stop a run: ` + "`orch stop <issue-id>#<run-id>`" + `
 - Resolve a run: ` + "`orch resolve <issue-id>#<run-id>`" + `

--- a/internal/monitor/agent_prompt_test.go
+++ b/internal/monitor/agent_prompt_test.go
@@ -201,14 +201,14 @@ func TestControlPromptTemplateContainsNewSections(t *testing.T) {
 	if !contains(controlPromptTemplate, "### Handling Waiting Runs") {
 		t.Error("template should contain Handling Waiting Runs subsection")
 	}
-	if !contains(controlPromptTemplate, "### Continuing Work") {
-		t.Error("template should contain Continuing Work subsection")
+	if !contains(controlPromptTemplate, "### Restarting Work") {
+		t.Error("template should contain Restarting Work subsection")
 	}
 	if !contains(controlPromptTemplate, "## Troubleshooting") {
 		t.Error("template should contain Troubleshooting section")
 	}
-	if !contains(controlPromptTemplate, "orch continue") {
-		t.Error("template should contain orch continue command")
+	if !contains(controlPromptTemplate, "orch restart-from") {
+		t.Error("template should contain orch restart-from command")
 	}
 	if !contains(controlPromptTemplate, "orch attach") {
 		t.Error("template should contain orch attach command")

--- a/internal/monitor/issue_keymap.go
+++ b/internal/monitor/issue_keymap.go
@@ -59,6 +59,6 @@ func DefaultIssueKeyMap() IssueKeyMap {
 }
 
 func (k IssueKeyMap) HelpLine() string {
-	return fmt.Sprintf("[%s] browser  [%s] edit  [%s] view  [%s] open run  [%s] start  [%s] continue  [%s] attach  [%s] resolve  [%s] filter  [%s] sort  [%s] quit  [%s] help",
+	return fmt.Sprintf("[%s] browser  [%s] edit  [%s] view  [%s] open run  [%s] start  [%s] restart  [%s] attach  [%s] resolve  [%s] filter  [%s] sort  [%s] quit  [%s] help",
 		k.OpenBrowser, k.EditIssue, k.ViewIssue, k.OpenRun, k.StartRun, k.ContinueRun, k.Attach, k.Resolve, k.Filter, k.Sort, k.Quit, k.Help)
 }

--- a/internal/monitor/issues_dashboard.go
+++ b/internal/monitor/issues_dashboard.go
@@ -1467,7 +1467,7 @@ func (d *IssueDashboard) viewContinueBranch() string {
 		return strings.Join(lines, "\n")
 	}
 
-	lines = append(lines, "Select a branch to continue from:", "")
+	lines = append(lines, "Select a branch to restart from:", "")
 	maxRows := d.continueBranchMaxRows()
 	visibleRows := d.continueBranchVisibleRows(maxRows)
 	start := d.continue_.offset

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -755,7 +755,7 @@ func (m *Monitor) ListBranchesForIssue(issueID string) ([]branchInfo, error) {
 
 func (m *Monitor) ContinueRun(issueID, branch, agentType, prompt string) (string, error) {
 	args := append([]string{}, m.globalFlags...)
-	args = append(args, "continue", "--issue", issueID, "--branch", branch)
+	args = append(args, "restart-from", "--issue", issueID, "--branch", branch)
 	if agentType != "" {
 		agentName, model, variant, profile := m.parseAgentPreset(agentType)
 		args = append(args, "--agent", agentName)
@@ -777,7 +777,7 @@ func (m *Monitor) ContinueRun(issueID, branch, agentType, prompt string) (string
 
 	// If prompt is provided, we need to inject it after the run starts
 	// For now, we'll pass it via environment variable or stdin
-	// The continue command doesn't have a --prompt flag, so we'll handle this differently
+	// The restart-from command doesn't have a --prompt flag, so we'll handle this differently
 	if prompt != "" {
 		// Store the prompt to be injected via tmux after the session starts
 		cmd.Env = append(os.Environ(), fmt.Sprintf("ORCH_CONTINUE_PROMPT=%s", prompt))
@@ -793,7 +793,7 @@ func (m *Monitor) ContinueRun(issueID, branch, agentType, prompt string) (string
 		return output, err
 	}
 	if strings.TrimSpace(output) == "" {
-		output = "run continued"
+		output = "run restarted"
 	}
 	return output, nil
 }

--- a/internal/orchapi/api.go
+++ b/internal/orchapi/api.go
@@ -92,7 +92,7 @@ type OrchAPI interface {
 	StartRun(ctx context.Context, req *StartRunRequest) (*StartRunResult, error)
 
 	// CreateRun creates a new run record without starting the agent.
-	// Used by continue command to create runs that reuse existing worktrees.
+	// Used by restart-from command to create runs that reuse existing worktrees.
 	CreateRun(ctx context.Context, req *CreateRunRequest) (*CreateRunResult, error)
 
 	// StopRun stops a running run.

--- a/specs/03-commands.md
+++ b/specs/03-commands.md
@@ -63,7 +63,7 @@
 
 ---
 
-## orch continue RUN_REF|ISSUE_ID
+## orch restart-from RUN_REF|ISSUE_ID
 
 既存runのworktree/branchを再利用して新しいrunを開始する。
 
@@ -85,7 +85,8 @@
 
 ### 挙動
 
-- 対象runがアクティブならエラー（stopで停止が必要）
+- 対象runが `failed` / `canceled` / `unknown` 以外ならエラー
+- アクティブrunへのエラー時は `orch send` / `orch capture` を案内し、`orch stop` は案内しない
 - `--branch` 指定時は既存branchからworktreeを作成（既存worktreeがあれば再利用）
 - 新しいrun docを作成し、continued_fromを記録
 - agentを起動

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -405,11 +405,11 @@ run: 20231221-110000
 	}
 }
 
-func TestContinueFromBranch(t *testing.T) {
-	issueID := "continue-branch"
-	createTestIssue(t, issueID, "---\ntitle: Continue Branch\n---\n# Continue Branch")
+func TestRestartFromBranch(t *testing.T) {
+	issueID := "restart-branch"
+	createTestIssue(t, issueID, "---\ntitle: Restart Branch\n---\n# Restart Branch")
 
-	runGitCmd(t, testRepo, "checkout", "-b", "feature/continue-branch")
+	runGitCmd(t, testRepo, "checkout", "-b", "feature/restart-branch")
 	if err := os.WriteFile(filepath.Join(testRepo, "feature.txt"), []byte("feature"), 0644); err != nil {
 		t.Fatalf("write file: %v", err)
 	}
@@ -417,9 +417,9 @@ func TestContinueFromBranch(t *testing.T) {
 	runGitCmd(t, testRepo, "commit", "-m", "feature work")
 	runGitCmd(t, testRepo, "checkout", "main")
 
-	output, err := runOrch(t, "--json", "continue", issueID, "--branch", "feature/continue-branch", "--tmux=false")
+	output, err := runOrch(t, "--json", "restart-from", issueID, "--branch", "feature/restart-branch", "--tmux=false")
 	if err != nil {
-		t.Fatalf("continue failed: %v", err)
+		t.Fatalf("restart-from failed: %v", err)
 	}
 
 	var result struct {
@@ -439,8 +439,8 @@ func TestContinueFromBranch(t *testing.T) {
 	if result.IssueID != issueID {
 		t.Fatalf("IssueID = %q, want %q", result.IssueID, issueID)
 	}
-	if result.Branch != "feature/continue-branch" {
-		t.Fatalf("Branch = %q, want %q", result.Branch, "feature/continue-branch")
+	if result.Branch != "feature/restart-branch" {
+		t.Fatalf("Branch = %q, want %q", result.Branch, "feature/restart-branch")
 	}
 	if !strings.HasPrefix(result.ContinuedFrom, "branch:") {
 		t.Fatalf("ContinuedFrom = %q, want prefix %q", result.ContinuedFrom, "branch:")
@@ -450,8 +450,22 @@ func TestContinueFromBranch(t *testing.T) {
 	}
 
 	branch := runGitCmd(t, result.WorktreePath, "rev-parse", "--abbrev-ref", "HEAD")
-	if branch != "feature/continue-branch" {
-		t.Fatalf("worktree branch = %q, want %q", branch, "feature/continue-branch")
+	if branch != "feature/restart-branch" {
+		t.Fatalf("worktree branch = %q, want %q", branch, "feature/restart-branch")
+	}
+}
+
+func TestHelpListsRestartFromAndNotContinue(t *testing.T) {
+	output, err := runOrch(t, "--help")
+	if err != nil {
+		t.Fatalf("help failed: %v", err)
+	}
+
+	if !strings.Contains(output, "restart-from") {
+		t.Fatalf("expected help output to contain restart-from command")
+	}
+	if strings.Contains(output, "\n  continue") {
+		t.Fatalf("expected help output to remove continue command")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Renames `orch continue` → `orch restart-from` to prevent accidental session destruction
- Only allows `restart-from` on terminal states (`failed`/`canceled`/`unknown`); rejects live runs with safe guidance pointing to `orch send` / `orch capture`
- Adds send failure escalation path in `orch send` error output and `--help`

## Context

`orch continue` sounded like "continue the conversation" but actually killed the session and started fresh. This caused an operator to accidentally destroy a running agent's full context when they intended to send review feedback. The error message compounded the problem by suggesting `orch stop` first.

## Changes

### CLI
- `orch continue` → `orch restart-from` (no alias, clean break)
- `validateRestartFromStatus()` rejects non-terminal runs with `NormalizeStatus()` for safety
- Live runs (`running`/`waiting`/`booting`/`pr_open`/etc.) get guidance: `orch send` + `orch capture`
- Error messages never mention `orch stop`

### `orch send` improvements
- `--help` now documents escalation path for send failures
- Error output includes 5-step recovery path (capture → ps → check mux → ORCH_PROMPT.md → native send)
- Explicitly warns against `orch restart-from` for send failures

### Documentation
- Updated: `CLAUDE.md`, `docs/`, `specs/03-commands.md`, skill files, plugin docs
- All references to `orch continue` replaced with `orch restart-from`

### Tests
- New daemon tests: live run rejection with send/capture guidance, done run rejection
- New CLI tests: send failure escalation format, help text guidance
- New integration test: `TestHelpListsRestartFromAndNotContinue`
- Integration test `TestRestartFromBranch` updated

## Acceptance Criteria (from issue)

- [x] `orch continue` renamed to `orch restart-from`
- [x] `orch continue` removed entirely (no alias, no deprecation)
- [x] Error message on live runs mentions `orch send` and `orch capture`, never `orch stop`
- [x] `orch restart-from` hard-rejects non-terminal states
- [x] Skill doc / AGENTS.md updated
- [x] `orch send` documentation emphasizes primary interaction with waiting agents
- [x] `orch send` failure message includes escalation path

Closes orch-451