### PR TITLE
Fix Claude bypass confirmation in tmux sessions

### DIFF
--- a/internal/agent/adapter.go
+++ b/internal/agent/adapter.go
@@ -91,6 +91,9 @@ type Adapter interface {
 	// LaunchCommand returns the command to launch the agent
 	LaunchCommand(cfg *LaunchConfig) (string, error)
 
+	// ExtraEnv returns agent-specific environment variables to inject at launch.
+	ExtraEnv() []string
+
 	// IsAvailable checks if the agent CLI is available
 	IsAvailable() bool
 

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -48,6 +48,10 @@ func (a *ClaudeAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 	return strings.Join(args, " "), nil
 }
 
+func (a *ClaudeAdapter) ExtraEnv() []string {
+	return []string{"IS_DEMO=1"}
+}
+
 func (a *ClaudeAdapter) PromptInjection() InjectionMethod {
 	return InjectionArg
 }

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -1,6 +1,15 @@
 package agent
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/s22625/orch/internal/multiplexer"
+)
 
 func TestDoubleQuote(t *testing.T) {
 	input := "path\\with \"quotes\" $HOME and `tick"
@@ -28,4 +37,61 @@ func TestClaudeLaunchCommand(t *testing.T) {
 	if cmd != want {
 		t.Fatalf("command = %q, want %q", cmd, want)
 	}
+}
+
+func TestClaudeExtraEnv(t *testing.T) {
+	adapter := &ClaudeAdapter{}
+	env := adapter.ExtraEnv()
+	if len(env) != 1 {
+		t.Fatalf("ExtraEnv() returned %d items, want 1", len(env))
+	}
+	if env[0] != "IS_DEMO=1" {
+		t.Fatalf("ExtraEnv()[0] = %q, want %q", env[0], "IS_DEMO=1")
+	}
+}
+
+func TestClaudeExtraEnvReachesTmuxSession(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	mux := multiplexer.NewTmuxMultiplexer()
+	if !mux.IsAvailable() {
+		t.Skip("tmux not available")
+	}
+
+	adapter := &ClaudeAdapter{}
+	outPath := filepath.Join(t.TempDir(), "is_demo.txt")
+	script := fmt.Sprintf(
+		"import os, pathlib, time; pathlib.Path(%q).write_text(os.getenv('IS_DEMO', '')); time.sleep(0.2)",
+		outPath,
+	)
+	sessionName := fmt.Sprintf("orch-claude-env-%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		_ = mux.KillSession(sessionName)
+	})
+
+	err := mux.NewSession(&multiplexer.SessionConfig{
+		SessionName: sessionName,
+		WorkDir:     t.TempDir(),
+		Command:     fmt.Sprintf("python3 -c %s", shellQuote(script)),
+		Env:         adapter.ExtraEnv(),
+	})
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(outPath)
+		if err == nil {
+			if got := string(data); got != "1" {
+				t.Fatalf("tmux session wrote %q, want %q", got, "1")
+			}
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for tmux session to write %s", outPath)
 }

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -47,6 +47,10 @@ func (a *CodexAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 	return strings.Join(args, " "), nil
 }
 
+func (a *CodexAdapter) ExtraEnv() []string {
+	return nil
+}
+
 func (a *CodexAdapter) PromptInjection() InjectionMethod {
 	return InjectionArg
 }

--- a/internal/agent/custom.go
+++ b/internal/agent/custom.go
@@ -23,6 +23,10 @@ func (a *CustomAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 	return cfg.CustomCmd, nil
 }
 
+func (a *CustomAdapter) ExtraEnv() []string {
+	return nil
+}
+
 func (a *CustomAdapter) PromptInjection() InjectionMethod {
 	return InjectionArg
 }

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -37,6 +37,10 @@ func (a *GeminiAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 	return strings.Join(args, " "), nil
 }
 
+func (a *GeminiAdapter) ExtraEnv() []string {
+	return nil
+}
+
 func (a *GeminiAdapter) PromptInjection() InjectionMethod {
 	return InjectionArg
 }

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -102,9 +102,9 @@ func (a *OpenCodeAdapter) HealthEndpoint(port int) string {
 	return fmt.Sprintf("http://127.0.0.1:%d/global/health", port)
 }
 
-// Env returns additional environment variables for opencode.
+// ExtraEnv returns additional environment variables for opencode.
 // Sets OPENCODE_PERMISSION for autonomous operation.
-func (a *OpenCodeAdapter) Env() []string {
+func (a *OpenCodeAdapter) ExtraEnv() []string {
 	return []string{
 		`OPENCODE_PERMISSION={"edit":"allow","bash":"allow","skill":"allow","webfetch":"allow","doom_loop":"allow","external_directory":"allow"}`,
 	}

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -70,15 +70,15 @@ func TestOpenCodeHealthEndpoint(t *testing.T) {
 	}
 }
 
-func TestOpenCodeEnv(t *testing.T) {
+func TestOpenCodeExtraEnv(t *testing.T) {
 	adapter := &OpenCodeAdapter{}
-	env := adapter.Env()
+	env := adapter.ExtraEnv()
 	if len(env) != 1 {
-		t.Fatalf("Env() returned %d items, want 1", len(env))
+		t.Fatalf("ExtraEnv() returned %d items, want 1", len(env))
 	}
 	// Check that the permission env var is set
 	if env[0] == "" {
-		t.Fatal("Env()[0] is empty")
+		t.Fatal("ExtraEnv()[0] is empty")
 	}
 }
 

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -362,6 +362,7 @@ func createMultiplexerSession(orchDir, projectRoot string, agentType agent.Agent
 		SessionName: controlAgentSessionName,
 		WorkDir:     workDir,
 		Command:     launchCmd,
+		Env:         adapter.ExtraEnv(),
 		WindowName:  "agent",
 	}
 

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -70,9 +70,9 @@ var (
 	// message was queued anyway before returning an error.
 	openCodeSendConfirmTimeout      = 600 * time.Millisecond
 	openCodeSendConfirmPollInterval = 200 * time.Millisecond
-	codexTmuxSubmitDelay           = 250 * time.Millisecond
-	codexTmuxExtraEnterDelay       = 200 * time.Millisecond
-	claudeTmuxMultilineSubmitDelay = 100 * time.Millisecond
+	codexTmuxSubmitDelay            = 250 * time.Millisecond
+	codexTmuxExtraEnterDelay        = 200 * time.Millisecond
+	claudeTmuxMultilineSubmitDelay  = 100 * time.Millisecond
 
 	getSendMultiplexer = func() sendMultiplexer {
 		return multiplexer.GetDefault()
@@ -3407,9 +3407,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 
 	if !serverAlreadyRunning {
 		env := launchCfg.Env()
-		if opencodeAdapter, ok := adapter.(*agent.OpenCodeAdapter); ok {
-			env = append(env, opencodeAdapter.Env()...)
-		}
+		env = append(env, adapter.ExtraEnv()...)
 
 		err = mux.NewSession(&multiplexer.SessionConfig{
 			SessionName: sessionName,
@@ -3738,9 +3736,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 
 	if !serverAlreadyRunning {
 		env := launchCfg.Env()
-		if opencodeAdapter, ok := adapter.(*agent.OpenCodeAdapter); ok {
-			env = append(env, opencodeAdapter.Env()...)
-		}
+		env = append(env, adapter.ExtraEnv()...)
 
 		err = mux.NewSession(&multiplexer.SessionConfig{
 			SessionName: sessionName,
@@ -4071,9 +4067,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 
 	if !serverAlreadyRunning {
 		env := launchCfg.Env()
-		if opencodeAdapter, ok := adapter.(*agent.OpenCodeAdapter); ok {
-			env = append(env, opencodeAdapter.Env()...)
-		}
+		env = append(env, adapter.ExtraEnv()...)
 
 		err = mux.NewSession(&multiplexer.SessionConfig{
 			SessionName: sessionName,
@@ -4431,9 +4425,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 
 	if !serverAlreadyRunning {
 		env := launchCfg.Env()
-		if opencodeAdapter, ok := adapter.(*agent.OpenCodeAdapter); ok {
-			env = append(env, opencodeAdapter.Env()...)
-		}
+		env = append(env, adapter.ExtraEnv()...)
 
 		err = mux.NewSession(&multiplexer.SessionConfig{
 			SessionName: sessionName,

--- a/internal/multiplexer/env.go
+++ b/internal/multiplexer/env.go
@@ -2,28 +2,36 @@ package multiplexer
 
 import (
 	"os"
+	"strings"
 
 	"github.com/s22625/orch/internal/executor"
 )
 
 func sessionEnv(exec executor.Executor, extra []string) []string {
+	filtered := sessionExtraEnv(exec, extra)
 	if _, ok := exec.(*executor.SSHExecutor); ok {
-		filtered := make([]string, 0, len(extra))
-		for _, entry := range extra {
-			switch {
-			case entry == "":
-				continue
-			case len(entry) > 5 && entry[:5] == "HOME=":
-				continue
-			case len(entry) > 5 && entry[:5] == "PATH=":
-				continue
-			default:
-				filtered = append(filtered, entry)
-			}
-		}
 		return filtered
 	}
 
 	env := append([]string{}, os.Environ()...)
-	return append(env, extra...)
+	return append(env, filtered...)
+}
+
+func sessionExtraEnv(exec executor.Executor, extra []string) []string {
+	filtered := make([]string, 0, len(extra))
+	_, isSSH := exec.(*executor.SSHExecutor)
+	for _, entry := range extra {
+		entry = strings.TrimSpace(entry)
+		switch {
+		case entry == "":
+			continue
+		case isSSH && strings.HasPrefix(entry, "HOME="):
+			continue
+		case isSSH && strings.HasPrefix(entry, "PATH="):
+			continue
+		default:
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
 }

--- a/internal/multiplexer/tmux.go
+++ b/internal/multiplexer/tmux.go
@@ -94,6 +94,10 @@ func (t *TmuxMultiplexer) NewSession(cfg *SessionConfig) error {
 		"-s", cfg.SessionName,
 	}
 
+	for _, entry := range sessionExtraEnv(t.executor, cfg.Env) {
+		args = append(args, "-e", entry)
+	}
+
 	if cfg.WorkDir != "" {
 		args = append(args, "-c", cfg.WorkDir)
 	}
@@ -104,8 +108,7 @@ func (t *TmuxMultiplexer) NewSession(cfg *SessionConfig) error {
 		args = append(args, cfg.Command)
 	}
 
-	env := sessionEnv(t.executor, cfg.Env)
-	if err := t.runWithOptions(args, executor.RunOptions{Env: env, Stderr: os.Stderr}); err != nil {
+	if err := t.runWithOptions(args, executor.RunOptions{Stderr: os.Stderr}); err != nil {
 		return fmt.Errorf("failed to create tmux session: %w", err)
 	}
 

--- a/internal/multiplexer/tmux_test.go
+++ b/internal/multiplexer/tmux_test.go
@@ -176,11 +176,11 @@ func TestTmuxMultiplexer_NewSession(t *testing.T) {
 	}
 
 	first := exec.recorded[0]
-	if !equalArgs(first.args, []string{"new-session", "-d", "-s", "sess", "-c", "/work", "-n", "main", "echo hi"}) {
+	if !equalArgs(first.args, []string{"new-session", "-d", "-s", "sess", "-e", "FOO=bar", "-c", "/work", "-n", "main", "echo hi"}) {
 		t.Fatalf("new-session args = %v", first.args)
 	}
-	if !envHas(first.cmd.Env, "FOO=bar") {
-		t.Fatalf("missing env in new-session: %v", first.cmd.Env)
+	if envHas(first.cmd.Env, "FOO=bar") {
+		t.Fatalf("expected tmux session env to be passed via -e, not client env: %v", first.cmd.Env)
 	}
 }
 
@@ -207,11 +207,11 @@ func TestTmuxMultiplexer_NewSession_ShellCommandUsesSendKeys(t *testing.T) {
 	}
 
 	first := exec.recorded[0]
-	if !equalArgs(first.args, []string{"new-session", "-d", "-s", "sess", "-c", "/work", "-n", "main"}) {
+	if !equalArgs(first.args, []string{"new-session", "-d", "-s", "sess", "-e", "FOO=bar", "-c", "/work", "-n", "main"}) {
 		t.Fatalf("new-session args = %v", first.args)
 	}
-	if !envHas(first.cmd.Env, "FOO=bar") {
-		t.Fatalf("missing env in new-session: %v", first.cmd.Env)
+	if envHas(first.cmd.Env, "FOO=bar") {
+		t.Fatalf("expected tmux session env to be passed via -e, not client env: %v", first.cmd.Env)
 	}
 
 	second := exec.recorded[1]


### PR DESCRIPTION
## Summary
- add shared agent-specific launch env via `Adapter.ExtraEnv()` and set Claude to `IS_DEMO=1`
- inject explicit tmux session environment with `tmux new-session -e ...` so the env reaches the first process even when the tmux server is already running
- wire the extra env into daemon-managed run launches and the CLI control-agent session, and add regression coverage for both the tmux args and a real tmux-backed Claude launch

## Acceptance Evidence
The issue does not include an explicit `Acceptance Criteria` section, so I verified the stated target behavior directly:
- Claude launches set `IS_DEMO=1`
- tmux session creation applies that env at session creation time, not only to the tmux client process
- daemon launch paths still pass with the new env plumbing

```text
$ PATH=/tmp/orch-go-1.25.3/go/bin:$PATH GOCACHE=/tmp/orch-go-cache go test ./internal/multiplexer ./internal/agent -run 'TestTmuxMultiplexer_NewSession|TestTmuxMultiplexer_NewSession_ShellCommandUsesSendKeys|TestClaudeExtraEnvReachesTmuxSession' -v
=== RUN   TestTmuxMultiplexer_NewSession
--- PASS: TestTmuxMultiplexer_NewSession (0.01s)
=== RUN   TestTmuxMultiplexer_NewSession_ShellCommandUsesSendKeys
--- PASS: TestTmuxMultiplexer_NewSession_ShellCommandUsesSendKeys (0.02s)
PASS
ok      github.com/s22625/orch/internal/multiplexer  0.045s
=== RUN   TestClaudeExtraEnvReachesTmuxSession
--- PASS: TestClaudeExtraEnvReachesTmuxSession (0.10s)
PASS
ok      github.com/s22625/orch/internal/agent        (cached)
```

```text
$ PATH=/tmp/orch-go-1.25.3/go/bin:$PATH GOCACHE=/tmp/orch-go-cache go test ./internal/daemon
ok      github.com/s22625/orch/internal/daemon       13.448s
```

```text
$ PATH=/tmp/orch-go-1.25.3/go/bin:$PATH GOCACHE=/tmp/orch-go-cache go build ./...
# exit 0
```

```text
$ PATH=/home/kento/.local/bin:/tmp/orch-go-1.25.3/go/bin:$PATH GOCACHE=/tmp/orch-go-cache make lint
Ran 100 rules on 67 files: 0 findings.
```

## Full Test Sweep Note
```text
$ PATH=/tmp/orch-go-1.25.3/go/bin:$PATH GOCACHE=/tmp/orch-go-cache go test ./...
...
--- FAIL: TestBuildAgentPromptCustomTemplate (0.01s)
    run_test.go:180: expected fallback prompt to include issue reference, got: "Issue: orch-3 - Custom"
FAIL    github.com/s22625/orch/internal/cli  0.734s
```
That `internal/cli` failure is unrelated to this change; the touched launch-path packages above are passing.

Issue: ISSUE-ORCH-CLAUDE-BYPASS
