### PR TITLE
refactor(daemon): decouple Slack notifier via runevents listener

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -18,6 +18,7 @@ import (
 	"github.com/s22625/orch/internal/github"
 	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/notify"
+	"github.com/s22625/orch/internal/runevents"
 	"github.com/s22625/orch/internal/store"
 	"github.com/s22625/orch/internal/store/file"
 	"github.com/s22625/orch/internal/xdg"
@@ -46,16 +47,18 @@ type Daemon struct {
 	startupMtime   time.Time
 	staleLogged    bool
 
-	socketServer  *SocketServer
-	config        *config.Config
-	slackNotifier *notify.SlackNotifier
-	debugMode     bool
-	lockFile      *os.File
+	socketServer *SocketServer
+	config       *config.Config
+	debugMode    bool
+	lockFile     *os.File
 
 	githubBackend  *github.Backend
 	lastGitHubSync time.Time
 	gitHubSyncMu   sync.Mutex
 	listenAddr     string
+
+	statusListeners   []runevents.StatusChangeListener
+	statusListenersMu sync.RWMutex
 }
 
 // RunState tracks the monitoring state of a single run
@@ -139,7 +142,7 @@ func (d *Daemon) Run() error {
 	} else {
 		d.config = cfg
 		if cfg.Slack.IsConfigured() {
-			d.slackNotifier = notify.NewSlackNotifier(&cfg.Slack)
+			d.AddStatusChangeListener(notify.NewSlackStatusListener(notify.NewSlackNotifier(&cfg.Slack), d.logger))
 			d.logger.Printf("slack notifications enabled")
 		}
 		if cfg.IsGitHubBackend() {

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/s22625/orch/internal/git"
 	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/pr"
+	"github.com/s22625/orch/internal/runevents"
 	"github.com/s22625/orch/internal/store"
 )
 
@@ -174,10 +175,18 @@ func (d *Daemon) monitorRun(run *model.Run, st store.Store) error {
 
 	if newStatus != "" && newStatus != run.Status {
 		d.logger.Printf("%s#%s: status change %s -> %s", run.IssueID, run.RunID, run.Status, newStatus)
+		prevStatus := run.Status
 		if err := d.updateStatus(run, newStatus, st); err != nil {
 			return err
 		}
-		d.notifyStatusChange(run, newStatus, output, st)
+		d.fireStatusChange(&runevents.StatusChangeEvent{
+			Run:        run,
+			From:       prevStatus,
+			To:         newStatus,
+			Source:     model.EventSourceDaemon,
+			LastOutput: output,
+			Store:      st,
+		})
 	}
 
 	return nil
@@ -463,38 +472,6 @@ func (d *Daemon) checkPRMergedWithURL(run *model.Run, st store.Store) (merged bo
 		return true, prInfo.URL
 	}
 	return false, ""
-}
-
-func (d *Daemon) notifyStatusChange(run *model.Run, newStatus model.Status, lastOutput string, st store.Store) {
-	if d.slackNotifier == nil || d.config == nil {
-		return
-	}
-
-	if !d.config.Slack.ShouldNotify(string(newStatus)) {
-		return
-	}
-
-	issueTitle := run.IssueID
-	if st != nil {
-		if issue, err := st.ResolveIssue(run.IssueID); err == nil && issue != nil {
-			if issue.Title != "" {
-				issueTitle = issue.Title
-			}
-		}
-	}
-
-	var err error
-	if newStatus == model.StatusWaiting || newStatus == model.StatusRateLimited {
-		err = d.slackNotifier.NotifyBlocked(run, issueTitle, lastOutput)
-	} else {
-		err = d.slackNotifier.NotifyStatusChange(run, issueTitle, newStatus)
-	}
-
-	if err != nil {
-		d.logger.Printf("%s#%s: failed to send slack notification: %v", run.IssueID, run.RunID, err)
-	} else {
-		d.logger.Printf("%s#%s: sent slack notification for status %s", run.IssueID, run.RunID, newStatus)
-	}
 }
 
 // inferStatusFromGitState infers a run's status from git state when the agent session

--- a/internal/daemon/status_listener.go
+++ b/internal/daemon/status_listener.go
@@ -1,0 +1,42 @@
+package daemon
+
+import (
+	"github.com/s22625/orch/internal/runevents"
+)
+
+// AddStatusChangeListener registers a listener that will be invoked for every
+// run status transition observed by monitorRun. Listeners are invoked in
+// registration order on the daemon's monitor goroutine.
+func (d *Daemon) AddStatusChangeListener(l runevents.StatusChangeListener) {
+	if d == nil || l == nil {
+		return
+	}
+	d.statusListenersMu.Lock()
+	defer d.statusListenersMu.Unlock()
+	d.statusListeners = append(d.statusListeners, l)
+}
+
+// fireStatusChange dispatches ev to every registered listener. A panic in one
+// listener is logged but does not stop subsequent listeners from running.
+func (d *Daemon) fireStatusChange(ev *runevents.StatusChangeEvent) {
+	if d == nil || ev == nil {
+		return
+	}
+	d.statusListenersMu.RLock()
+	listeners := make([]runevents.StatusChangeListener, len(d.statusListeners))
+	copy(listeners, d.statusListeners)
+	d.statusListenersMu.RUnlock()
+
+	for _, l := range listeners {
+		d.invokeListener(l, ev)
+	}
+}
+
+func (d *Daemon) invokeListener(l runevents.StatusChangeListener, ev *runevents.StatusChangeEvent) {
+	defer func() {
+		if r := recover(); r != nil && d.logger != nil {
+			d.logger.Printf("status change listener panicked: %v", r)
+		}
+	}()
+	l.OnStatusChange(ev)
+}

--- a/internal/daemon/status_listener_test.go
+++ b/internal/daemon/status_listener_test.go
@@ -1,0 +1,69 @@
+package daemon
+
+import (
+	"io"
+	"log"
+	"sync/atomic"
+	"testing"
+
+	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/runevents"
+)
+
+func TestAddStatusChangeListener_FanoutPreservesOrder(t *testing.T) {
+	d := newTestDaemon()
+
+	var order []string
+	d.AddStatusChangeListener(runevents.StatusChangeListenerFunc(func(_ *runevents.StatusChangeEvent) {
+		order = append(order, "first")
+	}))
+	d.AddStatusChangeListener(runevents.StatusChangeListenerFunc(func(_ *runevents.StatusChangeEvent) {
+		order = append(order, "second")
+	}))
+
+	d.fireStatusChange(&runevents.StatusChangeEvent{
+		Run: &model.Run{IssueID: "i", RunID: "r"},
+		To:  model.StatusDone,
+	})
+
+	if len(order) != 2 || order[0] != "first" || order[1] != "second" {
+		t.Fatalf("listeners fired in wrong order or count: %v", order)
+	}
+}
+
+func TestFireStatusChange_PanicInListenerDoesNotStopOthers(t *testing.T) {
+	d := newTestDaemon()
+	d.logger = log.New(io.Discard, "", 0)
+
+	var ran int32
+	d.AddStatusChangeListener(runevents.StatusChangeListenerFunc(func(_ *runevents.StatusChangeEvent) {
+		panic("boom")
+	}))
+	d.AddStatusChangeListener(runevents.StatusChangeListenerFunc(func(_ *runevents.StatusChangeEvent) {
+		atomic.StoreInt32(&ran, 1)
+	}))
+
+	d.fireStatusChange(&runevents.StatusChangeEvent{
+		Run: &model.Run{IssueID: "i", RunID: "r"},
+		To:  model.StatusDone,
+	})
+
+	if atomic.LoadInt32(&ran) != 1 {
+		t.Fatal("second listener was not invoked after first panicked")
+	}
+}
+
+func TestFireStatusChange_NilEventIsNoop(t *testing.T) {
+	d := newTestDaemon()
+
+	called := false
+	d.AddStatusChangeListener(runevents.StatusChangeListenerFunc(func(_ *runevents.StatusChangeEvent) {
+		called = true
+	}))
+
+	d.fireStatusChange(nil)
+
+	if called {
+		t.Fatal("listener was invoked for nil event")
+	}
+}

--- a/internal/notify/slack_listener.go
+++ b/internal/notify/slack_listener.go
@@ -1,0 +1,64 @@
+package notify
+
+import (
+	"log"
+
+	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/runevents"
+)
+
+// SlackStatusListener adapts a SlackNotifier to runevents.StatusChangeListener.
+// It encapsulates the previously-inline Slack-specific logic that used to
+// live in the daemon's monitor.notifyStatusChange — issue title resolution,
+// blocked-vs-status-change message routing, and error logging — so the
+// daemon body no longer depends on the notify package's specifics.
+//
+// The listener short-circuits when the underlying notifier is unconfigured
+// or when the configured status filter excludes the new state.
+type SlackStatusListener struct {
+	Notifier *SlackNotifier
+	Logger   *log.Logger
+}
+
+// NewSlackStatusListener returns a listener bound to the given notifier.
+// notifier and logger may be nil; nil notifier disables the listener (useful
+// for callers that always register but only sometimes have Slack configured).
+func NewSlackStatusListener(notifier *SlackNotifier, logger *log.Logger) *SlackStatusListener {
+	return &SlackStatusListener{Notifier: notifier, Logger: logger}
+}
+
+// OnStatusChange implements runevents.StatusChangeListener.
+func (l *SlackStatusListener) OnStatusChange(ev *runevents.StatusChangeEvent) {
+	if l == nil || l.Notifier == nil || ev == nil || ev.Run == nil {
+		return
+	}
+	if !l.Notifier.config.IsConfigured() {
+		return
+	}
+	if !l.Notifier.config.ShouldNotify(string(ev.To)) {
+		return
+	}
+
+	issueTitle := ev.Run.IssueID
+	if ev.Store != nil {
+		if issue, err := ev.Store.ResolveIssue(ev.Run.IssueID); err == nil && issue != nil && issue.Title != "" {
+			issueTitle = issue.Title
+		}
+	}
+
+	var err error
+	if ev.To == model.StatusWaiting || ev.To == model.StatusRateLimited {
+		err = l.Notifier.NotifyBlocked(ev.Run, issueTitle, ev.LastOutput)
+	} else {
+		err = l.Notifier.NotifyStatusChange(ev.Run, issueTitle, ev.To)
+	}
+
+	if l.Logger == nil {
+		return
+	}
+	if err != nil {
+		l.Logger.Printf("%s#%s: failed to send slack notification: %v", ev.Run.IssueID, ev.Run.RunID, err)
+	} else {
+		l.Logger.Printf("%s#%s: sent slack notification for status %s", ev.Run.IssueID, ev.Run.RunID, ev.To)
+	}
+}

--- a/internal/notify/slack_listener_test.go
+++ b/internal/notify/slack_listener_test.go
@@ -1,0 +1,120 @@
+package notify
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/s22625/orch/internal/config"
+	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/runevents"
+)
+
+// TestSlackStatusListener_RoutesBlockedAndStatusChange asserts that the
+// listener calls NotifyBlocked for waiting/rate_limited and NotifyStatusChange
+// otherwise — the same routing the daemon used to do inline.
+func TestSlackStatusListener_RoutesBlockedAndStatusChange(t *testing.T) {
+	var bodies []SlackMessage
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var msg SlackMessage
+		if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		bodies = append(bodies, msg)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &config.SlackConfig{
+		Enabled:    true,
+		WebhookURL: server.URL,
+		NotifyOn:   []string{"waiting", "rate_limited", "done"},
+	}
+	listener := NewSlackStatusListener(NewSlackNotifier(cfg), log.New(io.Discard, "", 0))
+
+	run := &model.Run{IssueID: "i", RunID: "r"}
+
+	listener.OnStatusChange(&runevents.StatusChangeEvent{
+		Run: run, From: model.StatusRunning, To: model.StatusWaiting, LastOutput: "scrollback",
+	})
+	listener.OnStatusChange(&runevents.StatusChangeEvent{
+		Run: run, From: model.StatusRunning, To: model.StatusRateLimited,
+	})
+	listener.OnStatusChange(&runevents.StatusChangeEvent{
+		Run: run, From: model.StatusRunning, To: model.StatusDone,
+	})
+
+	if len(bodies) != 3 {
+		t.Fatalf("expected 3 webhook calls, got %d", len(bodies))
+	}
+
+	// First two are NotifyBlocked (carries last_output / "blocked" framing in the text).
+	for i := 0; i < 2; i++ {
+		if !strings.Contains(strings.ToLower(bodies[i].Text), "blocked") &&
+			!strings.Contains(strings.ToLower(bodies[i].Text), "waiting") &&
+			!strings.Contains(strings.ToLower(bodies[i].Text), "rate") {
+			t.Errorf("event %d: expected blocked/waiting/rate framing, got text=%q", i, bodies[i].Text)
+		}
+	}
+	// Third is the generic status-change message.
+	if !strings.Contains(strings.ToLower(bodies[2].Text), "done") {
+		t.Errorf("event 2: expected status-change framing for done, got text=%q", bodies[2].Text)
+	}
+}
+
+func TestSlackStatusListener_NoOpsWhenUnconfigured(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &config.SlackConfig{Enabled: false} // no webhook, not configured
+	listener := NewSlackStatusListener(NewSlackNotifier(cfg), nil)
+
+	listener.OnStatusChange(&runevents.StatusChangeEvent{
+		Run: &model.Run{IssueID: "i", RunID: "r"}, To: model.StatusWaiting,
+	})
+
+	if calls != 0 {
+		t.Fatalf("expected zero webhook calls when unconfigured, got %d", calls)
+	}
+}
+
+func TestSlackStatusListener_RespectsShouldNotifyFilter(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &config.SlackConfig{
+		Enabled:    true,
+		WebhookURL: server.URL,
+		// NotifyOn explicitly excludes "running" so the listener should skip it.
+		NotifyOn: []string{"waiting", "done"},
+	}
+	listener := NewSlackStatusListener(NewSlackNotifier(cfg), nil)
+
+	listener.OnStatusChange(&runevents.StatusChangeEvent{
+		Run: &model.Run{IssueID: "i", RunID: "r"}, To: model.StatusRunning,
+	})
+
+	if calls != 0 {
+		t.Fatalf("expected listener to skip filtered status, got %d webhook calls", calls)
+	}
+}
+
+func TestSlackStatusListener_NilNotifierIsNoop(t *testing.T) {
+	listener := NewSlackStatusListener(nil, nil)
+	// Should not panic.
+	listener.OnStatusChange(&runevents.StatusChangeEvent{
+		Run: &model.Run{IssueID: "i", RunID: "r"}, To: model.StatusWaiting,
+	})
+}

--- a/internal/runevents/listener.go
+++ b/internal/runevents/listener.go
@@ -1,0 +1,44 @@
+// Package runevents defines the in-process lifecycle event types and
+// listener interface used by the daemon to fan out run status changes to
+// extensions like the Slack notifier.
+//
+// This package is intentionally small (model + store imports only) so both
+// the daemon and notification packages can depend on it without creating an
+// import cycle.
+package runevents
+
+import (
+	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/store"
+)
+
+// StatusChangeEvent carries the rich, in-process context for a run status
+// transition. Unlike orchpb.RunEventFrame (the wire-level public event), this
+// type also exposes the captured agent output and the store reference so
+// listeners (e.g. the Slack notifier) can resolve issue metadata or attach
+// terminal scrollback to outgoing notifications.
+//
+// StatusChangeEvent is in-process only; it must not be serialized to the
+// proto stream and must not leak large payloads to external observers.
+type StatusChangeEvent struct {
+	Run        *model.Run
+	From       model.Status
+	To         model.Status
+	Source     model.EventSource
+	LastOutput string
+	Store      store.Store
+}
+
+// StatusChangeListener is invoked once per status transition observed by the
+// daemon. Listeners run synchronously on the daemon's monitor goroutine;
+// long-running work should be offloaded by the listener itself.
+type StatusChangeListener interface {
+	OnStatusChange(ev *StatusChangeEvent)
+}
+
+// StatusChangeListenerFunc adapts a plain function to the interface so
+// callers can register inline closures.
+type StatusChangeListenerFunc func(ev *StatusChangeEvent)
+
+// OnStatusChange implements StatusChangeListener.
+func (f StatusChangeListenerFunc) OnStatusChange(ev *StatusChangeEvent) { f(ev) }


### PR DESCRIPTION
## Summary

Phase 2 of the events refactor (Phase 1 = #443). Moves Slack-specific logic out of \`monitor.go\` so the daemon body has no notifier-specific imports. Sets the stage for the upcoming external cmux bridge to register the same way.

## Changes

- New package \`internal/runevents\`: \`StatusChangeEvent\` (carries Run, From/To, Source, LastOutput, Store) and \`StatusChangeListener\` interface. Tiny package both \`daemon\` and \`notify\` can import without a cycle.
- Daemon gains \`AddStatusChangeListener\` / \`fireStatusChange\`. Synchronous on the monitor goroutine; per-listener panic recovery.
- \`monitor.go\`: \`d.notifyStatusChange(...)\` → \`d.fireStatusChange(...)\`. The old method and the \`slackNotifier\` field are removed.
- \`internal/notify/slack_listener.go\`: \`SlackStatusListener\` implements \`runevents.StatusChangeListener\` with identical routing (\`Waiting\`/\`RateLimited\` → \`NotifyBlocked\`, else → \`NotifyStatusChange\`) and the same log lines.
- \`daemon.go\` init wires the listener iff Slack is configured.

Behavior preserved: same triggers, payloads, log messages.

## Test plan

- [x] daemon: \`AddStatusChangeListener\` fanout order, panic recovery, nil-event no-op
- [x] notify: routing per status, unconfigured no-op, \`ShouldNotify\` filter respect, nil notifier no-op
- [x] existing daemon / notify / cli / orchapi / query suites pass
- [x] Lint: semgrep \`Go Architecture Lint\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)