### PR TITLE
[codex] enforce typed identifiers

### DIFF
--- a/.semgrep/architecture.yaml
+++ b/.semgrep/architecture.yaml
@@ -2153,3 +2153,28 @@ rules:
     metadata:
       category: architecture
       violation: daemon-bypass
+
+  # ---------------------------------------------------------------------------
+  # 14. Repo identifiers must be constructed through normalizing constructors
+  # ---------------------------------------------------------------------------
+
+  - id: no-raw-repoid-casts
+    patterns:
+      - pattern-either:
+          - pattern: model.RepoID(...)
+          - pattern: model.ProjectID(...)
+    paths:
+      include:
+        - /internal/
+      exclude:
+        - /internal/**/*_test.go
+        - /internal/model/ids.go
+    message: >
+      Do not construct RepoID/ProjectID with a raw type cast. These IDs are
+      on-disk keys and must pass through model.NewRepoID, model.NewProjectID,
+      model.NewNormalizedRepoID, or model.NewNormalizedProjectID.
+    severity: ERROR
+    languages: [go]
+    metadata:
+      category: architecture
+      violation: repo-id-constructor-bypass

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ test-compile:
 
 lint:
 	@command -v semgrep >/dev/null 2>&1 || uv tool install semgrep
-	semgrep --error --config .semgrep/ ./internal/cli/ ./internal/monitor/ ./internal/daemon/ --exclude='*_test.go'
+	semgrep --error --config .semgrep/ ./internal/ --exclude='*_test.go'
 
 lint-install:
 	uv tool install semgrep

--- a/internal/agent/adapter.go
+++ b/internal/agent/adapter.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"fmt"
 	"os"
+
+	"github.com/s22625/orch/internal/model"
 )
 
 // InjectionMethod specifies how the prompt should be sent to the agent
