### PR TITLE
feat(events): add short_id, skip redundant from==to publish

### DIFF
--- a/api/orch.proto
+++ b/api/orch.proto
@@ -401,6 +401,7 @@ message RunEventFrame {
   RunStatus to_status = 5;
   int64 timestamp_unix_ms = 6;
   string source = 7;          // "user" | "daemon" | "agent"
+  string short_id = 8;        // 6-char sha256 hex of issue_id#run_id
 }
 
 // --- Monitor Registration ---

--- a/api/orchpb/orch.pb.go
+++ b/api/orchpb/orch.pb.go
@@ -3455,7 +3455,8 @@ type RunEventFrame struct {
 	FromStatus      RunStatus              `protobuf:"varint,4,opt,name=from_status,json=fromStatus,proto3,enum=orch.v1.RunStatus" json:"from_status,omitempty"`
 	ToStatus        RunStatus              `protobuf:"varint,5,opt,name=to_status,json=toStatus,proto3,enum=orch.v1.RunStatus" json:"to_status,omitempty"`
 	TimestampUnixMs int64                  `protobuf:"varint,6,opt,name=timestamp_unix_ms,json=timestampUnixMs,proto3" json:"timestamp_unix_ms,omitempty"`
-	Source          string                 `protobuf:"bytes,7,opt,name=source,proto3" json:"source,omitempty"` // "user" | "daemon" | "agent"
+	Source          string                 `protobuf:"bytes,7,opt,name=source,proto3" json:"source,omitempty"`                  // "user" | "daemon" | "agent"
+	ShortId         string                 `protobuf:"bytes,8,opt,name=short_id,json=shortId,proto3" json:"short_id,omitempty"` // 6-char sha256 hex of issue_id#run_id
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -3535,6 +3536,13 @@ func (x *RunEventFrame) GetTimestampUnixMs() int64 {
 func (x *RunEventFrame) GetSource() string {
 	if x != nil {
 		return x.Source
+	}
+	return ""
+}
+
+func (x *RunEventFrame) GetShortId() string {
+	if x != nil {
+		return x.ShortId
 	}
 	return ""
 }
@@ -11092,7 +11100,7 @@ const file_orch_proto_rawDesc = "" +
 	"\acontext\x18\x01 \x01(\v2\x17.orch.v1.RequestContextR\acontext\x12\x19\n" +
 	"\bissue_id\x18\x02 \x01(\tR\aissueId\x12\x15\n" +
 	"\x06run_id\x18\x03 \x01(\tR\x05runId\"\x14\n" +
-	"\x12StreamRunEventsAck\"\x8a\x02\n" +
+	"\x12StreamRunEventsAck\"\xa5\x02\n" +
 	"\rRunEventFrame\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\x19\n" +
 	"\bissue_id\x18\x02 \x01(\tR\aissueId\x12\x1d\n" +
@@ -11102,7 +11110,8 @@ const file_orch_proto_rawDesc = "" +
 	"fromStatus\x12/\n" +
 	"\tto_status\x18\x05 \x01(\x0e2\x12.orch.v1.RunStatusR\btoStatus\x12*\n" +
 	"\x11timestamp_unix_ms\x18\x06 \x01(\x03R\x0ftimestampUnixMs\x12\x16\n" +
-	"\x06source\x18\a \x01(\tR\x06source\"\x9e\x01\n" +
+	"\x06source\x18\a \x01(\tR\x06source\x12\x19\n" +
+	"\bshort_id\x18\b \x01(\tR\ashortId\"\x9e\x01\n" +
 	"\x16RegisterMonitorRequest\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\x05R\x03pid\x12!\n" +
 	"\fmonitor_type\x18\x02 \x01(\tR\vmonitorType\x12\x12\n" +

--- a/internal/cli/events.go
+++ b/internal/cli/events.go
@@ -89,6 +89,7 @@ type eventJSON struct {
 	Timestamp string `json:"timestamp"`
 	IssueID   string `json:"issue_id"`
 	RunID     string `json:"run_id"`
+	ShortID   string `json:"short_id"`
 	From      string `json:"from"`
 	To        string `json:"to"`
 	Source    string `json:"source"`
@@ -100,6 +101,7 @@ func eventToJSON(ev *orchapi.RunEvent) *eventJSON {
 		Timestamp: ev.Timestamp.UTC().Format(time.RFC3339Nano),
 		IssueID:   ev.IssueID,
 		RunID:     ev.RunID,
+		ShortID:   ev.ShortID,
 		From:      string(ev.From),
 		To:        string(ev.To),
 		Source:    ev.Source,

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -374,13 +374,22 @@ func (d *Daemon) updateStatus(run *model.Run, status model.Status, st store.Stor
 // publishRunEvent broadcasts a status transition to subscribers of the
 // daemon's run event bus. Safe to call when the socket server is not yet
 // constructed (test daemons): the call becomes a no-op.
+//
+// Skips emission when from == to to avoid leaking redundant updates
+// caused by callers that re-affirm a status (e.g. PR detection running
+// every cycle after RunState in-memory bookkeeping is reset by a
+// daemon restart).
 func (d *Daemon) publishRunEvent(run *model.Run, from, to model.Status, source model.EventSource) {
 	if d == nil || d.socketServer == nil || run == nil {
+		return
+	}
+	if from == to {
 		return
 	}
 	frame := &orchpb.RunEventFrame{
 		RunId:           run.RunID,
 		IssueId:         run.IssueID,
+		ShortId:         model.GenerateShortID(run.IssueID, run.RunID),
 		FromStatus:      modelStatusToProto(from),
 		ToStatus:        modelStatusToProto(to),
 		TimestampUnixMs: time.Now().UnixMilli(),

--- a/internal/daemon/monitor_publish_test.go
+++ b/internal/daemon/monitor_publish_test.go
@@ -75,7 +75,60 @@ func TestUpdateStatus_PublishesTransitionToBus(t *testing.T) {
 		if ev.Source != string(model.EventSourceDaemon) {
 			t.Fatalf("source = %q, want %q", ev.Source, model.EventSourceDaemon)
 		}
+		expectedShort := model.GenerateShortID("issue-publish", "run-1")
+		if ev.ShortId != expectedShort {
+			t.Fatalf("short_id = %q, want %q", ev.ShortId, expectedShort)
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("no event received within timeout")
+	}
+}
+
+// TestUpdateStatus_SkipsRedundantPublish ensures that when daemon code
+// calls updateStatus with a status that already matches the run's stored
+// state, no proto event is emitted on the bus (the AppendEvent itself
+// may still record an audit line, but external observers should not see
+// transition noise).
+func TestUpdateStatus_SkipsRedundantPublish(t *testing.T) {
+	root := t.TempDir()
+	issuesRoot := filepath.Join(root, "issues")
+	if err := os.MkdirAll(issuesRoot, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	st, err := filestore.New(issuesRoot)
+	if err != nil {
+		t.Fatalf("filestore.New: %v", err)
+	}
+	if err := st.CreateIssue(&model.Issue{ID: "issue-skip", Title: "t", Status: model.IssueStatusOpen}); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	run, err := st.CreateRun("issue-skip", "run-1", nil)
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := st.AppendEvent(&model.RunRef{IssueID: run.IssueID, RunID: run.RunID}, model.NewStatusEvent(model.StatusPROpen)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	srv := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	d := newTestDaemon()
+	d.socketServer = srv
+
+	sub := srv.RunEventBus().Subscribe(RunEventFilter{})
+	defer sub.Close()
+
+	current, err := st.GetRun(&model.RunRef{IssueID: run.IssueID, RunID: run.RunID})
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if err := d.updateStatus(current, model.StatusPROpen, st); err != nil {
+		t.Fatalf("updateStatus: %v", err)
+	}
+
+	select {
+	case ev := <-sub.Events():
+		t.Fatalf("expected no event for from==to publish, got %+v", ev)
+	case <-time.After(200 * time.Millisecond):
+		// expected: no event
 	}
 }

--- a/internal/orchapi/daemon_client_stream.go
+++ b/internal/orchapi/daemon_client_stream.go
@@ -61,6 +61,7 @@ func protoEventToOrchAPI(ev *orchpb.RunEventFrame) *RunEvent {
 		Timestamp: time.UnixMilli(ev.TimestampUnixMs),
 		IssueID:   ev.IssueId,
 		RunID:     ev.RunId,
+		ShortID:   ev.ShortId,
 		From:      protoRunStatusToDomain(ev.FromStatus),
 		To:        protoRunStatusToDomain(ev.ToStatus),
 		Source:    ev.Source,

--- a/internal/orchapi/types.go
+++ b/internal/orchapi/types.go
@@ -142,6 +142,7 @@ type RunEvent struct {
 	Timestamp time.Time
 	IssueID   string
 	RunID     string
+	ShortID   string
 	From      RunStatus
 	To        RunStatus
 	Source    string // "user" | "daemon" | "agent"


### PR DESCRIPTION
## Summary

Fixes surfaced while running the orch-cmux-bridge against a real daemon.

1. \`RunEventFrame\` now carries \`short_id\` (sha256-derived 6-char hex of issue#run). External subscribers can map an event to the short reference shown in \`orch ps\` without recomputing.
2. \`publishRunEvent\` skips emission when \`from == to\`. Most visible after a daemon restart: PR detection at \`monitor.go:159\` re-affirms \`pr_open\` once per active PR run because in-memory \`PRRecorded\` bookkeeping resets, leaking no-op transitions to subscribers.

Both changes are additive on the wire (\`short_id\` is a new optional field; the from==to skip removes spurious traffic).

## Test plan
- [x] \`TestUpdateStatus_SkipsRedundantPublish\`: from==to does not emit
- [x] \`TestUpdateStatus_PublishesTransitionToBus\` extended to assert short_id matches \`model.GenerateShortID\`
- [x] Full daemon / cli / orchapi / notify / query suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)