@@ -51,8 +53,8 @@ type LaunchConfig struct {
 	Type            AgentType
 	CustomCmd       string // Used when Type is AgentCustom
 	WorkDir         string
-	IssueID         string
-	RunID           string
+	IssueID         model.IssueID
+	RunID           model.RunID
 	RunPath         string
 	IssuesRoot      string
 	Branch          string

--- a/internal/backend/issue.go
+++ b/internal/backend/issue.go
@@ -15,10 +15,10 @@ type ListIssuesFilter struct {
 }
 
 type IssueBackend interface {
-	GetIssue(ctx context.Context, issueID string) (*model.Issue, error)
+	GetIssue(ctx context.Context, issueID model.IssueID) (*model.Issue, error)
 	ListIssues(ctx context.Context, filter *ListIssuesFilter) ([]*model.Issue, error)
 	CreateIssue(ctx context.Context, issue *model.Issue) (*model.Issue, error)
-	SetIssueStatus(ctx context.Context, issueID string, status model.IssueStatus) error
+	SetIssueStatus(ctx context.Context, issueID model.IssueID, status model.IssueStatus) error
 
 	SupportsCreate() bool
 	SupportsPR() bool

--- a/internal/backend/run.go
+++ b/internal/backend/run.go
@@ -7,7 +7,7 @@ import (
 )
 
 type ListRunsFilter struct {
-	IssueID    string
+	IssueID    model.IssueID
 	Status     []model.Status
 	Agent      string
 	TextSearch string
@@ -18,10 +18,10 @@ type ListRunsFilter struct {
 
 type RunStore interface {
 	GetRun(ctx context.Context, ref *model.RunRef) (*model.Run, error)
-	GetRunByShortID(ctx context.Context, shortID string) (*model.Run, error)
-	GetLatestRun(ctx context.Context, issueID string) (*model.Run, error)
+	GetRunByShortID(ctx context.Context, shortID model.ShortID) (*model.Run, error)
+	GetLatestRun(ctx context.Context, issueID model.IssueID) (*model.Run, error)
 	ListRuns(ctx context.Context, filter *ListRunsFilter) ([]*model.Run, error)
-	CreateRun(ctx context.Context, issueID, runID string, metadata map[string]string) (*model.Run, error)
+	CreateRun(ctx context.Context, issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error)
 	AppendEvent(ctx context.Context, ref *model.RunRef, event *model.Event) error
 
 	RootPath() string

--- a/internal/cli/attach_test.go
+++ b/internal/cli/attach_test.go
@@ -140,8 +140,8 @@ func TestRunAttachWithDeps_SwitchesInsideMuxWithGeneratedSession(t *testing.T) {
 	runID := "20260101-030303"
 	api := &mockAttachAPI{
 		info: &orchapi.AttachInfo{
-			IssueID:       issueID,
-			RunID:         runID,
+			IssueID:       model.NewIssueID(issueID),
+			RunID:         model.NewRunID(runID),
 			Agent:         "claude",
 			SessionName:   "",
 			SessionExists: true,
@@ -161,7 +161,7 @@ func TestRunAttachWithDeps_SwitchesInsideMuxWithGeneratedSession(t *testing.T) {
 	if len(*exitCodes) != 0 {
 		t.Fatalf("exit codes = %v, want none", *exitCodes)
 	}
-	wantSession := model.GenerateSessionName(issueID, runID)
+	wantSession := model.GenerateSessionName(model.NewIssueID(issueID), model.NewRunID(runID))
 	if mux.switched != wantSession {
 		t.Fatalf("switched session = %q, want %q", mux.switched, wantSession)
 	}

--- a/internal/cli/capture.go
+++ b/internal/cli/capture.go
@@ -88,8 +88,8 @@ func outputCaptureResultAPI(run *orchapi.Run, resp *orchapi.CaptureResult, opts 
 	if globalOpts.JSON {
 		result := &captureResult{
 			OK:          true,
-			IssueID:     run.IssueID,
-			RunID:       run.RunID,
+			IssueID:     run.IssueID.String(),
+			RunID:       run.RunID.String(),
 			SessionName: run.SessionName,
 			Lines:       opts.Lines,
 			Content:     resp.Content,

--- a/internal/cli/capture_all.go
+++ b/internal/cli/capture_all.go
@@ -134,8 +134,8 @@ func captureAllItemForRun(ctx context.Context, deps *captureDeps, api orchapi.Or
 	}
 
 	item := captureAllItem{
-		IssueID:     run.IssueID,
-		RunID:       run.RunID,
+		IssueID:     run.IssueID.String(),
+		RunID:       run.RunID.String(),
 		Status:      string(run.Status),
 		SessionName: sessionName,
 		Lines:       lines,

--- a/internal/cli/capture_all_test.go
+++ b/internal/cli/capture_all_test.go
@@ -78,7 +78,7 @@ func (m *mockCaptureAllAPI) ListRuns(ctx context.Context, filter *orchapi.ListRu
 }
 
 func (m *mockCaptureAllAPI) CaptureSession(ctx context.Context, ref orchapi.RunRef, lines int) (*orchapi.CaptureResult, error) {
-	key := ref.IssueID + "#" + ref.RunID
+	key := ref.String()
 	m.capturedLines = append(m.capturedLines, lines)
 	if err, ok := m.captureErrors[key]; ok {
 		return nil, err

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/orchapi"
 	"github.com/spf13/cobra"
 )
@@ -191,7 +192,7 @@ func runCleanAll(ctx context.Context, opts *cleanOptions, deps *cleanDeps) error
 	return cleanRuns(ctx, api, result.Runs, opts)
 }
 
-func cleanIssueRuns(ctx context.Context, api orchapi.OrchAPI, issueID string, opts *cleanOptions) error {
+func cleanIssueRuns(ctx context.Context, api orchapi.OrchAPI, issueID model.IssueID, opts *cleanOptions) error {
 	filter := &orchapi.ListRunsFilter{
 		IssueID: issueID,
 	}
@@ -225,7 +226,7 @@ func cleanIssueRuns(ctx context.Context, api orchapi.OrchAPI, issueID string, op
 	return cleanRuns(ctx, api, result.Runs, opts)
 }
 
-func cleanLatestIssueRun(ctx context.Context, api orchapi.OrchAPI, issueID string, opts *cleanOptions) error {
+func cleanLatestIssueRun(ctx context.Context, api orchapi.OrchAPI, issueID model.IssueID, opts *cleanOptions) error {
 	statuses, err := cleanStatusFilter(opts.Status)
 	if err != nil {
 		return err
@@ -341,9 +342,9 @@ func cleanRuns(ctx context.Context, api orchapi.OrchAPI, runs []*orchapi.Run, op
 
 		if cleaned.Skipped {
 			result.Skipped = append(result.Skipped, cleanSkippedRun{
-				IssueID: cleaned.IssueID,
-				RunID:   cleaned.RunID,
-				ShortID: cleaned.ShortID,
+				IssueID: cleaned.IssueID.String(),
+				RunID:   cleaned.RunID.String(),
+				ShortID: cleaned.ShortID.String(),
 				Reason:  cleaned.Reason,
 			})
 			if !globalOpts.Quiet && !globalOpts.JSON {
@@ -353,9 +354,9 @@ func cleanRuns(ctx context.Context, api orchapi.OrchAPI, runs []*orchapi.Run, op
 		}
 
 		result.Cleaned = append(result.Cleaned, cleanedRun{
-			IssueID:      cleaned.IssueID,
-			RunID:        cleaned.RunID,
-			ShortID:      cleaned.ShortID,
+			IssueID:      cleaned.IssueID.String(),
+			RunID:        cleaned.RunID.String(),
+			ShortID:      cleaned.ShortID.String(),
 			WorktreePath: cleaned.WorktreePath,
 		})
 		if !globalOpts.Quiet && !globalOpts.JSON {

--- a/internal/cli/continue.go
+++ b/internal/cli/continue.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/orchapi"
 	"github.com/spf13/cobra"
 )
@@ -136,9 +137,9 @@ func runContinueWithDeps(ctx context.Context, refStr string, opts *continueOptio
 	}
 
 	resp, err := api.ContinueRun(ctx, &orchapi.ContinueRunRequest{
-		IssueID:        issueID,
-		RunID:          runID,
-		ShortID:        shortID,
+		IssueID:        model.NewIssueID(issueID),
+		RunID:          model.NewRunID(runID),
+		ShortID:        model.NewShortID(shortID),
 		Branch:         normalizeBranchName(opts.Branch),
 		Agent:          opts.Agent,
 		AgentCmd:       opts.AgentCmd,
@@ -156,8 +157,8 @@ func runContinueWithDeps(ctx context.Context, refStr string, opts *continueOptio
 
 	result := &continueResult{
 		OK:            true,
-		IssueID:       resp.IssueID,
-		RunID:         resp.RunID,
+		IssueID:       resp.IssueID.String(),
+		RunID:         resp.RunID.String(),
 		Branch:        resp.Branch,
 		WorktreePath:  resp.WorktreePath,
 		SessionName:   resp.SessionName,

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -168,7 +168,7 @@ func runDelete(refStr string, opts *deleteOptions) error {
 	return deleteRuns(ctx, api, []*orchapi.Run{run}, opts)
 }
 
-func deleteIssueRuns(ctx context.Context, api orchapi.OrchAPI, issueID string, opts *deleteOptions) error {
+func deleteIssueRuns(ctx context.Context, api orchapi.OrchAPI, issueID model.IssueID, opts *deleteOptions) error {
 	filter := &orchapi.ListRunsFilter{
 		IssueID: issueID,
 	}
@@ -334,9 +334,9 @@ func deleteRuns(ctx context.Context, api orchapi.OrchAPI, runs []*orchapi.Run, o
 			}
 		} else {
 			result.Deleted = append(result.Deleted, deletedRun{
-				IssueID:         deleteResult.IssueID,
-				RunID:           deleteResult.RunID,
-				ShortID:         deleteResult.ShortID,
+				IssueID:         deleteResult.IssueID.String(),
+				RunID:           deleteResult.RunID.String(),
+				ShortID:         deleteResult.ShortID.String(),
 				WorktreeRemoved: deleteResult.WorktreeRemoved,
 				BranchRemoved:   deleteResult.BranchRemoved,
 				SessionKilled:   deleteResult.SessionKilled,

--- a/internal/cli/events.go
+++ b/internal/cli/events.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/orchapi"
 	"github.com/spf13/cobra"
 )
@@ -56,8 +57,8 @@ func runEventsStream(ctx context.Context, issueFilter, runFilter string) error {
 	}
 
 	filter := &orchapi.RunEventFilter{
-		IssueID: strings.TrimSpace(issueFilter),
-		RunID:   strings.TrimSpace(runFilter),
+		IssueID: model.NewIssueID(strings.TrimSpace(issueFilter)),
+		RunID:   model.NewRunID(strings.TrimSpace(runFilter)),
 	}
 
 	stream, err := api.StreamRunEvents(ctx, filter)
@@ -99,12 +100,12 @@ type eventJSON struct {
 func eventToJSON(ev *orchapi.RunEvent) *eventJSON {
 	return &eventJSON{
 		Timestamp: ev.Timestamp.UTC().Format(time.RFC3339Nano),
-		IssueID:   ev.IssueID,
-		RunID:     ev.RunID,
-		ShortID:   ev.ShortID,
+		IssueID:   ev.IssueID.String(),
+		RunID:     ev.RunID.String(),
+		ShortID:   ev.ShortID.String(),
 		From:      string(ev.From),
 		To:        string(ev.To),
 		Source:    ev.Source,
-		ProjectID: ev.ProjectID,
+		ProjectID: ev.ProjectID.String(),
 	}
 }

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -147,7 +147,7 @@ func runExecWithDeps(ctx context.Context, refStr string, cmdArgs []string, opts 
 			fmt.Sprintf("ORCH_BRANCH=%s", run.Branch),
 		}
 		if issuesRoot != "" {
-			runPath := filepath.Join(issuesRoot, "runs", run.IssueID, run.RunID+".md")
+			runPath := filepath.Join(issuesRoot, "runs", run.IssueID.String(), run.RunID.String()+".md")
 			orchEnv = append(orchEnv, fmt.Sprintf("ORCH_RUN_PATH=%s", runPath))
 		}
 		env = append(env, orchEnv...)

--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -26,6 +26,14 @@ type issueCreateOptions struct {
 	bodyProvided bool
 }
 
+func normalizeCLIIssueID(issueID string) model.IssueID {
+	id := model.NewIssueID(issueID)
+	if model.IsGitHubIssueID(id) {
+		return model.NormalizeGitHubIssueID(id)
+	}
+	return id
+}
+
 func newIssueCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "issue",
@@ -125,7 +133,7 @@ func runIssueCreateWithInput(issueID string, opts *issueCreateOptions, stdin io.
 	}
 
 	issue, err := api.CreateIssue(ctx, &orchapi.CreateIssueRequest{
-		ID:         issueID,
+		ID:         model.NewIssueID(issueID),
 		Title:      title,
 		Body:       resolvedOpts.Body,
 		Tags:       resolvedOpts.Tags,
@@ -148,7 +156,7 @@ func runIssueCreateWithInput(issueID string, opts *issueCreateOptions, stdin io.
 			Path    string `json:"path"`
 		}{
 			OK:      true,
-			IssueID: issue.ID,
+			IssueID: issue.ID.String(),
 			Path:    issue.Path,
 		}
 		enc := json.NewEncoder(os.Stdout)
@@ -234,7 +242,7 @@ func runIssueCreateLocal(issueID, title string, opts *issueCreateOptions) error 
 	}
 
 	issueToWrite := &model.Issue{
-		ID:         issueID,
+		ID:         model.NewIssueID(issueID),
 		Title:      title,
 		Summary:    opts.Summary,
 		Status:     model.IssueStatusOpen,
@@ -304,7 +312,7 @@ func runIssueCreateWithEditor(api orchapi.OrchAPI, issueID, title string, opts *
 	}
 
 	issueToWrite := &model.Issue{
-		ID:         issueID,
+		ID:         model.NewIssueID(issueID),
 		Title:      title,
 		Summary:    opts.Summary,
 		Status:     model.IssueStatusOpen,
@@ -486,7 +494,8 @@ func runIssueListViaAPI(ctx context.Context, api orchapi.OrchAPI, opts *issueLis
 
 	runsByIssue := make(map[string][]*orchapi.Run)
 	for _, run := range runsResp.Runs {
-		runsByIssue[run.IssueID] = append(runsByIssue[run.IssueID], run)
+		issueID := run.IssueID.String()
+		runsByIssue[issueID] = append(runsByIssue[issueID], run)
 	}
 
 	var issueInfos []issueInfo
@@ -499,7 +508,7 @@ func runIssueListViaAPI(ctx context.Context, api orchapi.OrchAPI, opts *issueLis
 		}
 
 		info := issueInfo{
-			ID:         issue.ID,
+			ID:         issue.ID.String(),
 			Title:      issue.Title,
 			Summary:    issue.Summary,
 			Status:     string(issue.Status),
@@ -508,9 +517,9 @@ func runIssueListViaAPI(ctx context.Context, api orchapi.OrchAPI, opts *issueLis
 			ModifiedAt: issue.ModifiedAt.Format("2006-01-02T15:04:05Z07:00"),
 		}
 
-		for _, run := range runsByIssue[issue.ID] {
+		for _, run := range runsByIssue[issue.ID.String()] {
 			info.Runs = append(info.Runs, runSummary{
-				RunID:  run.RunID,
+				RunID:  run.RunID.String(),
 				Status: string(run.Status),
 			})
 		}
@@ -668,9 +677,8 @@ Examples:
 }
 
 func runIssueShow(issueID string, opts *issueShowOptions) error {
-	if model.IsGitHubIssueID(issueID) {
-		issueID = model.NormalizeGitHubIssueID(issueID)
-	}
+	normalizedIssueID := normalizeCLIIssueID(issueID)
+	issueID = normalizedIssueID.String()
 
 	ctx := context.Background()
 	api, err := getAPIForListing()
@@ -678,7 +686,7 @@ func runIssueShow(issueID string, opts *issueShowOptions) error {
 		return err
 	}
 
-	issue, err := api.GetIssue(ctx, issueID)
+	issue, err := api.GetIssue(ctx, normalizedIssueID)
 	if err != nil {
 		return err
 	}
@@ -749,9 +757,8 @@ Examples:
 }
 
 func runIssueEdit(issueID, title string) error {
-	if model.IsGitHubIssueID(issueID) {
-		issueID = model.NormalizeGitHubIssueID(issueID)
-	}
+	normalizedIssueID := normalizeCLIIssueID(issueID)
+	issueID = normalizedIssueID.String()
 
 	ctx := context.Background()
 	api, err := getAPI()
@@ -759,7 +766,7 @@ func runIssueEdit(issueID, title string) error {
 		return err
 	}
 
-	issue, err := api.GetIssue(ctx, issueID)
+	issue, err := api.GetIssue(ctx, normalizedIssueID)
 	if err != nil {
 		return err
 	}
@@ -850,9 +857,8 @@ Examples:
 }
 
 func runIssueClose(issueID string, opts *issueCloseOptions) error {
-	if model.IsGitHubIssueID(issueID) {
-		issueID = model.NormalizeGitHubIssueID(issueID)
-	}
+	normalizedIssueID := normalizeCLIIssueID(issueID)
+	issueID = normalizedIssueID.String()
 
 	ctx := context.Background()
 	api, err := getAPI()
@@ -860,7 +866,7 @@ func runIssueClose(issueID string, opts *issueCloseOptions) error {
 		return err
 	}
 
-	if err := api.CloseIssue(ctx, issueID); err != nil {
+	if err := api.CloseIssue(ctx, normalizedIssueID); err != nil {
 		return err
 	}
 

--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -79,7 +79,7 @@ func runOpen(refStr string, opts *openOptions) error {
 			if err == nil && issue.Path != "" {
 				path = issue.Path
 			} else if err == nil && issuesRoot != "" {
-				path = filepath.Join(issuesRoot, "issues", issue.ID+".md")
+				path = filepath.Join(issuesRoot, "issues", issue.ID.String()+".md")
 			} else {
 				run, err := api.GetLatestRun(ctx, ref.IssueID)
 				if err != nil {
@@ -133,7 +133,7 @@ func deriveRunDocPath(ctx context.Context, api orchapi.OrchAPI, run *orchapi.Run
 		return ""
 	}
 	if issuesRoot != "" {
-		return filepath.Join(issuesRoot, "runs", run.IssueID, run.RunID+".md")
+		return filepath.Join(issuesRoot, "runs", run.IssueID.String(), run.RunID.String()+".md")
 	}
 
 	issue, err := api.GetIssue(ctx, run.IssueID)
@@ -146,7 +146,7 @@ func deriveRunDocPath(ctx context.Context, api orchapi.OrchAPI, run *orchapi.Run
 		return ""
 	}
 
-	return filepath.Join(derivedRoot, "runs", run.IssueID, run.RunID+".md")
+	return filepath.Join(derivedRoot, "runs", run.IssueID.String(), run.RunID.String()+".md")
 }
 
 func deriveIssuesRootFromPath(path string) string {

--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -117,7 +117,7 @@ func runPsWithDeps(ctx context.Context, opts *psOptions, deps *psDeps) error {
 	}
 
 	filter := &orchapi.ListRunsFilter{
-		IssueID: opts.Issue,
+		IssueID: model.NewIssueID(opts.Issue),
 		Status:  statusFilter,
 		Limit:   limit,
 	}
@@ -133,10 +133,12 @@ func runPsWithDeps(ctx context.Context, opts *psOptions, deps *psDeps) error {
 	issueCache := make(map[string]psIssueInfo, len(result.Runs))
 	for i, r := range result.Runs {
 		runs[i] = apiRunToModelRun(r)
-		aliveByRun[r.RunID] = agentAliveInfo{alive: r.Alive, known: r.AliveKnown}
-		branchStateByRun[r.RunID] = string(r.BranchState)
-		if _, ok := issueCache[r.IssueID]; !ok {
-			issueCache[r.IssueID] = psIssueInfo{status: r.IssueStatus, display: formatTopic(r.IssueTopic)}
+		runID := r.RunID.String()
+		issueID := r.IssueID.String()
+		aliveByRun[runID] = agentAliveInfo{alive: r.Alive, known: r.AliveKnown}
+		branchStateByRun[runID] = string(r.BranchState)
+		if _, ok := issueCache[issueID]; !ok {
+			issueCache[issueID] = psIssueInfo{status: r.IssueStatus, display: formatTopic(r.IssueTopic)}
 		}
 	}
 
@@ -166,7 +168,8 @@ func runPsWithDeps(ctx context.Context, opts *psOptions, deps *psDeps) error {
 	if len(issueStatusFilter) > 0 {
 		filteredRuns := make([]*model.Run, 0, len(runs))
 		for _, r := range runs {
-			info := issueCache[r.IssueID]
+			issueID := r.IssueID.String()
+			info := issueCache[issueID]
 			if info.status == "" {
 				info = resolveIssueInfoAPI(ctx, api, issueCache, r.IssueID)
 			}
@@ -246,7 +249,7 @@ func collectPsExcludedStatusStats(
 	cursor := ""
 	for {
 		result, err := api.ListRuns(ctx, &orchapi.ListRunsFilter{
-			IssueID: opts.Issue,
+			IssueID: model.NewIssueID(opts.Issue),
 			Limit:   psExcludedStatsPageLimit,
 			Cursor:  cursor,
 		})
@@ -285,15 +288,17 @@ func psRunMatchesIssueStatusFilter(
 ) bool {
 	issueStatus := strings.TrimSpace(run.IssueStatus)
 	if issueStatus == "" {
-		info := issueCache[run.IssueID]
+		issueID := run.IssueID.String()
+		info := issueCache[issueID]
 		if info.status == "" {
 			info = resolveIssueInfoAPI(ctx, api, issueCache, run.IssueID)
 		}
 		issueStatus = info.status
 	}
 
-	if _, ok := issueCache[run.IssueID]; !ok {
-		issueCache[run.IssueID] = psIssueInfo{
+	issueID := run.IssueID.String()
+	if _, ok := issueCache[issueID]; !ok {
+		issueCache[issueID] = psIssueInfo{
 			status:  issueStatus,
 			display: formatTopic(run.IssueTopic),
 		}
@@ -375,21 +380,22 @@ func psHasConfigScope() bool {
 	return strings.TrimSpace(projectID) != ""
 }
 
-func resolveIssueInfoAPI(ctx context.Context, api orchapi.OrchAPI, cache map[string]psIssueInfo, issueID string) psIssueInfo {
-	if info, ok := cache[issueID]; ok {
+func resolveIssueInfoAPI(ctx context.Context, api orchapi.OrchAPI, cache map[string]psIssueInfo, issueID model.IssueID) psIssueInfo {
+	issueIDString := issueID.String()
+	if info, ok := cache[issueIDString]; ok {
 		return info
 	}
 
 	if api == nil {
 		info := psIssueInfo{}
-		cache[issueID] = info
+		cache[issueIDString] = info
 		return info
 	}
 
 	issue, err := api.GetIssue(ctx, issueID)
 	if err != nil || issue == nil {
 		info := psIssueInfo{}
-		cache[issueID] = info
+		cache[issueIDString] = info
 		return info
 	}
 
@@ -397,7 +403,7 @@ func resolveIssueInfoAPI(ctx context.Context, api orchapi.OrchAPI, cache map[str
 		status:  string(issue.Status),
 		display: formatIssueTopicAPI(issue),
 	}
-	cache[issueID] = info
+	cache[issueIDString] = info
 	return info
 }
 
@@ -469,28 +475,30 @@ func outputJSONWithIssueInfo(
 	}
 
 	for i, r := range runs {
+		runID := r.RunID.String()
+		issueID := r.IssueID.String()
 		issueStatus := ""
 		if issueCache != nil {
-			issueStatus = issueCache[r.IssueID].status
+			issueStatus = issueCache[issueID].status
 		}
 		aliveInfo := agentAliveInfo{}
 		if aliveByRun != nil {
-			aliveInfo = aliveByRun[r.RunID]
+			aliveInfo = aliveByRun[runID]
 		}
 		branchStatus := "-"
 		if branchStateByRun != nil {
-			if state := branchStateByRun[r.RunID]; state != "" {
+			if state := branchStateByRun[runID]; state != "" {
 				branchStatus = branchStatusFromGitState(state)
 			}
 		}
 		target := strings.TrimSpace(r.Target)
-		targetHost := strings.TrimSpace(targetHostByRun[r.RunID])
+		targetHost := strings.TrimSpace(targetHostByRun[runID])
 
 		output.Items[i] = runOutput{
-			IssueID:           r.IssueID,
+			IssueID:           issueID,
 			IssueStatus:       issueStatus,
-			RunID:             r.RunID,
-			ShortID:           r.ShortID(),
+			RunID:             runID,
+			ShortID:           r.ShortID().String(),
 			CLI:               r.Agent,
 			Model:             r.Model,
 			ModelVariant:      r.ModelVariant,
@@ -499,7 +507,7 @@ func outputJSONWithIssueInfo(
 			Status:            string(r.Status),
 			AgentStatus:       shortAgentStatus(r.Status),
 			BranchStatus:      branchStatus,
-			PRStatus:          prStatusFromRun(r, branchStateByRun[r.RunID]),
+			PRStatus:          prStatusFromRun(r, branchStateByRun[runID]),
 			AgentAlive:        formatAliveText(aliveInfo),
 			UpdatedAt:         r.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
 			UpdatedAgo:        formatRelativeTime(r.UpdatedAt, now),
@@ -534,28 +542,30 @@ func outputTSVWithIssueInfo(
 	}
 
 	for _, r := range runs {
+		runID := r.RunID.String()
+		issueID := r.IssueID.String()
 		issueStatus := ""
 		if issueCache != nil {
-			issueStatus = issueCache[r.IssueID].status
+			issueStatus = issueCache[issueID].status
 		}
 		aliveInfo := agentAliveInfo{}
 		if aliveByRun != nil {
-			aliveInfo = aliveByRun[r.RunID]
+			aliveInfo = aliveByRun[runID]
 		}
 		branchStatus := "-"
 		if branchStateByRun != nil {
-			if state := branchStateByRun[r.RunID]; state != "" {
+			if state := branchStateByRun[runID]; state != "" {
 				branchStatus = branchStatusFromGitState(state)
 			}
 		}
 		target := strings.TrimSpace(r.Target)
-		targetHost := strings.TrimSpace(targetHostByRun[r.RunID])
+		targetHost := strings.TrimSpace(targetHostByRun[runID])
 
 		fmt.Printf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			r.IssueID,
+			issueID,
 			issueStatus,
-			r.RunID,
-			r.ShortID(),
+			runID,
+			r.ShortID().String(),
 			r.Agent,
 			r.Model,
 			r.ModelVariant,
@@ -564,7 +574,7 @@ func outputTSVWithIssueInfo(
 			r.Status,
 			shortAgentStatus(r.Status),
 			branchStatus,
-			prStatusFromRun(r, branchStateByRun[r.RunID]),
+			prStatusFromRun(r, branchStateByRun[runID]),
 			formatAliveText(aliveInfo),
 			r.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
 			r.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
@@ -666,6 +676,8 @@ func outputTableWithGitStates(
 	var rows [][]string
 
 	for _, r := range runs {
+		runID := r.RunID.String()
+		issueID := r.IssueID.String()
 		started := formatRelativeTime(r.StartedAt, now)
 		if opts.AbsoluteTime {
 			started = r.StartedAt.Format("01-02 15:04")
@@ -674,12 +686,12 @@ func outputTableWithGitStates(
 		if opts.AbsoluteTime {
 			updated = r.UpdatedAt.Format("01-02 15:04")
 		}
-		displayID := r.ShortID()
+		displayID := r.ShortID().String()
 		if r.WorktreePath != "" && !r.WorktreeExists {
 			displayID += "*"
 		}
 
-		info := issueCache[r.IssueID]
+		info := issueCache[issueID]
 		display := info.display
 		if display == "" {
 			display = "-"
@@ -691,7 +703,7 @@ func outputTableWithGitStates(
 		}
 
 		gitState := "-"
-		if state, ok := gitStates[r.RunID]; ok {
+		if state, ok := gitStates[runID]; ok {
 			gitState = state
 		}
 
@@ -701,16 +713,16 @@ func outputTableWithGitStates(
 		cliDisplay := agent.AgentDisplayName(r.Agent, r.Model, r.ModelVariant)
 		modelDisplay := formatModelDisplay(r.Model, r.ModelVariant)
 		targetDisplay := formatTargetDisplay(r.Target, targetMaxLen)
-		targetHostDisplay := formatTargetDisplay(targetHostByRun[r.RunID], targetHostMaxLen)
+		targetHostDisplay := formatTargetDisplay(targetHostByRun[runID], targetHostMaxLen)
 		worktree := formatWorktreeDisplay(r.WorktreePath, worktreeMaxLen)
 		aliveInfo := agentAliveInfo{}
 		if aliveByRun != nil {
-			aliveInfo = aliveByRun[r.RunID]
+			aliveInfo = aliveByRun[runID]
 		}
 
 		rows = append(rows, []string{
 			displayID,
-			r.IssueID,
+			issueID,
 			issueStatus,
 			cliDisplay,
 			modelDisplay,
@@ -957,13 +969,13 @@ func resolveTargetHostByRun(runs []*model.Run) map[string]string {
 		}
 		targetHost := strings.TrimSpace(run.TargetHost)
 		if targetHost != "" {
-			resolved[run.RunID] = targetHost
+			resolved[run.RunID.String()] = targetHost
 			continue
 		}
 
 		targetName := strings.TrimSpace(run.Target)
 		if targetName != "" {
-			resolved[run.RunID] = targetName
+			resolved[run.RunID.String()] = targetName
 		}
 	}
 

--- a/internal/cli/ps_test.go
+++ b/internal/cli/ps_test.go
@@ -21,7 +21,7 @@ type mockPsAPI struct {
 	issuesRoot string
 }
 
-func (m *mockPsAPI) GetIssue(ctx context.Context, issueID string) (*orchapi.Issue, error) {
+func (m *mockPsAPI) GetIssue(ctx context.Context, issueID model.IssueID) (*orchapi.Issue, error) {
 	st, err := filestore.New(m.issuesRoot)
 	if err != nil {
 		return nil, err
@@ -71,8 +71,8 @@ func (m *recordingPsAPI) ListRuns(ctx context.Context, filter *orchapi.ListRunsF
 
 func psTestRun(issueID string, runID string, status orchapi.RunStatus, when time.Time) *orchapi.Run {
 	return &orchapi.Run{
-		IssueID:     issueID,
-		RunID:       runID,
+		IssueID:     model.NewIssueID(issueID),
+		RunID:       model.NewRunID(runID),
 		Status:      status,
 		IssueStatus: "open",
 		StartedAt:   when,
@@ -384,7 +384,7 @@ func TestOutputJSON(t *testing.T) {
 		t.Fatalf("unexpected response: %+v", got)
 	}
 	item := got.Items[0]
-	if item.ShortID != run.ShortID() {
+	if item.ShortID != run.ShortID().String() {
 		t.Fatalf("short_id = %q, want %q", item.ShortID, run.ShortID())
 	}
 	if item.IssueStatus != "" {

--- a/internal/cli/query_test.go
+++ b/internal/cli/query_test.go
@@ -18,7 +18,7 @@ type mockQueryAPI struct {
 	runs   []*model.Run
 }
 
-func (m *mockQueryAPI) GetIssue(ctx context.Context, issueID string) (*orchapi.Issue, error) {
+func (m *mockQueryAPI) GetIssue(ctx context.Context, issueID model.IssueID) (*orchapi.Issue, error) {
 	return nil, nil
 }
 
@@ -38,17 +38,17 @@ func (m *mockQueryAPI) ListIssues(ctx context.Context, filter *orchapi.ListIssue
 func (m *mockQueryAPI) CreateIssue(ctx context.Context, req *orchapi.CreateIssueRequest) (*orchapi.Issue, error) {
 	return nil, nil
 }
-func (m *mockQueryAPI) SetIssueStatus(ctx context.Context, issueID string, status orchapi.IssueStatus) error {
+func (m *mockQueryAPI) SetIssueStatus(ctx context.Context, issueID model.IssueID, status orchapi.IssueStatus) error {
 	return nil
 }
-func (m *mockQueryAPI) CloseIssue(ctx context.Context, issueID string) error { return nil }
+func (m *mockQueryAPI) CloseIssue(ctx context.Context, issueID model.IssueID) error { return nil }
 func (m *mockQueryAPI) ResolveRun(ctx context.Context, ref orchapi.RunRef) (*orchapi.Run, error) {
 	return nil, nil
 }
-func (m *mockQueryAPI) GetRun(ctx context.Context, issueID, runID string) (*orchapi.Run, error) {
+func (m *mockQueryAPI) GetRun(ctx context.Context, issueID model.IssueID, runID model.RunID) (*orchapi.Run, error) {
 	return nil, nil
 }
-func (m *mockQueryAPI) GetLatestRun(ctx context.Context, issueID string) (*orchapi.Run, error) {
+func (m *mockQueryAPI) GetLatestRun(ctx context.Context, issueID model.IssueID) (*orchapi.Run, error) {
 	return nil, nil
 }
 
@@ -112,7 +112,7 @@ func (m *mockQueryAPI) GetBranchState(ctx context.Context, ref orchapi.RunRef) (
 func (m *mockQueryAPI) GetDiff(ctx context.Context, ref orchapi.RunRef) (string, error) {
 	return "", nil
 }
-func (m *mockQueryAPI) ResolveIssue(ctx context.Context, issueID string, force bool) error {
+func (m *mockQueryAPI) ResolveIssue(ctx context.Context, issueID model.IssueID, force bool) error {
 	return nil
 }
 func (m *mockQueryAPI) DeleteRun(ctx context.Context, ref orchapi.RunRef, opts *orchapi.DeleteRunOptions) (*orchapi.DeleteRunResult, error) {
@@ -121,10 +121,10 @@ func (m *mockQueryAPI) DeleteRun(ctx context.Context, ref orchapi.RunRef, opts *
 func (m *mockQueryAPI) CleanRunWorktree(ctx context.Context, ref orchapi.RunRef) (*orchapi.CleanRunWorktreeResult, error) {
 	return nil, nil
 }
-func (m *mockQueryAPI) UpdateIssue(ctx context.Context, issueID string, req *orchapi.UpdateIssueRequest) (*orchapi.Issue, error) {
+func (m *mockQueryAPI) UpdateIssue(ctx context.Context, issueID model.IssueID, req *orchapi.UpdateIssueRequest) (*orchapi.Issue, error) {
 	return nil, nil
 }
-func (m *mockQueryAPI) ValidateIssueFiles(ctx context.Context, issueID string) (*orchapi.ValidateIssueFilesResult, error) {
+func (m *mockQueryAPI) ValidateIssueFiles(ctx context.Context, issueID model.IssueID) (*orchapi.ValidateIssueFilesResult, error) {
 	return nil, nil
 }
 func (m *mockQueryAPI) WriteAgentPrompt(ctx context.Context, ref orchapi.RunRef, content string) error {

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -54,7 +54,10 @@ func runResolveWithDeps(ctx context.Context, issueID string, opts *resolveOption
 		return err
 	}
 
-	err = api.ResolveIssue(ctx, issueID, opts.Force)
+	normalizedIssueID := normalizeCLIIssueID(issueID)
+	issueID = normalizedIssueID.String()
+
+	err = api.ResolveIssue(ctx, normalizedIssueID, opts.Force)
 	if err != nil {
 		errStr := err.Error()
 		if strings.Contains(errStr, "not_found") || strings.Contains(errStr, "not found") {

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/orchapi"
 )
 
@@ -17,7 +18,8 @@ type mockResolveAPI struct {
 	hasCompletedRun map[string]bool
 }
 
-func (m *mockResolveAPI) ResolveIssue(ctx context.Context, issueID string, force bool) error {
+func (m *mockResolveAPI) ResolveIssue(ctx context.Context, issueID model.IssueID, force bool) error {
+	issueIDString := issueID.String()
 	if m.resolved == nil {
 		m.resolved = make(map[string]bool)
 	}
@@ -25,17 +27,18 @@ func (m *mockResolveAPI) ResolveIssue(ctx context.Context, issueID string, force
 		m.hasCompletedRun = make(map[string]bool)
 	}
 
-	if !m.hasCompletedRun[issueID] && !force {
+	if !m.hasCompletedRun[issueIDString] && !force {
 		return errors.New("no completed runs")
 	}
 
-	m.resolved[issueID] = true
+	m.resolved[issueIDString] = true
 	return nil
 }
 
-func (m *mockResolveAPI) GetIssue(ctx context.Context, issueID string) (*orchapi.Issue, error) {
+func (m *mockResolveAPI) GetIssue(ctx context.Context, issueID model.IssueID) (*orchapi.Issue, error) {
+	issueIDString := issueID.String()
 	status := orchapi.IssueStatusOpen
-	if m.resolved != nil && m.resolved[issueID] {
+	if m.resolved != nil && m.resolved[issueIDString] {
 		status = orchapi.IssueStatusResolved
 	}
 	return &orchapi.Issue{ID: issueID, Status: status}, nil

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -238,7 +238,7 @@ func getProjectIDWithSource(projectRoot string) (string, bool, error) {
 		return "", false, err
 	}
 
-	return projectID, false, nil
+	return projectID.String(), false, nil
 }
 
 func resolveProjectIdentity(projectRoot string) (string, error) {
@@ -263,13 +263,17 @@ func normalizeProjectIdentityInput(project string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("invalid project identity %q: %w", project, err)
 		}
-		return normalized, nil
+		return normalized.String(), nil
 	}
 	if looksLikeProjectPath(project) {
 		return "", fmt.Errorf("project identity %q looks like a filesystem path; use git repo URL or normalized repo ID", project)
 	}
 
-	return project, nil
+	normalized, err := model.NewNormalizedRepoID(project)
+	if err != nil {
+		return "", fmt.Errorf("invalid project identity %q: %w", project, err)
+	}
+	return normalized.String(), nil
 }
 
 func looksLikeProjectRepoURL(project string) bool {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -98,9 +98,8 @@ type runResult struct {
 }
 
 func runRun(issueID string, opts *runOptions) error {
-	if model.IsGitHubIssueID(issueID) {
-		issueID = model.NormalizeGitHubIssueID(issueID)
-	}
+	normalizedIssueID := normalizeCLIIssueID(issueID)
+	issueID = normalizedIssueID.String()
 
 	_, _, rootErr := getProjectRootWithSource()
 	remoteMode := strings.TrimSpace(getRemoteAddr()) != ""
@@ -124,8 +123,8 @@ func runRun(issueID string, opts *runOptions) error {
 	applyConfigDefaults(opts, cfg, remoteMode)
 
 	resp, err := api.StartRun(ctx, &orchapi.StartRunRequest{
-		IssueID:        issueID,
-		RunID:          opts.RunID,
+		IssueID:        normalizedIssueID,
+		RunID:          model.NewRunID(opts.RunID),
 		Agent:          opts.Agent,
 		AgentCmd:       opts.AgentCmd,
 		AgentProfile:   opts.AgentProfile,
@@ -150,7 +149,7 @@ func runRun(issueID string, opts *runOptions) error {
 	result := &runResult{
 		OK:           true,
 		IssueID:      issueID,
-		RunID:        resp.RunID,
+		RunID:        resp.RunID.String(),
 		Branch:       resp.Branch,
 		WorktreePath: resp.WorktreePath,
 		SessionName:  resp.SessionName,
@@ -179,7 +178,7 @@ func runRun(issueID string, opts *runOptions) error {
 	}
 
 	if !globalOpts.Quiet {
-		shortID := orchapi.ComputeShortID(issueID, resp.RunID)
+		shortID := orchapi.ComputeShortID(normalizedIssueID, resp.RunID)
 		fmt.Printf("Run started: %s#%s (%s)\n", issueID, resp.RunID, shortID)
 		fmt.Printf("  Branch:   %s\n", resp.Branch)
 		fmt.Printf("  Worktree: %s\n", resp.WorktreePath)
@@ -221,7 +220,7 @@ func renderInitialPromptTemplate(tmplStr string, issue *model.Issue) string {
 	}
 
 	result := strings.ReplaceAll(tmplStr, "{{issue}}", issueContent)
-	result = strings.ReplaceAll(result, "{{issue_id}}", issue.ID)
+	result = strings.ReplaceAll(result, "{{issue_id}}", issue.ID.String())
 	result = strings.ReplaceAll(result, "{{issue_title}}", issue.Title)
 
 	return result
@@ -271,14 +270,29 @@ func applyPromptDefaults(opts *promptOptions) *promptOptions {
 }
 
 func buildAgentPrompt(issue *model.Issue, opts *promptOptions) string {
+	return buildAgentPromptWithTemplateReader(issue, opts, readPromptTemplateViaAPI)
+}
+
+type promptTemplateReader func(path string) (string, error)
+
+func readPromptTemplateViaAPI(path string) (string, error) {
+	api, err := getAPIForListing()
+	if err != nil {
+		return "", err
+	}
+	content, err := api.ReadFile(context.Background(), path)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func buildAgentPromptWithTemplateReader(issue *model.Issue, opts *promptOptions, readTemplate promptTemplateReader) string {
 	opts = applyPromptDefaults(opts)
 
 	if opts.PromptTemplate != "" {
-		if api, err := getAPIForListing(); err == nil {
-			ctx := context.Background()
-			if content, err := api.ReadFile(ctx, opts.PromptTemplate); err == nil {
-				return executeTemplate(string(content), issue, opts)
-			}
+		if content, err := readTemplate(opts.PromptTemplate); err == nil {
+			return executeTemplate(content, issue, opts)
 		}
 	}
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -175,9 +175,19 @@ func TestBuildAgentPromptCustomTemplate(t *testing.T) {
 	}
 
 	issue := &model.Issue{ID: "orch-3", Title: "Custom"}
-	prompt := buildAgentPrompt(issue, &promptOptions{PromptTemplate: tmplPath})
-	if !strings.Contains(prompt, "Reference to the issue: orch-3") {
-		t.Fatalf("expected fallback prompt to include issue reference, got: %q", prompt)
+	prompt := buildAgentPromptWithTemplateReader(
+		issue,
+		&promptOptions{PromptTemplate: tmplPath},
+		func(path string) (string, error) {
+			if path != tmplPath {
+				t.Fatalf("template path = %q, want %q", path, tmplPath)
+			}
+			content, err := os.ReadFile(path)
+			return string(content), err
+		},
+	)
+	if prompt != "Issue: orch-3 - Custom" {
+		t.Fatalf("custom prompt = %q, want template output", prompt)
 	}
 }
 

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -176,8 +176,8 @@ func runSend(refStr, message string, opts *sendOptions) error {
 
 	result := &sendResult{
 		OK:      true,
-		IssueID: run.IssueID,
-		RunID:   run.RunID,
+		IssueID: run.IssueID.String(),
+		RunID:   run.RunID.String(),
 		Message: message,
 	}
 
@@ -203,9 +203,9 @@ func formatSendFailureMessage(err error, run *orchapi.Run) string {
 	promptPath := "ORCH_PROMPT.md"
 	if run != nil {
 		if run.IssueID != "" && run.RunID != "" {
-			runRef = run.IssueID + "#" + run.RunID
+			runRef = fmt.Sprintf("%s#%s", run.IssueID, run.RunID)
 		} else if run.IssueID != "" {
-			runRef = run.IssueID
+			runRef = run.IssueID.String()
 		}
 		if run.WorktreePath != "" {
 			promptPath = filepath.Join(run.WorktreePath, "ORCH_PROMPT.md")

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -84,8 +84,8 @@ func showJSON(run *orchapi.Run, opts *showOptions) error {
 		Events        []eventOutput `json:"events,omitempty"`
 	}{
 		OK:            true,
-		IssueID:       run.IssueID,
-		RunID:         run.RunID,
+		IssueID:       run.IssueID.String(),
+		RunID:         run.RunID.String(),
 		Status:        string(run.Status),
 		Phase:         string(run.Phase),
 		ContinuedFrom: run.ContinuedFrom,

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/orchapi"
 	"github.com/spf13/cobra"
 )
@@ -96,7 +97,7 @@ func runStopWithDeps(ctx context.Context, refStr string, opts *stopOptions, deps
 	return nil
 }
 
-func stopAllForIssue(ctx context.Context, api orchapi.OrchAPI, issueID string, opts *stopOptions) error {
+func stopAllForIssue(ctx context.Context, api orchapi.OrchAPI, issueID model.IssueID, opts *stopOptions) error {
 	resp, err := api.ListRuns(ctx, &orchapi.ListRunsFilter{
 		IssueID: issueID,
 		Status: []orchapi.RunStatus{

--- a/internal/cli/tick.go
+++ b/internal/cli/tick.go
@@ -105,8 +105,8 @@ func runTick(refStr string, opts *tickOptions) error {
 		// Only check blocked status for single-run case; --all already filters at daemon level
 		if !opts.All && opts.OnlyWaiting && run.Status != orchapi.RunStatusWaiting && run.Status != orchapi.RunStatusRateLimited {
 			result.Skipped = append(result.Skipped, skippedRun{
-				IssueID: run.IssueID,
-				RunID:   run.RunID,
+				IssueID: run.IssueID.String(),
+				RunID:   run.RunID.String(),
 				Reason:  fmt.Sprintf("status is %s, not waiting", run.Status),
 			})
 			continue
@@ -114,16 +114,16 @@ func runTick(refStr string, opts *tickOptions) error {
 
 		if err := resumeRun(ctx, api, run, opts.Agent); err != nil {
 			result.Skipped = append(result.Skipped, skippedRun{
-				IssueID: run.IssueID,
-				RunID:   run.RunID,
+				IssueID: run.IssueID.String(),
+				RunID:   run.RunID.String(),
 				Reason:  err.Error(),
 			})
 			continue
 		}
 
 		result.Processed = append(result.Processed, tickedRun{
-			IssueID: run.IssueID,
-			RunID:   run.RunID,
+			IssueID: run.IssueID.String(),
+			RunID:   run.RunID.String(),
 			Status:  string(orchapi.RunStatusRunning),
 		})
 	}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/orchapi"
 	"github.com/spf13/cobra"
 )
@@ -96,7 +97,7 @@ func runValidateIssueFiles(issueID string) error {
 		return err
 	}
 
-	apiResult, err := api.ValidateIssueFiles(context.Background(), issueID)
+	apiResult, err := api.ValidateIssueFiles(context.Background(), model.NewIssueID(issueID))
 	if err != nil {
 		return err
 	}
@@ -137,7 +138,7 @@ func convertValidationResults(results []*orchapi.ValidationResult) []*Validation
 		}
 		out = append(out, &ValidationResult{
 			File:     result.File,
-			IssueID:  result.IssueID,
+			IssueID:  result.IssueID.String(),
 			Errors:   convertValidationIssues(result.Errors),
 			Warnings: convertValidationIssues(result.Warnings),
 		})
@@ -171,7 +172,7 @@ func convertDuplicateIDs(duplicates []orchapi.DuplicateID) []DuplicateID {
 
 	out := make([]DuplicateID, 0, len(duplicates))
 	for _, duplicate := range duplicates {
-		out = append(out, DuplicateID{ID: duplicate.ID, Files: duplicate.Files})
+		out = append(out, DuplicateID{ID: duplicate.ID.String(), Files: duplicate.Files})
 	}
 
 	return out

--- a/internal/cli/wait.go
+++ b/internal/cli/wait.go
@@ -95,9 +95,9 @@ func runWaitWithDeps(ctx context.Context, refs []string, opts *waitOptions, deps
 	}
 
 	return json.NewEncoder(deps.stdout).Encode(waitCommandResult{
-		RunID:  result.RunID,
+		RunID:  result.RunID.String(),
 		Status: string(result.Status),
-		Issue:  result.IssueID,
+		Issue:  result.IssueID.String(),
 		PRURL:  result.PRURL,
 	})
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	DefaultInterval    = 5 * time.Second
-	StallThreshold     = 60 * time.Second
-	FetchInterval      = 90 * time.Second
+	DefaultInterval      = 5 * time.Second
+	StallThreshold       = 60 * time.Second
+	FetchInterval        = 90 * time.Second
 	DefaultTCPListenAddr = "0.0.0.0:7777"
 )
 
@@ -414,7 +414,7 @@ func (d *Daemon) cleanupStates(activeRuns []*model.Run) {
 
 	activeKeys := make(map[string]bool)
 	for _, run := range activeRuns {
-		activeKeys[run.IssueID+"#"+run.RunID] = true
+		activeKeys[run.Ref().String()] = true
 	}
 
 	for key := range d.runStates {
@@ -429,7 +429,7 @@ func (d *Daemon) getOrCreateState(run *model.Run) *RunState {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	key := run.IssueID + "#" + run.RunID
+	key := run.Ref().String()
 	state, ok := d.runStates[key]
 	if !ok {
 		state = &RunState{

--- a/internal/daemon/managed_servers_db.go
+++ b/internal/daemon/managed_servers_db.go
@@ -204,7 +204,7 @@ func (s *managedServerStore) migrateManagedServersTable() error {
 		}
 
 		repoID, err := xdg.RepoIDStrict(projectRoot)
-		if err != nil || strings.TrimSpace(repoID) == "" {
+		if err != nil || strings.TrimSpace(repoID.String()) == "" {
 			continue
 		}
 
@@ -218,7 +218,7 @@ func (s *managedServerStore) migrateManagedServersTable() error {
 				log_path = excluded.log_path,
 				started_at = excluded.started_at,
 				last_healthy = excluded.last_healthy
-		`, strings.TrimSpace(repoID), projectRoot, pid, port, nullStringValue(logPath), startedAt, nullStringValue(lastHealthy)); err != nil {
+		`, strings.TrimSpace(repoID.String()), projectRoot, pid, port, nullStringValue(logPath), startedAt, nullStringValue(lastHealthy)); err != nil {
 			return fmt.Errorf("migrate managed_servers row for %s: %w", projectRoot, err)
 		}
 	}

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -387,9 +387,9 @@ func (d *Daemon) publishRunEvent(run *model.Run, from, to model.Status, source m
 		return
 	}
 	frame := &orchpb.RunEventFrame{
-		RunId:           run.RunID,
-		IssueId:         run.IssueID,
-		ShortId:         model.GenerateShortID(run.IssueID, run.RunID),
+		RunId:           run.RunID.String(),
+		IssueId:         run.IssueID.String(),
+		ShortId:         model.GenerateShortID(run.IssueID, run.RunID).String(),
 		FromStatus:      modelStatusToProto(from),
 		ToStatus:        modelStatusToProto(to),
 		TimestampUnixMs: time.Now().UnixMilli(),

--- a/internal/daemon/monitor_publish_test.go
+++ b/internal/daemon/monitor_publish_test.go
@@ -75,7 +75,7 @@ func TestUpdateStatus_PublishesTransitionToBus(t *testing.T) {
 		if ev.Source != string(model.EventSourceDaemon) {
 			t.Fatalf("source = %q, want %q", ev.Source, model.EventSourceDaemon)
 		}
-		expectedShort := model.GenerateShortID("issue-publish", "run-1")
+		expectedShort := model.GenerateShortID("issue-publish", "run-1").String()
 		if ev.ShortId != expectedShort {
 			t.Fatalf("short_id = %q, want %q", ev.ShortId, expectedShort)
 		}

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -134,18 +134,18 @@ type mockStoreForUpdate struct {
 	appendEventCalls int
 }
 
-func (m *mockStoreForUpdate) ResolveIssue(issueID string) (*model.Issue, error) {
+func (m *mockStoreForUpdate) ResolveIssue(issueID model.IssueID) (*model.Issue, error) {
 	if m.resolveIssueErr != nil {
 		return nil, m.resolveIssueErr
 	}
 	return m.issue, nil
 }
 
-func (m *mockStoreForUpdate) SetIssueStatus(issueID string, status model.IssueStatus) error {
+func (m *mockStoreForUpdate) SetIssueStatus(issueID model.IssueID, status model.IssueStatus) error {
 	m.setIssueStatusCalls = append(m.setIssueStatusCalls, struct {
 		issueID string
 		status  model.IssueStatus
-	}{issueID, status})
+	}{issueID.String(), status})
 	return m.setIssueStatusErr
 }
 
@@ -155,17 +155,17 @@ func (m *mockStoreForUpdate) AppendEvent(ref *model.RunRef, event *model.Event) 
 }
 
 func (m *mockStoreForUpdate) ListIssues() ([]*model.Issue, error) { return nil, nil }
-func (m *mockStoreForUpdate) CreateRun(string, string, map[string]string) (*model.Run, error) {
+func (m *mockStoreForUpdate) CreateRun(model.IssueID, model.RunID, map[string]string) (*model.Run, error) {
 	return nil, nil
 }
 func (m *mockStoreForUpdate) ListRuns(*store.ListRunsFilter) ([]*model.Run, error) { return nil, nil }
 func (m *mockStoreForUpdate) GetRun(*model.RunRef) (*model.Run, error)             { return nil, nil }
-func (m *mockStoreForUpdate) GetRunByShortID(string) (*model.Run, error)           { return nil, nil }
-func (m *mockStoreForUpdate) GetLatestRun(string) (*model.Run, error)              { return nil, nil }
+func (m *mockStoreForUpdate) GetRunByShortID(model.ShortID) (*model.Run, error)    { return nil, nil }
+func (m *mockStoreForUpdate) GetLatestRun(model.IssueID) (*model.Run, error)       { return nil, nil }
 func (m *mockStoreForUpdate) RootPath() string                                     { return "" }
 func (m *mockStoreForUpdate) DeleteRun(ref *model.RunRef) error                    { return nil }
 func (m *mockStoreForUpdate) UpdateIssue(issue *model.Issue) error                 { return nil }
-func (m *mockStoreForUpdate) ValidateIssueFiles(issueID string) (*store.ValidationResult, error) {
+func (m *mockStoreForUpdate) ValidateIssueFiles(issueID model.IssueID) (*store.ValidationResult, error) {
 	return nil, nil
 }
 func (m *mockStoreForUpdate) WriteAgentPrompt(ref *model.RunRef, content string) error { return nil }
@@ -297,7 +297,7 @@ func TestMonitorRunSkipsCanceledStatus(t *testing.T) {
 		t.Errorf("expected no AppendEvent calls for canceled run, got %d", st.appendEventCalls)
 	}
 
-	state := d.runStates[run.IssueID+"#"+run.RunID]
+	state := d.runStates[run.Ref().String()]
 	if state != nil {
 		t.Error("expected no state to be created for canceled run")
 	}

--- a/internal/daemon/proto_client.go
+++ b/internal/daemon/proto_client.go
@@ -619,8 +619,8 @@ func (c *ProtoClient) StartRun(opts *StartRunOptions) (*StartRunResponse, error)
 	req := &orchpb.Request{
 		Request: &orchpb.Request_StartRun{
 			StartRun: &orchpb.StartRunRequest{
-				IssueId:        opts.IssueID,
-				RunId:          opts.RunID,
+				IssueId:        opts.IssueID.String(),
+				RunId:          opts.RunID.String(),
 				Agent:          opts.Agent,
 				AgentCmd:       opts.AgentCmd,
 				AgentProfile:   opts.AgentProfile,
@@ -670,9 +670,9 @@ func (c *ProtoClient) ContinueRun(opts *ContinueRunOptions) (*ContinueRunRespons
 	req := &orchpb.Request{
 		Request: &orchpb.Request_ContinueRun{
 			ContinueRun: &orchpb.ContinueRunRequest{
-				IssueId:        opts.IssueID,
-				RunId:          opts.RunID,
-				ShortId:        opts.ShortID,
+				IssueId:        opts.IssueID.String(),
+				RunId:          opts.RunID.String(),
+				ShortId:        opts.ShortID.String(),
 				Branch:         opts.Branch,
 				Agent:          opts.Agent,
 				AgentCmd:       opts.AgentCmd,

--- a/internal/daemon/proto_convert.go
+++ b/internal/daemon/proto_convert.go
@@ -111,8 +111,8 @@ func modelRunToProto(run *model.Run) *orchpb.Run {
 	}
 
 	protoRun := &orchpb.Run{
-		IssueId:           sanitizeUTF8(run.IssueID),
-		RunId:             sanitizeUTF8(run.RunID),
+		IssueId:           sanitizeUTF8(run.IssueID.String()),
+		RunId:             sanitizeUTF8(run.RunID.String()),
 		Status:            modelStatusToProto(run.Status),
 		Agent:             sanitizeUTF8(run.Agent),
 		Model:             sanitizeUTF8(run.Model),
@@ -144,8 +144,8 @@ func protoRunToModel(run *orchpb.Run) *model.Run {
 		return nil
 	}
 	return &model.Run{
-		IssueID:           run.IssueId,
-		RunID:             run.RunId,
+		IssueID:           model.NewIssueID(run.IssueId),
+		RunID:             model.NewRunID(run.RunId),
 		Status:            protoStatusToModel(run.Status),
 		Agent:             run.Agent,
 		Model:             run.Model,
@@ -171,7 +171,7 @@ func modelIssueToProto(issue *model.Issue) *orchpb.Issue {
 		return nil
 	}
 	return &orchpb.Issue{
-		Id:             sanitizeUTF8(issue.ID),
+		Id:             sanitizeUTF8(issue.ID.String()),
 		Title:          sanitizeUTF8(issue.Title),
 		Topic:          sanitizeUTF8(issue.Topic),
 		Summary:        sanitizeUTF8(issue.Summary),
@@ -189,7 +189,7 @@ func protoIssueToModel(issue *orchpb.Issue) *model.Issue {
 		return nil
 	}
 	return &model.Issue{
-		ID:         issue.Id,
+		ID:         model.NewIssueID(issue.Id),
 		Title:      issue.Title,
 		Topic:      issue.Topic,
 		Summary:    issue.Summary,

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -314,9 +314,9 @@ func (s *SocketServer) handleProtoRequest(req *orchpb.Request) *orchpb.Response 
 
 func resolveRunForMutation(st store.Store, issueID, runID, shortID string) (*model.Run, error) {
 	if shortID != "" {
-		return st.GetRunByShortID(shortID)
+		return st.GetRunByShortID(model.NewShortID(shortID))
 	}
-	return st.GetRun(&model.RunRef{IssueID: issueID, RunID: runID})
+	return st.GetRun(&model.RunRef{IssueID: model.NewIssueID(issueID), RunID: model.NewRunID(runID)})
 }
 
 func (s *SocketServer) resolveMainRepoRootForRun(ctx *orchpb.RequestContext, run *model.Run) (string, error) {
@@ -521,8 +521,15 @@ type runStoreEntry struct {
 type resolvedProtoRun struct {
 	run         *model.Run
 	store       store.Store
-	projectID   string
+	projectID   model.ProjectID
 	projectRoot string
+}
+
+func (r *resolvedProtoRun) projectIDString() string {
+	if r == nil {
+		return ""
+	}
+	return strings.TrimSpace(r.projectID.String())
 }
 
 type waitRunTarget struct {
@@ -552,19 +559,23 @@ func (s *SocketServer) repoContextForStore(st store.Store) *RepoContext {
 }
 
 func (s *SocketServer) resolveProtoRun(ctx *orchpb.RequestContext, issueID, runID string) (*resolvedProtoRun, *orchpb.Response) {
-	ref := &model.RunRef{IssueID: issueID, RunID: runID}
-	projectID := projectIDFromContext(ctx)
+	ref := &model.RunRef{IssueID: model.NewIssueID(issueID), RunID: model.NewRunID(runID)}
+	projectIDString := projectIDFromContext(ctx)
 
-	if projectID != "" {
+	if projectIDString != "" {
+		projectID, err := model.NewNormalizedProjectID(projectIDString)
+		if err != nil {
+			return nil, errorResponse(fmt.Sprintf("invalid project_id %q: %v", projectIDString, err))
+		}
 		st := s.resolveStoreFromContextOrProto(ctx, "")
 		if st == nil {
-			return nil, errorResponse(fmt.Sprintf("no store available for project_id %q (register daemon project mapping)", projectID))
+			return nil, errorResponse(fmt.Sprintf("no store available for project_id %q (register daemon project mapping)", projectIDString))
 		}
 		run, err := st.GetRun(ref)
 		if err != nil {
 			return nil, errorResponse("not_found")
 		}
-		repo := s.ensureRepoContextByID(projectID)
+		repo := s.ensureRepoContextByID(projectIDString)
 		projectRoot := ""
 		if repo != nil {
 			projectRoot = strings.TrimSpace(repo.ProjectRoot)
@@ -593,10 +604,14 @@ func (s *SocketServer) resolveProtoRun(ctx *orchpb.RequestContext, issueID, runI
 			return nil, errorResponse("ambiguous_run_ref")
 		}
 		repo := s.repoContextForStore(st)
-		projectID := ""
+		var projectID model.ProjectID
 		projectRoot := ""
 		if repo != nil {
-			projectID = strings.TrimSpace(repo.RepoID)
+			normalizedProjectID, err := model.NewNormalizedProjectID(repo.RepoID)
+			if err != nil {
+				return nil, errorResponse(fmt.Sprintf("invalid registered project_id %q: %v", repo.RepoID, err))
+			}
+			projectID = normalizedProjectID
 			projectRoot = strings.TrimSpace(repo.ProjectRoot)
 		}
 		resolved = &resolvedProtoRun{
@@ -650,7 +665,7 @@ func (s *SocketServer) resolveWaitRunTarget(ctx *orchpb.RequestContext, ref stri
 	projectID := projectIDFromContext(ctx)
 	resolveInStore := func(st store.Store) (*model.Run, error) {
 		if shortID != "" {
-			return st.GetRunByShortID(shortID)
+			return st.GetRunByShortID(model.NewShortID(shortID))
 		}
 		return st.GetRun(runRef)
 	}
@@ -764,7 +779,7 @@ func (s *SocketServer) handleProtoListRuns(req *orchpb.ListRunsRequest) *orchpb.
 	projectID := projectIDFromContext(req.Context)
 
 	filter := &store.ListRunsFilter{
-		IssueID:    req.IssueId,
+		IssueID:    model.NewIssueID(req.IssueId),
 		Status:     protoRunStatusSliceToModel(req.Status),
 		Agent:      req.Agent,
 		TextSearch: req.TextSearch,
@@ -870,7 +885,7 @@ func applyIssueMetadataToRunEntries(entries []runStoreEntry, protoRuns []*orchpb
 		return
 	}
 
-	issuesByStore := make(map[store.Store]map[string]*model.Issue)
+	issuesByStore := make(map[store.Store]map[model.IssueID]*model.Issue)
 
 	for i, entry := range entries {
 		if i >= len(protoRuns) || protoRuns[i] == nil || entry.run == nil || entry.store == nil {
@@ -885,7 +900,7 @@ func applyIssueMetadataToRunEntries(entries []runStoreEntry, protoRuns []*orchpb
 				continue
 			}
 
-			byID = make(map[string]*model.Issue, len(issues))
+			byID = make(map[model.IssueID]*model.Issue, len(issues))
 			for _, issue := range issues {
 				if issue == nil {
 					continue
@@ -1140,9 +1155,9 @@ func (s *SocketServer) handleProtoWaitForRuns(req *orchpb.WaitForRunsRequest) *o
 					Ok: true,
 					Response: &orchpb.Response_WaitForRuns{
 						WaitForRuns: &orchpb.WaitForRunsResponse{
-							RunId:  current.ShortID(),
+							RunId:  current.ShortID().String(),
 							Status: sanitizeUTF8(string(current.Status)),
-							Issue:  sanitizeUTF8(current.IssueID),
+							Issue:  sanitizeUTF8(current.IssueID.String()),
 							PrUrl:  sanitizeUTF8(current.PRUrl),
 						},
 					},
@@ -1166,7 +1181,7 @@ func (s *SocketServer) handleProtoWaitForRuns(req *orchpb.WaitForRunsRequest) *o
 }
 
 func (s *SocketServer) handleProtoGetRun(req *orchpb.GetRunRequest) *orchpb.Response {
-	ref := &model.RunRef{IssueID: req.IssueId, RunID: req.RunId}
+	ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueId), RunID: model.NewRunID(req.RunId)}
 	projectID := projectIDFromContext(req.Context)
 
 	var run *model.Run
@@ -1238,8 +1253,8 @@ func (s *SocketServer) handleProtoStartRun(req *orchpb.StartRunRequest) *orchpb.
 	st := repoCtx.Store
 
 	opts := &StartRunOptions{
-		IssueID:        req.IssueId,
-		RunID:          req.RunId,
+		IssueID:        model.NewIssueID(req.IssueId),
+		RunID:          model.NewRunID(req.RunId),
 		Agent:          req.Agent,
 		AgentCmd:       req.AgentCmd,
 		AgentProfile:   req.AgentProfile,
@@ -1266,7 +1281,7 @@ func (s *SocketServer) handleProtoStartRun(req *orchpb.StartRunRequest) *orchpb.
 		opts.TargetWorkerID = target.WorkerID
 	}
 
-	if issue, err := st.ResolveIssue(req.IssueId); err == nil {
+	if issue, err := st.ResolveIssue(model.NewIssueID(req.IssueId)); err == nil {
 		opts.IssueSnapshot = issue
 	}
 
@@ -1294,7 +1309,7 @@ func (s *SocketServer) handleProtoStartRun(req *orchpb.StartRunRequest) *orchpb.
 		Ok: true,
 		Response: &orchpb.Response_StartRun{
 			StartRun: &orchpb.StartRunResponse{
-				RunId:        result.RunID,
+				RunId:        result.RunID.String(),
 				Branch:       result.Branch,
 				WorktreePath: result.WorktreePath,
 				SessionName:  result.SessionName,
@@ -1309,7 +1324,7 @@ func (s *SocketServer) syncStartRunResultToMasterStore(st store.Store, req *orch
 		return nil
 	}
 
-	ref := &model.RunRef{IssueID: req.IssueId, RunID: result.RunID}
+	ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueId), RunID: result.RunID}
 	run, err := st.GetRun(ref)
 	if err != nil {
 		metadata := map[string]string{}
@@ -1326,7 +1341,7 @@ func (s *SocketServer) syncStartRunResultToMasterStore(st store.Store, req *orch
 			metadata["target"] = req.Target
 		}
 
-		run, err = st.CreateRun(req.IssueId, result.RunID, metadata)
+		run, err = st.CreateRun(model.NewIssueID(req.IssueId), result.RunID, metadata)
 		if err != nil {
 			return err
 		}
@@ -1484,9 +1499,9 @@ func (s *SocketServer) handleProtoContinueRun(req *orchpb.ContinueRunRequest) *o
 	st := repoCtx.Store
 
 	opts := &ContinueRunOptions{
-		IssueID:        req.IssueId,
-		RunID:          req.RunId,
-		ShortID:        req.ShortId,
+		IssueID:        model.NewIssueID(req.IssueId),
+		RunID:          model.NewRunID(req.RunId),
+		ShortID:        model.NewShortID(req.ShortId),
 		Branch:         req.Branch,
 		Agent:          req.Agent,
 		AgentCmd:       req.AgentCmd,
@@ -1499,11 +1514,11 @@ func (s *SocketServer) handleProtoContinueRun(req *orchpb.ContinueRunRequest) *o
 		SessionName:    req.SessionName,
 	}
 	if req.ShortId != "" {
-		if run, err := st.GetRunByShortID(req.ShortId); err == nil && run != nil {
+		if run, err := st.GetRunByShortID(model.NewShortID(req.ShortId)); err == nil && run != nil {
 			opts.Target = strings.TrimSpace(run.Target)
 		}
 	} else if req.IssueId != "" && req.RunId != "" {
-		if run, err := st.GetRun(&model.RunRef{IssueID: req.IssueId, RunID: req.RunId}); err == nil && run != nil {
+		if run, err := st.GetRun(&model.RunRef{IssueID: model.NewIssueID(req.IssueId), RunID: model.NewRunID(req.RunId)}); err == nil && run != nil {
 			opts.Target = strings.TrimSpace(run.Target)
 		}
 	}
@@ -1537,13 +1552,13 @@ func (s *SocketServer) handleProtoContinueRun(req *orchpb.ContinueRunRequest) *o
 		Ok: true,
 		Response: &orchpb.Response_ContinueRun{
 			ContinueRun: &orchpb.ContinueRunResponse{
-				RunId:         result.RunID,
+				RunId:         result.RunID.String(),
 				Branch:        result.Branch,
 				WorktreePath:  result.WorktreePath,
 				SessionName:   result.SessionName,
 				Status:        result.Status,
 				ContinuedFrom: result.ContinuedFrom,
-				IssueId:       result.IssueID,
+				IssueId:       result.IssueID.String(),
 			},
 		},
 	}
@@ -1560,7 +1575,7 @@ func (s *SocketServer) handleProtoStopRun(req *orchpb.StopRunRequest) *orchpb.Re
 	}
 	st := repoCtx.Store
 
-	ref := &model.RunRef{IssueID: req.IssueId, RunID: req.RunId}
+	ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueId), RunID: model.NewRunID(req.RunId)}
 	run, err := st.GetRun(ref)
 	if err != nil {
 		return errorResponse("not_found")
@@ -1580,7 +1595,7 @@ func (s *SocketServer) handleProtoStopRun(req *orchpb.StopRunRequest) *orchpb.Re
 		}
 		payload.StopRun = stopPayload
 	}
-	if _, err := s.withWorkerLease(projectID, "stop_run", run.IssueID, run.RunID, payload); err != nil {
+	if _, err := s.withWorkerLease(projectID, "stop_run", run.IssueID.String(), run.RunID.String(), payload); err != nil {
 		return errorResponse(err.Error())
 	}
 
@@ -1599,7 +1614,7 @@ func (s *SocketServer) handleProtoResolveRun(req *orchpb.ResolveRunRequest) *orc
 		return errorResponse("no store available")
 	}
 
-	if err := st.SetIssueStatus(req.IssueId, model.IssueStatusResolved); err != nil {
+	if err := st.SetIssueStatus(model.NewIssueID(req.IssueId), model.IssueStatusResolved); err != nil {
 		return errorResponse("store_error")
 	}
 
@@ -1670,7 +1685,7 @@ func (s *SocketServer) handleProtoListIssues(req *orchpb.ListIssuesRequest) *orc
 		search := strings.ToLower(req.TextSearch)
 		var filtered []*model.Issue
 		for _, issue := range issues {
-			if strings.Contains(strings.ToLower(issue.ID), search) ||
+			if strings.Contains(strings.ToLower(issue.ID.String()), search) ||
 				strings.Contains(strings.ToLower(issue.Title), search) ||
 				strings.Contains(strings.ToLower(issue.Summary), search) {
 				filtered = append(filtered, issue)
@@ -1731,14 +1746,14 @@ func (s *SocketServer) handleProtoGetIssue(req *orchpb.GetIssueRequest) *orchpb.
 			return errorResponse(fmt.Sprintf("no store available for project_id %q (register daemon project mapping)", projectID))
 		}
 
-		resolved, err := st.ResolveIssue(req.IssueId)
+		resolved, err := st.ResolveIssue(model.NewIssueID(req.IssueId))
 		if err != nil {
 			return errorResponse("not_found")
 		}
 		issue = resolved
 	} else {
 		for _, st := range s.listStores() {
-			resolved, err := st.ResolveIssue(req.IssueId)
+			resolved, err := st.ResolveIssue(model.NewIssueID(req.IssueId))
 			if err != nil {
 				if isStoreNotFoundError(err) {
 					continue
@@ -1778,7 +1793,7 @@ func (s *SocketServer) handleProtoCreateIssue(req *orchpb.CreateIssueRequest) *o
 	}
 
 	params := &CreateIssueParams{
-		IssueID:    req.IssueId,
+		IssueID:    model.NewIssueID(req.IssueId),
 		Title:      req.Title,
 		Body:       req.Body,
 		Tags:       req.Tags,
@@ -1809,7 +1824,7 @@ func (s *SocketServer) handleProtoCloseIssue(req *orchpb.CloseIssueRequest) *orc
 		return errorResponse("no store available")
 	}
 
-	if err := st.SetIssueStatus(req.IssueId, model.IssueStatusClosed); err != nil {
+	if err := st.SetIssueStatus(model.NewIssueID(req.IssueId), model.IssueStatusClosed); err != nil {
 		return errorResponse("not_found")
 	}
 
@@ -1909,9 +1924,9 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 
 		var err error
 		if req.ShortId != "" {
-			run, err = st.GetRunByShortID(req.ShortId)
+			run, err = st.GetRunByShortID(model.NewShortID(req.ShortId))
 		} else {
-			ref := &model.RunRef{IssueID: req.IssueId, RunID: req.RunId}
+			ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueId), RunID: model.NewRunID(req.RunId)}
 			run, err = st.GetRun(ref)
 		}
 		if err != nil {
@@ -1924,7 +1939,7 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 				err      error
 			)
 			if req.ShortId != "" {
-				resolved, err = st.GetRunByShortID(req.ShortId)
+				resolved, err = st.GetRunByShortID(model.NewShortID(req.ShortId))
 				if err != nil {
 					if isStoreNotFoundError(err) {
 						continue
@@ -1935,7 +1950,7 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 					return errorResponse("store_error")
 				}
 			} else {
-				ref := &model.RunRef{IssueID: req.IssueId, RunID: req.RunId}
+				ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueId), RunID: model.NewRunID(req.RunId)}
 				resolved, err = st.GetRun(ref)
 				if err != nil {
 					if isStoreNotFoundError(err) {
@@ -1969,8 +1984,8 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 		Agent:             run.Agent,
 		ServerPort:        int32(run.ServerPort),
 		OpencodeSessionId: run.OpenCodeSessionID,
-		IssueId:           run.IssueID,
-		RunId:             run.RunID,
+		IssueId:           run.IssueID.String(),
+		RunId:             run.RunID.String(),
 	}
 
 	if strings.TrimSpace(run.TargetHost) != "" {
@@ -2037,7 +2052,8 @@ func (s *SocketServer) handleProtoCaptureSession(req *orchpb.CaptureSessionReque
 	}
 
 	if s.runRequiresWorkerDelegation(runCtx.run, "") {
-		if strings.TrimSpace(runCtx.projectID) == "" {
+		projectID := runCtx.projectIDString()
+		if projectID == "" {
 			return errorResponse(fmt.Sprintf("no project context available for remote run %s#%s", runCtx.run.IssueID, runCtx.run.RunID))
 		}
 		target, err := resolveWorkerTargetForRun(runCtx)
@@ -2052,7 +2068,7 @@ func (s *SocketServer) handleProtoCaptureSession(req *orchpb.CaptureSessionReque
 				TargetWorkerID: target.WorkerID,
 			},
 		}
-		completedLease, err := s.withWorkerLease(runCtx.projectID, "capture_session", runCtx.run.IssueID, runCtx.run.RunID, payload)
+		completedLease, err := s.withWorkerLease(projectID, "capture_session", runCtx.run.IssueID.String(), runCtx.run.RunID.String(), payload)
 		if err != nil {
 			return errorResponse(err.Error())
 		}
@@ -2132,7 +2148,8 @@ func (s *SocketServer) handleProtoSendMessage(req *orchpb.SendMessageRequest) *o
 	}
 
 	if s.runRequiresWorkerDelegation(runCtx.run, "") {
-		if strings.TrimSpace(runCtx.projectID) == "" {
+		projectID := runCtx.projectIDString()
+		if projectID == "" {
 			return errorResponse(fmt.Sprintf("no project context available for remote run %s#%s", runCtx.run.IssueID, runCtx.run.RunID))
 		}
 		target, err := resolveWorkerTargetForRun(runCtx)
@@ -2148,7 +2165,7 @@ func (s *SocketServer) handleProtoSendMessage(req *orchpb.SendMessageRequest) *o
 				TargetWorkerID: target.WorkerID,
 			},
 		}
-		if _, err := s.withWorkerLease(runCtx.projectID, "send_message", runCtx.run.IssueID, runCtx.run.RunID, payload); err != nil {
+		if _, err := s.withWorkerLease(projectID, "send_message", runCtx.run.IssueID.String(), runCtx.run.RunID.String(), payload); err != nil {
 			return errorResponse(err.Error())
 		}
 		return &orchpb.Response{
@@ -2158,8 +2175,8 @@ func (s *SocketServer) handleProtoSendMessage(req *orchpb.SendMessageRequest) *o
 	}
 
 	params := &SendMessageParams{
-		IssueID: req.IssueId,
-		RunID:   req.RunId,
+		IssueID: model.NewIssueID(req.IssueId),
+		RunID:   model.NewRunID(req.RunId),
 		Message: req.Message,
 		NoEnter: req.NoEnter,
 	}
@@ -2181,7 +2198,8 @@ func (s *SocketServer) handleProtoGetDiffStats(req *orchpb.GetDiffStatsRequest) 
 	}
 
 	if s.runRequiresWorkerDelegation(runCtx.run, "") {
-		if strings.TrimSpace(runCtx.projectID) == "" {
+		projectID := runCtx.projectIDString()
+		if projectID == "" {
 			return errorResponse(fmt.Sprintf("no project context available for remote run %s#%s", runCtx.run.IssueID, runCtx.run.RunID))
 		}
 		target, err := resolveWorkerTargetForRun(runCtx)
@@ -2195,7 +2213,7 @@ func (s *SocketServer) handleProtoGetDiffStats(req *orchpb.GetDiffStatsRequest) 
 				TargetWorkerID: target.WorkerID,
 			},
 		}
-		completedLease, err := s.withWorkerLease(runCtx.projectID, "get_diff_stats", runCtx.run.IssueID, runCtx.run.RunID, payload)
+		completedLease, err := s.withWorkerLease(projectID, "get_diff_stats", runCtx.run.IssueID.String(), runCtx.run.RunID.String(), payload)
 		if err != nil {
 			return errorResponse(err.Error())
 		}
@@ -2246,7 +2264,8 @@ func (s *SocketServer) handleProtoGetBranchState(req *orchpb.GetBranchStateReque
 	}
 
 	if s.runRequiresWorkerDelegation(runCtx.run, "") {
-		if strings.TrimSpace(runCtx.projectID) == "" {
+		projectID := runCtx.projectIDString()
+		if projectID == "" {
 			return errorResponse(fmt.Sprintf("no project context available for remote run %s#%s", runCtx.run.IssueID, runCtx.run.RunID))
 		}
 		target, err := resolveWorkerTargetForRun(runCtx)
@@ -2260,7 +2279,7 @@ func (s *SocketServer) handleProtoGetBranchState(req *orchpb.GetBranchStateReque
 				TargetWorkerID: target.WorkerID,
 			},
 		}
-		completedLease, err := s.withWorkerLease(runCtx.projectID, "get_branch_state", runCtx.run.IssueID, runCtx.run.RunID, payload)
+		completedLease, err := s.withWorkerLease(projectID, "get_branch_state", runCtx.run.IssueID.String(), runCtx.run.RunID.String(), payload)
 		if err != nil {
 			return errorResponse(err.Error())
 		}
@@ -2353,7 +2372,8 @@ func (s *SocketServer) handleProtoGetDiff(req *orchpb.GetDiffRequest) *orchpb.Re
 	}
 
 	if s.runRequiresWorkerDelegation(runCtx.run, "") {
-		if strings.TrimSpace(runCtx.projectID) == "" {
+		projectID := runCtx.projectIDString()
+		if projectID == "" {
 			return errorResponse(fmt.Sprintf("no project context available for remote run %s#%s", runCtx.run.IssueID, runCtx.run.RunID))
 		}
 		target, err := resolveWorkerTargetForRun(runCtx)
@@ -2367,7 +2387,7 @@ func (s *SocketServer) handleProtoGetDiff(req *orchpb.GetDiffRequest) *orchpb.Re
 				TargetWorkerID: target.WorkerID,
 			},
 		}
-		completedLease, err := s.withWorkerLease(runCtx.projectID, "get_diff", runCtx.run.IssueID, runCtx.run.RunID, payload)
+		completedLease, err := s.withWorkerLease(projectID, "get_diff", runCtx.run.IssueID.String(), runCtx.run.RunID.String(), payload)
 		if err != nil {
 			return errorResponse(err.Error())
 		}
@@ -2658,14 +2678,14 @@ func (s *SocketServer) handleProtoGetRunByShortID(req *orchpb.GetRunByShortIDReq
 			return errorResponse(fmt.Sprintf("no store available for project_id %q (register daemon project mapping)", projectID))
 		}
 
-		resolved, err := st.GetRunByShortID(req.ShortId)
+		resolved, err := st.GetRunByShortID(model.NewShortID(req.ShortId))
 		if err != nil {
 			return errorResponse("not_found")
 		}
 		run = resolved
 	} else {
 		for _, st := range s.listStores() {
-			resolved, err := st.GetRunByShortID(req.ShortId)
+			resolved, err := st.GetRunByShortID(model.NewShortID(req.ShortId))
 			if err != nil {
 				if isStoreNotFoundError(err) {
 					continue
@@ -2716,7 +2736,7 @@ func (s *SocketServer) handleProtoResolveIssue(req *orchpb.ResolveIssueRequest) 
 		return errorResponse("no store available")
 	}
 
-	if err := st.SetIssueStatus(req.IssueId, model.IssueStatusResolved); err != nil {
+	if err := st.SetIssueStatus(model.NewIssueID(req.IssueId), model.IssueStatusResolved); err != nil {
 		return errorResponse(err.Error())
 	}
 
@@ -2739,7 +2759,7 @@ func (s *SocketServer) handleProtoAppendEvent(req *orchpb.AppendEventRequest) *o
 		return errorResponse("no store available")
 	}
 
-	ref := &model.RunRef{IssueID: req.IssueId, RunID: req.RunId}
+	ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueId), RunID: model.NewRunID(req.RunId)}
 	event := model.NewEvent(model.EventType(req.EventType), req.EventName, req.EventAttrs)
 
 	if err := st.AppendEvent(ref, event); err != nil {
@@ -2803,7 +2823,7 @@ func (s *SocketServer) handleProtoRegisterRepo(req *orchpb.RegisterRepoRequest) 
 		if err != nil {
 			return errorResponse(fmt.Sprintf("invalid repo URL %q: %v", input, err))
 		}
-		repoID = strings.TrimSpace(parsedID)
+		repoID = strings.TrimSpace(parsedID.String())
 		repoURL = input
 		workspaceRoot, err := ensureManagedRepoWorkspace(repoID, repoURL)
 		if err != nil {
@@ -2909,9 +2929,9 @@ func (s *SocketServer) handleProtoDeleteRun(req *orchpb.DeleteRunRequest) *orchp
 	}
 
 	result := &orchpb.DeleteRunResponse{
-		IssueId: run.IssueID,
-		RunId:   run.RunID,
-		ShortId: run.ShortID(),
+		IssueId: run.IssueID.String(),
+		RunId:   run.RunID.String(),
+		ShortId: run.ShortID().String(),
 	}
 
 	if req.WithWorktree && run.WorktreePath != "" {
@@ -2968,9 +2988,9 @@ func (s *SocketServer) handleProtoCleanRunWorktree(req *orchpb.CleanRunWorktreeR
 	}
 
 	result := &orchpb.CleanRunWorktreeResponse{
-		IssueId:         run.IssueID,
-		RunId:           run.RunID,
-		ShortId:         run.ShortID(),
+		IssueId:         run.IssueID.String(),
+		RunId:           run.RunID.String(),
+		ShortId:         run.ShortID().String(),
 		WorktreePath:    run.WorktreePath,
 		WorktreeRemoved: removed,
 		Skipped:         skipped,
@@ -2994,7 +3014,7 @@ func (s *SocketServer) handleProtoUpdateIssue(req *orchpb.UpdateIssueRequest) *o
 		return errorResponse("no store available")
 	}
 
-	issue, err := st.ResolveIssue(req.IssueId)
+	issue, err := st.ResolveIssue(model.NewIssueID(req.IssueId))
 	if err != nil {
 		return errorResponse(fmt.Sprintf("issue not found: %v", err))
 	}
@@ -3036,7 +3056,7 @@ func (s *SocketServer) handleProtoValidateIssueFiles(req *orchpb.ValidateIssueFi
 			return errorResponse(fmt.Sprintf("no store available for project_id %q (register daemon project mapping)", projectID))
 		}
 
-		result, err := st.ValidateIssueFiles(req.IssueId)
+		result, err := st.ValidateIssueFiles(model.NewIssueID(req.IssueId))
 		if err != nil {
 			return errorResponse(fmt.Sprintf("validation failed: %v", err))
 		}
@@ -3049,7 +3069,7 @@ func (s *SocketServer) handleProtoValidateIssueFiles(req *orchpb.ValidateIssueFi
 	} else {
 		stores := s.listStores()
 		for _, st := range stores {
-			result, err := st.ValidateIssueFiles(req.IssueId)
+			result, err := st.ValidateIssueFiles(model.NewIssueID(req.IssueId))
 			if err != nil {
 				if req.IssueId != "" && isStoreNotFoundError(err) {
 					continue
@@ -3074,7 +3094,7 @@ func (s *SocketServer) handleProtoValidateIssueFiles(req *orchpb.ValidateIssueFi
 	for _, e := range aggregated.Errors {
 		item := &orchpb.ValidationResultItem{
 			File:    e.File,
-			IssueId: e.IssueID,
+			IssueId: e.IssueID.String(),
 		}
 		for _, issue := range e.Errors {
 			item.Errors = append(item.Errors, &orchpb.ValidationIssue{
@@ -3089,7 +3109,7 @@ func (s *SocketServer) handleProtoValidateIssueFiles(req *orchpb.ValidateIssueFi
 
 	for _, d := range aggregated.Duplicates {
 		protoResult.Duplicates = append(protoResult.Duplicates, &orchpb.DuplicateIDItem{
-			Id:    d.ID,
+			Id:    d.ID.String(),
 			Files: d.Files,
 		})
 	}
@@ -3115,9 +3135,9 @@ func (s *SocketServer) handleProtoWriteAgentPrompt(req *orchpb.WriteAgentPromptR
 	var err error
 
 	if req.ShortId != "" {
-		run, err = st.GetRunByShortID(req.ShortId)
+		run, err = st.GetRunByShortID(model.NewShortID(req.ShortId))
 	} else {
-		ref := &model.RunRef{IssueID: req.IssueId, RunID: req.RunId}
+		ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueId), RunID: model.NewRunID(req.RunId)}
 		run, err = st.GetRun(ref)
 	}
 	if err != nil {
@@ -3149,9 +3169,9 @@ func (s *SocketServer) handleProtoReadAgentPrompt(req *orchpb.ReadAgentPromptReq
 		}
 
 		if req.ShortId != "" {
-			run, err = st.GetRunByShortID(req.ShortId)
+			run, err = st.GetRunByShortID(model.NewShortID(req.ShortId))
 		} else {
-			ref := &model.RunRef{IssueID: req.IssueId, RunID: req.RunId}
+			ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueId), RunID: model.NewRunID(req.RunId)}
 			run, err = st.GetRun(ref)
 		}
 		if err != nil {
@@ -3165,7 +3185,7 @@ func (s *SocketServer) handleProtoReadAgentPrompt(req *orchpb.ReadAgentPromptReq
 			)
 
 			if req.ShortId != "" {
-				resolved, err = candidateStore.GetRunByShortID(req.ShortId)
+				resolved, err = candidateStore.GetRunByShortID(model.NewShortID(req.ShortId))
 				if err != nil {
 					if isStoreNotFoundError(err) {
 						continue
@@ -3176,7 +3196,7 @@ func (s *SocketServer) handleProtoReadAgentPrompt(req *orchpb.ReadAgentPromptReq
 					return errorResponse(fmt.Sprintf("run lookup failed: %v", err))
 				}
 			} else {
-				ref := &model.RunRef{IssueID: req.IssueId, RunID: req.RunId}
+				ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueId), RunID: model.NewRunID(req.RunId)}
 				resolved, err = candidateStore.GetRun(ref)
 				if err != nil {
 					if isStoreNotFoundError(err) {
@@ -3357,7 +3377,7 @@ func (s *SocketServer) handleProtoCreateRun(req *orchpb.CreateRunRequest) *orchp
 		return errorResponse("no store available")
 	}
 
-	run, err := st.CreateRun(req.IssueId, req.RunId, req.Metadata)
+	run, err := st.CreateRun(model.NewIssueID(req.IssueId), model.NewRunID(req.RunId), req.Metadata)
 	if err != nil {
 		return errorResponse(fmt.Sprintf("failed to create run: %v", err))
 	}
@@ -3366,8 +3386,8 @@ func (s *SocketServer) handleProtoCreateRun(req *orchpb.CreateRunRequest) *orchp
 		Ok: true,
 		Response: &orchpb.Response_CreateRun{
 			CreateRun: &orchpb.CreateRunResponse{
-				IssueId: run.IssueID,
-				RunId:   run.RunID,
+				IssueId: run.IssueID.String(),
+				RunId:   run.RunID.String(),
 				Path:    run.Path,
 			},
 		},
@@ -3383,7 +3403,7 @@ func (s *SocketServer) handleProtoInjectInitialPrompt(req *orchpb.InjectInitialP
 		return errorResponse("no store available")
 	}
 
-	ref := &model.RunRef{IssueID: req.IssueId, RunID: req.RunId}
+	ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueId), RunID: model.NewRunID(req.RunId)}
 	run, err := st.GetRun(ref)
 	if err != nil {
 		return errorResponse(fmt.Sprintf("run not found: %v", err))
@@ -3540,9 +3560,9 @@ func (s *SocketServer) handleProtoResumeRun(req *orchpb.ResumeRunRequest) *orchp
 	var err error
 
 	if req.ShortId != "" {
-		run, err = st.GetRunByShortID(req.ShortId)
+		run, err = st.GetRunByShortID(model.NewShortID(req.ShortId))
 	} else {
-		ref := &model.RunRef{IssueID: req.IssueId, RunID: req.RunId}
+		ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueId), RunID: model.NewRunID(req.RunId)}
 		run, err = st.GetRun(ref)
 	}
 	if err != nil {

--- a/internal/daemon/proto_handler_test.go
+++ b/internal/daemon/proto_handler_test.go
@@ -211,8 +211,8 @@ func TestBuildAttachInfoResponse(t *testing.T) {
 				Agent:             tt.run.Agent,
 				ServerPort:        int32(tt.run.ServerPort),
 				OpencodeSessionId: tt.run.OpenCodeSessionID,
-				IssueId:           tt.run.IssueID,
-				RunId:             tt.run.RunID,
+				IssueId:           tt.run.IssueID.String(),
+				RunId:             tt.run.RunID.String(),
 			}
 
 			if attachInfo.Agent != tt.want.agent {
@@ -893,13 +893,13 @@ func TestHandleProtoWaitForRunsReturnsImmediatelyForShortID(t *testing.T) {
 	}
 	st := &mockStore{
 		runs: map[string]*model.Run{
-			run.IssueID + "#" + run.RunID: run,
+			run.Ref().String(): run,
 		},
 	}
 	server := newTestServer(t, st)
 
 	resp := server.handleProtoWaitForRuns(&orchpb.WaitForRunsRequest{
-		RunRefs: []string{run.ShortID()},
+		RunRefs: []string{run.ShortID().String()},
 		Context: &orchpb.RequestContext{ProjectId: testProjectID},
 	})
 	if !resp.Ok {
@@ -910,13 +910,13 @@ func TestHandleProtoWaitForRunsReturnsImmediatelyForShortID(t *testing.T) {
 	if waitResp == nil {
 		t.Fatal("expected WaitForRuns response payload")
 	}
-	if waitResp.RunId != run.ShortID() {
-		t.Fatalf("run_id = %q, want %q", waitResp.RunId, run.ShortID())
+	if waitResp.RunId != run.ShortID().String() {
+		t.Fatalf("run_id = %q, want %q", waitResp.RunId, run.ShortID().String())
 	}
 	if waitResp.Status != string(model.StatusPROpen) {
 		t.Fatalf("status = %q, want %q", waitResp.Status, model.StatusPROpen)
 	}
-	if waitResp.Issue != run.IssueID {
+	if waitResp.Issue != run.IssueID.String() {
 		t.Fatalf("issue = %q, want %q", waitResp.Issue, run.IssueID)
 	}
 	if waitResp.PrUrl != run.PRUrl {
@@ -941,7 +941,7 @@ func TestHandleProtoWaitForRunsWaitsForStatusChange(t *testing.T) {
 	}
 	st := &mockStore{
 		runs: map[string]*model.Run{
-			run.IssueID + "#" + run.RunID: run,
+			run.Ref().String(): run,
 		},
 	}
 	server := newTestServer(t, st)
@@ -952,7 +952,7 @@ func TestHandleProtoWaitForRunsWaitsForStatusChange(t *testing.T) {
 	}()
 
 	resp := server.handleProtoWaitForRuns(&orchpb.WaitForRunsRequest{
-		RunRefs: []string{run.IssueID + "#" + run.RunID},
+		RunRefs: []string{run.Ref().String()},
 		Context: &orchpb.RequestContext{ProjectId: testProjectID},
 	})
 	if !resp.Ok {
@@ -985,13 +985,13 @@ func TestHandleProtoWaitForRunsTimesOut(t *testing.T) {
 	}
 	st := &mockStore{
 		runs: map[string]*model.Run{
-			run.IssueID + "#" + run.RunID: run,
+			run.Ref().String(): run,
 		},
 	}
 	server := newTestServer(t, st)
 
 	resp := server.handleProtoWaitForRuns(&orchpb.WaitForRunsRequest{
-		RunRefs:        []string{run.IssueID + "#" + run.RunID},
+		RunRefs:        []string{run.Ref().String()},
 		TimeoutSeconds: 3,
 		Context:        &orchpb.RequestContext{ProjectId: testProjectID},
 	})

--- a/internal/daemon/repo_identity.go
+++ b/internal/daemon/repo_identity.go
@@ -12,7 +12,7 @@ func derivePortableRepoID(projectRoot string) string {
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(repoID)
+	return strings.TrimSpace(repoID.String())
 }
 
 func repoIDFromProjectSelector(value string) string {
@@ -26,7 +26,7 @@ func repoIDFromProjectSelector(value string) string {
 	if looksLikeRepoURL(target) {
 		repoID, err := xdg.ParseRepoID(target)
 		if err == nil {
-			return strings.TrimSpace(repoID)
+			return strings.TrimSpace(repoID.String())
 		}
 		return ""
 	}

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -410,8 +410,8 @@ func (s *SocketServer) repoIDForProjectRoot(projectRoot string) (string, error) 
 		return "", fmt.Errorf("project_root required")
 	}
 
-	if repoID, err := xdg.RepoIDStrict(projectRoot); err == nil && strings.TrimSpace(repoID) != "" {
-		return strings.TrimSpace(repoID), nil
+	if repoID, err := xdg.RepoIDStrict(projectRoot); err == nil && strings.TrimSpace(repoID.String()) != "" {
+		return strings.TrimSpace(repoID.String()), nil
 	}
 
 	s.reposMu.RLock()
@@ -973,7 +973,7 @@ func (s *SocketServer) getOrCreateStore(issuesRoot, projectRoot string) store.St
 		}
 		if ctx.RepoID == "" && projectRoot != "" {
 			if id, err := xdg.RepoID(projectRoot); err == nil && id != "" {
-				ctx.RepoID = id
+				ctx.RepoID = id.String()
 			}
 		}
 		return ctx.Store
@@ -988,7 +988,7 @@ func (s *SocketServer) getOrCreateStore(issuesRoot, projectRoot string) store.St
 	repoID := ""
 	if projectRoot != "" {
 		if id, err := xdg.RepoID(projectRoot); err == nil && id != "" {
-			repoID = id
+			repoID = id.String()
 		}
 	}
 
@@ -1897,8 +1897,8 @@ func (s *SocketServer) resetManagedOpenCodeRuntime(projectRoot string) error {
 func (s *SocketServer) bootstrapOpenCodeRunSession(
 	st store.Store,
 	run *model.Run,
-	issueID string,
-	runID string,
+	issueID model.IssueID,
+	runID model.RunID,
 	launchCfg *agent.LaunchConfig,
 	timeout time.Duration,
 ) (int, string, error) {
@@ -2554,7 +2554,7 @@ func (s *SocketServer) processSend(req SendRequest) error {
 		return fmt.Errorf("no store available for project")
 	}
 
-	ref := &model.RunRef{IssueID: req.IssueID, RunID: req.RunID}
+	ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueID), RunID: model.NewRunID(req.RunID)}
 	run, err := st.GetRun(ref)
 	if err != nil {
 		return fmt.Errorf("run %s#%s not found: %w", req.IssueID, req.RunID, err)
@@ -2906,7 +2906,7 @@ func (s *SocketServer) handleListRuns(req SendRequest, encoder *json.Encoder) {
 			return
 		}
 		filter := &store.ListRunsFilter{
-			IssueID:    req.IssueID,
+			IssueID:    model.NewIssueID(req.IssueID),
 			Agent:      req.Agent,
 			TextSearch: req.TextSearch,
 			TimeRange:  req.TimeRange,
@@ -2972,7 +2972,7 @@ func (s *SocketServer) listAllRepoRuns(req SendRequest) ([]*model.Run, error) {
 	var allRuns []*model.Run
 	for _, st := range stores {
 		filter := &store.ListRunsFilter{
-			IssueID:    req.IssueID,
+			IssueID:    model.NewIssueID(req.IssueID),
 			Agent:      req.Agent,
 			TextSearch: req.TextSearch,
 			TimeRange:  req.TimeRange,
@@ -3065,7 +3065,7 @@ func (s *SocketServer) handleListIssues(req SendRequest, encoder *json.Encoder) 
 		search := strings.ToLower(req.TextSearch)
 		var filtered []*model.Issue
 		for _, issue := range issues {
-			if strings.Contains(strings.ToLower(issue.ID), search) ||
+			if strings.Contains(strings.ToLower(issue.ID.String()), search) ||
 				strings.Contains(strings.ToLower(issue.Title), search) ||
 				strings.Contains(strings.ToLower(issue.Summary), search) {
 				filtered = append(filtered, issue)
@@ -3143,7 +3143,7 @@ func (s *SocketServer) handleGetRun(req SendRequest, encoder *json.Encoder) {
 		return
 	}
 
-	ref := &model.RunRef{IssueID: req.IssueID, RunID: req.RunID}
+	ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueID), RunID: model.NewRunID(req.RunID)}
 	run, err := st.GetRun(ref)
 	if err != nil {
 		s.logger.Printf("error getting run %s#%s: %v", req.IssueID, req.RunID, err)
@@ -3179,7 +3179,7 @@ func (s *SocketServer) handleGetIssue(req SendRequest, encoder *json.Encoder) {
 			encoder.Encode(GetIssueResponse{OK: false, Error: "no store available"})
 			return
 		}
-		issue, err = st.ResolveIssue(req.IssueID)
+		issue, err = st.ResolveIssue(model.NewIssueID(req.IssueID))
 	}
 
 	if err != nil {
@@ -3197,7 +3197,7 @@ func (s *SocketServer) handleGetIssue(req SendRequest, encoder *json.Encoder) {
 func SendViaDaemon(projectRoot, _ string, run *model.Run, message string, noEnter bool) error {
 	client := NewProtoClientLocal(projectRoot)
 	client.SetTimeout(35 * time.Second)
-	return client.SendMessage(run.IssueID, run.RunID, message, noEnter)
+	return client.SendMessage(run.IssueID.String(), run.RunID.String(), message, noEnter)
 }
 
 // IsDaemonSocketAvailable checks if the global daemon socket exists.
@@ -3212,6 +3212,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		encoder.Encode(StartRunResponse{OK: false, Error: "invalid_request: issue_id required"})
 		return
 	}
+	issueID := model.NewIssueID(req.IssueID)
 
 	st := s.resolveStore(req)
 	if st == nil {
@@ -3219,7 +3220,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		return
 	}
 
-	issue, err := st.ResolveIssue(req.IssueID)
+	issue, err := st.ResolveIssue(issueID)
 	if err != nil {
 		encoder.Encode(StartRunResponse{OK: false, Error: "issue not found: " + req.IssueID})
 		return
@@ -3257,10 +3258,10 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		return
 	}
 
-	runID := req.RunID
+	runID := model.NewRunID(req.RunID)
 	if runID == "" {
 		if req.Reuse {
-			runs, _ := st.ListRuns(&store.ListRunsFilter{IssueID: req.IssueID})
+			runs, _ := st.ListRuns(&store.ListRunsFilter{IssueID: issueID})
 			for _, r := range runs {
 				if r.Status == model.StatusWaiting || r.Status == model.StatusRateLimited {
 					runID = r.RunID
@@ -3274,9 +3275,9 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 	}
 	branch := req.Branch
 	if branch == "" {
-		branch = model.GenerateBranchName(req.IssueID, runID)
+		branch = model.GenerateBranchName(issueID, runID)
 	}
-	sessionName := model.GenerateSessionName(req.IssueID, runID)
+	sessionName := model.GenerateSessionName(issueID, runID)
 
 	repoRoot := s.resolveProjectRoot(req)
 
@@ -3294,18 +3295,18 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		worktreeDir = filepath.Join(home, ".orch", "worktrees")
 	}
 
-	worktreeName := model.GenerateWorktreeName(req.IssueID, runID, agentName)
+	worktreeName := model.GenerateWorktreeName(issueID, runID, agentName)
 	var worktreePath string
 	if filepath.IsAbs(worktreeDir) {
-		worktreePath = filepath.Join(worktreeDir, req.IssueID, worktreeName)
+		worktreePath = filepath.Join(worktreeDir, issueID.String(), worktreeName)
 	} else {
-		worktreePath = filepath.Join(repoRoot, worktreeDir, req.IssueID, worktreeName)
+		worktreePath = filepath.Join(repoRoot, worktreeDir, issueID.String(), worktreeName)
 	}
 
 	if req.DryRun {
 		encoder.Encode(StartRunResponse{
 			OK:           true,
-			RunID:        runID,
+			RunID:        runID.String(),
 			Branch:       branch,
 			WorktreePath: worktreePath,
 			SessionName:  sessionName,
@@ -3321,7 +3322,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 	if req.Model != "" {
 		metadata["model"] = req.Model
 	}
-	run, err := st.CreateRun(req.IssueID, runID, metadata)
+	run, err := st.CreateRun(issueID, runID, metadata)
 	if err != nil {
 		encoder.Encode(StartRunResponse{OK: false, Error: "failed to create run: " + err.Error()})
 		return
@@ -3334,7 +3335,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 	worktreeResult, err := git.CreateWorktree(&git.WorktreeConfig{
 		RepoRoot:    repoRoot,
 		WorktreeDir: worktreeDir,
-		IssueID:     req.IssueID,
+		IssueID:     issueID,
 		RunID:       runID,
 		Agent:       agentName,
 		BaseBranch:  baseBranch,
@@ -3368,7 +3369,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		Type:         agentType,
 		CustomCmd:    req.AgentCmd,
 		WorkDir:      worktreeResult.WorktreePath,
-		IssueID:      req.IssueID,
+		IssueID:      issueID,
 		RunID:        runID,
 		RunPath:      run.Path,
 		IssuesRoot:   st.RootPath(),
@@ -3454,7 +3455,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		}
 
 	case agent.InjectionHTTP:
-		_, _, err = s.bootstrapOpenCodeRunSession(st, run, req.IssueID, runID, launchCfg, 30*time.Second)
+		_, _, err = s.bootstrapOpenCodeRunSession(st, run, issueID, runID, launchCfg, 30*time.Second)
 		if err != nil {
 			encoder.Encode(StartRunResponse{OK: false, Error: err.Error()})
 			return
@@ -3467,7 +3468,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 
 	encoder.Encode(StartRunResponse{
 		OK:           true,
-		RunID:        runID,
+		RunID:        runID.String(),
 		Branch:       worktreeResult.Branch,
 		WorktreePath: worktreeResult.WorktreePath,
 		SessionName:  sessionName,
@@ -3518,7 +3519,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 	}
 
 	issue := opts.IssueSnapshot
-	if issue == nil || strings.TrimSpace(issue.ID) != opts.IssueID {
+	if issue == nil || strings.TrimSpace(issue.ID.String()) != opts.IssueID.String() {
 		resolvedIssue, err := st.ResolveIssue(opts.IssueID)
 		if err != nil {
 			return nil, fmt.Errorf("issue not found: %s", opts.IssueID)
@@ -3634,9 +3635,9 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 	worktreeName := model.GenerateWorktreeName(opts.IssueID, runID, agentName)
 	var worktreePath string
 	if filepath.IsAbs(worktreeDir) {
-		worktreePath = filepath.Join(worktreeDir, opts.IssueID, worktreeName)
+		worktreePath = filepath.Join(worktreeDir, opts.IssueID.String(), worktreeName)
 	} else {
-		worktreePath = filepath.Join(executionProjectRoot, worktreeDir, opts.IssueID, worktreeName)
+		worktreePath = filepath.Join(executionProjectRoot, worktreeDir, opts.IssueID.String(), worktreeName)
 	}
 
 	if opts.DryRun {
@@ -3846,7 +3847,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
-	var issueID string
+	var issueID model.IssueID
 	var branch string
 	var worktreePath string
 	var continuedFrom string
@@ -4188,7 +4189,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 		return
 	}
 
-	var issueID string
+	var issueID model.IssueID
 	var branch string
 	var worktreePath string
 	var continuedFrom string
@@ -4199,12 +4200,12 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 			encoder.Encode(ContinueRunResponse{OK: false, Error: "issue_id required with branch"})
 			return
 		}
-		issueID = req.IssueID
+		issueID = model.NewIssueID(req.IssueID)
 		branch = req.Branch
 
 		_, err := st.ResolveIssue(issueID)
 		if err != nil {
-			encoder.Encode(ContinueRunResponse{OK: false, Error: "issue not found: " + issueID})
+			encoder.Encode(ContinueRunResponse{OK: false, Error: "issue not found: " + issueID.String()})
 			return
 		}
 
@@ -4287,13 +4288,13 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 	} else {
 		var fromRun *model.Run
 		if req.ShortID != "" {
-			fromRun, err = st.GetRunByShortID(req.ShortID)
+			fromRun, err = st.GetRunByShortID(model.NewShortID(req.ShortID))
 			if err != nil {
 				encoder.Encode(ContinueRunResponse{OK: false, Error: "run not found: " + req.ShortID})
 				return
 			}
 		} else if req.IssueID != "" && req.RunID != "" {
-			ref := &model.RunRef{IssueID: req.IssueID, RunID: req.RunID}
+			ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueID), RunID: model.NewRunID(req.RunID)}
 			fromRun, err = st.GetRun(ref)
 			if err != nil {
 				encoder.Encode(ContinueRunResponse{OK: false, Error: "run not found: " + req.IssueID + "#" + req.RunID})
@@ -4347,7 +4348,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 
 	issue, err := st.ResolveIssue(issueID)
 	if err != nil {
-		encoder.Encode(ContinueRunResponse{OK: false, Error: "issue not found: " + issueID})
+		encoder.Encode(ContinueRunResponse{OK: false, Error: "issue not found: " + issueID.String()})
 		return
 	}
 
@@ -4520,13 +4521,13 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 
 	encoder.Encode(ContinueRunResponse{
 		OK:            true,
-		RunID:         runID,
+		RunID:         runID.String(),
 		Branch:        branch,
 		WorktreePath:  worktreePath,
 		SessionName:   sessionName,
 		Status:        string(model.StatusRunning),
 		ContinuedFrom: continuedFrom,
-		IssueID:       issueID,
+		IssueID:       issueID.String(),
 	})
 }
 
@@ -4634,7 +4635,7 @@ func (s *SocketServer) handleStopRun(req SendRequest, encoder *json.Encoder) {
 	var stoppedRuns []string
 
 	if req.RunID != "" {
-		ref := &model.RunRef{IssueID: req.IssueID, RunID: req.RunID}
+		ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueID), RunID: model.NewRunID(req.RunID)}
 		run, err := st.GetRun(ref)
 		if err != nil {
 			s.logger.Printf("error getting run %s#%s: %v", req.IssueID, req.RunID, err)
@@ -4646,10 +4647,10 @@ func (s *SocketServer) handleStopRun(req SendRequest, encoder *json.Encoder) {
 			encoder.Encode(StopRunResponse{OK: false, Error: err.Error()})
 			return
 		}
-		stoppedRuns = append(stoppedRuns, run.RunID)
+		stoppedRuns = append(stoppedRuns, run.RunID.String())
 	} else {
 		runs, err := st.ListRuns(&store.ListRunsFilter{
-			IssueID: req.IssueID,
+			IssueID: model.NewIssueID(req.IssueID),
 			Status:  []model.Status{model.StatusRunning, model.StatusBooting, model.StatusWaiting, model.StatusRateLimited, model.StatusQueued},
 		})
 		if err != nil {
@@ -4661,7 +4662,7 @@ func (s *SocketServer) handleStopRun(req SendRequest, encoder *json.Encoder) {
 			if err := s.stopSingleRun(run, st); err != nil {
 				s.logger.Printf("error stopping run %s#%s: %v", run.IssueID, run.RunID, err)
 			} else {
-				stoppedRuns = append(stoppedRuns, run.RunID)
+				stoppedRuns = append(stoppedRuns, run.RunID.String())
 			}
 		}
 	}
@@ -4727,7 +4728,7 @@ func (s *SocketServer) handleResolveIssue(req SendRequest, encoder *json.Encoder
 		return
 	}
 
-	issue, err := st.ResolveIssue(req.IssueID)
+	issue, err := st.ResolveIssue(model.NewIssueID(req.IssueID))
 	if err != nil {
 		s.logger.Printf("error getting issue %s: %v", req.IssueID, err)
 		encoder.Encode(ResolveIssueResponse{OK: false, Error: "not_found"})
@@ -4741,7 +4742,7 @@ func (s *SocketServer) handleResolveIssue(req SendRequest, encoder *json.Encoder
 
 	forceResolve := req.Force
 	if !forceResolve {
-		runs, err := st.ListRuns(&store.ListRunsFilter{IssueID: req.IssueID})
+		runs, err := st.ListRuns(&store.ListRunsFilter{IssueID: model.NewIssueID(req.IssueID)})
 		if err != nil {
 			s.logger.Printf("error listing runs for %s: %v", req.IssueID, err)
 			encoder.Encode(ResolveIssueResponse{OK: false, Error: "store_error"})
@@ -4762,7 +4763,7 @@ func (s *SocketServer) handleResolveIssue(req SendRequest, encoder *json.Encoder
 		}
 	}
 
-	if err := st.SetIssueStatus(req.IssueID, model.IssueStatusResolved); err != nil {
+	if err := st.SetIssueStatus(model.NewIssueID(req.IssueID), model.IssueStatusResolved); err != nil {
 		s.logger.Printf("error resolving issue %s: %v", req.IssueID, err)
 		encoder.Encode(ResolveIssueResponse{OK: false, Error: "store_error"})
 		return
@@ -4790,7 +4791,7 @@ func (s *SocketServer) handleCreateIssue(req SendRequest, encoder *json.Encoder)
 			return
 		}
 		s.logger.Printf("created GitHub issue: %s (%s)", issue.ID, issue.Path)
-		encoder.Encode(CreateIssueResponse{OK: true, IssueID: issue.ID, Path: issue.Path})
+		encoder.Encode(CreateIssueResponse{OK: true, IssueID: issue.ID.String(), Path: issue.Path})
 		return
 	}
 
@@ -4829,7 +4830,7 @@ func (s *SocketServer) handleCreateIssue(req SendRequest, encoder *json.Encoder)
 	}
 
 	issueToWrite := &model.Issue{
-		ID:         req.IssueID,
+		ID:         model.NewIssueID(req.IssueID),
 		Title:      title,
 		Summary:    req.Summary,
 		Status:     model.IssueStatusOpen,
@@ -4858,7 +4859,7 @@ func (s *SocketServer) handleCreateIssue(req SendRequest, encoder *json.Encoder)
 func (s *SocketServer) processCreateIssueCore(st store.Store, params *CreateIssueParams) (*CreateIssueResult, error) {
 	title := params.Title
 	if title == "" {
-		title = params.IssueID
+		title = params.IssueID.String()
 	}
 	if title == "" {
 		return nil, fmt.Errorf("invalid_request: title required")
@@ -4868,7 +4869,7 @@ func (s *SocketServer) processCreateIssueCore(st store.Store, params *CreateIssu
 		return nil, fmt.Errorf("invalid_request: issue_id required")
 	}
 
-	if strings.Contains(params.IssueID, "/") || strings.Contains(params.IssueID, "..") || strings.Contains(params.IssueID, "\\") {
+	if strings.Contains(params.IssueID.String(), "/") || strings.Contains(params.IssueID.String(), "..") || strings.Contains(params.IssueID.String(), "\\") {
 		return nil, fmt.Errorf("invalid_request: issue_id contains invalid characters")
 	}
 
@@ -4882,7 +4883,7 @@ func (s *SocketServer) processCreateIssueCore(st store.Store, params *CreateIssu
 		return nil, fmt.Errorf("io_error")
 	}
 
-	issuePath := filepath.Join(issuesDir, params.IssueID+".md")
+	issuePath := filepath.Join(issuesDir, params.IssueID.String()+".md")
 	if _, err := os.Stat(issuePath); err == nil {
 		return nil, fmt.Errorf("already_exists")
 	}
@@ -4911,7 +4912,7 @@ func (s *SocketServer) processCreateIssueCore(st store.Store, params *CreateIssu
 
 	s.logger.Printf("created issue: %s at %s", params.IssueID, issuePath)
 	return &CreateIssueResult{
-		IssueID: params.IssueID,
+		IssueID: params.IssueID.String(),
 		Path:    issuePath,
 	}, nil
 }
@@ -4923,7 +4924,7 @@ func (s *SocketServer) handleCloseIssue(req SendRequest, encoder *json.Encoder) 
 	}
 
 	if s.githubBackend != nil {
-		number, err := model.ParseGitHubIssueNumber(req.IssueID)
+		number, err := model.ParseGitHubIssueNumber(model.NewIssueID(req.IssueID))
 		if err != nil {
 			encoder.Encode(CloseIssueResponse{OK: false, Error: "invalid_issue_id: " + err.Error()})
 			return
@@ -4944,7 +4945,7 @@ func (s *SocketServer) handleCloseIssue(req SendRequest, encoder *json.Encoder) 
 		return
 	}
 
-	if err := st.SetIssueStatus(req.IssueID, model.IssueStatusClosed); err != nil {
+	if err := st.SetIssueStatus(model.NewIssueID(req.IssueID), model.IssueStatusClosed); err != nil {
 		s.logger.Printf("error closing issue %s: %v", req.IssueID, err)
 		encoder.Encode(CloseIssueResponse{OK: false, Error: "not_found"})
 		return
@@ -4965,12 +4966,12 @@ func (s *SocketServer) handleGetAttachInfo(req SendRequest, encoder *json.Encode
 	var err error
 
 	if req.RunID != "" {
-		ref := &model.RunRef{IssueID: req.IssueID, RunID: req.RunID}
+		ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueID), RunID: model.NewRunID(req.RunID)}
 		run, err = st.GetRun(ref)
 	} else if req.ShortID != "" {
-		run, err = st.GetRunByShortID(req.ShortID)
+		run, err = st.GetRunByShortID(model.NewShortID(req.ShortID))
 	} else if req.IssueID != "" {
-		run, err = st.GetLatestRun(req.IssueID)
+		run, err = st.GetLatestRun(model.NewIssueID(req.IssueID))
 	} else {
 		encoder.Encode(GetAttachInfoResponse{OK: false, Error: "invalid_request: issue_id, run_id, or short_id required"})
 		return
@@ -4994,8 +4995,8 @@ func (s *SocketServer) handleGetAttachInfo(req SendRequest, encoder *json.Encode
 
 	encoder.Encode(GetAttachInfoResponse{
 		OK:                true,
-		IssueID:           run.IssueID,
-		RunID:             run.RunID,
+		IssueID:           run.IssueID.String(),
+		RunID:             run.RunID.String(),
 		Agent:             run.Agent,
 		SessionName:       sessionName,
 		Multiplexer:       run.Multiplexer,
@@ -5033,7 +5034,7 @@ func (s *SocketServer) handleGetRunByShortID(req SendRequest, encoder *json.Enco
 		return
 	}
 
-	run, err := st.GetRunByShortID(shortID)
+	run, err := st.GetRunByShortID(model.NewShortID(shortID))
 	if err != nil {
 		s.logger.Printf("error getting run by short id %s: %v", shortID, err)
 		encoder.Encode(GetRunResponse{OK: false, Error: "not_found"})
@@ -5270,7 +5271,7 @@ func (s *SocketServer) handleAppendEvent(req SendRequest, encoder *json.Encoder)
 		return
 	}
 
-	ref := &model.RunRef{IssueID: req.IssueID, RunID: req.RunID}
+	ref := &model.RunRef{IssueID: model.NewIssueID(req.IssueID), RunID: model.NewRunID(req.RunID)}
 	run, err := st.GetRun(ref)
 	if err != nil {
 		encoder.Encode(AppendEventResponse{OK: false, Error: "run not found"})

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -88,8 +88,8 @@ type mockStore struct {
 	issues map[string]*model.Issue
 }
 
-func (m *mockStore) ResolveIssue(issueID string) (*model.Issue, error) {
-	if issue, ok := m.issues[issueID]; ok {
+func (m *mockStore) ResolveIssue(issueID model.IssueID) (*model.Issue, error) {
+	if issue, ok := m.issues[issueID.String()]; ok {
 		return issue, nil
 	}
 	return nil, os.ErrNotExist
@@ -103,11 +103,11 @@ func (m *mockStore) ListIssues() ([]*model.Issue, error) {
 	return issues, nil
 }
 
-func (m *mockStore) SetIssueStatus(issueID string, status model.IssueStatus) error {
+func (m *mockStore) SetIssueStatus(issueID model.IssueID, status model.IssueStatus) error {
 	return nil
 }
 
-func (m *mockStore) CreateRun(issueID, runID string, metadata map[string]string) (*model.Run, error) {
+func (m *mockStore) CreateRun(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
 	if m.runs == nil {
 		m.runs = make(map[string]*model.Run)
 	}
@@ -121,7 +121,7 @@ func (m *mockStore) CreateRun(issueID, runID string, metadata map[string]string)
 		ContinuedFrom: metadata["continued_from"],
 		Status:        model.StatusQueued,
 	}
-	m.runs[issueID+"#"+runID] = run
+	m.runs[run.Ref().String()] = run
 	return run, nil
 }
 
@@ -129,7 +129,7 @@ func (m *mockStore) AppendEvent(ref *model.RunRef, event *model.Event) error {
 	if m.runs == nil || ref == nil || event == nil {
 		return nil
 	}
-	if run, ok := m.runs[ref.IssueID+"#"+ref.RunID]; ok && run != nil {
+	if run, ok := m.runs[ref.String()]; ok && run != nil {
 		run.Events = append(run.Events, event)
 		run.DeriveState()
 	}
@@ -163,20 +163,20 @@ func (m *mockStore) ListRuns(filter *store.ListRunsFilter) ([]*model.Run, error)
 }
 
 func (m *mockStore) GetRun(ref *model.RunRef) (*model.Run, error) {
-	key := ref.IssueID + "#" + ref.RunID
+	key := ref.String()
 	if run, ok := m.runs[key]; ok {
 		return run, nil
 	}
 	return nil, os.ErrNotExist
 }
 
-func (m *mockStore) GetRunByShortID(shortID string) (*model.Run, error) {
+func (m *mockStore) GetRunByShortID(shortID model.ShortID) (*model.Run, error) {
 	var match *model.Run
 	for _, run := range m.runs {
 		if run == nil {
 			continue
 		}
-		if strings.HasPrefix(run.ShortID(), shortID) {
+		if strings.HasPrefix(run.ShortID().String(), shortID.String()) {
 			if match != nil {
 				return nil, fmt.Errorf("ambiguous short ID")
 			}
@@ -189,7 +189,7 @@ func (m *mockStore) GetRunByShortID(shortID string) (*model.Run, error) {
 	return match, nil
 }
 
-func (m *mockStore) GetLatestRun(issueID string) (*model.Run, error) {
+func (m *mockStore) GetLatestRun(issueID model.IssueID) (*model.Run, error) {
 	return nil, nil
 }
 
@@ -205,7 +205,7 @@ func (m *mockStore) UpdateIssue(issue *model.Issue) error {
 	return nil
 }
 
-func (m *mockStore) ValidateIssueFiles(issueID string) (*store.ValidationResult, error) {
+func (m *mockStore) ValidateIssueFiles(issueID model.IssueID) (*store.ValidationResult, error) {
 	return &store.ValidationResult{}, nil
 }
 
@@ -383,8 +383,8 @@ func TestWithWorkerLeaseUsesEmbeddedDispatcherRPCPath(t *testing.T) {
 	st := &mockStore{
 		runs: map[string]*model.Run{
 			issueID + "#" + runID: {
-				IssueID: issueID,
-				RunID:   runID,
+				IssueID: model.NewIssueID(issueID),
+				RunID:   model.NewRunID(runID),
 				Status:  model.StatusRunning,
 			},
 		},
@@ -836,6 +836,7 @@ func TestProcessSendOpenCodeReturnsAfterAck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to resolve repo id: %v", err)
 	}
+	repoIDString := repoID.String()
 
 	const bodyDelay = 600 * time.Millisecond
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -861,8 +862,8 @@ func TestProcessSendOpenCodeReturnsAfterAck(t *testing.T) {
 
 	logger := log.New(io.Discard, "", 0)
 	server := NewSocketServer(nil, logger)
-	server.openCodeServers[repoID] = &managedServer{
-		RepoID:      repoID,
+	server.openCodeServers[repoIDString] = &managedServer{
+		RepoID:      repoIDString,
 		ProjectRoot: projectRoot,
 		Port:        getPortFromURL(t, testServer.URL),
 		WaitResult:  make(chan error, 1),
@@ -904,6 +905,7 @@ func TestProcessSendOpenCodeTimesOutPromptlyWithoutAck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to resolve repo id: %v", err)
 	}
+	repoIDString := repoID.String()
 
 	const ackDelay = 300 * time.Millisecond
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -926,8 +928,8 @@ func TestProcessSendOpenCodeTimesOutPromptlyWithoutAck(t *testing.T) {
 
 	logger := log.New(io.Discard, "", 0)
 	server := NewSocketServer(nil, logger)
-	server.openCodeServers[repoID] = &managedServer{
-		RepoID:      repoID,
+	server.openCodeServers[repoIDString] = &managedServer{
+		RepoID:      repoIDString,
 		ProjectRoot: projectRoot,
 		Port:        getPortFromURL(t, testServer.URL),
 		WaitResult:  make(chan error, 1),
@@ -972,6 +974,7 @@ func TestProcessSendOpenCodeAckTimeoutButQueuedMessageSucceeds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to resolve repo id: %v", err)
 	}
+	repoIDString := repoID.String()
 
 	const ackDelay = 300 * time.Millisecond
 	var (
@@ -1033,8 +1036,8 @@ func TestProcessSendOpenCodeAckTimeoutButQueuedMessageSucceeds(t *testing.T) {
 
 	logger := log.New(io.Discard, "", 0)
 	server := NewSocketServer(nil, logger)
-	server.openCodeServers[repoID] = &managedServer{
-		RepoID:      repoID,
+	server.openCodeServers[repoIDString] = &managedServer{
+		RepoID:      repoIDString,
 		ProjectRoot: projectRoot,
 		Port:        getPortFromURL(t, testServer.URL),
 		WaitResult:  make(chan error, 1),
@@ -1256,8 +1259,8 @@ func TestHandleProtoCleanRunWorktreeRemovesWorktree(t *testing.T) {
 	worktree, err := git.CreateWorktree(&git.WorktreeConfig{
 		RepoRoot:    repo,
 		WorktreeDir: worktreeRoot,
-		IssueID:     issueID,
-		RunID:       runID,
+		IssueID:     model.NewIssueID(issueID),
+		RunID:       model.NewRunID(runID),
 		Agent:       "codex",
 	})
 	if err != nil {
@@ -1267,8 +1270,8 @@ func TestHandleProtoCleanRunWorktreeRemovesWorktree(t *testing.T) {
 	st := &mockStore{
 		runs: map[string]*model.Run{
 			issueID + "#" + runID: {
-				IssueID:      issueID,
-				RunID:        runID,
+				IssueID:      model.NewIssueID(issueID),
+				RunID:        model.NewRunID(runID),
 				Status:       model.StatusFailed,
 				WorktreePath: worktree.WorktreePath,
 				Branch:       worktree.Branch,
@@ -1354,8 +1357,8 @@ func TestHandleProtoCleanRunWorktreeRemovesMissingWorktreeRegistration(t *testin
 	worktree, err := git.CreateWorktree(&git.WorktreeConfig{
 		RepoRoot:    repo,
 		WorktreeDir: worktreeRoot,
-		IssueID:     issueID,
-		RunID:       runID,
+		IssueID:     model.NewIssueID(issueID),
+		RunID:       model.NewRunID(runID),
 		Agent:       "codex",
 	})
 	if err != nil {
@@ -1368,8 +1371,8 @@ func TestHandleProtoCleanRunWorktreeRemovesMissingWorktreeRegistration(t *testin
 	st := &mockStore{
 		runs: map[string]*model.Run{
 			issueID + "#" + runID: {
-				IssueID:      issueID,
-				RunID:        runID,
+				IssueID:      model.NewIssueID(issueID),
+				RunID:        model.NewRunID(runID),
 				Status:       model.StatusCanceled,
 				WorktreePath: worktree.WorktreePath,
 				Branch:       worktree.Branch,
@@ -1424,8 +1427,8 @@ func TestProtoClientCleanRunWorktreeDispatchesToHandler(t *testing.T) {
 	worktree, err := git.CreateWorktree(&git.WorktreeConfig{
 		RepoRoot:    repo,
 		WorktreeDir: worktreeRoot,
-		IssueID:     issueID,
-		RunID:       runID,
+		IssueID:     model.NewIssueID(issueID),
+		RunID:       model.NewRunID(runID),
 		Agent:       "codex",
 	})
 	if err != nil {
@@ -1435,8 +1438,8 @@ func TestProtoClientCleanRunWorktreeDispatchesToHandler(t *testing.T) {
 	st := &mockStore{
 		runs: map[string]*model.Run{
 			issueID + "#" + runID: {
-				IssueID:      issueID,
-				RunID:        runID,
+				IssueID:      model.NewIssueID(issueID),
+				RunID:        model.NewRunID(runID),
 				Status:       model.StatusFailed,
 				WorktreePath: worktree.WorktreePath,
 				Branch:       worktree.Branch,
@@ -1474,8 +1477,8 @@ func TestHandleProtoDeleteRunRemovesMissingWorktreeRegistration(t *testing.T) {
 	worktree, err := git.CreateWorktree(&git.WorktreeConfig{
 		RepoRoot:    repo,
 		WorktreeDir: worktreeRoot,
-		IssueID:     issueID,
-		RunID:       runID,
+		IssueID:     model.NewIssueID(issueID),
+		RunID:       model.NewRunID(runID),
 		Agent:       "codex",
 	})
 	if err != nil {
@@ -1488,8 +1491,8 @@ func TestHandleProtoDeleteRunRemovesMissingWorktreeRegistration(t *testing.T) {
 	st := &mockStore{
 		runs: map[string]*model.Run{
 			issueID + "#" + runID: {
-				IssueID:      issueID,
-				RunID:        runID,
+				IssueID:      model.NewIssueID(issueID),
+				RunID:        model.NewRunID(runID),
 				Status:       model.StatusFailed,
 				WorktreePath: worktree.WorktreePath,
 				Branch:       worktree.Branch,
@@ -3769,7 +3772,7 @@ func TestGetRunByShortIDWithoutProjectContextAggregatesAcrossStores(t *testing.T
 	resp := sendProtoRequest(t, &orchpb.Request{
 		Request: &orchpb.Request_GetRunByShortId{
 			GetRunByShortId: &orchpb.GetRunByShortIDRequest{
-				ShortId: runShortID,
+				ShortId: runShortID.String(),
 				Context: &orchpb.RequestContext{},
 			},
 		},
@@ -3880,7 +3883,7 @@ func TestGetAttachInfoByShortIDWithoutProjectContextAggregatesAcrossStores(t *te
 	resp := sendProtoRequest(t, &orchpb.Request{
 		Request: &orchpb.Request_GetAttachInfo{
 			GetAttachInfo: &orchpb.GetAttachInfoRequest{
-				ShortId: shortID,
+				ShortId: shortID.String(),
 				Context: &orchpb.RequestContext{},
 			},
 		},
@@ -5118,7 +5121,7 @@ type mockStoreWithValidation struct {
 	validationErr    error
 }
 
-func (m *mockStoreWithValidation) ValidateIssueFiles(issueID string) (*store.ValidationResult, error) {
+func (m *mockStoreWithValidation) ValidateIssueFiles(issueID model.IssueID) (*store.ValidationResult, error) {
 	if m.validationErr != nil {
 		return nil, m.validationErr
 	}
@@ -5135,7 +5138,7 @@ func (m *mockStoreWithPrompt) WriteAgentPrompt(ref *model.RunRef, content string
 	if ref == nil {
 		return fmt.Errorf("nil run ref")
 	}
-	key := ref.IssueID + "#" + ref.RunID
+	key := ref.String()
 	m.prompts[key] = content
 	return nil
 }
@@ -5144,20 +5147,20 @@ func (m *mockStoreWithPrompt) ReadAgentPrompt(ref *model.RunRef) (string, error)
 	if ref == nil {
 		return "", os.ErrNotExist
 	}
-	key := ref.IssueID + "#" + ref.RunID
+	key := ref.String()
 	if content, ok := m.prompts[key]; ok {
 		return content, nil
 	}
 	return "", os.ErrNotExist
 }
 
-func (m *mockStoreWithCapture) CreateRun(issueID, runID string, metadata map[string]string) (*model.Run, error) {
+func (m *mockStoreWithCapture) CreateRun(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
 	m.capturedMetadata = metadata
 	return &model.Run{
 		IssueID: issueID,
 		RunID:   runID,
 		Status:  model.StatusQueued,
-		Path:    "/test/runs/" + issueID + "/" + runID + ".md",
+		Path:    "/test/runs/" + issueID.String() + "/" + runID.String() + ".md",
 	}, nil
 }
 

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -385,9 +385,9 @@ func RunToSummary(run *model.Run) *RunSummary {
 	prNumber, prState := lookupPRInfo(run)
 
 	return &RunSummary{
-		IssueID:           run.IssueID,
-		RunID:             run.RunID,
-		ShortID:           run.ShortID(),
+		IssueID:           run.IssueID.String(),
+		RunID:             run.RunID.String(),
+		ShortID:           run.ShortID().String(),
 		Status:            string(run.Status),
 		IsActive:          run.Status.IsActive(),
 		IsTerminal:        run.Status.IsTerminal(),
@@ -452,9 +452,9 @@ func RunToFull(run *model.Run) *RunFull {
 	prNumber, prState := lookupPRInfo(run)
 
 	return &RunFull{
-		IssueID:           run.IssueID,
-		RunID:             run.RunID,
-		ShortID:           run.ShortID(),
+		IssueID:           run.IssueID.String(),
+		RunID:             run.RunID.String(),
+		ShortID:           run.ShortID().String(),
 		Status:            string(run.Status),
 		IsActive:          run.Status.IsActive(),
 		IsTerminal:        run.Status.IsTerminal(),
@@ -506,7 +506,7 @@ func RunToFullWithAlive(run *model.Run, computeAlive func(*model.Run) bool) *Run
 // IssueToSummary converts a model.Issue to an IssueSummary
 func IssueToSummary(issue *model.Issue) *IssueSummary {
 	return &IssueSummary{
-		ID:         issue.ID,
+		ID:         issue.ID.String(),
 		Title:      issue.Title,
 		Topic:      issue.Topic,
 		Summary:    issue.Summary,
@@ -520,7 +520,7 @@ func IssueToSummary(issue *model.Issue) *IssueSummary {
 // IssueToFull converts a model.Issue to an IssueFull
 func IssueToFull(issue *model.Issue) *IssueFull {
 	return &IssueFull{
-		ID:          issue.ID,
+		ID:          issue.ID.String(),
 		Title:       issue.Title,
 		Topic:       issue.Topic,
 		Summary:     issue.Summary,
@@ -574,8 +574,8 @@ func SummaryToRun(s *RunSummary) *model.Run {
 	updatedAt, _ := time.Parse(time.RFC3339, s.UpdatedAt)
 
 	return &model.Run{
-		IssueID:      s.IssueID,
-		RunID:        s.RunID,
+		IssueID:      model.NewIssueID(s.IssueID),
+		RunID:        model.NewRunID(s.RunID),
 		Status:       model.NormalizeStatus(s.Status),
 		Phase:        model.Phase(s.Phase),
 		Agent:        s.Agent,
@@ -599,9 +599,9 @@ func SummaryAliveInfo(s *RunSummary) (alive bool, known bool) {
 }
 
 type StartRunOptions struct {
-	IssueID        string
+	IssueID        model.IssueID
 	IssueSnapshot  *model.Issue
-	RunID          string
+	RunID          model.RunID
 	Agent          string
 	AgentCmd       string
 	AgentProfile   string
@@ -634,7 +634,7 @@ type StartRunResponse struct {
 
 // StartRunResult holds the success data from a start_run operation (no OK/Error).
 type StartRunResult struct {
-	RunID             string
+	RunID             model.RunID
 	Branch            string
 	WorktreePath      string
 	SessionName       string
@@ -647,9 +647,9 @@ type StartRunResult struct {
 }
 
 type ContinueRunOptions struct {
-	IssueID        string
-	RunID          string
-	ShortID        string
+	IssueID        model.IssueID
+	RunID          model.RunID
+	ShortID        model.ShortID
 	Branch         string
 	Agent          string
 	AgentCmd       string
@@ -679,13 +679,13 @@ type ContinueRunResponse struct {
 
 // ContinueRunResult holds the success data from a continue_run operation (no OK/Error).
 type ContinueRunResult struct {
-	RunID             string
+	RunID             model.RunID
 	Branch            string
 	WorktreePath      string
 	SessionName       string
 	Status            string
 	ContinuedFrom     string
-	IssueID           string
+	IssueID           model.IssueID
 	Multiplexer       string
 	SessionHost       string
 	WorkerID          string
@@ -790,15 +790,15 @@ type ControlAgentConfigResult struct {
 }
 
 type SendMessageParams struct {
-	IssueID        string
-	RunID          string
+	IssueID        model.IssueID
+	RunID          model.RunID
 	Message        string
 	NoEnter        bool
 	TargetWorkerID string
 }
 
 type CreateIssueParams struct {
-	IssueID    string
+	IssueID    model.IssueID
 	Title      string
 	Body       string
 	Summary    string

--- a/internal/daemon/worker_plane.go
+++ b/internal/daemon/worker_plane.go
@@ -615,7 +615,7 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 		}
 		return &WorkerEffectResult{ContinueRunResult: result}, nil
 	case "stop_run":
-		run, err := repoCtx.Store.GetRun(&model.RunRef{IssueID: lease.IssueID, RunID: lease.RunID})
+		run, err := repoCtx.Store.GetRun(&model.RunRef{IssueID: model.NewIssueID(lease.IssueID), RunID: model.NewRunID(lease.RunID)})
 		if err != nil {
 			return nil, fmt.Errorf("not_found")
 		}
@@ -627,7 +627,7 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 		if lease.Payload == nil || lease.Payload.CaptureSession == nil {
 			return nil, fmt.Errorf("capture_session payload missing")
 		}
-		run, err := repoCtx.Store.GetRun(&model.RunRef{IssueID: lease.IssueID, RunID: lease.RunID})
+		run, err := repoCtx.Store.GetRun(&model.RunRef{IssueID: model.NewIssueID(lease.IssueID), RunID: model.NewRunID(lease.RunID)})
 		if err != nil {
 			return nil, fmt.Errorf("not_found")
 		}
@@ -659,8 +659,8 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 			return nil, fmt.Errorf("send_message payload missing")
 		}
 		if err := s.processSendMessage(repoCtx.Store, &SendMessageParams{
-			IssueID:        lease.IssueID,
-			RunID:          lease.RunID,
+			IssueID:        model.NewIssueID(lease.IssueID),
+			RunID:          model.NewRunID(lease.RunID),
 			Message:        lease.Payload.SendMessage.Message,
 			NoEnter:        lease.Payload.SendMessage.NoEnter,
 			TargetWorkerID: lease.Payload.SendMessage.TargetWorkerID,
@@ -669,7 +669,7 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 		}
 		return nil, nil
 	case "get_diff_stats":
-		run, err := repoCtx.Store.GetRun(&model.RunRef{IssueID: lease.IssueID, RunID: lease.RunID})
+		run, err := repoCtx.Store.GetRun(&model.RunRef{IssueID: model.NewIssueID(lease.IssueID), RunID: model.NewRunID(lease.RunID)})
 		if err != nil {
 			return nil, fmt.Errorf("not_found")
 		}
@@ -683,7 +683,7 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 			},
 		}, nil
 	case "get_branch_state":
-		run, err := repoCtx.Store.GetRun(&model.RunRef{IssueID: lease.IssueID, RunID: lease.RunID})
+		run, err := repoCtx.Store.GetRun(&model.RunRef{IssueID: model.NewIssueID(lease.IssueID), RunID: model.NewRunID(lease.RunID)})
 		if err != nil {
 			return nil, fmt.Errorf("not_found")
 		}
@@ -692,7 +692,7 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 			BranchStateResult: &GetBranchStateResult{State: int32(state)},
 		}, nil
 	case "get_diff":
-		run, err := repoCtx.Store.GetRun(&model.RunRef{IssueID: lease.IssueID, RunID: lease.RunID})
+		run, err := repoCtx.Store.GetRun(&model.RunRef{IssueID: model.NewIssueID(lease.IssueID), RunID: model.NewRunID(lease.RunID)})
 		if err != nil {
 			return nil, fmt.Errorf("not_found")
 		}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -47,8 +47,8 @@ func runGitWithStderrWithExecutor(exec executor.Executor, args ...string) error 
 type WorktreeConfig struct {
 	RepoRoot     string
 	WorktreeDir  string
-	IssueID      string
-	RunID        string
+	IssueID      model.IssueID
+	RunID        model.RunID
 	Agent        string
 	BaseBranch   string
 	Branch       string
@@ -71,7 +71,7 @@ type WorktreeInfo struct {
 func normalizeWorktreePath(cfg *WorktreeConfig) error {
 	if cfg.WorktreePath == "" {
 		worktreeName := model.GenerateWorktreeName(cfg.IssueID, cfg.RunID, cfg.Agent)
-		cfg.WorktreePath = filepath.Join(cfg.WorktreeDir, cfg.IssueID, worktreeName)
+		cfg.WorktreePath = filepath.Join(cfg.WorktreeDir, cfg.IssueID.String(), worktreeName)
 	}
 
 	if filepath.IsAbs(cfg.WorktreePath) {

--- a/internal/github/backend.go
+++ b/internal/github/backend.go
@@ -312,7 +312,7 @@ func (b *Backend) ghToIssue(gh *ghIssue) *model.Issue {
 		}
 	}
 
-	issueID := fmt.Sprintf("gh-%d", gh.Number)
+	issueID := model.NewIssueID(fmt.Sprintf("gh-%d", gh.Number))
 
 	return &model.Issue{
 		ID:      issueID,

--- a/internal/github/cache.go
+++ b/internal/github/cache.go
@@ -217,7 +217,7 @@ func (c *IssueCache) buildIssue(issueID, title, status, body, labels, url string
 	}
 
 	return &model.Issue{
-		ID:          issueID,
+		ID:          model.NewIssueID(issueID),
 		Title:       title,
 		Summary:     summary,
 		Status:      model.IssueStatus(status),

--- a/internal/github/cache_test.go
+++ b/internal/github/cache_test.go
@@ -221,7 +221,7 @@ func TestCacheClear(t *testing.T) {
 
 	for i := 1; i <= 5; i++ {
 		issue := &model.Issue{
-			ID:     "gh-" + string(rune('0'+i)),
+			ID:     model.NewIssueID("gh-" + string(rune('0'+i))),
 			Title:  "Issue",
 			Status: model.IssueStatusOpen,
 			Frontmatter: map[string]string{

--- a/internal/model/ids.go
+++ b/internal/model/ids.go
@@ -1,0 +1,131 @@
+package model
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type IssueID string
+type RunID string
+type ShortID string
+type RepoID string
+type ProjectID string
+
+func (id IssueID) String() string {
+	return string(id)
+}
+
+func (id RunID) String() string {
+	return string(id)
+}
+
+func (id ShortID) String() string {
+	return string(id)
+}
+
+func (id RepoID) String() string {
+	return string(id)
+}
+
+func (id ProjectID) String() string {
+	return string(id)
+}
+
+func NewIssueID(id string) IssueID {
+	return IssueID(strings.TrimSpace(id))
+}
+
+func NewRunID(id string) RunID {
+	return RunID(strings.TrimSpace(id))
+}
+
+func NewShortID(id string) ShortID {
+	return ShortID(strings.TrimSpace(id))
+}
+
+// NewRepoID normalizes a git remote URL, SSH remote, or owner/repo-like path
+// into orch's stable repo identifier format: owner-repo.
+func NewRepoID(value string) (RepoID, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("empty repo ID source")
+	}
+
+	// SSH format: git@github.com:owner/repo.git
+	sshPattern := regexp.MustCompile(`^git@[^:]+:([^/]+)/([^/]+?)(?:\.git)?$`)
+	if matches := sshPattern.FindStringSubmatch(value); len(matches) == 3 {
+		return sanitizeRepoID(matches[1], matches[2])
+	}
+
+	// HTTPS/Git/SSH URL: https://github.com/owner/repo.git
+	urlPattern := regexp.MustCompile(`^(?:https?|git|ssh)://[^/]+/([^/]+)/([^/]+?)(?:\.git)?/?$`)
+	if matches := urlPattern.FindStringSubmatch(value); len(matches) == 3 {
+		return sanitizeRepoID(matches[1], matches[2])
+	}
+
+	cleaned := strings.TrimSuffix(value, ".git")
+	parts := strings.Split(cleaned, "/")
+	if len(parts) >= 2 {
+		owner := parts[len(parts)-2]
+		repo := parts[len(parts)-1]
+		if idx := strings.LastIndex(owner, ":"); idx != -1 {
+			owner = owner[idx+1:]
+		}
+		return sanitizeRepoID(owner, repo)
+	}
+
+	return "", fmt.Errorf("could not parse repo ID from %q", value)
+}
+
+func NewNormalizedRepoID(value string) (RepoID, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("empty repo ID")
+	}
+	if strings.ContainsAny(value, `/\`) {
+		return "", fmt.Errorf("repo ID must be normalized, got %q", value)
+	}
+	if !strings.Contains(value, "-") {
+		return "", fmt.Errorf("repo ID must include owner and repo components, got %q", value)
+	}
+	return RepoID(value), nil
+}
+
+func NewProjectID(value string) (ProjectID, error) {
+	repoID, err := NewRepoID(value)
+	if err != nil {
+		return "", err
+	}
+	return ProjectID(repoID.String()), nil
+}
+
+func NewNormalizedProjectID(value string) (ProjectID, error) {
+	repoID, err := NewNormalizedRepoID(value)
+	if err != nil {
+		return "", err
+	}
+	return ProjectID(repoID.String()), nil
+}
+
+func sanitizeRepoID(owner, repo string) (RepoID, error) {
+	owner = strings.TrimSpace(owner)
+	repo = strings.TrimSpace(repo)
+	repo = strings.TrimSuffix(repo, ".git")
+	repo = strings.TrimSuffix(repo, "/")
+
+	if owner == "" || repo == "" {
+		return "", fmt.Errorf("repo ID requires non-empty owner and repo components")
+	}
+
+	// Keep the historical XDG repo-id behavior because this value is the
+	// on-disk data directory key under ~/.local/share/orch/{repoID}.
+	re := regexp.MustCompile(`[^a-zA-Z0-9_-]`)
+	owner = re.ReplaceAllString(owner, "")
+	repo = re.ReplaceAllString(repo, "")
+
+	if owner == "" || repo == "" {
+		return "", fmt.Errorf("repo ID components became empty after normalization")
+	}
+	return RepoID(owner + "-" + repo), nil
+}

--- a/internal/model/ids_test.go
+++ b/internal/model/ids_test.go
@@ -1,0 +1,240 @@
+package model
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+	"testing/quick"
+)
+
+func TestNewRepoIDNormalizesRemoteForms(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  RepoID
+	}{
+		{
+			name:  "https remote",
+			input: "https://github.com/openai/orch.git",
+			want:  "openai-orch",
+		},
+		{
+			name:  "ssh scp remote",
+			input: "git@github.com:openai/orch.git",
+			want:  "openai-orch",
+		},
+		{
+			name:  "ssh url remote",
+			input: "ssh://git@github.com/openai/orch.git",
+			want:  "openai-orch",
+		},
+		{
+			name:  "owner repo path",
+			input: "openai/orch",
+			want:  "openai-orch",
+		},
+		{
+			name:  "filesystem path",
+			input: "/tmp/openai/orch.git",
+			want:  "openai-orch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewRepoID(tt.input)
+			if err != nil {
+				t.Fatalf("NewRepoID(%q) returned error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("NewRepoID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewRepoIDPreservesLegacyOnDiskNormalization(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  RepoID
+	}{
+		{
+			name:  "dotted owner and repo",
+			input: "git@github.com:my.org/my.repo.git",
+			want:  "myorg-myrepo",
+		},
+		{
+			name:  "apostrophe",
+			input: "https://github.com/O'Brien/repo.git",
+			want:  "OBrien-repo",
+		},
+		{
+			name:  "space",
+			input: "https://github.com/owner/repo bad.git",
+			want:  "owner-repobad",
+		},
+		{
+			name:  "unicode",
+			input: "https://github.com/ownér/répo.git",
+			want:  "ownr-rpo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewRepoID(tt.input)
+			if err != nil {
+				t.Fatalf("NewRepoID(%q) returned error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("NewRepoID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepoIDRoundTripProperty(t *testing.T) {
+	prop := func(ownerRaw, repoRaw string) bool {
+		owner := noisyRepoPart("owner", ownerRaw)
+		repo := noisyRepoPart("repo", repoRaw)
+
+		id, err := NewRepoID("https://github.com/" + owner + "/" + repo + ".git")
+		if err != nil {
+			return false
+		}
+		if strings.ContainsAny(id.String(), `/\`) {
+			return false
+		}
+
+		roundTripped, err := NewNormalizedRepoID(id.String())
+		return err == nil && roundTripped == id && roundTripped.String() == id.String()
+	}
+
+	if err := quick.Check(prop, &quick.Config{MaxCount: 200}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRepoIDNormalizationIsIdempotent(t *testing.T) {
+	first, err := NewRepoID("https://github.com/my.org/my repo.git")
+	if err != nil {
+		t.Fatalf("NewRepoID() returned error: %v", err)
+	}
+	second, err := NewNormalizedRepoID(first.String())
+	if err != nil {
+		t.Fatalf("NewNormalizedRepoID(first) returned error: %v", err)
+	}
+	third, err := NewNormalizedRepoID(second.String())
+	if err != nil {
+		t.Fatalf("NewNormalizedRepoID(second) returned error: %v", err)
+	}
+	if first != second || second != third {
+		t.Fatalf("normalization is not idempotent: first=%q second=%q third=%q", first, second, third)
+	}
+}
+
+func TestNewRepoIDRejectsDegenerateComponents(t *testing.T) {
+	tests := []string{
+		"https://github.com/owner/.git",
+		"https://github.com/./repo.git",
+		"https://github.com/owner/!!!.git",
+		"owner/.git",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			if got, err := NewRepoID(input); err == nil {
+				t.Fatalf("NewRepoID(%q) = %q, want error", input, got)
+			}
+		})
+	}
+}
+
+func TestNewNormalizedRepoIDRejectsUnnormalizedValues(t *testing.T) {
+	tests := []string{
+		"",
+		"openai",
+		"openai/orch",
+		`openai\orch`,
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			if got, err := NewNormalizedRepoID(input); err == nil {
+				t.Fatalf("NewNormalizedRepoID(%q) = %q, want error", input, got)
+			}
+		})
+	}
+}
+
+func TestRepoIDRejectsRawStringAtCompileTime(t *testing.T) {
+	fset := token.NewFileSet()
+	idsFile, err := parser.ParseFile(fset, "ids.go", nil, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("parse ids.go: %v", err)
+	}
+
+	const source = `package model
+
+func compileCheckNeedsRepoID(id RepoID) {}
+
+func compileCheckRawURL() {
+	rawURL := "https://github.com/openai/orch.git"
+	compileCheckNeedsRepoID(rawURL)
+}
+`
+	compileCheckFile, err := parser.ParseFile(fset, "repo_id_compilecheck.go", source, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("parse compile check source: %v", err)
+	}
+
+	var typeErrors []error
+	config := types.Config{
+		Importer: importer.Default(),
+		Error: func(err error) {
+			typeErrors = append(typeErrors, err)
+		},
+	}
+	_, _ = config.Check("github.com/s22625/orch/internal/model", fset, []*ast.File{idsFile, compileCheckFile}, nil)
+
+	if len(typeErrors) == 0 {
+		t.Fatal("expected raw string to be rejected as RepoID, got no type errors")
+	}
+
+	foundRepoIDTypeError := false
+	for _, err := range typeErrors {
+		msg := err.Error()
+		if strings.Contains(msg, "(variable of type string)") && strings.Contains(msg, "as RepoID value") {
+			foundRepoIDTypeError = true
+			continue
+		}
+		t.Fatalf("unexpected type error: %v", err)
+	}
+
+	if !foundRepoIDTypeError {
+		t.Fatalf("expected raw string to be rejected as RepoID, got errors: %v", typeErrors)
+	}
+}
+
+func noisyRepoPart(prefix string, value string) string {
+	var b strings.Builder
+	b.WriteString(prefix)
+	for _, r := range value {
+		if r == '/' || r == '\\' {
+			continue
+		}
+		b.WriteRune(r)
+		if b.Len() >= 24 {
+			break
+		}
+	}
+	if b.String() == prefix {
+		b.WriteString(" bad.name")
+	}
+	return b.String()
+}

--- a/internal/model/issue.go
+++ b/internal/model/issue.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Issue struct {
-	ID          string
+	ID          IssueID
 	Title       string
 	Topic       string
 	Summary     string
@@ -37,7 +37,7 @@ func (i *Issue) RenderFrontmatter() string {
 	var sb strings.Builder
 	sb.WriteString("---\n")
 	sb.WriteString("type: issue\n")
-	sb.WriteString("id: " + QuoteYAMLValue(i.ID) + "\n")
+	sb.WriteString("id: " + QuoteYAMLValue(i.ID.String()) + "\n")
 	sb.WriteString("title: " + QuoteYAMLValue(i.Title) + "\n")
 	if i.Summary != "" {
 		sb.WriteString("summary: " + QuoteYAMLValue(i.Summary) + "\n")
@@ -53,39 +53,42 @@ func (i *Issue) RenderFrontmatter() string {
 	return sb.String()
 }
 
-func IsGitHubIssueID(id string) bool {
-	if strings.HasPrefix(id, "gh-") || strings.HasPrefix(id, "gh#") {
+func IsGitHubIssueID(id IssueID) bool {
+	idStr := id.String()
+	if strings.HasPrefix(idStr, "gh-") || strings.HasPrefix(idStr, "gh#") {
 		return true
 	}
-	if strings.HasPrefix(id, "#") {
-		_, err := strconv.Atoi(strings.TrimPrefix(id, "#"))
+	if strings.HasPrefix(idStr, "#") {
+		_, err := strconv.Atoi(strings.TrimPrefix(idStr, "#"))
 		return err == nil
 	}
-	_, err := strconv.Atoi(id)
+	_, err := strconv.Atoi(idStr)
 	return err == nil
 }
 
-func NormalizeGitHubIssueID(id string) string {
-	if strings.HasPrefix(id, "gh-") {
+func NormalizeGitHubIssueID(id IssueID) IssueID {
+	idStr := id.String()
+	if strings.HasPrefix(idStr, "gh-") {
 		return id
 	}
-	if strings.HasPrefix(id, "gh#") {
-		return "gh-" + strings.TrimPrefix(id, "gh#")
+	if strings.HasPrefix(idStr, "gh#") {
+		return IssueID("gh-" + strings.TrimPrefix(idStr, "gh#"))
 	}
-	id = strings.TrimPrefix(id, "#")
-	if _, err := strconv.Atoi(id); err == nil {
-		return "gh-" + id
+	idStr = strings.TrimPrefix(idStr, "#")
+	if _, err := strconv.Atoi(idStr); err == nil {
+		return IssueID("gh-" + idStr)
 	}
-	return id
+	return IssueID(idStr)
 }
 
-func ParseGitHubIssueNumber(id string) (int, error) {
-	id = strings.TrimPrefix(id, "gh-")
-	id = strings.TrimPrefix(id, "gh#")
-	id = strings.TrimPrefix(id, "#")
-	n, err := strconv.Atoi(id)
+func ParseGitHubIssueNumber(id IssueID) (int, error) {
+	idStr := id.String()
+	idStr = strings.TrimPrefix(idStr, "gh-")
+	idStr = strings.TrimPrefix(idStr, "gh#")
+	idStr = strings.TrimPrefix(idStr, "#")
+	n, err := strconv.Atoi(idStr)
 	if err != nil {
-		return 0, fmt.Errorf("invalid GitHub issue ID: %s", id)
+		return 0, fmt.Errorf("invalid GitHub issue ID: %s", idStr)
 	}
 	return n, nil
 }

--- a/internal/model/issue_test.go
+++ b/internal/model/issue_test.go
@@ -20,7 +20,7 @@ func TestIsGitHubIssueID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := IsGitHubIssueID(tt.input)
+			got := IsGitHubIssueID(NewIssueID(tt.input))
 			if got != tt.want {
 				t.Errorf("IsGitHubIssueID(%q) = %v, want %v", tt.input, got, tt.want)
 			}
@@ -43,8 +43,8 @@ func TestNormalizeGitHubIssueID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := NormalizeGitHubIssueID(tt.input)
-			if got != tt.want {
+			got := NormalizeGitHubIssueID(NewIssueID(tt.input))
+			if got.String() != tt.want {
 				t.Errorf("NormalizeGitHubIssueID(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
@@ -69,7 +69,7 @@ func TestParseGitHubIssueNumber(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got, err := ParseGitHubIssueNumber(tt.input)
+			got, err := ParseGitHubIssueNumber(NewIssueID(tt.input))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseGitHubIssueNumber(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
 				return

--- a/internal/model/run.go
+++ b/internal/model/run.go
@@ -11,8 +11,8 @@ import (
 
 // RunRef represents a reference to a run (ISSUE_ID#RUN_ID)
 type RunRef struct {
-	IssueID string
-	RunID   string
+	IssueID IssueID
+	RunID   RunID
 }
 
 // ParseRunRef parses a RUN_REF string (ISSUE_ID#RUN_ID or just ISSUE_ID for latest)
@@ -24,17 +24,17 @@ func ParseRunRef(ref string) (*RunRef, error) {
 
 	lastHash := strings.LastIndex(ref, "#")
 	if lastHash == -1 {
-		return &RunRef{IssueID: ref}, nil
+		return &RunRef{IssueID: NewIssueID(ref)}, nil
 	}
 
 	candidate := ref[lastHash+1:]
 	if looksLikeRunID(candidate) {
 		return &RunRef{
-			IssueID: ref[:lastHash],
-			RunID:   candidate,
+			IssueID: NewIssueID(ref[:lastHash]),
+			RunID:   NewRunID(candidate),
 		}, nil
 	}
-	return &RunRef{IssueID: ref}, nil
+	return &RunRef{IssueID: NewIssueID(ref)}, nil
 }
 
 func looksLikeRunID(s string) bool {
@@ -52,9 +52,9 @@ func looksLikeRunID(s string) bool {
 // String returns the canonical RUN_REF format
 func (r *RunRef) String() string {
 	if r.RunID == "" {
-		return r.IssueID
+		return r.IssueID.String()
 	}
-	return r.IssueID + "#" + r.RunID
+	return r.IssueID.String() + "#" + r.RunID.String()
 }
 
 // IsLatest returns true if this ref points to the latest run (no RunID specified)
@@ -64,8 +64,8 @@ func (r *RunRef) IsLatest() bool {
 
 // Run represents a single execution of an issue
 type Run struct {
-	IssueID string
-	RunID   string
+	IssueID IssueID
+	RunID   RunID
 	Path    string // File path to run document
 
 	// Derived from events
@@ -113,18 +113,18 @@ func (r *Run) Ref() *RunRef {
 }
 
 // ShortID returns a 6-character hex identifier for the run (git-style)
-func (r *Run) ShortID() string {
+func (r *Run) ShortID() ShortID {
 	return GenerateShortID(r.IssueID, r.RunID)
 }
 
 // GenerateShortID generates a 6-char hex ID from issue and run IDs
-func GenerateShortID(issueID, runID string) string {
-	h := sha256.Sum256([]byte(issueID + "#" + runID))
-	return hex.EncodeToString(h[:])[:6]
+func GenerateShortID(issueID IssueID, runID RunID) ShortID {
+	h := sha256.Sum256([]byte(issueID.String() + "#" + runID.String()))
+	return ShortID(hex.EncodeToString(h[:])[:6])
 }
 
 // GenerateWorktreeName generates a worktree directory name using a short ID.
-func GenerateWorktreeName(issueID, runID, agent string) string {
+func GenerateWorktreeName(issueID IssueID, runID RunID, agent string) string {
 	agent = strings.TrimSpace(agent)
 	if agent == "" {
 		agent = "unknown"
@@ -260,16 +260,16 @@ func (r *Run) lastArtifactAttr(name, key string) string {
 }
 
 // GenerateRunID generates a run ID using the convention YYYYMMDD-HHMMSS
-func GenerateRunID() string {
-	return time.Now().Format("20060102-150405")
+func GenerateRunID() RunID {
+	return RunID(time.Now().Format("20060102-150405"))
 }
 
 // GenerateBranchName generates a branch name using the convention
-func GenerateBranchName(issueID, runID string) string {
+func GenerateBranchName(issueID IssueID, runID RunID) string {
 	return fmt.Sprintf("issue/%s/run-%s", issueID, runID)
 }
 
 // GenerateSessionName generates a session name using the convention
-func GenerateSessionName(issueID, runID string) string {
+func GenerateSessionName(issueID IssueID, runID RunID) string {
 	return fmt.Sprintf("run-%s-%s", issueID, runID)
 }

--- a/internal/model/run_test.go
+++ b/internal/model/run_test.go
@@ -63,10 +63,10 @@ func TestParseRunRef(t *testing.T) {
 				return
 			}
 			if !tt.wantErr {
-				if ref.IssueID != tt.issueID {
+				if ref.IssueID.String() != tt.issueID {
 					t.Errorf("IssueID = %v, want %v", ref.IssueID, tt.issueID)
 				}
-				if ref.RunID != tt.runID {
+				if ref.RunID.String() != tt.runID {
 					t.Errorf("RunID = %v, want %v", ref.RunID, tt.runID)
 				}
 			}
@@ -232,7 +232,7 @@ func TestGenerateSessionName(t *testing.T) {
 
 func TestGenerateWorktreeName(t *testing.T) {
 	got := GenerateWorktreeName("plc124", "20231220-100000", "claude")
-	want := GenerateShortID("plc124", "20231220-100000") + "_claude_20231220-100000"
+	want := GenerateShortID("plc124", "20231220-100000").String() + "_claude_20231220-100000"
 	if got != want {
 		t.Errorf("GenerateWorktreeName() = %v, want %v", got, want)
 	}

--- a/internal/monitor/agent_prompt.go
+++ b/internal/monitor/agent_prompt.go
@@ -206,7 +206,7 @@ func detectIssueIDConvention(issues []*model.Issue) (pattern, example, nextID st
 	// Extract all issue IDs
 	ids := make([]string, 0, len(issues))
 	for _, issue := range issues {
-		ids = append(ids, issue.ID)
+		ids = append(ids, issue.ID.String())
 	}
 
 	// Try to detect pattern: prefix-number (most common)
@@ -382,7 +382,7 @@ func buildControlAgentPromptViaAPI(ctx context.Context, api orchapi.OrchAPI, iss
 			title = title[:47] + "..."
 		}
 		issueInfos = append(issueInfos, IssueInfo{
-			ID:     issue.ID,
+			ID:     issue.ID.String(),
 			Status: status,
 			Title:  title,
 		})
@@ -391,8 +391,8 @@ func buildControlAgentPromptViaAPI(ctx context.Context, api orchapi.OrchAPI, iss
 	runInfos := make([]RunInfo, 0, len(runs))
 	for _, run := range runs {
 		runInfos = append(runInfos, RunInfo{
-			IssueID: run.IssueID,
-			ShortID: run.ShortID,
+			IssueID: run.IssueID.String(),
+			ShortID: run.ShortID.String(),
 			Status:  string(run.Status),
 		})
 	}
@@ -450,7 +450,7 @@ func detectIssueIDConventionFromAPI(issues []*orchapi.Issue) (pattern, example, 
 
 	ids := make([]string, 0, len(issues))
 	for _, issue := range issues {
-		ids = append(ids, issue.ID)
+		ids = append(ids, issue.ID.String())
 	}
 
 	prefixNumRegex := regexp.MustCompile(`^([a-zA-Z][\w-]*)-(\d+)$`)
@@ -510,8 +510,8 @@ func sortIssuesByID(issues []*model.Issue) {
 	prefixNumRegex := regexp.MustCompile(`^([a-zA-Z][\w-]*)-(\d+)$`)
 
 	sort.Slice(issues, func(i, j int) bool {
-		matchI := prefixNumRegex.FindStringSubmatch(issues[i].ID)
-		matchJ := prefixNumRegex.FindStringSubmatch(issues[j].ID)
+		matchI := prefixNumRegex.FindStringSubmatch(issues[i].ID.String())
+		matchJ := prefixNumRegex.FindStringSubmatch(issues[j].ID.String())
 
 		// If both match pattern, compare by prefix then number
 		if matchI != nil && matchJ != nil {
@@ -524,7 +524,7 @@ func sortIssuesByID(issues []*model.Issue) {
 		}
 
 		// Fall back to string comparison
-		return issues[i].ID < issues[j].ID
+		return issues[i].ID.String() < issues[j].ID.String()
 	})
 }
 

--- a/internal/monitor/agent_prompt_test.go
+++ b/internal/monitor/agent_prompt_test.go
@@ -98,7 +98,7 @@ func TestSortIssuesByID(t *testing.T) {
 
 	expected := []string{"orch-001", "orch-002", "orch-005", "orch-010"}
 	for i, issue := range issues {
-		if issue.ID != expected[i] {
+		if issue.ID.String() != expected[i] {
 			t.Errorf("issues[%d].ID = %q, want %q", i, issue.ID, expected[i])
 		}
 	}

--- a/internal/monitor/dashboard.go
+++ b/internal/monitor/dashboard.go
@@ -398,7 +398,7 @@ func (d *Dashboard) handleDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if d.cursor >= 0 && d.cursor < len(d.runs) {
 			run := d.runs[d.cursor].Run
 			if run != nil {
-				return d, d.openIssueInNvimCmd(run.IssueID)
+				return d, d.openIssueInNvimCmd(run.IssueID.String())
 			}
 		}
 		d.message = "no run selected"
@@ -460,7 +460,7 @@ func (d *Dashboard) handleNewRunKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if d.newRun.cursor >= 0 && d.newRun.cursor < len(d.newRun.issues) {
 			issueID := d.newRun.issues[d.newRun.cursor].ID
 			d.mode = modeDashboard
-			return d, d.startRunCmd(issueID)
+			return d, d.startRunCmd(issueID.String())
 		}
 		return d, nil
 	}
@@ -469,7 +469,7 @@ func (d *Dashboard) handleNewRunKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if index >= 1 && index <= len(d.newRun.issues) {
 			issueID := d.newRun.issues[index-1].ID
 			d.mode = modeDashboard
-			return d, d.startRunCmd(issueID)
+			return d, d.startRunCmd(issueID.String())
 		}
 	}
 	return d, nil
@@ -606,11 +606,11 @@ func (d *Dashboard) startCapture() tea.Cmd {
 
 func (d *Dashboard) startIssueContent() tea.Cmd {
 	run := d.selectedRun()
-	if run == nil || strings.TrimSpace(run.IssueID) == "" {
+	if run == nil || strings.TrimSpace(run.IssueID.String()) == "" {
 		d.issue = issueState{message: "No issue content available."}
 		return nil
 	}
-	issueID := run.IssueID
+	issueID := run.IssueID.String()
 	if d.issue.issueID != issueID {
 		d.issue.content = ""
 	}
@@ -728,8 +728,8 @@ func (d *Dashboard) execShellCmd(run *model.Run) tea.Cmd {
 
 	windowName := fmt.Sprintf("exec-%s", run.ShortID())
 	env := []string{
-		fmt.Sprintf("ORCH_ISSUE_ID=%s", shellQuote(run.IssueID)),
-		fmt.Sprintf("ORCH_RUN_ID=%s", shellQuote(run.RunID)),
+		fmt.Sprintf("ORCH_ISSUE_ID=%s", shellQuote(run.IssueID.String())),
+		fmt.Sprintf("ORCH_RUN_ID=%s", shellQuote(run.RunID.String())),
 		fmt.Sprintf("ORCH_RUN_PATH=%s", shellQuote(run.Path)),
 		fmt.Sprintf("ORCH_WORKTREE_PATH=%s", shellQuote(worktreePath)),
 		fmt.Sprintf("ORCH_BRANCH=%s", shellQuote(run.Branch)),
@@ -746,7 +746,7 @@ func (d *Dashboard) execShellCmd(run *model.Run) tea.Cmd {
 
 func (d *Dashboard) openIssueInNvimCmd(issueID string) tea.Cmd {
 	ctx := context.Background()
-	apiIssue, err := d.monitor.api.GetIssue(ctx, issueID)
+	apiIssue, err := d.monitor.api.GetIssue(ctx, model.NewIssueID(issueID))
 	if err != nil || apiIssue == nil {
 		return func() tea.Msg {
 			return errMsg{err: fmt.Errorf("could not resolve issue %s: %v", issueID, err)}
@@ -1147,7 +1147,7 @@ func (d *Dashboard) renderDetails(maxLines int) string {
 		d.styles.Header.Render("DETAILS"),
 	}
 	lines = append(lines, wrapLabelValue("Run: ", run.Ref().String(), contentWidth)...)
-	lines = append(lines, wrapLabelValue("Issue: ", run.IssueID, contentWidth)...)
+	lines = append(lines, wrapLabelValue("Issue: ", run.IssueID.String(), contentWidth)...)
 	lines = append(lines, wrapLabelValue("Summary: ", summary, contentWidth)...)
 	lines = append(lines, wrapLabelValue("Target: ", target, contentWidth)...)
 	lines = append(lines, wrapLabelValue("Host: ", targetHost, contentWidth)...)
@@ -1171,7 +1171,7 @@ func (d *Dashboard) renderContext(height int) string {
 	issueLabel := "ISSUE"
 	captureLabel := "CAPTURE"
 	if run := d.selectedRun(); run != nil {
-		if strings.TrimSpace(run.IssueID) != "" {
+		if strings.TrimSpace(run.IssueID.String()) != "" {
 			issueLabel = fmt.Sprintf("ISSUE %s", run.IssueID)
 		}
 		captureLabel = fmt.Sprintf("CAPTURE %s", run.Ref().String())

--- a/internal/monitor/issue_content.go
+++ b/internal/monitor/issue_content.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/s22625/orch/internal/model"
 )
 
 func (m *Monitor) IssueContent(issueID string) (string, error) {
@@ -11,7 +13,7 @@ func (m *Monitor) IssueContent(issueID string) (string, error) {
 		return "", fmt.Errorf("issue id is required")
 	}
 	ctx := context.Background()
-	issue, err := m.api.GetIssue(ctx, issueID)
+	issue, err := m.api.GetIssue(ctx, model.NewIssueID(issueID))
 	if err != nil {
 		return "", err
 	}

--- a/internal/monitor/issues_dashboard.go
+++ b/internal/monitor/issues_dashboard.go
@@ -1066,7 +1066,7 @@ func (d *IssueDashboard) renderDetails(maxLines int) string {
 
 	title := issue.Issue.Title
 	if strings.TrimSpace(title) == "" {
-		title = issue.Issue.ID
+		title = issue.Issue.ID.String()
 	}
 
 	contentWidth := d.safeWidth()

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -724,7 +724,7 @@ func (m *Monitor) CreateIssue(issueID, title string) (string, error) {
 
 func (m *Monitor) SetIssueStatus(issueID string, status model.IssueStatus) error {
 	ctx := context.Background()
-	return m.api.SetIssueStatus(ctx, issueID, orchapi.IssueStatus(status))
+	return m.api.SetIssueStatus(ctx, model.NewIssueID(issueID), orchapi.IssueStatus(status))
 }
 
 func (m *Monitor) ResolveRun(run *model.Run) error {
@@ -762,7 +762,7 @@ func (m *Monitor) ListRunsForIssue(issueID string) ([]*model.Run, error) {
 		return nil, fmt.Errorf("issue id is required")
 	}
 	ctx := context.Background()
-	result, err := m.api.ListRuns(ctx, &orchapi.ListRunsFilter{IssueID: issueID})
+	result, err := m.api.ListRuns(ctx, &orchapi.ListRunsFilter{IssueID: model.NewIssueID(issueID)})
 	if err != nil {
 		return nil, err
 	}
@@ -779,7 +779,7 @@ func (m *Monitor) ListBranchesForIssue(issueID string) ([]branchInfo, error) {
 	}
 
 	ctx := context.Background()
-	result, err := m.api.ListRuns(ctx, &orchapi.ListRunsFilter{IssueID: issueID})
+	result, err := m.api.ListRuns(ctx, &orchapi.ListRunsFilter{IssueID: model.NewIssueID(issueID)})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list runs: %w", err)
 	}
@@ -990,7 +990,7 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 		if w == nil || w.Run == nil {
 			continue
 		}
-		info := issueInfo[w.Run.IssueID]
+		info := issueInfo[w.Run.IssueID.String()]
 		issueStatus := info.status
 		if issueStatus == "" {
 			issueStatus = "-"
@@ -1015,12 +1015,12 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 		if merged == "" {
 			merged = "-"
 		}
-		shortID := w.Run.ShortID()
+		shortID := w.Run.ShortID().String()
 		if w.Run.WorktreePath != "" && !w.Run.WorktreeExists {
 			shortID += "*"
 		}
 		target := formatTargetDisplay(w.Run.Target, runTableTargetWidth)
-		targetHost := formatTargetDisplay(targetHostByRun[w.Run.RunID], runTableTargetHostWidth)
+		targetHost := formatTargetDisplay(targetHostByRun[w.Run.RunID.String()], runTableTargetHostWidth)
 		branch := formatBranchDisplay(w.Run.Branch, runTableBranchWidth)
 		worktree := formatWorktreeDisplay(w.Run.WorktreePath, runTableWorktreeWidth)
 
@@ -1029,7 +1029,7 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 		rows = append(rows, RunRow{
 			Index:        w.Index,
 			ShortID:      shortID,
-			IssueID:      w.Run.IssueID,
+			IssueID:      w.Run.IssueID.String(),
 			IssueStatus:  issueStatus,
 			IssueSummary: info.summary,
 			Agent:        agentDisplay,
@@ -1057,7 +1057,7 @@ func (m *Monitor) buildRunRows(windows []*RunWindow) ([]RunRow, error) {
 func buildIssueDisplayMap(issues []*model.Issue) map[string]issueDisplay {
 	result := make(map[string]issueDisplay, len(issues))
 	for _, issue := range issues {
-		if issue == nil || strings.TrimSpace(issue.ID) == "" {
+		if issue == nil || strings.TrimSpace(issue.ID.String()) == "" {
 			continue
 		}
 
@@ -1074,7 +1074,7 @@ func buildIssueDisplayMap(issues []*model.Issue) map[string]issueDisplay {
 			summary = "-"
 		}
 
-		result[issue.ID] = issueDisplay{
+		result[issue.ID.String()] = issueDisplay{
 			status:  status,
 			topic:   topic,
 			summary: summary,
@@ -1099,7 +1099,8 @@ func runAliveLabel(run *model.Run) string {
 func (m *Monitor) buildIssueRows(issues []*model.Issue, runs []*model.Run) []IssueRow {
 	runsByIssue := make(map[string][]*model.Run)
 	for _, run := range runs {
-		runsByIssue[run.IssueID] = append(runsByIssue[run.IssueID], run)
+		issueID := run.IssueID.String()
+		runsByIssue[issueID] = append(runsByIssue[issueID], run)
 	}
 
 	rows := make([]IssueRow, 0, len(issues))
@@ -1119,7 +1120,7 @@ func (m *Monitor) buildIssueRows(issues []*model.Issue, runs []*model.Run) []Iss
 
 		var latest *model.Run
 		activeCount := 0
-		for _, run := range runsByIssue[issue.ID] {
+		for _, run := range runsByIssue[issue.ID.String()] {
 			if latest == nil || run.UpdatedAt.After(latest.UpdatedAt) {
 				latest = run
 			}
@@ -1130,14 +1131,14 @@ func (m *Monitor) buildIssueRows(issues []*model.Issue, runs []*model.Run) []Iss
 
 		row := IssueRow{
 			Index:      i + 1,
-			ID:         issue.ID,
+			ID:         issue.ID.String(),
 			Status:     status,
 			Summary:    summary,
 			ActiveRuns: activeCount,
 			Issue:      issue,
 		}
 		if latest != nil {
-			row.LatestRunID = latest.RunID
+			row.LatestRunID = latest.RunID.String()
 			row.LatestStatus = latest.Status
 			row.LatestUpdated = latest.UpdatedAt
 		}

--- a/internal/monitor/ps_helpers.go
+++ b/internal/monitor/ps_helpers.go
@@ -152,7 +152,7 @@ func resolveTargetHostByRun(runs []*model.Run) map[string]string {
 		if targetHost == "" {
 			targetHost = targetName
 		}
-		resolved[run.RunID] = targetHost
+		resolved[run.RunID.String()] = targetHost
 	}
 
 	return resolved

--- a/internal/monitor/sort.go
+++ b/internal/monitor/sort.go
@@ -182,7 +182,7 @@ func runRowRunID(row RunRow) string {
 	if row.Run == nil {
 		return ""
 	}
-	return row.Run.RunID
+	return row.Run.RunID.String()
 }
 
 func sortRunRows(rows []RunRow, key SortKey) {
@@ -422,22 +422,22 @@ func sortRuns(runs []*model.Run, key SortKey) {
 
 		switch key {
 		case SortByName:
-			if cmp := strings.Compare(a.IssueID, b.IssueID); cmp != 0 {
+			if cmp := strings.Compare(a.IssueID.String(), b.IssueID.String()); cmp != 0 {
 				return cmp < 0
 			}
-			if cmp := strings.Compare(a.RunID, b.RunID); cmp != 0 {
+			if cmp := strings.Compare(a.RunID.String(), b.RunID.String()); cmp != 0 {
 				return cmp < 0
 			}
-			return a.ShortID() < b.ShortID()
+			return a.ShortID().String() < b.ShortID().String()
 
 		case SortByIssue:
-			if cmp := strings.Compare(a.IssueID, b.IssueID); cmp != 0 {
+			if cmp := strings.Compare(a.IssueID.String(), b.IssueID.String()); cmp != 0 {
 				return cmp < 0
 			}
 			if !a.UpdatedAt.Equal(b.UpdatedAt) {
 				return a.UpdatedAt.After(b.UpdatedAt)
 			}
-			return a.ShortID() < b.ShortID()
+			return a.ShortID().String() < b.ShortID().String()
 
 		case SortByAgent:
 			if cmp := strings.Compare(a.Agent, b.Agent); cmp != 0 {
@@ -446,7 +446,7 @@ func sortRuns(runs []*model.Run, key SortKey) {
 			if !a.UpdatedAt.Equal(b.UpdatedAt) {
 				return a.UpdatedAt.After(b.UpdatedAt)
 			}
-			return a.ShortID() < b.ShortID()
+			return a.ShortID().String() < b.ShortID().String()
 
 		case SortByStatus:
 			if ar, br := runStatusRank(a.Status), runStatusRank(b.Status); ar != br {
@@ -455,19 +455,19 @@ func sortRuns(runs []*model.Run, key SortKey) {
 			if !a.UpdatedAt.Equal(b.UpdatedAt) {
 				return a.UpdatedAt.After(b.UpdatedAt)
 			}
-			if cmp := strings.Compare(a.IssueID, b.IssueID); cmp != 0 {
+			if cmp := strings.Compare(a.IssueID.String(), b.IssueID.String()); cmp != 0 {
 				return cmp < 0
 			}
-			return a.ShortID() < b.ShortID()
+			return a.ShortID().String() < b.ShortID().String()
 
 		case SortByStarted:
 			if !a.StartedAt.Equal(b.StartedAt) {
 				return a.StartedAt.After(b.StartedAt)
 			}
-			if cmp := strings.Compare(a.IssueID, b.IssueID); cmp != 0 {
+			if cmp := strings.Compare(a.IssueID.String(), b.IssueID.String()); cmp != 0 {
 				return cmp < 0
 			}
-			return a.ShortID() < b.ShortID()
+			return a.ShortID().String() < b.ShortID().String()
 
 		case SortByElapsed:
 			aElapsed := now.Sub(a.StartedAt)
@@ -475,10 +475,10 @@ func sortRuns(runs []*model.Run, key SortKey) {
 			if aElapsed != bElapsed {
 				return aElapsed > bElapsed
 			}
-			if cmp := strings.Compare(a.IssueID, b.IssueID); cmp != 0 {
+			if cmp := strings.Compare(a.IssueID.String(), b.IssueID.String()); cmp != 0 {
 				return cmp < 0
 			}
-			return a.ShortID() < b.ShortID()
+			return a.ShortID().String() < b.ShortID().String()
 
 		case SortByUpdated:
 			fallthrough
@@ -486,10 +486,10 @@ func sortRuns(runs []*model.Run, key SortKey) {
 			if !a.UpdatedAt.Equal(b.UpdatedAt) {
 				return a.UpdatedAt.After(b.UpdatedAt)
 			}
-			if cmp := strings.Compare(a.IssueID, b.IssueID); cmp != 0 {
+			if cmp := strings.Compare(a.IssueID.String(), b.IssueID.String()); cmp != 0 {
 				return cmp < 0
 			}
-			return a.ShortID() < b.ShortID()
+			return a.ShortID().String() < b.ShortID().String()
 		}
 	})
 }

--- a/internal/notify/slack_listener.go
+++ b/internal/notify/slack_listener.go
@@ -39,7 +39,7 @@ func (l *SlackStatusListener) OnStatusChange(ev *runevents.StatusChangeEvent) {
 		return
 	}
 
-	issueTitle := ev.Run.IssueID
+	issueTitle := ev.Run.IssueID.String()
 	if ev.Store != nil {
 		if issue, err := ev.Store.ResolveIssue(ev.Run.IssueID); err == nil && issue != nil && issue.Title != "" {
 			issueTitle = issue.Title

--- a/internal/orchapi/api.go
+++ b/internal/orchapi/api.go
@@ -19,6 +19,8 @@ package orchapi
 
 import (
 	"context"
+
+	"github.com/s22625/orch/internal/model"
 )
 
 // OrchAPI is the unified interface for all orch CLI operations.
@@ -39,7 +41,7 @@ type OrchAPI interface {
 
 	// GetIssue retrieves an issue by ID.
 	// Returns ErrNotFound if the issue does not exist.
-	GetIssue(ctx context.Context, issueID string) (*Issue, error)
+	GetIssue(ctx context.Context, issueID model.IssueID) (*Issue, error)
 
 	// ListIssues returns issues matching the filter.
 	// If filter is nil, returns all issues.
@@ -51,10 +53,10 @@ type OrchAPI interface {
 
 	// SetIssueStatus updates an issue's status.
 	// Returns ErrNotFound if the issue does not exist.
-	SetIssueStatus(ctx context.Context, issueID string, status IssueStatus) error
+	SetIssueStatus(ctx context.Context, issueID model.IssueID, status IssueStatus) error
 
 	// CloseIssue closes an issue (convenience wrapper for SetIssueStatus).
-	CloseIssue(ctx context.Context, issueID string) error
+	CloseIssue(ctx context.Context, issueID model.IssueID) error
 
 	// =========================================================================
 	// Runs - Resolution
@@ -73,11 +75,11 @@ type OrchAPI interface {
 
 	// GetRun retrieves a run by full issue_id and run_id.
 	// Prefer ResolveRun for user-facing lookups.
-	GetRun(ctx context.Context, issueID, runID string) (*Run, error)
+	GetRun(ctx context.Context, issueID model.IssueID, runID model.RunID) (*Run, error)
 
 	// GetLatestRun retrieves the most recent run for an issue.
 	// Returns ErrNotFound if the issue has no runs.
-	GetLatestRun(ctx context.Context, issueID string) (*Run, error)
+	GetLatestRun(ctx context.Context, issueID model.IssueID) (*Run, error)
 
 	// ListRuns returns runs matching the filter.
 	// If filter is nil, returns all runs.
@@ -151,7 +153,7 @@ type OrchAPI interface {
 
 	// ResolveIssue marks an issue as resolved and merges the latest run's branch.
 	// If force is true, skips confirmation checks.
-	ResolveIssue(ctx context.Context, issueID string, force bool) error
+	ResolveIssue(ctx context.Context, issueID model.IssueID, force bool) error
 
 	// =========================================================================
 	// Run Deletion
@@ -168,10 +170,10 @@ type OrchAPI interface {
 	// =========================================================================
 
 	// UpdateIssue updates an existing issue's content.
-	UpdateIssue(ctx context.Context, issueID string, req *UpdateIssueRequest) (*Issue, error)
+	UpdateIssue(ctx context.Context, issueID model.IssueID, req *UpdateIssueRequest) (*Issue, error)
 
 	// ValidateIssueFiles validates issue files for proper formatting.
-	ValidateIssueFiles(ctx context.Context, issueID string) (*ValidateIssueFilesResult, error)
+	ValidateIssueFiles(ctx context.Context, issueID model.IssueID) (*ValidateIssueFilesResult, error)
 
 	// =========================================================================
 	// Agent Prompt Operations

--- a/internal/orchapi/daemon_client.go
+++ b/internal/orchapi/daemon_client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/s22625/orch/internal/daemon"
+	"github.com/s22625/orch/internal/model"
 )
 
 type DaemonClient struct {
@@ -91,11 +92,11 @@ func (c *DaemonClient) EnsureDaemonHealthy(ctx context.Context) error {
 	return fmt.Errorf("daemon did not become healthy within %v", daemonRepairTimeout)
 }
 
-func (c *DaemonClient) GetIssue(ctx context.Context, issueID string) (*Issue, error) {
-	resp, err := c.proto.GetIssue(issueID)
+func (c *DaemonClient) GetIssue(ctx context.Context, issueID model.IssueID) (*Issue, error) {
+	resp, err := c.proto.GetIssue(issueID.String())
 	if err != nil {
 		if isNotFoundError(err) {
-			return nil, IssueNotFound(issueID)
+			return nil, IssueNotFound(issueID.String())
 		}
 		return nil, err
 	}
@@ -138,12 +139,12 @@ func (c *DaemonClient) ListIssues(ctx context.Context, filter *ListIssuesFilter)
 }
 
 func (c *DaemonClient) CreateIssue(ctx context.Context, req *CreateIssueRequest) (*Issue, error) {
-	resp, err := c.proto.CreateIssue(req.ID, req.Title, "", req.Body, req.Tags, req.BaseBranch)
+	resp, err := c.proto.CreateIssue(req.ID.String(), req.Title, "", req.Body, req.Tags, req.BaseBranch)
 	if err != nil {
 		return nil, err
 	}
 	return &Issue{
-		ID:         resp.IssueID,
+		ID:         model.NewIssueID(resp.IssueID),
 		Path:       resp.Path,
 		Title:      req.Title,
 		Body:       req.Body,
@@ -151,25 +152,25 @@ func (c *DaemonClient) CreateIssue(ctx context.Context, req *CreateIssueRequest)
 	}, nil
 }
 
-func (c *DaemonClient) SetIssueStatus(ctx context.Context, issueID string, status IssueStatus) error {
+func (c *DaemonClient) SetIssueStatus(ctx context.Context, issueID model.IssueID, status IssueStatus) error {
 	if status == IssueStatusClosed || status == IssueStatusResolved {
-		_, err := c.proto.CloseIssue(issueID, "")
+		_, err := c.proto.CloseIssue(issueID.String(), "")
 		return err
 	}
 	return errors.New("only close/resolved status supported via daemon")
 }
 
-func (c *DaemonClient) CloseIssue(ctx context.Context, issueID string) error {
-	_, err := c.proto.CloseIssue(issueID, "")
+func (c *DaemonClient) CloseIssue(ctx context.Context, issueID model.IssueID) error {
+	_, err := c.proto.CloseIssue(issueID.String(), "")
 	return err
 }
 
 func (c *DaemonClient) ResolveRun(ctx context.Context, ref RunRef) (*Run, error) {
 	if ref.ShortID != "" {
-		resp, err := c.proto.GetRunByShortID(ref.ShortID)
+		resp, err := c.proto.GetRunByShortID(ref.ShortID.String())
 		if err != nil {
 			if isNotFoundError(err) {
-				return nil, RunNotFound(ref.ShortID)
+				return nil, RunNotFound(ref.ShortID.String())
 			}
 			return nil, err
 		}
@@ -177,7 +178,7 @@ func (c *DaemonClient) ResolveRun(ctx context.Context, ref RunRef) (*Run, error)
 	}
 
 	if ref.RunID != "" {
-		resp, err := c.proto.GetRun(ref.IssueID, ref.RunID)
+		resp, err := c.proto.GetRun(ref.IssueID.String(), ref.RunID.String())
 		if err != nil {
 			if isNotFoundError(err) {
 				return nil, RunNotFound(ref.String())
@@ -187,12 +188,12 @@ func (c *DaemonClient) ResolveRun(ctx context.Context, ref RunRef) (*Run, error)
 		return runFromDaemonFull(resp.Run), nil
 	}
 
-	runs, err := c.proto.ListRuns(&daemon.ListRunsFilter{IssueID: ref.IssueID, Limit: 1})
+	runs, err := c.proto.ListRuns(&daemon.ListRunsFilter{IssueID: ref.IssueID.String(), Limit: 1})
 	if err != nil {
 		return nil, err
 	}
 	if len(runs.Runs) == 0 {
-		return nil, RunNotFound(ref.IssueID)
+		return nil, RunNotFound(ref.IssueID.String())
 	}
 	resp, err := c.proto.GetRun(runs.Runs[0].IssueID, runs.Runs[0].RunID)
 	if err != nil {
@@ -201,24 +202,24 @@ func (c *DaemonClient) ResolveRun(ctx context.Context, ref RunRef) (*Run, error)
 	return runFromDaemonFull(resp.Run), nil
 }
 
-func (c *DaemonClient) GetRun(ctx context.Context, issueID, runID string) (*Run, error) {
-	resp, err := c.proto.GetRun(issueID, runID)
+func (c *DaemonClient) GetRun(ctx context.Context, issueID model.IssueID, runID model.RunID) (*Run, error) {
+	resp, err := c.proto.GetRun(issueID.String(), runID.String())
 	if err != nil {
 		if isNotFoundError(err) {
-			return nil, RunNotFound(issueID + "#" + runID)
+			return nil, RunNotFound(issueID.String() + "#" + runID.String())
 		}
 		return nil, err
 	}
 	return runFromDaemonFull(resp.Run), nil
 }
 
-func (c *DaemonClient) GetLatestRun(ctx context.Context, issueID string) (*Run, error) {
-	runs, err := c.proto.ListRuns(&daemon.ListRunsFilter{IssueID: issueID, Limit: 1})
+func (c *DaemonClient) GetLatestRun(ctx context.Context, issueID model.IssueID) (*Run, error) {
+	runs, err := c.proto.ListRuns(&daemon.ListRunsFilter{IssueID: issueID.String(), Limit: 1})
 	if err != nil {
 		return nil, err
 	}
 	if len(runs.Runs) == 0 {
-		return nil, RunNotFound(issueID)
+		return nil, RunNotFound(issueID.String())
 	}
 	resp, err := c.proto.GetRun(runs.Runs[0].IssueID, runs.Runs[0].RunID)
 	if err != nil {
@@ -235,7 +236,7 @@ func (c *DaemonClient) ListRuns(ctx context.Context, filter *ListRunsFilter) (*L
 			statuses[i] = string(s)
 		}
 		protoFilter = &daemon.ListRunsFilter{
-			IssueID:   filter.IssueID,
+			IssueID:   filter.IssueID.String(),
 			Status:    statuses,
 			Limit:     filter.Limit,
 			Cursor:    filter.Cursor,
@@ -290,7 +291,7 @@ func (c *DaemonClient) StartRun(ctx context.Context, req *StartRunRequest) (*Sta
 		return nil, err
 	}
 	return &StartRunResult{
-		RunID:        resp.RunID,
+		RunID:        model.NewRunID(resp.RunID),
 		Branch:       resp.Branch,
 		WorktreePath: resp.WorktreePath,
 		SessionName:  resp.SessionName,
@@ -303,7 +304,7 @@ func (c *DaemonClient) StopRun(ctx context.Context, ref RunRef) error {
 	if err != nil {
 		return err
 	}
-	_, err = c.proto.StopRun(run.IssueID, run.RunID, false)
+	_, err = c.proto.StopRun(run.IssueID.String(), run.RunID.String(), false)
 	return err
 }
 
@@ -312,7 +313,7 @@ func (c *DaemonClient) AppendEvent(ctx context.Context, ref RunRef, event *Event
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.proto.AppendEvent(run.IssueID, run.RunID, event.Type, event.Name, event.Attrs, "cli")
+	resp, err := c.proto.AppendEvent(run.IssueID.String(), run.RunID.String(), event.Type, event.Name, event.Attrs, "cli")
 	if err != nil {
 		return nil, err
 	}
@@ -335,15 +336,15 @@ func (c *DaemonClient) WaitForRuns(ctx context.Context, refs []string, timeoutSe
 	}
 
 	return &WaitForRunsResult{
-		RunID:   resp.RunID,
+		RunID:   model.NewRunID(resp.RunID),
 		Status:  NormalizeRunStatus(resp.Status),
-		IssueID: resp.Issue,
+		IssueID: model.NewIssueID(resp.Issue),
 		PRURL:   resp.PRURL,
 	}, nil
 }
 
 func (c *DaemonClient) GetAttachInfo(ctx context.Context, ref RunRef) (*AttachInfo, error) {
-	resp, err := c.proto.GetAttachInfo(ref.IssueID, ref.RunID, ref.ShortID)
+	resp, err := c.proto.GetAttachInfo(ref.IssueID.String(), ref.RunID.String(), ref.ShortID.String())
 	if err != nil {
 		if isNotFoundError(err) {
 			return nil, RunNotFound(ref.String())
@@ -353,8 +354,8 @@ func (c *DaemonClient) GetAttachInfo(ctx context.Context, ref RunRef) (*AttachIn
 	if !resp.OK {
 		if resp.Error == "session_not_found" || resp.Error == "no sessions" {
 			return &AttachInfo{
-				IssueID:       resp.IssueID,
-				RunID:         resp.RunID,
+				IssueID:       model.NewIssueID(resp.IssueID),
+				RunID:         model.NewRunID(resp.RunID),
 				SessionName:   resp.SessionName,
 				Multiplexer:   Multiplexer(resp.Multiplexer),
 				WorktreePath:  resp.WorktreePath,
@@ -365,8 +366,8 @@ func (c *DaemonClient) GetAttachInfo(ctx context.Context, ref RunRef) (*AttachIn
 		return nil, errors.New(resp.Error)
 	}
 	return &AttachInfo{
-		IssueID:           resp.IssueID,
-		RunID:             resp.RunID,
+		IssueID:           model.NewIssueID(resp.IssueID),
+		RunID:             model.NewRunID(resp.RunID),
 		Agent:             resp.Agent,
 		SessionName:       resp.SessionName,
 		Multiplexer:       Multiplexer(resp.Multiplexer),
@@ -385,7 +386,7 @@ func (c *DaemonClient) CaptureSession(ctx context.Context, ref RunRef, lines int
 		return nil, err
 	}
 
-	resp, err := c.proto.CaptureSession(run.IssueID, run.RunID, lines)
+	resp, err := c.proto.CaptureSession(run.IssueID.String(), run.RunID.String(), lines)
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +404,7 @@ func (c *DaemonClient) SendMessage(ctx context.Context, ref RunRef, message stri
 		return err
 	}
 
-	return c.proto.SendMessage(run.IssueID, run.RunID, message, noEnter)
+	return c.proto.SendMessage(run.IssueID.String(), run.RunID.String(), message, noEnter)
 }
 
 func (c *DaemonClient) InjectInitialPrompt(ctx context.Context, ref RunRef, prompt string) error {
@@ -412,7 +413,7 @@ func (c *DaemonClient) InjectInitialPrompt(ctx context.Context, ref RunRef, prom
 		return err
 	}
 
-	return c.proto.InjectInitialPrompt(run.IssueID, run.RunID, prompt)
+	return c.proto.InjectInitialPrompt(run.IssueID.String(), run.RunID.String(), prompt)
 }
 
 func (c *DaemonClient) GetDiffStats(ctx context.Context, ref RunRef) (*DiffStats, error) {
@@ -421,7 +422,7 @@ func (c *DaemonClient) GetDiffStats(ctx context.Context, ref RunRef) (*DiffStats
 		return nil, err
 	}
 
-	resp, err := c.proto.GetDiffStats(run.IssueID, run.RunID)
+	resp, err := c.proto.GetDiffStats(run.IssueID.String(), run.RunID.String())
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +441,7 @@ func (c *DaemonClient) GetBranchState(ctx context.Context, ref RunRef) (BranchSt
 		return "", err
 	}
 
-	state, err := c.proto.GetBranchState(run.IssueID, run.RunID)
+	state, err := c.proto.GetBranchState(run.IssueID.String(), run.RunID.String())
 	if err != nil {
 		return "", err
 	}
@@ -454,11 +455,11 @@ func (c *DaemonClient) GetDiff(ctx context.Context, ref RunRef) (string, error) 
 		return "", err
 	}
 
-	return c.proto.GetDiff(run.IssueID, run.RunID)
+	return c.proto.GetDiff(run.IssueID.String(), run.RunID.String())
 }
 
-func (c *DaemonClient) ResolveIssue(ctx context.Context, issueID string, force bool) error {
-	_, err := c.proto.ResolveIssue(issueID, force)
+func (c *DaemonClient) ResolveIssue(ctx context.Context, issueID model.IssueID, force bool) error {
+	_, err := c.proto.ResolveIssue(issueID.String(), force)
 	return err
 }
 
@@ -544,7 +545,7 @@ func issueFromDaemon(iss *daemon.IssueFull) *Issue {
 		return nil
 	}
 	return &Issue{
-		ID:          iss.ID,
+		ID:          model.NewIssueID(iss.ID),
 		Title:       iss.Title,
 		Topic:       iss.Topic,
 		Summary:     iss.Summary,
@@ -565,7 +566,7 @@ func issueSummaryToIssue(iss *daemon.IssueSummary) *Issue {
 		modTime, _ = time.Parse(time.RFC3339, iss.ModifiedAt)
 	}
 	return &Issue{
-		ID:         iss.ID,
+		ID:         model.NewIssueID(iss.ID),
 		Title:      iss.Title,
 		Topic:      iss.Topic,
 		Summary:    iss.Summary,
@@ -609,9 +610,9 @@ func runFromDaemonFull(r *daemon.RunFull) *Run {
 		}
 	}
 	return &Run{
-		IssueID:           r.IssueID,
-		RunID:             r.RunID,
-		ShortID:           r.ShortID,
+		IssueID:           model.NewIssueID(r.IssueID),
+		RunID:             model.NewRunID(r.RunID),
+		ShortID:           model.NewShortID(r.ShortID),
 		IssueStatus:       r.IssueStatus,
 		IssueTopic:        r.IssueTopic,
 		Status:            RunStatus(r.Status),
@@ -664,9 +665,9 @@ func runFromDaemonSummary(r *daemon.RunSummary) *Run {
 		}
 	}
 	return &Run{
-		IssueID:           r.IssueID,
-		RunID:             r.RunID,
-		ShortID:           r.ShortID,
+		IssueID:           model.NewIssueID(r.IssueID),
+		RunID:             model.NewRunID(r.RunID),
+		ShortID:           model.NewShortID(r.ShortID),
 		IssueStatus:       r.IssueStatus,
 		IssueTopic:        r.IssueTopic,
 		Status:            RunStatus(r.Status),
@@ -700,14 +701,14 @@ func (c *DaemonClient) DeleteRun(ctx context.Context, ref RunRef, opts *DeleteRu
 	if opts == nil {
 		opts = &DeleteRunOptions{}
 	}
-	resp, err := c.proto.DeleteRun(ref.IssueID, ref.RunID, ref.ShortID, opts.WithWorktree, opts.WithBranch, opts.Force)
+	resp, err := c.proto.DeleteRun(ref.IssueID.String(), ref.RunID.String(), ref.ShortID.String(), opts.WithWorktree, opts.WithBranch, opts.Force)
 	if err != nil {
 		return nil, err
 	}
 	return &DeleteRunResult{
-		IssueID:         resp.IssueID,
-		RunID:           resp.RunID,
-		ShortID:         resp.ShortID,
+		IssueID:         model.NewIssueID(resp.IssueID),
+		RunID:           model.NewRunID(resp.RunID),
+		ShortID:         model.NewShortID(resp.ShortID),
 		WorktreeRemoved: resp.WorktreeRemoved,
 		BranchRemoved:   resp.BranchRemoved,
 		SessionKilled:   resp.SessionKilled,
@@ -715,14 +716,14 @@ func (c *DaemonClient) DeleteRun(ctx context.Context, ref RunRef, opts *DeleteRu
 }
 
 func (c *DaemonClient) CleanRunWorktree(ctx context.Context, ref RunRef) (*CleanRunWorktreeResult, error) {
-	resp, err := c.proto.CleanRunWorktree(ref.IssueID, ref.RunID, ref.ShortID)
+	resp, err := c.proto.CleanRunWorktree(ref.IssueID.String(), ref.RunID.String(), ref.ShortID.String())
 	if err != nil {
 		return nil, err
 	}
 	return &CleanRunWorktreeResult{
-		IssueID:         resp.IssueID,
-		RunID:           resp.RunID,
-		ShortID:         resp.ShortID,
+		IssueID:         model.NewIssueID(resp.IssueID),
+		RunID:           model.NewRunID(resp.RunID),
+		ShortID:         model.NewShortID(resp.ShortID),
 		WorktreePath:    resp.WorktreePath,
 		WorktreeRemoved: resp.WorktreeRemoved,
 		Skipped:         resp.Skipped,
@@ -730,16 +731,16 @@ func (c *DaemonClient) CleanRunWorktree(ctx context.Context, ref RunRef) (*Clean
 	}, nil
 }
 
-func (c *DaemonClient) UpdateIssue(ctx context.Context, issueID string, req *UpdateIssueRequest) (*Issue, error) {
-	resp, err := c.proto.UpdateIssue(issueID, req.Title, req.Summary, req.Body, string(req.Status))
+func (c *DaemonClient) UpdateIssue(ctx context.Context, issueID model.IssueID, req *UpdateIssueRequest) (*Issue, error) {
+	resp, err := c.proto.UpdateIssue(issueID.String(), req.Title, req.Summary, req.Body, string(req.Status))
 	if err != nil {
 		return nil, err
 	}
 	return issueFromDaemon(resp), nil
 }
 
-func (c *DaemonClient) ValidateIssueFiles(ctx context.Context, issueID string) (*ValidateIssueFilesResult, error) {
-	resp, err := c.proto.ValidateIssueFiles(issueID)
+func (c *DaemonClient) ValidateIssueFiles(ctx context.Context, issueID model.IssueID) (*ValidateIssueFilesResult, error) {
+	resp, err := c.proto.ValidateIssueFiles(issueID.String())
 	if err != nil {
 		return nil, err
 	}
@@ -750,7 +751,7 @@ func (c *DaemonClient) ValidateIssueFiles(ctx context.Context, issueID string) (
 	for _, e := range resp.Errors {
 		vr := &ValidationResult{
 			File:    e.File,
-			IssueID: e.IssueID,
+			IssueID: model.NewIssueID(e.IssueID),
 		}
 		for _, issue := range e.Errors {
 			vr.Errors = append(vr.Errors, ValidationIssue{
@@ -773,7 +774,7 @@ func (c *DaemonClient) ValidateIssueFiles(ctx context.Context, issueID string) (
 	for _, w := range resp.Warnings {
 		vr := &ValidationResult{
 			File:    w.File,
-			IssueID: w.IssueID,
+			IssueID: model.NewIssueID(w.IssueID),
 		}
 		for _, issue := range w.Warnings {
 			vr.Warnings = append(vr.Warnings, ValidationIssue{
@@ -787,7 +788,7 @@ func (c *DaemonClient) ValidateIssueFiles(ctx context.Context, issueID string) (
 	}
 	for _, d := range resp.Duplicates {
 		result.Duplicates = append(result.Duplicates, DuplicateID{
-			ID:    d.ID,
+			ID:    model.NewIssueID(d.ID),
 			Files: d.Files,
 		})
 	}
@@ -795,11 +796,11 @@ func (c *DaemonClient) ValidateIssueFiles(ctx context.Context, issueID string) (
 }
 
 func (c *DaemonClient) WriteAgentPrompt(ctx context.Context, ref RunRef, content string) error {
-	return c.proto.WriteAgentPrompt(ref.IssueID, ref.RunID, ref.ShortID, content)
+	return c.proto.WriteAgentPrompt(ref.IssueID.String(), ref.RunID.String(), ref.ShortID.String(), content)
 }
 
 func (c *DaemonClient) ReadAgentPrompt(ctx context.Context, ref RunRef) (string, error) {
-	return c.proto.ReadAgentPrompt(ref.IssueID, ref.RunID, ref.ShortID)
+	return c.proto.ReadAgentPrompt(ref.IssueID.String(), ref.RunID.String(), ref.ShortID.String())
 }
 
 func (c *DaemonClient) RepairState(ctx context.Context, opts *RepairOptions) (*RepairResult, error) {
@@ -830,13 +831,13 @@ func (c *DaemonClient) WriteFile(ctx context.Context, path string, content []byt
 }
 
 func (c *DaemonClient) CreateRun(ctx context.Context, req *CreateRunRequest) (*CreateRunResult, error) {
-	resp, err := c.proto.CreateRun(req.IssueID, req.RunID, req.Metadata)
+	resp, err := c.proto.CreateRun(req.IssueID.String(), req.RunID.String(), req.Metadata)
 	if err != nil {
 		return nil, err
 	}
 	return &CreateRunResult{
-		IssueID: resp.IssueId,
-		RunID:   resp.RunId,
+		IssueID: model.NewIssueID(resp.IssueId),
+		RunID:   model.NewRunID(resp.RunId),
 		Path:    resp.Path,
 	}, nil
 }
@@ -970,13 +971,13 @@ func (c *DaemonClient) ContinueRun(ctx context.Context, req *ContinueRunRequest)
 		return nil, err
 	}
 	return &ContinueRunResult{
-		RunID:         resp.RunID,
+		RunID:         model.NewRunID(resp.RunID),
 		Branch:        resp.Branch,
 		WorktreePath:  resp.WorktreePath,
 		SessionName:   resp.SessionName,
 		Status:        resp.Status,
 		ContinuedFrom: resp.ContinuedFrom,
-		IssueID:       resp.IssueID,
+		IssueID:       model.NewIssueID(resp.IssueID),
 	}, nil
 }
 

--- a/internal/orchapi/daemon_client_stream.go
+++ b/internal/orchapi/daemon_client_stream.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/s22625/orch/api/orchpb"
 	"github.com/s22625/orch/internal/daemon"
+	"github.com/s22625/orch/internal/model"
 )
 
 // daemonRunEventStream adapts a daemon.RunEventStream (proto-typed) into the
@@ -17,7 +18,7 @@ type daemonRunEventStream struct {
 }
 
 func (s *daemonRunEventStream) Events() <-chan *RunEvent { return s.events }
-func (s *daemonRunEventStream) Err() error                { return s.raw.Err() }
+func (s *daemonRunEventStream) Err() error               { return s.raw.Err() }
 func (s *daemonRunEventStream) Close() error {
 	err := s.raw.Close()
 	<-s.done
@@ -35,8 +36,8 @@ func (s *daemonRunEventStream) translateLoop() {
 func (c *DaemonClient) StreamRunEvents(ctx context.Context, filter *RunEventFilter) (RunEventStream, error) {
 	pbReq := &orchpb.StreamRunEventsRequest{}
 	if filter != nil {
-		pbReq.IssueId = filter.IssueID
-		pbReq.RunId = filter.RunID
+		pbReq.IssueId = filter.IssueID.String()
+		pbReq.RunId = filter.RunID.String()
 	}
 
 	raw, err := c.proto.StreamRunEvents(ctx, pbReq)
@@ -57,15 +58,21 @@ func protoEventToOrchAPI(ev *orchpb.RunEventFrame) *RunEvent {
 	if ev == nil {
 		return nil
 	}
+	var projectID model.ProjectID
+	if ev.ProjectId != "" {
+		if id, err := model.NewNormalizedProjectID(ev.ProjectId); err == nil {
+			projectID = id
+		}
+	}
 	return &RunEvent{
 		Timestamp: time.UnixMilli(ev.TimestampUnixMs),
-		IssueID:   ev.IssueId,
-		RunID:     ev.RunId,
-		ShortID:   ev.ShortId,
+		IssueID:   model.NewIssueID(ev.IssueId),
+		RunID:     model.NewRunID(ev.RunId),
+		ShortID:   model.NewShortID(ev.ShortId),
 		From:      protoRunStatusToDomain(ev.FromStatus),
 		To:        protoRunStatusToDomain(ev.ToStatus),
 		Source:    ev.Source,
-		ProjectID: ev.ProjectId,
+		ProjectID: projectID,
 	}
 }
 

--- a/internal/orchapi/types.go
+++ b/internal/orchapi/types.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/s22625/orch/internal/model"
 )
 
 type IssueStatus string
@@ -63,9 +65,9 @@ const (
 //   - Full: IssueID + RunID (e.g., "my-task#20231220-100000")
 //   - Latest: IssueID only (resolves to latest run)
 type RunRef struct {
-	IssueID string
-	RunID   string
-	ShortID string
+	IssueID model.IssueID
+	RunID   model.RunID
+	ShortID model.ShortID
 }
 
 var shortIDRegex = regexp.MustCompile(`^[0-9a-f]{2,6}$`)
@@ -77,22 +79,22 @@ func ParseRunRef(s string) (RunRef, error) {
 	}
 
 	if shortIDRegex.MatchString(s) {
-		return RunRef{ShortID: s}, nil
+		return RunRef{ShortID: model.NewShortID(s)}, nil
 	}
 
 	lastHash := strings.LastIndex(s, "#")
 	if lastHash == -1 {
-		return RunRef{IssueID: s}, nil
+		return RunRef{IssueID: model.NewIssueID(s)}, nil
 	}
 
 	candidate := s[lastHash+1:]
 	if looksLikeRunID(candidate) {
 		return RunRef{
-			IssueID: s[:lastHash],
-			RunID:   candidate,
+			IssueID: model.NewIssueID(s[:lastHash]),
+			RunID:   model.NewRunID(candidate),
 		}, nil
 	}
-	return RunRef{IssueID: s}, nil
+	return RunRef{IssueID: model.NewIssueID(s)}, nil
 }
 
 func looksLikeRunID(s string) bool {
@@ -121,10 +123,10 @@ func (r RunRef) IsFull() bool {
 
 func (r RunRef) String() string {
 	if r.ShortID != "" {
-		return r.ShortID
+		return r.ShortID.String()
 	}
 	if r.RunID == "" {
-		return r.IssueID
+		return r.IssueID.String()
 	}
 	return fmt.Sprintf("%s#%s", r.IssueID, r.RunID)
 }
@@ -132,28 +134,28 @@ func (r RunRef) String() string {
 // ComputeShortID returns the 6-char hex short ID derived from issueID#runID
 // via SHA-256. Mirrors model.GenerateShortID so callers (CLI hints,
 // notifications) present the same short reference users see in `orch ps`.
-func ComputeShortID(issueID, runID string) string {
-	h := sha256.Sum256([]byte(issueID + "#" + runID))
-	return hex.EncodeToString(h[:])[:6]
+func ComputeShortID(issueID model.IssueID, runID model.RunID) model.ShortID {
+	h := sha256.Sum256([]byte(issueID.String() + "#" + runID.String()))
+	return model.ShortID(hex.EncodeToString(h[:])[:6])
 }
 
 // RunEvent is a single state transition observed for a run.
 type RunEvent struct {
 	Timestamp time.Time
-	IssueID   string
-	RunID     string
-	ShortID   string
+	IssueID   model.IssueID
+	RunID     model.RunID
+	ShortID   model.ShortID
 	From      RunStatus
 	To        RunStatus
 	Source    string // "user" | "daemon" | "agent"
-	ProjectID string
+	ProjectID model.ProjectID
 }
 
 // RunEventFilter narrows a subscription to events matching the given fields.
 // Empty fields match anything.
 type RunEventFilter struct {
-	IssueID string
-	RunID   string
+	IssueID model.IssueID
+	RunID   model.RunID
 }
 
 // RunEventStream is a long-lived subscription to run state transitions.
@@ -166,7 +168,7 @@ type RunEventStream interface {
 }
 
 type Issue struct {
-	ID          string
+	ID          model.IssueID
 	Title       string
 	Topic       string
 	Summary     string
@@ -180,9 +182,9 @@ type Issue struct {
 }
 
 type Run struct {
-	IssueID           string
-	RunID             string
-	ShortID           string
+	IssueID           model.IssueID
+	RunID             model.RunID
+	ShortID           model.ShortID
 	IssueStatus       string
 	IssueTopic        string
 	Status            RunStatus
@@ -222,9 +224,9 @@ func (r *Run) Ref() RunRef {
 }
 
 type WaitForRunsResult struct {
-	RunID   string
+	RunID   model.RunID
 	Status  RunStatus
-	IssueID string
+	IssueID model.IssueID
 	PRURL   string
 }
 
@@ -243,9 +245,9 @@ type DiffStats struct {
 }
 
 type AttachInfo struct {
-	IssueID           string
-	RunID             string
-	ShortID           string
+	IssueID           model.IssueID
+	RunID             model.RunID
+	ShortID           model.ShortID
 	Agent             string
 	SessionName       string
 	Multiplexer       Multiplexer
@@ -288,7 +290,7 @@ type ListIssuesResult struct {
 }
 
 type CreateIssueRequest struct {
-	ID         string
+	ID         model.IssueID
 	Title      string
 	Body       string
 	Tags       []string
@@ -296,7 +298,7 @@ type CreateIssueRequest struct {
 }
 
 type ListRunsFilter struct {
-	IssueID    string
+	IssueID    model.IssueID
 	Status     []RunStatus
 	Agent      string
 	TextSearch string
@@ -313,8 +315,8 @@ type ListRunsResult struct {
 }
 
 type StartRunRequest struct {
-	IssueID        string
-	RunID          string
+	IssueID        model.IssueID
+	RunID          model.RunID
 	Agent          string
 	AgentCmd       string
 	AgentProfile   string
@@ -334,7 +336,7 @@ type StartRunRequest struct {
 }
 
 type StartRunResult struct {
-	RunID        string
+	RunID        model.RunID
 	Branch       string
 	WorktreePath string
 	SessionName  string
@@ -342,14 +344,14 @@ type StartRunResult struct {
 }
 
 type CreateRunRequest struct {
-	IssueID  string
-	RunID    string
+	IssueID  model.IssueID
+	RunID    model.RunID
 	Metadata map[string]string
 }
 
 type CreateRunResult struct {
-	IssueID string
-	RunID   string
+	IssueID model.IssueID
+	RunID   model.RunID
 	Path    string
 }
 
@@ -365,18 +367,18 @@ type DeleteRunOptions struct {
 }
 
 type DeleteRunResult struct {
-	IssueID         string
-	RunID           string
-	ShortID         string
+	IssueID         model.IssueID
+	RunID           model.RunID
+	ShortID         model.ShortID
 	WorktreeRemoved bool
 	BranchRemoved   bool
 	SessionKilled   bool
 }
 
 type CleanRunWorktreeResult struct {
-	IssueID         string
-	RunID           string
-	ShortID         string
+	IssueID         model.IssueID
+	RunID           model.RunID
+	ShortID         model.ShortID
 	WorktreePath    string
 	WorktreeRemoved bool
 	Skipped         bool
@@ -400,7 +402,7 @@ type ValidateIssueFilesResult struct {
 
 type ValidationResult struct {
 	File     string
-	IssueID  string
+	IssueID  model.IssueID
 	Errors   []ValidationIssue
 	Warnings []ValidationIssue
 }
@@ -413,7 +415,7 @@ type ValidationIssue struct {
 }
 
 type DuplicateID struct {
-	ID    string
+	ID    model.IssueID
 	Files []string
 }
 
@@ -584,9 +586,9 @@ type ControlAgentConfig struct {
 }
 
 type ContinueRunRequest struct {
-	IssueID        string
-	RunID          string
-	ShortID        string
+	IssueID        model.IssueID
+	RunID          model.RunID
+	ShortID        model.ShortID
 	Branch         string
 	Agent          string
 	AgentCmd       string
@@ -600,11 +602,11 @@ type ContinueRunRequest struct {
 }
 
 type ContinueRunResult struct {
-	RunID         string
+	RunID         model.RunID
 	Branch        string
 	WorktreePath  string
 	SessionName   string
 	Status        string
 	ContinuedFrom string
-	IssueID       string
+	IssueID       model.IssueID
 }

--- a/internal/orchapi/types_test.go
+++ b/internal/orchapi/types_test.go
@@ -1,6 +1,10 @@
 package orchapi
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/s22625/orch/internal/model"
+)
 
 func TestNormalizeRunStatus(t *testing.T) {
 	tests := []struct {
@@ -38,8 +42,8 @@ func TestComputeShortID(t *testing.T) {
 		{"TRD-081", "20260425-135017", "2fdb42"},
 	}
 	for _, c := range cases {
-		got := ComputeShortID(c.issueID, c.runID)
-		if got != c.want {
+		got := ComputeShortID(model.NewIssueID(c.issueID), model.NewRunID(c.runID))
+		if got.String() != c.want {
 			t.Errorf("ComputeShortID(%q, %q) = %q, want %q",
 				c.issueID, c.runID, got, c.want)
 		}

--- a/internal/pr/cache_test.go
+++ b/internal/pr/cache_test.go
@@ -108,7 +108,7 @@ func TestPopulateRunInfo_RespectsMaxFetches(t *testing.T) {
 	for i := range runs {
 		runs[i] = &model.Run{
 			IssueID: "test",
-			RunID:   fmt.Sprintf("run-%d", i),
+			RunID:   model.NewRunID(fmt.Sprintf("run-%d", i)),
 			Branch:  fmt.Sprintf("branch-%d", i),
 		}
 	}

--- a/internal/query/loader.go
+++ b/internal/query/loader.go
@@ -118,7 +118,7 @@ func LoadEvents(db *DB, api orchapi.OrchAPI) error {
 				Name:      event.Name,
 				Attrs:     event.Attrs,
 			}
-			if err := insertEvent(db, run.IssueID, run.RunID, modelEvent); err != nil {
+			if err := insertEvent(db, run.IssueID.String(), run.RunID.String(), modelEvent); err != nil {
 				return err
 			}
 		}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -16,7 +16,7 @@ type mockAPI struct {
 	runs   []*model.Run
 }
 
-func (m *mockAPI) GetIssue(ctx context.Context, issueID string) (*orchapi.Issue, error) {
+func (m *mockAPI) GetIssue(ctx context.Context, issueID model.IssueID) (*orchapi.Issue, error) {
 	return nil, nil
 }
 
@@ -36,17 +36,17 @@ func (m *mockAPI) ListIssues(ctx context.Context, filter *orchapi.ListIssuesFilt
 func (m *mockAPI) CreateIssue(ctx context.Context, req *orchapi.CreateIssueRequest) (*orchapi.Issue, error) {
 	return nil, nil
 }
-func (m *mockAPI) SetIssueStatus(ctx context.Context, issueID string, status orchapi.IssueStatus) error {
+func (m *mockAPI) SetIssueStatus(ctx context.Context, issueID model.IssueID, status orchapi.IssueStatus) error {
 	return nil
 }
-func (m *mockAPI) CloseIssue(ctx context.Context, issueID string) error { return nil }
+func (m *mockAPI) CloseIssue(ctx context.Context, issueID model.IssueID) error { return nil }
 func (m *mockAPI) ResolveRun(ctx context.Context, ref orchapi.RunRef) (*orchapi.Run, error) {
 	return nil, nil
 }
-func (m *mockAPI) GetRun(ctx context.Context, issueID, runID string) (*orchapi.Run, error) {
+func (m *mockAPI) GetRun(ctx context.Context, issueID model.IssueID, runID model.RunID) (*orchapi.Run, error) {
 	return nil, nil
 }
-func (m *mockAPI) GetLatestRun(ctx context.Context, issueID string) (*orchapi.Run, error) {
+func (m *mockAPI) GetLatestRun(ctx context.Context, issueID model.IssueID) (*orchapi.Run, error) {
 	return nil, nil
 }
 
@@ -114,7 +114,7 @@ func (m *mockAPI) GetBranchState(ctx context.Context, ref orchapi.RunRef) (orcha
 	return "", nil
 }
 func (m *mockAPI) GetDiff(ctx context.Context, ref orchapi.RunRef) (string, error) { return "", nil }
-func (m *mockAPI) ResolveIssue(ctx context.Context, issueID string, force bool) error {
+func (m *mockAPI) ResolveIssue(ctx context.Context, issueID model.IssueID, force bool) error {
 	return nil
 }
 func (m *mockAPI) DeleteRun(ctx context.Context, ref orchapi.RunRef, opts *orchapi.DeleteRunOptions) (*orchapi.DeleteRunResult, error) {
@@ -123,10 +123,10 @@ func (m *mockAPI) DeleteRun(ctx context.Context, ref orchapi.RunRef, opts *orcha
 func (m *mockAPI) CleanRunWorktree(ctx context.Context, ref orchapi.RunRef) (*orchapi.CleanRunWorktreeResult, error) {
 	return nil, nil
 }
-func (m *mockAPI) UpdateIssue(ctx context.Context, issueID string, req *orchapi.UpdateIssueRequest) (*orchapi.Issue, error) {
+func (m *mockAPI) UpdateIssue(ctx context.Context, issueID model.IssueID, req *orchapi.UpdateIssueRequest) (*orchapi.Issue, error) {
 	return nil, nil
 }
-func (m *mockAPI) ValidateIssueFiles(ctx context.Context, issueID string) (*orchapi.ValidateIssueFilesResult, error) {
+func (m *mockAPI) ValidateIssueFiles(ctx context.Context, issueID model.IssueID) (*orchapi.ValidateIssueFilesResult, error) {
 	return nil, nil
 }
 func (m *mockAPI) WriteAgentPrompt(ctx context.Context, ref orchapi.RunRef, content string) error {

--- a/internal/store/file/file.go
+++ b/internal/store/file/file.go
@@ -19,7 +19,7 @@ import (
 type FileStore struct {
 	rootPath    string
 	issueMu     sync.RWMutex
-	issueCache  map[string]*model.Issue // id -> issue
+	issueCache  map[model.IssueID]*model.Issue // id -> issue
 	cacheDirty  bool
 	warnFunc    func(format string, args ...any) // optional warning function
 	warnedFiles sync.Map                         // dedup warnings per file
@@ -47,7 +47,7 @@ func New(rootPath string) (*FileStore, error) {
 
 	return &FileStore{
 		rootPath:   absPath,
-		issueCache: make(map[string]*model.Issue),
+		issueCache: make(map[model.IssueID]*model.Issue),
 		cacheDirty: true,
 		// warnFunc defaults to nil (no warnings); set via SetWarnFunc
 	}, nil
@@ -261,7 +261,7 @@ func walkWithSymlinks(root string, walkFn filepath.WalkFunc) error {
 
 func (s *FileStore) scanIssues() error {
 	issuesDir := s.issuesDir()
-	issues := make(map[string]*model.Issue)
+	issues := make(map[model.IssueID]*model.Issue)
 
 	s.issueMu.Lock()
 	defer s.issueMu.Unlock()
@@ -426,9 +426,9 @@ func (s *FileStore) parseIssueFile(path string) (*model.Issue, error) {
 	}
 
 	// Get issue ID from frontmatter or filename
-	issueID := stringFM["id"]
+	issueID := model.NewIssueID(stringFM["id"])
 	if issueID == "" {
-		issueID = strings.TrimSuffix(filepath.Base(path), ".md")
+		issueID = model.NewIssueID(strings.TrimSuffix(filepath.Base(path), ".md"))
 	}
 
 	// Get title
@@ -527,7 +527,7 @@ func (s *FileStore) markCacheDirty() {
 	s.issueMu.Unlock()
 }
 
-func (s *FileStore) issueFromCache(issueID string) (*model.Issue, bool) {
+func (s *FileStore) issueFromCache(issueID model.IssueID) (*model.Issue, bool) {
 	s.issueMu.RLock()
 	issue, ok := s.issueCache[issueID]
 	if !ok {
@@ -569,26 +569,27 @@ func cloneIssue(issue *model.Issue) *model.Issue {
 }
 
 // runPath returns the path to a run document
-func (s *FileStore) runPath(issueID, runID string) string {
-	return filepath.Join(s.resolveRunsDir(issueID), runID+".md")
+func (s *FileStore) runPath(issueID model.IssueID, runID model.RunID) string {
+	return filepath.Join(s.resolveRunsDir(issueID), runID.String()+".md")
 }
 
 // runsDir returns the path to the runs directory for an issue
-func (s *FileStore) runsDir(issueID string) string {
+func (s *FileStore) runsDir(issueID model.IssueID) string {
 	return s.resolveRunsDir(issueID)
 }
 
 // resolveRunsDir resolves the runs directory, checking both gh- and gh# formats for backward compat.
-func (s *FileStore) resolveRunsDir(issueID string) string {
+func (s *FileStore) resolveRunsDir(issueID model.IssueID) string {
 	runsRoot := filepath.Join(s.rootPath, "runs")
+	issueIDStr := issueID.String()
 
-	if strings.HasPrefix(issueID, "gh-") {
-		canonicalDir := filepath.Join(runsRoot, issueID)
+	if strings.HasPrefix(issueIDStr, "gh-") {
+		canonicalDir := filepath.Join(runsRoot, issueIDStr)
 		if _, err := os.Stat(canonicalDir); err == nil {
 			return canonicalDir
 		}
 
-		legacyID := "gh#" + strings.TrimPrefix(issueID, "gh-")
+		legacyID := "gh#" + strings.TrimPrefix(issueIDStr, "gh-")
 		legacyDir := filepath.Join(runsRoot, legacyID)
 		if _, err := os.Stat(legacyDir); err == nil {
 			return legacyDir
@@ -597,13 +598,13 @@ func (s *FileStore) resolveRunsDir(issueID string) string {
 		return canonicalDir
 	}
 
-	if strings.HasPrefix(issueID, "gh#") {
-		legacyDir := filepath.Join(runsRoot, issueID)
+	if strings.HasPrefix(issueIDStr, "gh#") {
+		legacyDir := filepath.Join(runsRoot, issueIDStr)
 		if _, err := os.Stat(legacyDir); err == nil {
 			return legacyDir
 		}
 
-		canonicalID := "gh-" + strings.TrimPrefix(issueID, "gh#")
+		canonicalID := "gh-" + strings.TrimPrefix(issueIDStr, "gh#")
 		canonicalDir := filepath.Join(runsRoot, canonicalID)
 		if _, err := os.Stat(canonicalDir); err == nil {
 			return canonicalDir
@@ -612,11 +613,11 @@ func (s *FileStore) resolveRunsDir(issueID string) string {
 		return legacyDir
 	}
 
-	return filepath.Join(runsRoot, issueID)
+	return filepath.Join(runsRoot, issueIDStr)
 }
 
 // ResolveIssue retrieves an issue by ID
-func (s *FileStore) ResolveIssue(issueID string) (*model.Issue, error) {
+func (s *FileStore) ResolveIssue(issueID model.IssueID) (*model.Issue, error) {
 	// Scan if cache is dirty
 	if s.isCacheDirty() {
 		if err := s.scanIssues(); err != nil {
@@ -655,9 +656,9 @@ func (s *FileStore) ListIssues() ([]*model.Issue, error) {
 }
 
 // CreateRun creates a new run for an issue
-func (s *FileStore) CreateRun(issueID, runID string, metadata map[string]string) (*model.Run, error) {
+func (s *FileStore) CreateRun(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
 	// Skip verification for GitHub issues - they're not local files
-	if !strings.HasPrefix(issueID, "gh-") && !strings.HasPrefix(issueID, "gh#") {
+	if !strings.HasPrefix(issueID.String(), "gh-") && !strings.HasPrefix(issueID.String(), "gh#") {
 		_, err := s.ResolveIssue(issueID)
 		if err != nil {
 			return nil, err
@@ -755,7 +756,7 @@ func (s *FileStore) GetRun(ref *model.RunRef) (*model.Run, error) {
 }
 
 // GetLatestRun retrieves the latest run for an issue
-func (s *FileStore) GetLatestRun(issueID string) (*model.Run, error) {
+func (s *FileStore) GetLatestRun(issueID model.IssueID) (*model.Run, error) {
 	runsDir := s.runsDir(issueID)
 	entries, err := os.ReadDir(runsDir)
 	if err != nil {
@@ -784,12 +785,13 @@ func (s *FileStore) GetLatestRun(issueID string) (*model.Run, error) {
 		return nil, fmt.Errorf("no runs found for issue: %s", issueID)
 	}
 
-	return s.loadRun(issueID, latestName, s.runPath(issueID, latestName))
+	runID := model.NewRunID(latestName)
+	return s.loadRun(issueID, runID, s.runPath(issueID, runID))
 }
 
 // GetRunByShortID finds a run by its short ID prefix (2-6 hex chars)
 // Returns an error if no match found or if multiple runs match (ambiguous)
-func (s *FileStore) GetRunByShortID(shortID string) (*model.Run, error) {
+func (s *FileStore) GetRunByShortID(shortID model.ShortID) (*model.Run, error) {
 	// List all runs and find matching short ID prefix
 	runs, err := s.ListRuns(&store.ListRunsFilter{})
 	if err != nil {
@@ -798,7 +800,7 @@ func (s *FileStore) GetRunByShortID(shortID string) (*model.Run, error) {
 
 	var matches []*model.Run
 	for _, run := range runs {
-		if strings.HasPrefix(run.ShortID(), shortID) {
+		if strings.HasPrefix(run.ShortID().String(), shortID.String()) {
 			matches = append(matches, run)
 		}
 
@@ -816,7 +818,7 @@ func (s *FileStore) GetRunByShortID(shortID string) (*model.Run, error) {
 }
 
 // formatAmbiguousError formats an error message for ambiguous short ID matches
-func formatAmbiguousError(shortID string, matches []*model.Run) error {
+func formatAmbiguousError(shortID model.ShortID, matches []*model.Run) error {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("ambiguous run ID '%s': matches %d runs\n", shortID, len(matches)))
 
@@ -841,7 +843,7 @@ func formatAmbiguousError(shortID string, matches []*model.Run) error {
 }
 
 // loadRun loads a run from its file
-func (s *FileStore) loadRun(issueID, runID, path string) (*model.Run, error) {
+func (s *FileStore) loadRun(issueID model.IssueID, runID model.RunID, path string) (*model.Run, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -928,7 +930,7 @@ func (s *FileStore) ListRuns(filter *store.ListRunsFilter) ([]*model.Run, error)
 }
 
 // SetIssueStatus updates the status of an issue in its frontmatter
-func (s *FileStore) SetIssueStatus(issueID string, status model.IssueStatus) error {
+func (s *FileStore) SetIssueStatus(issueID model.IssueID, status model.IssueStatus) error {
 	issue, err := s.ResolveIssue(issueID)
 	if err != nil {
 		return err
@@ -1077,7 +1079,7 @@ func (s *FileStore) UpdateIssue(issue *model.Issue) error {
 	return nil
 }
 
-func (s *FileStore) ValidateIssueFiles(issueID string) (*store.ValidationResult, error) {
+func (s *FileStore) ValidateIssueFiles(issueID model.IssueID) (*store.ValidationResult, error) {
 	result := &store.ValidationResult{}
 
 	var issues []*model.Issue
@@ -1097,7 +1099,7 @@ func (s *FileStore) ValidateIssueFiles(issueID string) (*store.ValidationResult,
 	}
 
 	result.Total = len(issues)
-	idMap := make(map[string][]string)
+	idMap := make(map[model.IssueID][]string)
 
 	for _, issue := range issues {
 		idMap[issue.ID] = append(idMap[issue.ID], issue.Path)
@@ -1171,7 +1173,7 @@ func (s *FileStore) CreateIssue(issue *model.Issue) error {
 		return fmt.Errorf("issue ID is required")
 	}
 
-	issuePath := filepath.Join(s.issuesDir(), issue.ID+".md")
+	issuePath := filepath.Join(s.issuesDir(), issue.ID.String()+".md")
 	if _, err := os.Stat(issuePath); err == nil {
 		return fmt.Errorf("issue already exists: %s", issue.ID)
 	}

--- a/internal/store/file/file_test.go
+++ b/internal/store/file/file_test.go
@@ -500,7 +500,7 @@ func TestGetRunByShortIDAmbiguous(t *testing.T) {
 	run3, _ := s.CreateRun("test456", "20231220-120000", nil)
 
 	// Find the shortest common prefix among all runs
-	ids := []string{run1.ShortID(), run2.ShortID(), run3.ShortID()}
+	ids := []string{run1.ShortID().String(), run2.ShortID().String(), run3.ShortID().String()}
 
 	// Find runs that share a common prefix (testing ambiguity)
 	// Try to find any 2-char prefix that matches multiple runs
@@ -520,7 +520,7 @@ func TestGetRunByShortIDAmbiguous(t *testing.T) {
 
 	if ambiguousPrefix != "" {
 		// Test that ambiguous prefix returns error
-		_, err := s.GetRunByShortID(ambiguousPrefix)
+		_, err := s.GetRunByShortID(model.NewShortID(ambiguousPrefix))
 		if err == nil {
 			t.Error("expected error for ambiguous short ID prefix")
 		}
@@ -549,7 +549,7 @@ func TestGetRunByShortIDAmbiguousForced(t *testing.T) {
 	var runs []*model.Run
 	for i := 0; i < 20; i++ {
 		runID := fmt.Sprintf("20231220-%02d0000", i)
-		run, err := s.CreateRun("test", runID, nil)
+		run, err := s.CreateRun("test", model.NewRunID(runID), nil)
 		if err != nil {
 			t.Fatalf("failed to create run %d: %v", i, err)
 		}
@@ -559,7 +559,7 @@ func TestGetRunByShortIDAmbiguousForced(t *testing.T) {
 	// Find any prefix that has collisions
 	prefixCounts := make(map[string][]*model.Run)
 	for _, run := range runs {
-		prefix := run.ShortID()[:2]
+		prefix := run.ShortID().String()[:2]
 		prefixCounts[prefix] = append(prefixCounts[prefix], run)
 	}
 
@@ -576,7 +576,7 @@ func TestGetRunByShortIDAmbiguousForced(t *testing.T) {
 	}
 
 	// Test that ambiguous prefix returns error
-	_, err := s.GetRunByShortID(ambiguousPrefix)
+	_, err := s.GetRunByShortID(model.NewShortID(ambiguousPrefix))
 	if err == nil {
 		t.Error("expected error for ambiguous short ID prefix")
 	}
@@ -665,15 +665,15 @@ func TestGitHubIssueIDAliasing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	run, err := s.GetLatestRun(canonicalIssueID)
+	run, err := s.GetLatestRun(model.NewIssueID(canonicalIssueID))
 	if err != nil {
 		t.Fatalf("GetLatestRun(%q) should find run in legacy dir %q: %v", canonicalIssueID, legacyIssueID, err)
 	}
-	if run.RunID != runID {
+	if run.RunID.String() != runID {
 		t.Errorf("expected run ID %s, got %s", runID, run.RunID)
 	}
 
-	runs, err := s.ListRuns(&store.ListRunsFilter{IssueID: canonicalIssueID})
+	runs, err := s.ListRuns(&store.ListRunsFilter{IssueID: model.NewIssueID(canonicalIssueID)})
 	if err != nil {
 		t.Fatalf("ListRuns(%q) error: %v", canonicalIssueID, err)
 	}
@@ -681,12 +681,12 @@ func TestGitHubIssueIDAliasing(t *testing.T) {
 		t.Errorf("expected 1 run, got %d", len(runs))
 	}
 
-	ref := &model.RunRef{IssueID: canonicalIssueID, RunID: runID}
+	ref := &model.RunRef{IssueID: model.NewIssueID(canonicalIssueID), RunID: model.NewRunID(runID)}
 	run, err = s.GetRun(ref)
 	if err != nil {
 		t.Fatalf("GetRun(%q#%s) error: %v", canonicalIssueID, runID, err)
 	}
-	if run.RunID != runID {
+	if run.RunID.String() != runID {
 		t.Errorf("expected run ID %s, got %s", runID, run.RunID)
 	}
 }
@@ -775,7 +775,7 @@ status: open
 	// Check tags were parsed correctly
 	issueMap := make(map[string]*model.Issue)
 	for _, issue := range issues {
-		issueMap[issue.ID] = issue
+		issueMap[issue.ID.String()] = issue
 	}
 
 	// Check issue-1 tags
@@ -1440,7 +1440,7 @@ Note: This is just a note, not frontmatter.
 				warnings = append(warnings, fmt.Sprintf(format, args...))
 			})
 
-			issue, err := s.ResolveIssue(issueID)
+			issue, err := s.ResolveIssue(model.NewIssueID(issueID))
 			if err != nil {
 				t.Fatalf("ResolveIssue() error = %v", err)
 			}

--- a/internal/store/file/run_index.go
+++ b/internal/store/file/run_index.go
@@ -14,25 +14,25 @@ import (
 )
 
 type runIndexEntry struct {
-	IssueID           string       `json:"issue_id"`
-	RunID             string       `json:"run_id"`
-	Status            model.Status `json:"status"`
-	Agent             string       `json:"agent,omitempty"`
-	Target            string       `json:"target,omitempty"`
-	TargetHost        string       `json:"target_host,omitempty"`
-	TargetWorkerID    string       `json:"target_worker_id,omitempty"`
-	Model             string       `json:"model,omitempty"`
-	ModelVariant      string       `json:"model_variant,omitempty"`
-	Branch            string       `json:"branch,omitempty"`
-	WorktreePath      string       `json:"worktree_path,omitempty"`
-	SessionName       string       `json:"session_name,omitempty"`
-	Multiplexer       string       `json:"multiplexer,omitempty"`
-	PRUrl             string       `json:"pr_url,omitempty"`
-	ServerPort        int          `json:"server_port,omitempty"`
-	OpenCodeSessionID string       `json:"opencode_session_id,omitempty"`
-	StartedAt         time.Time    `json:"started_at"`
-	UpdatedAt         time.Time    `json:"updated_at"`
-	FileMtime         time.Time    `json:"file_mtime"`
+	IssueID           model.IssueID `json:"issue_id"`
+	RunID             model.RunID   `json:"run_id"`
+	Status            model.Status  `json:"status"`
+	Agent             string        `json:"agent,omitempty"`
+	Target            string        `json:"target,omitempty"`
+	TargetHost        string        `json:"target_host,omitempty"`
+	TargetWorkerID    string        `json:"target_worker_id,omitempty"`
+	Model             string        `json:"model,omitempty"`
+	ModelVariant      string        `json:"model_variant,omitempty"`
+	Branch            string        `json:"branch,omitempty"`
+	WorktreePath      string        `json:"worktree_path,omitempty"`
+	SessionName       string        `json:"session_name,omitempty"`
+	Multiplexer       string        `json:"multiplexer,omitempty"`
+	PRUrl             string        `json:"pr_url,omitempty"`
+	ServerPort        int           `json:"server_port,omitempty"`
+	OpenCodeSessionID string        `json:"opencode_session_id,omitempty"`
+	StartedAt         time.Time     `json:"started_at"`
+	UpdatedAt         time.Time     `json:"updated_at"`
+	FileMtime         time.Time     `json:"file_mtime"`
 }
 
 // UnmarshalJSON implements custom unmarshalling to support both the legacy
@@ -234,8 +234,9 @@ func (s *FileStore) listRunsIndexed(filter *store.ListRunsFilter) ([]*model.Run,
 				continue
 			}
 
-			runID := strings.TrimSuffix(e.Name(), ".md")
-			key := issueID + "/" + runID
+			typedIssueID := model.NewIssueID(issueID)
+			runID := model.NewRunID(strings.TrimSuffix(e.Name(), ".md"))
+			key := issueID + "/" + runID.String()
 			runPath := filepath.Join(issueRunsDir, e.Name())
 
 			info, err := e.Info()
@@ -254,7 +255,7 @@ func (s *FileStore) listRunsIndexed(filter *store.ListRunsFilter) ([]*model.Run,
 				continue
 			}
 
-			run, err := s.loadRun(issueID, runID, runPath)
+			run, err := s.loadRun(typedIssueID, runID, runPath)
 			if err != nil {
 				continue
 			}
@@ -380,8 +381,8 @@ func matchesRunFilters(entry *runIndexEntry, statusSet map[model.Status]bool, si
 		return false
 	}
 	if textSearch != "" {
-		if !strings.Contains(strings.ToLower(entry.RunID), textSearch) &&
-			!strings.Contains(strings.ToLower(entry.IssueID), textSearch) &&
+		if !strings.Contains(strings.ToLower(entry.RunID.String()), textSearch) &&
+			!strings.Contains(strings.ToLower(entry.IssueID.String()), textSearch) &&
 			!strings.Contains(strings.ToLower(entry.Branch), textSearch) {
 			return false
 		}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6,7 +6,7 @@ import (
 
 // ListRunsFilter specifies criteria for filtering runs
 type ListRunsFilter struct {
-	IssueID    string
+	IssueID    model.IssueID
 	Status     []model.Status
 	Agent      string // Filter by agent name (e.g., "opencode", "claude")
 	TextSearch string // Search in run_id, issue_id, branch
@@ -28,16 +28,16 @@ type ListIssuesFilter struct {
 // Store defines the interface for knowledge store backends
 type Store interface {
 	// ResolveIssue retrieves an issue by ID (looks for type: issue frontmatter)
-	ResolveIssue(issueID string) (*model.Issue, error)
+	ResolveIssue(issueID model.IssueID) (*model.Issue, error)
 
 	// ListIssues returns all issues in the issues root
 	ListIssues() ([]*model.Issue, error)
 
 	// SetIssueStatus updates an issue's status in frontmatter
-	SetIssueStatus(issueID string, status model.IssueStatus) error
+	SetIssueStatus(issueID model.IssueID, status model.IssueStatus) error
 
 	// CreateRun creates a new run for an issue
-	CreateRun(issueID, runID string, metadata map[string]string) (*model.Run, error)
+	CreateRun(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error)
 
 	// AppendEvent appends an event to a run
 	AppendEvent(ref *model.RunRef, event *model.Event) error
@@ -50,10 +50,10 @@ type Store interface {
 
 	// GetRunByShortID finds a run by its short ID prefix (2-6 hex chars)
 	// Returns an error if no match found or if multiple runs match (ambiguous)
-	GetRunByShortID(shortID string) (*model.Run, error)
+	GetRunByShortID(shortID model.ShortID) (*model.Run, error)
 
 	// GetLatestRun retrieves the latest run for an issue
-	GetLatestRun(issueID string) (*model.Run, error)
+	GetLatestRun(issueID model.IssueID) (*model.Run, error)
 
 	// RootPath returns the issues root path (where issues and runs are stored)
 	RootPath() string
@@ -65,7 +65,7 @@ type Store interface {
 	UpdateIssue(issue *model.Issue) error
 
 	// ValidateIssueFiles validates issue files and returns results
-	ValidateIssueFiles(issueID string) (*ValidationResult, error)
+	ValidateIssueFiles(issueID model.IssueID) (*ValidationResult, error)
 
 	// WriteAgentPrompt writes the agent control prompt for a run
 	WriteAgentPrompt(ref *model.RunRef, content string) error
@@ -86,7 +86,7 @@ type ValidationResult struct {
 
 type ValidationResultItem struct {
 	File    string
-	IssueID string
+	IssueID model.IssueID
 	Errors  []ValidationIssue
 }
 
@@ -98,6 +98,6 @@ type ValidationIssue struct {
 }
 
 type DuplicateID struct {
-	ID    string
+	ID    model.IssueID
 	Files []string
 }

--- a/internal/testutil/mock_orchapi.go
+++ b/internal/testutil/mock_orchapi.go
@@ -5,6 +5,7 @@ package testutil
 
 import (
 	"context"
+	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/orchapi"
 	"sync"
 )
@@ -28,7 +29,7 @@ var _ orchapi.OrchAPI = &OrchAPIMock{}
 //			CleanRunWorktreeFunc: func(ctx context.Context, ref orchapi.RunRef) (*orchapi.CleanRunWorktreeResult, error) {
 //				panic("mock out the CleanRunWorktree method")
 //			},
-//			CloseIssueFunc: func(ctx context.Context, issueID string) error {
+//			CloseIssueFunc: func(ctx context.Context, issueID model.IssueID) error {
 //				panic("mock out the CloseIssue method")
 //			},
 //			ContinueRunFunc: func(ctx context.Context, req *orchapi.ContinueRunRequest) (*orchapi.ContinueRunResult, error) {
@@ -67,13 +68,13 @@ var _ orchapi.OrchAPI = &OrchAPIMock{}
 //			GetDiffStatsFunc: func(ctx context.Context, ref orchapi.RunRef) (*orchapi.DiffStats, error) {
 //				panic("mock out the GetDiffStats method")
 //			},
-//			GetIssueFunc: func(ctx context.Context, issueID string) (*orchapi.Issue, error) {
+//			GetIssueFunc: func(ctx context.Context, issueID model.IssueID) (*orchapi.Issue, error) {
 //				panic("mock out the GetIssue method")
 //			},
-//			GetLatestRunFunc: func(ctx context.Context, issueID string) (*orchapi.Run, error) {
+//			GetLatestRunFunc: func(ctx context.Context, issueID model.IssueID) (*orchapi.Run, error) {
 //				panic("mock out the GetLatestRun method")
 //			},
-//			GetRunFunc: func(ctx context.Context, issueID string, runID string) (*orchapi.Run, error) {
+//			GetRunFunc: func(ctx context.Context, issueID model.IssueID, runID model.RunID) (*orchapi.Run, error) {
 //				panic("mock out the GetRun method")
 //			},
 //			InjectInitialPromptFunc: func(ctx context.Context, ref orchapi.RunRef, prompt string) error {
@@ -100,7 +101,7 @@ var _ orchapi.OrchAPI = &OrchAPIMock{}
 //			RepairStateFunc: func(ctx context.Context, opts *orchapi.RepairOptions) (*orchapi.RepairResult, error) {
 //				panic("mock out the RepairState method")
 //			},
-//			ResolveIssueFunc: func(ctx context.Context, issueID string, force bool) error {
+//			ResolveIssueFunc: func(ctx context.Context, issueID model.IssueID, force bool) error {
 //				panic("mock out the ResolveIssue method")
 //			},
 //			ResolveRunFunc: func(ctx context.Context, ref orchapi.RunRef) (*orchapi.Run, error) {
@@ -109,7 +110,7 @@ var _ orchapi.OrchAPI = &OrchAPIMock{}
 //			SendMessageFunc: func(ctx context.Context, ref orchapi.RunRef, message string, noEnter bool) error {
 //				panic("mock out the SendMessage method")
 //			},
-//			SetIssueStatusFunc: func(ctx context.Context, issueID string, status orchapi.IssueStatus) error {
+//			SetIssueStatusFunc: func(ctx context.Context, issueID model.IssueID, status orchapi.IssueStatus) error {
 //				panic("mock out the SetIssueStatus method")
 //			},
 //			StartRunFunc: func(ctx context.Context, req *orchapi.StartRunRequest) (*orchapi.StartRunResult, error) {
@@ -121,10 +122,10 @@ var _ orchapi.OrchAPI = &OrchAPIMock{}
 //			StreamRunEventsFunc: func(ctx context.Context, filter *orchapi.RunEventFilter) (orchapi.RunEventStream, error) {
 //				panic("mock out the StreamRunEvents method")
 //			},
-//			UpdateIssueFunc: func(ctx context.Context, issueID string, req *orchapi.UpdateIssueRequest) (*orchapi.Issue, error) {
+//			UpdateIssueFunc: func(ctx context.Context, issueID model.IssueID, req *orchapi.UpdateIssueRequest) (*orchapi.Issue, error) {
 //				panic("mock out the UpdateIssue method")
 //			},
-//			ValidateIssueFilesFunc: func(ctx context.Context, issueID string) (*orchapi.ValidateIssueFilesResult, error) {
+//			ValidateIssueFilesFunc: func(ctx context.Context, issueID model.IssueID) (*orchapi.ValidateIssueFilesResult, error) {
 //				panic("mock out the ValidateIssueFiles method")
 //			},
 //			WaitForRunsFunc: func(ctx context.Context, refs []string, timeoutSeconds int) (*orchapi.WaitForRunsResult, error) {
@@ -153,7 +154,7 @@ type OrchAPIMock struct {
 	CleanRunWorktreeFunc func(ctx context.Context, ref orchapi.RunRef) (*orchapi.CleanRunWorktreeResult, error)
 
 	// CloseIssueFunc mocks the CloseIssue method.
-	CloseIssueFunc func(ctx context.Context, issueID string) error
+	CloseIssueFunc func(ctx context.Context, issueID model.IssueID) error
 
 	// ContinueRunFunc mocks the ContinueRun method.
 	ContinueRunFunc func(ctx context.Context, req *orchapi.ContinueRunRequest) (*orchapi.ContinueRunResult, error)
@@ -192,13 +193,13 @@ type OrchAPIMock struct {
 	GetDiffStatsFunc func(ctx context.Context, ref orchapi.RunRef) (*orchapi.DiffStats, error)
 
 	// GetIssueFunc mocks the GetIssue method.
-	GetIssueFunc func(ctx context.Context, issueID string) (*orchapi.Issue, error)
+	GetIssueFunc func(ctx context.Context, issueID model.IssueID) (*orchapi.Issue, error)
 
 	// GetLatestRunFunc mocks the GetLatestRun method.
-	GetLatestRunFunc func(ctx context.Context, issueID string) (*orchapi.Run, error)
+	GetLatestRunFunc func(ctx context.Context, issueID model.IssueID) (*orchapi.Run, error)
 
 	// GetRunFunc mocks the GetRun method.
-	GetRunFunc func(ctx context.Context, issueID string, runID string) (*orchapi.Run, error)
+	GetRunFunc func(ctx context.Context, issueID model.IssueID, runID model.RunID) (*orchapi.Run, error)
 
 	// InjectInitialPromptFunc mocks the InjectInitialPrompt method.
 	InjectInitialPromptFunc func(ctx context.Context, ref orchapi.RunRef, prompt string) error
@@ -225,7 +226,7 @@ type OrchAPIMock struct {
 	RepairStateFunc func(ctx context.Context, opts *orchapi.RepairOptions) (*orchapi.RepairResult, error)
 
 	// ResolveIssueFunc mocks the ResolveIssue method.
-	ResolveIssueFunc func(ctx context.Context, issueID string, force bool) error
+	ResolveIssueFunc func(ctx context.Context, issueID model.IssueID, force bool) error
 
 	// ResolveRunFunc mocks the ResolveRun method.
 	ResolveRunFunc func(ctx context.Context, ref orchapi.RunRef) (*orchapi.Run, error)
@@ -234,7 +235,7 @@ type OrchAPIMock struct {
 	SendMessageFunc func(ctx context.Context, ref orchapi.RunRef, message string, noEnter bool) error
 
 	// SetIssueStatusFunc mocks the SetIssueStatus method.
-	SetIssueStatusFunc func(ctx context.Context, issueID string, status orchapi.IssueStatus) error
+	SetIssueStatusFunc func(ctx context.Context, issueID model.IssueID, status orchapi.IssueStatus) error
 
 	// StartRunFunc mocks the StartRun method.
 	StartRunFunc func(ctx context.Context, req *orchapi.StartRunRequest) (*orchapi.StartRunResult, error)
@@ -246,10 +247,10 @@ type OrchAPIMock struct {
 	StreamRunEventsFunc func(ctx context.Context, filter *orchapi.RunEventFilter) (orchapi.RunEventStream, error)
 
 	// UpdateIssueFunc mocks the UpdateIssue method.
-	UpdateIssueFunc func(ctx context.Context, issueID string, req *orchapi.UpdateIssueRequest) (*orchapi.Issue, error)
+	UpdateIssueFunc func(ctx context.Context, issueID model.IssueID, req *orchapi.UpdateIssueRequest) (*orchapi.Issue, error)
 
 	// ValidateIssueFilesFunc mocks the ValidateIssueFiles method.
-	ValidateIssueFilesFunc func(ctx context.Context, issueID string) (*orchapi.ValidateIssueFilesResult, error)
+	ValidateIssueFilesFunc func(ctx context.Context, issueID model.IssueID) (*orchapi.ValidateIssueFilesResult, error)
 
 	// WaitForRunsFunc mocks the WaitForRuns method.
 	WaitForRunsFunc func(ctx context.Context, refs []string, timeoutSeconds int) (*orchapi.WaitForRunsResult, error)
@@ -292,7 +293,7 @@ type OrchAPIMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// IssueID is the issueID argument value.
-			IssueID string
+			IssueID model.IssueID
 		}
 		// ContinueRun holds details about calls to the ContinueRun method.
 		ContinueRun []struct {
@@ -379,23 +380,23 @@ type OrchAPIMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// IssueID is the issueID argument value.
-			IssueID string
+			IssueID model.IssueID
 		}
 		// GetLatestRun holds details about calls to the GetLatestRun method.
 		GetLatestRun []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// IssueID is the issueID argument value.
-			IssueID string
+			IssueID model.IssueID
 		}
 		// GetRun holds details about calls to the GetRun method.
 		GetRun []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// IssueID is the issueID argument value.
-			IssueID string
+			IssueID model.IssueID
 			// RunID is the runID argument value.
-			RunID string
+			RunID model.RunID
 		}
 		// InjectInitialPrompt holds details about calls to the InjectInitialPrompt method.
 		InjectInitialPrompt []struct {
@@ -458,7 +459,7 @@ type OrchAPIMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// IssueID is the issueID argument value.
-			IssueID string
+			IssueID model.IssueID
 			// Force is the force argument value.
 			Force bool
 		}
@@ -485,7 +486,7 @@ type OrchAPIMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// IssueID is the issueID argument value.
-			IssueID string
+			IssueID model.IssueID
 			// Status is the status argument value.
 			Status orchapi.IssueStatus
 		}
@@ -515,7 +516,7 @@ type OrchAPIMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// IssueID is the issueID argument value.
-			IssueID string
+			IssueID model.IssueID
 			// Req is the req argument value.
 			Req *orchapi.UpdateIssueRequest
 		}
@@ -524,7 +525,7 @@ type OrchAPIMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// IssueID is the issueID argument value.
-			IssueID string
+			IssueID model.IssueID
 		}
 		// WaitForRuns holds details about calls to the WaitForRuns method.
 		WaitForRuns []struct {
@@ -714,13 +715,13 @@ func (mock *OrchAPIMock) CleanRunWorktreeCalls() []struct {
 }
 
 // CloseIssue calls CloseIssueFunc.
-func (mock *OrchAPIMock) CloseIssue(ctx context.Context, issueID string) error {
+func (mock *OrchAPIMock) CloseIssue(ctx context.Context, issueID model.IssueID) error {
 	if mock.CloseIssueFunc == nil {
 		panic("OrchAPIMock.CloseIssueFunc: method is nil but OrchAPI.CloseIssue was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 	}{
 		Ctx:     ctx,
 		IssueID: issueID,
@@ -737,11 +738,11 @@ func (mock *OrchAPIMock) CloseIssue(ctx context.Context, issueID string) error {
 //	len(mockedOrchAPI.CloseIssueCalls())
 func (mock *OrchAPIMock) CloseIssueCalls() []struct {
 	Ctx     context.Context
-	IssueID string
+	IssueID model.IssueID
 } {
 	var calls []struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 	}
 	mock.lockCloseIssue.RLock()
 	calls = mock.calls.CloseIssue
@@ -1174,13 +1175,13 @@ func (mock *OrchAPIMock) GetDiffStatsCalls() []struct {
 }
 
 // GetIssue calls GetIssueFunc.
-func (mock *OrchAPIMock) GetIssue(ctx context.Context, issueID string) (*orchapi.Issue, error) {
+func (mock *OrchAPIMock) GetIssue(ctx context.Context, issueID model.IssueID) (*orchapi.Issue, error) {
 	if mock.GetIssueFunc == nil {
 		panic("OrchAPIMock.GetIssueFunc: method is nil but OrchAPI.GetIssue was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 	}{
 		Ctx:     ctx,
 		IssueID: issueID,
@@ -1197,11 +1198,11 @@ func (mock *OrchAPIMock) GetIssue(ctx context.Context, issueID string) (*orchapi
 //	len(mockedOrchAPI.GetIssueCalls())
 func (mock *OrchAPIMock) GetIssueCalls() []struct {
 	Ctx     context.Context
-	IssueID string
+	IssueID model.IssueID
 } {
 	var calls []struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 	}
 	mock.lockGetIssue.RLock()
 	calls = mock.calls.GetIssue
@@ -1210,13 +1211,13 @@ func (mock *OrchAPIMock) GetIssueCalls() []struct {
 }
 
 // GetLatestRun calls GetLatestRunFunc.
-func (mock *OrchAPIMock) GetLatestRun(ctx context.Context, issueID string) (*orchapi.Run, error) {
+func (mock *OrchAPIMock) GetLatestRun(ctx context.Context, issueID model.IssueID) (*orchapi.Run, error) {
 	if mock.GetLatestRunFunc == nil {
 		panic("OrchAPIMock.GetLatestRunFunc: method is nil but OrchAPI.GetLatestRun was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 	}{
 		Ctx:     ctx,
 		IssueID: issueID,
@@ -1233,11 +1234,11 @@ func (mock *OrchAPIMock) GetLatestRun(ctx context.Context, issueID string) (*orc
 //	len(mockedOrchAPI.GetLatestRunCalls())
 func (mock *OrchAPIMock) GetLatestRunCalls() []struct {
 	Ctx     context.Context
-	IssueID string
+	IssueID model.IssueID
 } {
 	var calls []struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 	}
 	mock.lockGetLatestRun.RLock()
 	calls = mock.calls.GetLatestRun
@@ -1246,14 +1247,14 @@ func (mock *OrchAPIMock) GetLatestRunCalls() []struct {
 }
 
 // GetRun calls GetRunFunc.
-func (mock *OrchAPIMock) GetRun(ctx context.Context, issueID string, runID string) (*orchapi.Run, error) {
+func (mock *OrchAPIMock) GetRun(ctx context.Context, issueID model.IssueID, runID model.RunID) (*orchapi.Run, error) {
 	if mock.GetRunFunc == nil {
 		panic("OrchAPIMock.GetRunFunc: method is nil but OrchAPI.GetRun was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
-		IssueID string
-		RunID   string
+		IssueID model.IssueID
+		RunID   model.RunID
 	}{
 		Ctx:     ctx,
 		IssueID: issueID,
@@ -1271,13 +1272,13 @@ func (mock *OrchAPIMock) GetRun(ctx context.Context, issueID string, runID strin
 //	len(mockedOrchAPI.GetRunCalls())
 func (mock *OrchAPIMock) GetRunCalls() []struct {
 	Ctx     context.Context
-	IssueID string
-	RunID   string
+	IssueID model.IssueID
+	RunID   model.RunID
 } {
 	var calls []struct {
 		Ctx     context.Context
-		IssueID string
-		RunID   string
+		IssueID model.IssueID
+		RunID   model.RunID
 	}
 	mock.lockGetRun.RLock()
 	calls = mock.calls.GetRun
@@ -1574,13 +1575,13 @@ func (mock *OrchAPIMock) RepairStateCalls() []struct {
 }
 
 // ResolveIssue calls ResolveIssueFunc.
-func (mock *OrchAPIMock) ResolveIssue(ctx context.Context, issueID string, force bool) error {
+func (mock *OrchAPIMock) ResolveIssue(ctx context.Context, issueID model.IssueID, force bool) error {
 	if mock.ResolveIssueFunc == nil {
 		panic("OrchAPIMock.ResolveIssueFunc: method is nil but OrchAPI.ResolveIssue was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 		Force   bool
 	}{
 		Ctx:     ctx,
@@ -1599,12 +1600,12 @@ func (mock *OrchAPIMock) ResolveIssue(ctx context.Context, issueID string, force
 //	len(mockedOrchAPI.ResolveIssueCalls())
 func (mock *OrchAPIMock) ResolveIssueCalls() []struct {
 	Ctx     context.Context
-	IssueID string
+	IssueID model.IssueID
 	Force   bool
 } {
 	var calls []struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 		Force   bool
 	}
 	mock.lockResolveIssue.RLock()
@@ -1694,13 +1695,13 @@ func (mock *OrchAPIMock) SendMessageCalls() []struct {
 }
 
 // SetIssueStatus calls SetIssueStatusFunc.
-func (mock *OrchAPIMock) SetIssueStatus(ctx context.Context, issueID string, status orchapi.IssueStatus) error {
+func (mock *OrchAPIMock) SetIssueStatus(ctx context.Context, issueID model.IssueID, status orchapi.IssueStatus) error {
 	if mock.SetIssueStatusFunc == nil {
 		panic("OrchAPIMock.SetIssueStatusFunc: method is nil but OrchAPI.SetIssueStatus was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 		Status  orchapi.IssueStatus
 	}{
 		Ctx:     ctx,
@@ -1719,12 +1720,12 @@ func (mock *OrchAPIMock) SetIssueStatus(ctx context.Context, issueID string, sta
 //	len(mockedOrchAPI.SetIssueStatusCalls())
 func (mock *OrchAPIMock) SetIssueStatusCalls() []struct {
 	Ctx     context.Context
-	IssueID string
+	IssueID model.IssueID
 	Status  orchapi.IssueStatus
 } {
 	var calls []struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 		Status  orchapi.IssueStatus
 	}
 	mock.lockSetIssueStatus.RLock()
@@ -1842,13 +1843,13 @@ func (mock *OrchAPIMock) StreamRunEventsCalls() []struct {
 }
 
 // UpdateIssue calls UpdateIssueFunc.
-func (mock *OrchAPIMock) UpdateIssue(ctx context.Context, issueID string, req *orchapi.UpdateIssueRequest) (*orchapi.Issue, error) {
+func (mock *OrchAPIMock) UpdateIssue(ctx context.Context, issueID model.IssueID, req *orchapi.UpdateIssueRequest) (*orchapi.Issue, error) {
 	if mock.UpdateIssueFunc == nil {
 		panic("OrchAPIMock.UpdateIssueFunc: method is nil but OrchAPI.UpdateIssue was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 		Req     *orchapi.UpdateIssueRequest
 	}{
 		Ctx:     ctx,
@@ -1867,12 +1868,12 @@ func (mock *OrchAPIMock) UpdateIssue(ctx context.Context, issueID string, req *o
 //	len(mockedOrchAPI.UpdateIssueCalls())
 func (mock *OrchAPIMock) UpdateIssueCalls() []struct {
 	Ctx     context.Context
-	IssueID string
+	IssueID model.IssueID
 	Req     *orchapi.UpdateIssueRequest
 } {
 	var calls []struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 		Req     *orchapi.UpdateIssueRequest
 	}
 	mock.lockUpdateIssue.RLock()
@@ -1882,13 +1883,13 @@ func (mock *OrchAPIMock) UpdateIssueCalls() []struct {
 }
 
 // ValidateIssueFiles calls ValidateIssueFilesFunc.
-func (mock *OrchAPIMock) ValidateIssueFiles(ctx context.Context, issueID string) (*orchapi.ValidateIssueFilesResult, error) {
+func (mock *OrchAPIMock) ValidateIssueFiles(ctx context.Context, issueID model.IssueID) (*orchapi.ValidateIssueFilesResult, error) {
 	if mock.ValidateIssueFilesFunc == nil {
 		panic("OrchAPIMock.ValidateIssueFilesFunc: method is nil but OrchAPI.ValidateIssueFiles was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 	}{
 		Ctx:     ctx,
 		IssueID: issueID,
@@ -1905,11 +1906,11 @@ func (mock *OrchAPIMock) ValidateIssueFiles(ctx context.Context, issueID string)
 //	len(mockedOrchAPI.ValidateIssueFilesCalls())
 func (mock *OrchAPIMock) ValidateIssueFilesCalls() []struct {
 	Ctx     context.Context
-	IssueID string
+	IssueID model.IssueID
 } {
 	var calls []struct {
 		Ctx     context.Context
-		IssueID string
+		IssueID model.IssueID
 	}
 	mock.lockValidateIssueFiles.RLock()
 	calls = mock.calls.ValidateIssueFiles

--- a/internal/testutil/mock_store.go
+++ b/internal/testutil/mock_store.go
@@ -25,19 +25,19 @@ var _ store.Store = &StoreMock{}
 //			CreateIssueFunc: func(issue *model.Issue) error {
 //				panic("mock out the CreateIssue method")
 //			},
-//			CreateRunFunc: func(issueID string, runID string, metadata map[string]string) (*model.Run, error) {
+//			CreateRunFunc: func(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
 //				panic("mock out the CreateRun method")
 //			},
 //			DeleteRunFunc: func(ref *model.RunRef) error {
 //				panic("mock out the DeleteRun method")
 //			},
-//			GetLatestRunFunc: func(issueID string) (*model.Run, error) {
+//			GetLatestRunFunc: func(issueID model.IssueID) (*model.Run, error) {
 //				panic("mock out the GetLatestRun method")
 //			},
 //			GetRunFunc: func(ref *model.RunRef) (*model.Run, error) {
 //				panic("mock out the GetRun method")
 //			},
-//			GetRunByShortIDFunc: func(shortID string) (*model.Run, error) {
+//			GetRunByShortIDFunc: func(shortID model.ShortID) (*model.Run, error) {
 //				panic("mock out the GetRunByShortID method")
 //			},
 //			ListIssuesFunc: func() ([]*model.Issue, error) {
@@ -49,19 +49,19 @@ var _ store.Store = &StoreMock{}
 //			ReadAgentPromptFunc: func(ref *model.RunRef) (string, error) {
 //				panic("mock out the ReadAgentPrompt method")
 //			},
-//			ResolveIssueFunc: func(issueID string) (*model.Issue, error) {
+//			ResolveIssueFunc: func(issueID model.IssueID) (*model.Issue, error) {
 //				panic("mock out the ResolveIssue method")
 //			},
 //			RootPathFunc: func() string {
 //				panic("mock out the RootPath method")
 //			},
-//			SetIssueStatusFunc: func(issueID string, status model.IssueStatus) error {
+//			SetIssueStatusFunc: func(issueID model.IssueID, status model.IssueStatus) error {
 //				panic("mock out the SetIssueStatus method")
 //			},
 //			UpdateIssueFunc: func(issue *model.Issue) error {
 //				panic("mock out the UpdateIssue method")
 //			},
-//			ValidateIssueFilesFunc: func(issueID string) (*store.ValidationResult, error) {
+//			ValidateIssueFilesFunc: func(issueID model.IssueID) (*store.ValidationResult, error) {
 //				panic("mock out the ValidateIssueFiles method")
 //			},
 //			WriteAgentPromptFunc: func(ref *model.RunRef, content string) error {
@@ -81,19 +81,19 @@ type StoreMock struct {
 	CreateIssueFunc func(issue *model.Issue) error
 
 	// CreateRunFunc mocks the CreateRun method.
-	CreateRunFunc func(issueID string, runID string, metadata map[string]string) (*model.Run, error)
+	CreateRunFunc func(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error)
 
 	// DeleteRunFunc mocks the DeleteRun method.
 	DeleteRunFunc func(ref *model.RunRef) error
 
 	// GetLatestRunFunc mocks the GetLatestRun method.
-	GetLatestRunFunc func(issueID string) (*model.Run, error)
+	GetLatestRunFunc func(issueID model.IssueID) (*model.Run, error)
 
 	// GetRunFunc mocks the GetRun method.
 	GetRunFunc func(ref *model.RunRef) (*model.Run, error)
 
 	// GetRunByShortIDFunc mocks the GetRunByShortID method.
-	GetRunByShortIDFunc func(shortID string) (*model.Run, error)
+	GetRunByShortIDFunc func(shortID model.ShortID) (*model.Run, error)
 
 	// ListIssuesFunc mocks the ListIssues method.
 	ListIssuesFunc func() ([]*model.Issue, error)
@@ -105,19 +105,19 @@ type StoreMock struct {
 	ReadAgentPromptFunc func(ref *model.RunRef) (string, error)
 
 	// ResolveIssueFunc mocks the ResolveIssue method.
-	ResolveIssueFunc func(issueID string) (*model.Issue, error)
+	ResolveIssueFunc func(issueID model.IssueID) (*model.Issue, error)
 
 	// RootPathFunc mocks the RootPath method.
 	RootPathFunc func() string
 
 	// SetIssueStatusFunc mocks the SetIssueStatus method.
-	SetIssueStatusFunc func(issueID string, status model.IssueStatus) error
+	SetIssueStatusFunc func(issueID model.IssueID, status model.IssueStatus) error
 
 	// UpdateIssueFunc mocks the UpdateIssue method.
 	UpdateIssueFunc func(issue *model.Issue) error
 
 	// ValidateIssueFilesFunc mocks the ValidateIssueFiles method.
-	ValidateIssueFilesFunc func(issueID string) (*store.ValidationResult, error)
+	ValidateIssueFilesFunc func(issueID model.IssueID) (*store.ValidationResult, error)
 
 	// WriteAgentPromptFunc mocks the WriteAgentPrompt method.
 	WriteAgentPromptFunc func(ref *model.RunRef, content string) error
@@ -139,9 +139,9 @@ type StoreMock struct {
 		// CreateRun holds details about calls to the CreateRun method.
 		CreateRun []struct {
 			// IssueID is the issueID argument value.
-			IssueID string
+			IssueID model.IssueID
 			// RunID is the runID argument value.
-			RunID string
+			RunID model.RunID
 			// Metadata is the metadata argument value.
 			Metadata map[string]string
 		}
@@ -153,7 +153,7 @@ type StoreMock struct {
 		// GetLatestRun holds details about calls to the GetLatestRun method.
 		GetLatestRun []struct {
 			// IssueID is the issueID argument value.
-			IssueID string
+			IssueID model.IssueID
 		}
 		// GetRun holds details about calls to the GetRun method.
 		GetRun []struct {
@@ -163,7 +163,7 @@ type StoreMock struct {
 		// GetRunByShortID holds details about calls to the GetRunByShortID method.
 		GetRunByShortID []struct {
 			// ShortID is the shortID argument value.
-			ShortID string
+			ShortID model.ShortID
 		}
 		// ListIssues holds details about calls to the ListIssues method.
 		ListIssues []struct {
@@ -181,7 +181,7 @@ type StoreMock struct {
 		// ResolveIssue holds details about calls to the ResolveIssue method.
 		ResolveIssue []struct {
 			// IssueID is the issueID argument value.
-			IssueID string
+			IssueID model.IssueID
 		}
 		// RootPath holds details about calls to the RootPath method.
 		RootPath []struct {
@@ -189,7 +189,7 @@ type StoreMock struct {
 		// SetIssueStatus holds details about calls to the SetIssueStatus method.
 		SetIssueStatus []struct {
 			// IssueID is the issueID argument value.
-			IssueID string
+			IssueID model.IssueID
 			// Status is the status argument value.
 			Status model.IssueStatus
 		}
@@ -201,7 +201,7 @@ type StoreMock struct {
 		// ValidateIssueFiles holds details about calls to the ValidateIssueFiles method.
 		ValidateIssueFiles []struct {
 			// IssueID is the issueID argument value.
-			IssueID string
+			IssueID model.IssueID
 		}
 		// WriteAgentPrompt holds details about calls to the WriteAgentPrompt method.
 		WriteAgentPrompt []struct {
@@ -298,13 +298,13 @@ func (mock *StoreMock) CreateIssueCalls() []struct {
 }
 
 // CreateRun calls CreateRunFunc.
-func (mock *StoreMock) CreateRun(issueID string, runID string, metadata map[string]string) (*model.Run, error) {
+func (mock *StoreMock) CreateRun(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
 	if mock.CreateRunFunc == nil {
 		panic("StoreMock.CreateRunFunc: method is nil but Store.CreateRun was just called")
 	}
 	callInfo := struct {
-		IssueID  string
-		RunID    string
+		IssueID  model.IssueID
+		RunID    model.RunID
 		Metadata map[string]string
 	}{
 		IssueID:  issueID,
@@ -322,13 +322,13 @@ func (mock *StoreMock) CreateRun(issueID string, runID string, metadata map[stri
 //
 //	len(mockedStore.CreateRunCalls())
 func (mock *StoreMock) CreateRunCalls() []struct {
-	IssueID  string
-	RunID    string
+	IssueID  model.IssueID
+	RunID    model.RunID
 	Metadata map[string]string
 } {
 	var calls []struct {
-		IssueID  string
-		RunID    string
+		IssueID  model.IssueID
+		RunID    model.RunID
 		Metadata map[string]string
 	}
 	mock.lockCreateRun.RLock()
@@ -370,12 +370,12 @@ func (mock *StoreMock) DeleteRunCalls() []struct {
 }
 
 // GetLatestRun calls GetLatestRunFunc.
-func (mock *StoreMock) GetLatestRun(issueID string) (*model.Run, error) {
+func (mock *StoreMock) GetLatestRun(issueID model.IssueID) (*model.Run, error) {
 	if mock.GetLatestRunFunc == nil {
 		panic("StoreMock.GetLatestRunFunc: method is nil but Store.GetLatestRun was just called")
 	}
 	callInfo := struct {
-		IssueID string
+		IssueID model.IssueID
 	}{
 		IssueID: issueID,
 	}
@@ -390,10 +390,10 @@ func (mock *StoreMock) GetLatestRun(issueID string) (*model.Run, error) {
 //
 //	len(mockedStore.GetLatestRunCalls())
 func (mock *StoreMock) GetLatestRunCalls() []struct {
-	IssueID string
+	IssueID model.IssueID
 } {
 	var calls []struct {
-		IssueID string
+		IssueID model.IssueID
 	}
 	mock.lockGetLatestRun.RLock()
 	calls = mock.calls.GetLatestRun
@@ -434,12 +434,12 @@ func (mock *StoreMock) GetRunCalls() []struct {
 }
 
 // GetRunByShortID calls GetRunByShortIDFunc.
-func (mock *StoreMock) GetRunByShortID(shortID string) (*model.Run, error) {
+func (mock *StoreMock) GetRunByShortID(shortID model.ShortID) (*model.Run, error) {
 	if mock.GetRunByShortIDFunc == nil {
 		panic("StoreMock.GetRunByShortIDFunc: method is nil but Store.GetRunByShortID was just called")
 	}
 	callInfo := struct {
-		ShortID string
+		ShortID model.ShortID
 	}{
 		ShortID: shortID,
 	}
@@ -454,10 +454,10 @@ func (mock *StoreMock) GetRunByShortID(shortID string) (*model.Run, error) {
 //
 //	len(mockedStore.GetRunByShortIDCalls())
 func (mock *StoreMock) GetRunByShortIDCalls() []struct {
-	ShortID string
+	ShortID model.ShortID
 } {
 	var calls []struct {
-		ShortID string
+		ShortID model.ShortID
 	}
 	mock.lockGetRunByShortID.RLock()
 	calls = mock.calls.GetRunByShortID
@@ -557,12 +557,12 @@ func (mock *StoreMock) ReadAgentPromptCalls() []struct {
 }
 
 // ResolveIssue calls ResolveIssueFunc.
-func (mock *StoreMock) ResolveIssue(issueID string) (*model.Issue, error) {
+func (mock *StoreMock) ResolveIssue(issueID model.IssueID) (*model.Issue, error) {
 	if mock.ResolveIssueFunc == nil {
 		panic("StoreMock.ResolveIssueFunc: method is nil but Store.ResolveIssue was just called")
 	}
 	callInfo := struct {
-		IssueID string
+		IssueID model.IssueID
 	}{
 		IssueID: issueID,
 	}
@@ -577,10 +577,10 @@ func (mock *StoreMock) ResolveIssue(issueID string) (*model.Issue, error) {
 //
 //	len(mockedStore.ResolveIssueCalls())
 func (mock *StoreMock) ResolveIssueCalls() []struct {
-	IssueID string
+	IssueID model.IssueID
 } {
 	var calls []struct {
-		IssueID string
+		IssueID model.IssueID
 	}
 	mock.lockResolveIssue.RLock()
 	calls = mock.calls.ResolveIssue
@@ -616,12 +616,12 @@ func (mock *StoreMock) RootPathCalls() []struct {
 }
 
 // SetIssueStatus calls SetIssueStatusFunc.
-func (mock *StoreMock) SetIssueStatus(issueID string, status model.IssueStatus) error {
+func (mock *StoreMock) SetIssueStatus(issueID model.IssueID, status model.IssueStatus) error {
 	if mock.SetIssueStatusFunc == nil {
 		panic("StoreMock.SetIssueStatusFunc: method is nil but Store.SetIssueStatus was just called")
 	}
 	callInfo := struct {
-		IssueID string
+		IssueID model.IssueID
 		Status  model.IssueStatus
 	}{
 		IssueID: issueID,
@@ -638,11 +638,11 @@ func (mock *StoreMock) SetIssueStatus(issueID string, status model.IssueStatus) 
 //
 //	len(mockedStore.SetIssueStatusCalls())
 func (mock *StoreMock) SetIssueStatusCalls() []struct {
-	IssueID string
+	IssueID model.IssueID
 	Status  model.IssueStatus
 } {
 	var calls []struct {
-		IssueID string
+		IssueID model.IssueID
 		Status  model.IssueStatus
 	}
 	mock.lockSetIssueStatus.RLock()
@@ -684,12 +684,12 @@ func (mock *StoreMock) UpdateIssueCalls() []struct {
 }
 
 // ValidateIssueFiles calls ValidateIssueFilesFunc.
-func (mock *StoreMock) ValidateIssueFiles(issueID string) (*store.ValidationResult, error) {
+func (mock *StoreMock) ValidateIssueFiles(issueID model.IssueID) (*store.ValidationResult, error) {
 	if mock.ValidateIssueFilesFunc == nil {
 		panic("StoreMock.ValidateIssueFilesFunc: method is nil but Store.ValidateIssueFiles was just called")
 	}
 	callInfo := struct {
-		IssueID string
+		IssueID model.IssueID
 	}{
 		IssueID: issueID,
 	}
@@ -704,10 +704,10 @@ func (mock *StoreMock) ValidateIssueFiles(issueID string) (*store.ValidationResu
 //
 //	len(mockedStore.ValidateIssueFilesCalls())
 func (mock *StoreMock) ValidateIssueFilesCalls() []struct {
-	IssueID string
+	IssueID model.IssueID
 } {
 	var calls []struct {
-		IssueID string
+		IssueID model.IssueID
 	}
 	mock.lockValidateIssueFiles.RLock()
 	calls = mock.calls.ValidateIssueFiles

--- a/internal/xdg/paths.go
+++ b/internal/xdg/paths.go
@@ -7,9 +7,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
+
+	"github.com/s22625/orch/internal/model"
 )
 
 const appName = "orch"
@@ -142,13 +143,13 @@ func DaemonDBPath() string {
 
 // RepoDataDir returns the data directory for a specific repo.
 // ~/.local/share/orch/{repoID}/
-func RepoDataDir(repoID string) string {
-	return filepath.Join(DataDir(), repoID)
+func RepoDataDir(repoID model.RepoID) string {
+	return filepath.Join(DataDir(), repoID.String())
 }
 
 // RepoRunsDir returns the runs directory for a specific repo.
 // ~/.local/share/orch/{repoID}/runs/
-func RepoRunsDir(repoID string) string {
+func RepoRunsDir(repoID model.RepoID) string {
 	return filepath.Join(RepoDataDir(repoID), "runs")
 }
 
@@ -190,17 +191,17 @@ func EnsureDataDir() error {
 
 // RepoID derives a repo identifier strictly from the git remote URL.
 // Returns "owner-repo" format (e.g., "proboscis-orch").
-func RepoID(projectRoot string) (string, error) {
+func RepoID(projectRoot string) (model.RepoID, error) {
 	return repoIDFromRemote(projectRoot)
 }
 
 // RepoIDStrict derives repo identifier strictly from git remote URL.
 // Unlike RepoID, it does not fall back to a path-derived identifier.
-func RepoIDStrict(projectRoot string) (string, error) {
+func RepoIDStrict(projectRoot string) (model.RepoID, error) {
 	return repoIDFromRemote(projectRoot)
 }
 
-func repoIDFromRemote(projectRoot string) (string, error) {
+func repoIDFromRemote(projectRoot string) (model.RepoID, error) {
 	cmd := exec.Command("git", "-C", projectRoot, "config", "--get", "remote.origin.url")
 	output, err := cmd.Output()
 	if err != nil {
@@ -227,47 +228,12 @@ func LegacyRepoID(projectRoot string) string {
 //   - git@github.com:owner/repo.git
 //   - git://github.com/owner/repo.git
 //   - ssh://git@github.com/owner/repo.git
-func ParseRepoID(remoteURL string) (string, error) {
-	if remoteURL == "" {
-		return "", fmt.Errorf("empty remote URL")
+func ParseRepoID(remoteURL string) (model.RepoID, error) {
+	repoID, err := model.NewRepoID(remoteURL)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse remote URL: %s", remoteURL)
 	}
-
-	// SSH format: git@github.com:owner/repo.git
-	sshPattern := regexp.MustCompile(`^git@[^:]+:([^/]+)/([^/]+?)(?:\.git)?$`)
-	if matches := sshPattern.FindStringSubmatch(remoteURL); len(matches) == 3 {
-		return sanitizeRepoID(matches[1], matches[2]), nil
-	}
-
-	// HTTPS/Git format: https://github.com/owner/repo.git
-	httpsPattern := regexp.MustCompile(`^(?:https?|git|ssh)://[^/]+/([^/]+)/([^/]+?)(?:\.git)?/?$`)
-	if matches := httpsPattern.FindStringSubmatch(remoteURL); len(matches) == 3 {
-		return sanitizeRepoID(matches[1], matches[2]), nil
-	}
-
-	// Last resort: try to extract from path
-	// Remove .git suffix and split by /
-	cleaned := strings.TrimSuffix(remoteURL, ".git")
-	parts := strings.Split(cleaned, "/")
-	if len(parts) >= 2 {
-		owner := parts[len(parts)-2]
-		repo := parts[len(parts)-1]
-		// Handle colon in SSH format
-		if idx := strings.LastIndex(owner, ":"); idx != -1 {
-			owner = owner[idx+1:]
-		}
-		return sanitizeRepoID(owner, repo), nil
-	}
-
-	return "", fmt.Errorf("unable to parse remote URL: %s", remoteURL)
-}
-
-// sanitizeRepoID creates a safe directory name from owner and repo.
-func sanitizeRepoID(owner, repo string) string {
-	// Remove any unsafe characters, keeping alphanumeric, dash, underscore
-	safePattern := regexp.MustCompile(`[^a-zA-Z0-9_-]`)
-	safeOwner := safePattern.ReplaceAllString(owner, "")
-	safeRepo := safePattern.ReplaceAllString(repo, "")
-	return safeOwner + "-" + safeRepo
+	return repoID, nil
 }
 
 // LegacyOrchDir returns the legacy .orch directory path for a project.

--- a/internal/xdg/paths_test.go
+++ b/internal/xdg/paths_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/s22625/orch/internal/model"
 )
 
 func TestParseRepoID(t *testing.T) {
@@ -75,7 +77,7 @@ func TestParseRepoID(t *testing.T) {
 				t.Errorf("ParseRepoID() error = %v", err)
 				return
 			}
-			if got != tt.want {
+			if got.String() != tt.want {
 				t.Errorf("ParseRepoID() = %q, want %q", got, tt.want)
 			}
 		})
@@ -165,7 +167,11 @@ func TestRepoDataDir(t *testing.T) {
 	defer os.Setenv("XDG_DATA_HOME", original)
 
 	os.Setenv("XDG_DATA_HOME", "/home/test/.local/share")
-	got := RepoDataDir("proboscis-orch")
+	repoID, err := model.NewNormalizedRepoID("proboscis-orch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := RepoDataDir(repoID)
 	want := "/home/test/.local/share/orch/proboscis-orch"
 	if got != want {
 		t.Errorf("RepoDataDir() = %q, want %q", got, want)
@@ -177,7 +183,11 @@ func TestRepoRunsDir(t *testing.T) {
 	defer os.Setenv("XDG_DATA_HOME", original)
 
 	os.Setenv("XDG_DATA_HOME", "/home/test/.local/share")
-	got := RepoRunsDir("proboscis-orch")
+	repoID, err := model.NewNormalizedRepoID("proboscis-orch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := RepoRunsDir(repoID)
 	want := "/home/test/.local/share/orch/proboscis-orch/runs"
 	if got != want {
 		t.Errorf("RepoRunsDir() = %q, want %q", got, want)
@@ -201,25 +211,29 @@ func TestLegacyPaths(t *testing.T) {
 	}
 }
 
-func TestSanitizeRepoID(t *testing.T) {
+func TestNewRepoIDSanitizesUnsafeCharacters(t *testing.T) {
 	tests := []struct {
-		owner string
-		repo  string
-		want  string
+		remoteURL string
+		want      string
 	}{
-		{"owner", "repo", "owner-repo"},
-		{"my-org", "my-repo", "my-org-my-repo"},
-		{"owner_name", "repo_name", "owner_name-repo_name"},
-		{"owner/bad", "repo", "ownerbad-repo"}, // slashes removed
-		{"owner", "repo.git", "repogit-"},      // wait this is wrong
+		{"https://github.com/owner/repo.git", "owner-repo"},
+		{"https://github.com/my-org/my-repo.git", "my-org-my-repo"},
+		{"https://github.com/owner_name/repo_name.git", "owner_name-repo_name"},
+		{"https://github.com/owner.bad/repo.git", "ownerbad-repo"},
+		{"https://github.com/owner/repo bad.git", "owner-repobad"},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.owner+"/"+tt.repo, func(t *testing.T) {
-			got := sanitizeRepoID(tt.owner, tt.repo)
-			// Just check it doesn't have unsafe chars
-			if strings.ContainsAny(got, "/\\:*?\"<>|") {
-				t.Errorf("sanitizeRepoID(%q, %q) = %q contains unsafe characters", tt.owner, tt.repo, got)
+		t.Run(tt.remoteURL, func(t *testing.T) {
+			got, err := model.NewRepoID(tt.remoteURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.String() != tt.want {
+				t.Fatalf("NewRepoID(%q) = %q, want %q", tt.remoteURL, got, tt.want)
+			}
+			if strings.ContainsAny(got.String(), "/\\:*?\"<>|") {
+				t.Errorf("NewRepoID(%q) = %q contains unsafe characters", tt.remoteURL, got)
 			}
 		})
 	}
@@ -248,8 +262,44 @@ func TestRepoIDUsesRemoteOrigin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RepoID() unexpected error: %v", err)
 	}
-	if id != "example-repo-id" {
+	if id.String() != "example-repo-id" {
 		t.Fatalf("RepoID() = %q, want %q", id, "example-repo-id")
+	}
+}
+
+func TestRepoDataDirPreservesLegacyDottedRepoID(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+
+	repo := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s failed: %v (%s)", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	run("git", "init", repo)
+	run("git", "-C", repo, "remote", "add", "origin", "git@github.com:my.org/my.repo.git")
+
+	id, err := RepoID(repo)
+	if err != nil {
+		t.Fatalf("RepoID() unexpected error: %v", err)
+	}
+	if id.String() != "myorg-myrepo" {
+		t.Fatalf("RepoID() = %q, want %q", id, "myorg-myrepo")
+	}
+
+	existingDir := filepath.Join(dataHome, "orch", "myorg-myrepo")
+	if err := os.MkdirAll(existingDir, 0755); err != nil {
+		t.Fatalf("create existing data dir: %v", err)
+	}
+	if got := RepoDataDir(id); got != existingDir {
+		t.Fatalf("RepoDataDir() = %q, want existing legacy dir %q", got, existingDir)
+	}
+	if _, err := os.Stat(RepoDataDir(id)); err != nil {
+		t.Fatalf("expected existing legacy data dir to resolve: %v", err)
 	}
 }
 

--- a/test/integration/opencode_session_test.go
+++ b/test/integration/opencode_session_test.go
@@ -243,7 +243,7 @@ func TestNewRunStatusNotImmediatelyDone(t *testing.T) {
 
 	run := &model.Run{
 		IssueID:           "orch-347-test",
-		RunID:             time.Now().Format("20060102-150405"),
+		RunID:             model.NewRunID(time.Now().Format("20060102-150405")),
 		Agent:             "opencode",
 		Status:            model.StatusBooting,
 		WorktreePath:      worktreePath,


### PR DESCRIPTION
## Summary

- Added distinct Go identifier types for `IssueID`, `RunID`, `ShortID`, `RepoID`, and now distinct `ProjectID` in `internal/model`.
- Routed repo identity construction through `NewRepoID` / `NewProjectID` and normalized-id constructors, preserving the historical XDG on-disk repo-id format for dotted/special-character remotes.
- Converted store, daemon, orchapi, CLI, monitor, backend, git, GitHub, query, and test mocks to typed signatures while keeping JSON/proto/display boundaries as strings.
- Added RepoID normalization, legacy on-disk compatibility, invalid-component rejection, idempotency, round-trip/property, and compile-time implicit raw-string rejection tests.
- Added a Semgrep guard that bans explicit `model.RepoID(...)` / `model.ProjectID(...)` casts in production code outside the constructors.

## Round 1 Review Fixes

- Made `TestBuildAgentPromptCustomTemplate` daemon-independent by injecting a template reader; production still reads custom templates through daemon `ReadFile`.
- Restored legacy RepoID sanitization: unsafe characters are deleted and dots are not preserved, so `my.org/my.repo.git` still resolves to `myorg-myrepo`.
- `NewRepoID` now rejects degenerate owner/repo inputs such as `https://github.com/owner/.git` instead of silently collapsing to a single-component ID.
- Strengthened the compile-time test to assert the semantic type error, not the variable name.
- Threaded `model.ProjectID` through resolved proto run context and unwraps it only at worker/proto string boundaries.

## Evidence

- `PATH=/tmp/go1.25.3/bin:$PATH go test ./...` passed, including `test/integration`.
- `PATH=/tmp/go1.25.3/bin:$PATH go build ./...` passed.
- `PATH=/tmp/go1.25.3/bin:/home/kento/.local/bin:$PATH make lint` passed with Semgrep findings: 0.
- `PATH=/tmp/go1.25.3/bin:$PATH ORCH_REMOTE=unix:///tmp/orch-no-daemon-review.sock go test ./internal/cli -run TestBuildAgentPromptCustomTemplate -count=1` passed.
- `PATH=/tmp/go1.25.3/bin:$PATH go test ./internal/xdg -run TestRepoDataDirPreservesLegacyDottedRepoID -count=1` passed.
- `git diff --check` passed.
- `rg "model\\.(RepoID|ProjectID)\\(" internal --glob '*.go'` found no production call sites.

## Acceptance

- [x] newtypes + RepoID smart constructor added
- [x] all signatures converted and compiler green
- [x] RepoID property/round-trip tests added
- [x] implicit raw string -> RepoID passing is rejected by the compiler and covered by a `go/types` test
- [x] explicit raw `model.RepoID(...)` / `model.ProjectID(...)` casts are blocked by Semgrep in production code
- [x] `make lint`, `go build ./...`, and `go test ./...` green

Reference: inv-typed-ids