### PR TITLE
fix(daemon): master resolves issue & passes snapshot to worker (cross-machine worker support)

### DIFF
--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -158,6 +158,9 @@ func (m *mockStoreForUpdate) ListIssues() ([]*model.Issue, error) { return nil, 
 func (m *mockStoreForUpdate) CreateRun(model.IssueID, model.RunID, map[string]string) (*model.Run, error) {
 	return nil, nil
 }
+func (m *mockStoreForUpdate) CreateRunForExistingIssue(model.IssueID, model.RunID, map[string]string) (*model.Run, error) {
+	return nil, nil
+}
 func (m *mockStoreForUpdate) ListRuns(*store.ListRunsFilter) ([]*model.Run, error) { return nil, nil }
 func (m *mockStoreForUpdate) GetRun(*model.RunRef) (*model.Run, error)             { return nil, nil }
 func (m *mockStoreForUpdate) GetRunByShortID(model.ShortID) (*model.Run, error)    { return nil, nil }

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -1279,9 +1279,15 @@ func (s *SocketServer) handleProtoStartRun(req *orchpb.StartRunRequest) *orchpb.
 		opts.TargetWorkerID = target.WorkerID
 	}
 
-	if issue, err := st.ResolveIssue(model.IssueID(req.IssueId)); err == nil {
-		opts.IssueSnapshot = issue
+	// Resolve the issue on the MASTER (issue-store SSOT) and carry the snapshot in
+	// the worker payload. Fail fast here, before delegating, so a missing issue
+	// surfaces on the master (where the store lives) instead of on a worker that may
+	// run on a different host and have no issue store at all.
+	issue, err := st.ResolveIssue(model.IssueID(req.IssueId))
+	if err != nil {
+		return errorResponse(fmt.Sprintf("issue not found: %s", req.IssueId))
 	}
+	opts.IssueSnapshot = issue
 
 	payload := &WorkerEffectPayload{StartRun: opts}
 	completedLease, err := s.withWorkerLease(projectID, "start_run", req.IssueId, req.RunId, payload)
@@ -1516,17 +1522,32 @@ func (s *SocketServer) handleProtoContinueRun(req *orchpb.ContinueRunRequest) *o
 		SessionName:    req.SessionName,
 	}
 	// Inherit the prior run's target and agent so the codex profile constraint
-	// and CODEX_HOME are re-applied identically on restart-from/continue.
+	// and CODEX_HOME are re-applied identically on restart-from/continue. Also
+	// capture the issue ID so the master (issue-store SSOT) can resolve the issue
+	// and carry it in the worker payload below.
 	var fromRunAgent string
+	issueID := model.IssueID(req.IssueId)
 	if req.ShortId != "" {
-		if run, err := st.GetRunByShortID(model.ShortID(req.ShortId)); err == nil && run != nil {
-			opts.Target = strings.TrimSpace(run.Target)
-			fromRunAgent = strings.TrimSpace(run.Agent)
+		// The short-id mode derives the issue ID solely from the referenced run, so
+		// fail fast on the master if it cannot be resolved. Otherwise issueID would
+		// stay empty and the worker would fall back to its own-store ResolveIssue
+		// (which it may not have), producing a misleading error on the wrong host.
+		run, err := st.GetRunByShortID(model.ShortID(req.ShortId))
+		if err != nil || run == nil {
+			return errorResponse(fmt.Sprintf("run not found: %s", req.ShortId))
+		}
+		opts.Target = strings.TrimSpace(run.Target)
+		fromRunAgent = strings.TrimSpace(run.Agent)
+		if run.IssueID != "" {
+			issueID = run.IssueID
 		}
 	} else if req.IssueId != "" && req.RunId != "" {
 		if run, err := st.GetRun(&model.RunRef{IssueID: model.IssueID(req.IssueId), RunID: model.RunID(req.RunId)}); err == nil && run != nil {
 			opts.Target = strings.TrimSpace(run.Target)
 			fromRunAgent = strings.TrimSpace(run.Agent)
+			if run.IssueID != "" {
+				issueID = run.IssueID
+			}
 		}
 	}
 
@@ -1548,6 +1569,20 @@ func (s *SocketServer) handleProtoContinueRun(req *orchpb.ContinueRunRequest) *o
 		}
 		opts.TargetHost = target.Host
 		opts.TargetWorkerID = target.WorkerID
+	}
+
+	// Resolve the issue on the MASTER (issue-store SSOT) and carry the snapshot in
+	// the worker payload. Fail fast here, before delegating, so a missing issue
+	// surfaces on the master instead of on a worker that may run on a different host
+	// and have no issue store. The issue ID is known for every continue mode: the
+	// branch/run-ref modes use req.IssueId, the short-id mode uses the resolved
+	// run's IssueID captured above.
+	if strings.TrimSpace(string(issueID)) != "" {
+		issue, err := st.ResolveIssue(issueID)
+		if err != nil {
+			return errorResponse(fmt.Sprintf("issue not found: %s", issueID))
+		}
+		opts.IssueSnapshot = issue
 	}
 
 	payload := &WorkerEffectPayload{ContinueRun: opts}

--- a/internal/daemon/proto_handler_test.go
+++ b/internal/daemon/proto_handler_test.go
@@ -860,8 +860,12 @@ func TestWorkerLeaseRedispatchToSecondWorkerAfterExpiry(t *testing.T) {
 
 func TestSyncStartRunResultToMasterStorePreservesOpenCodeArtifacts(t *testing.T) {
 	st := &mockStore{
-		runs:   map[string]*model.Run{},
-		issues: map[string]*model.Issue{},
+		runs: map[string]*model.Run{},
+		issues: map[string]*model.Issue{
+			// The master store owns the issue; syncStartRunResultToMasterStore runs
+			// on the master and creates the run projection via the verifying CreateRun.
+			"issue-opencode-sync": {ID: "issue-opencode-sync", Status: model.IssueStatusOpen},
+		},
 	}
 	server := NewSocketServer(nil, &timingTestLogger{})
 

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -3525,31 +3525,38 @@ func resolvePRTargetBranch(explicit, resolvedBaseBranch string) string {
 	return "main"
 }
 
+// createRunForIssue creates a run, choosing whether to verify the issue against
+// the local store. issuePreVerified is true on the worker-delegation path where
+// the master (issue-store SSOT) already resolved the issue and carried it in the
+// payload snapshot; in that case the worker must NOT re-verify against a store it
+// may not own (it can run on a different host than the master). On the
+// non-delegated direct/co-located path it verifies as usual.
+func createRunForIssue(st store.Store, issuePreVerified bool, issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
+	if issuePreVerified {
+		return st.CreateRunForExistingIssue(issueID, runID, metadata)
+	}
+	return st.CreateRun(issueID, runID, metadata)
+}
+
 func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, opts *StartRunOptions) (*StartRunResult, error) {
 	if opts.IssueID == "" {
 		return nil, fmt.Errorf("invalid_request: issue_id required")
 	}
 
+	// The issue is resolved by the MASTER (issue-store SSOT) and carried in
+	// opts.IssueSnapshot. The worker must NOT read the run's own issue from its
+	// local store: when the worker runs on a different host than the master it has
+	// no issue store at all. The delegation path (handleProtoStartRun) always sets
+	// IssueSnapshot. We only fall back to the local store for non-delegated direct
+	// calls (e.g. legacy/co-located in-process paths or tests), and never silently
+	// swallow a missing issue.
 	issue := opts.IssueSnapshot
-	if issue == nil || strings.TrimSpace(string(issue.ID)) != string(opts.IssueID) {
+	if issue == nil {
 		resolvedIssue, err := st.ResolveIssue(opts.IssueID)
 		if err != nil {
 			return nil, fmt.Errorf("issue not found: %s", opts.IssueID)
 		}
 		issue = resolvedIssue
-	}
-
-	if _, err := st.ResolveIssue(opts.IssueID); err != nil {
-		issueCopy := *issue
-		if issueCopy.ID == "" {
-			issueCopy.ID = opts.IssueID
-		}
-		if issueCopy.Status == "" {
-			issueCopy.Status = model.IssueStatusOpen
-		}
-		if err := st.CreateIssue(&issueCopy); err != nil {
-			return nil, fmt.Errorf("failed to sync issue for worker execution: %w", err)
-		}
 	}
 
 	cfg, err := loadConfigForProjectRoot(projectRoot)
@@ -3672,7 +3679,10 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 	if targetName != "" {
 		metadata["target"] = targetName
 	}
-	run, err := st.CreateRun(opts.IssueID, runID, metadata)
+	// When the issue came from the master snapshot (worker-delegation path), the
+	// master has already verified it; the worker must not re-verify against a
+	// store it may not own. Otherwise (legacy direct/co-located call) verify.
+	run, err := createRunForIssue(st, opts.IssueSnapshot != nil, opts.IssueID, runID, metadata)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create run: %w", err)
 	}
@@ -3873,9 +3883,14 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		issueID = opts.IssueID
 		branch = opts.Branch
 
-		_, err := st.ResolveIssue(issueID)
-		if err != nil {
-			return nil, fmt.Errorf("issue not found: %s", issueID)
+		// The master (issue-store SSOT) already resolved and validated the issue
+		// and carried it in opts.IssueSnapshot. Only re-read the local store for
+		// non-delegated direct calls (no snapshot); never silently ignore a
+		// missing issue.
+		if opts.IssueSnapshot == nil {
+			if _, err := st.ResolveIssue(issueID); err != nil {
+				return nil, fmt.Errorf("issue not found: %s", issueID)
+			}
 		}
 
 		if projectRoot == "" {
@@ -3995,9 +4010,19 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		continuedFrom = fmt.Sprintf("%s#%s", fromRun.IssueID, fromRun.RunID)
 	}
 
-	issue, err := st.ResolveIssue(issueID)
-	if err != nil {
-		return nil, fmt.Errorf("issue not found: %s", issueID)
+	// The issue is resolved by the MASTER (issue-store SSOT) and carried in
+	// opts.IssueSnapshot; the worker must NOT read the run's own issue from its
+	// local store (it may have none when pinned to a different host than the
+	// master). The delegation path (handleProtoContinueRun) always sets the
+	// snapshot. Fall back to the local store only for non-delegated direct calls,
+	// and never silently swallow a missing issue.
+	issue := opts.IssueSnapshot
+	if issue == nil {
+		resolvedIssue, err := st.ResolveIssue(issueID)
+		if err != nil {
+			return nil, fmt.Errorf("issue not found: %s", issueID)
+		}
+		issue = resolvedIssue
 	}
 
 	agentName := opts.Agent
@@ -4038,7 +4063,10 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 	if targetName := strings.TrimSpace(opts.Target); targetName != "" {
 		metadata["target"] = targetName
 	}
-	run, err := st.CreateRun(issueID, runID, metadata)
+	// When the issue came from the master snapshot (worker-delegation path), the
+	// master has already verified it; the worker must not re-verify against a
+	// store it may not own. Otherwise (legacy direct/co-located call) verify.
+	run, err := createRunForIssue(st, opts.IssueSnapshot != nil, issueID, runID, metadata)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create run: %w", err)
 	}

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -108,6 +108,21 @@ func (m *mockStore) SetIssueStatus(issueID model.IssueID, status model.IssueStat
 }
 
 func (m *mockStore) CreateRun(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
+	// Mirror FileStore: verify the issue exists for non-GitHub issues.
+	if !strings.HasPrefix(string(issueID), "gh-") && !strings.HasPrefix(string(issueID), "gh#") {
+		if _, err := m.ResolveIssue(issueID); err != nil {
+			return nil, fmt.Errorf("issue not found: %s", issueID)
+		}
+	}
+	return m.createRunDoc(issueID, runID, metadata)
+}
+
+func (m *mockStore) CreateRunForExistingIssue(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
+	// No issue verification: worker-delegated path.
+	return m.createRunDoc(issueID, runID, metadata)
+}
+
+func (m *mockStore) createRunDoc(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
 	if m.runs == nil {
 		m.runs = make(map[string]*model.Run)
 	}
@@ -652,7 +667,14 @@ func TestProtoContinueRunUsesExternalWorkerResultJSON(t *testing.T) {
 	defer cleanup()
 
 	projectID := testProjectID
-	st := &mockStore{runs: map[string]*model.Run{}, issues: map[string]*model.Issue{}}
+	st := &mockStore{
+		runs: map[string]*model.Run{},
+		issues: map[string]*model.Issue{
+			// The master (issue-store SSOT) resolves the issue before delegating to
+			// the worker, so the issue must exist on the master store.
+			"issue-cont": {ID: "issue-cont", Title: "Cont", Status: model.IssueStatusOpen},
+		},
+	}
 
 	server := newTestServer(t, st)
 	if err := server.Start(); err != nil {
@@ -5528,6 +5550,101 @@ func TestProcessStartRunCoreValidation(t *testing.T) {
 			t.Errorf("expected 'no project root available' error, got: %v", err)
 		}
 	})
+
+	t.Run("uses payload issue snapshot without reading worker store", func(t *testing.T) {
+		// A worker pinned to a different host than the master has no issue store.
+		// The master carries the resolved issue in opts.IssueSnapshot; the worker
+		// must consume it and never read its own store for the run's issue.
+		emptyStore := &mockStore{
+			runs:   make(map[string]*model.Run),
+			issues: make(map[string]*model.Issue), // intentionally empty: worker has no issue
+		}
+		opts := &StartRunOptions{
+			IssueID: "remote-issue",
+			Agent:   "custom",
+			IssueSnapshot: &model.Issue{
+				ID:     "remote-issue",
+				Title:  "Remote",
+				Body:   "do the thing",
+				Status: model.IssueStatusOpen,
+			},
+		}
+		// projectRoot="" makes the core fail at the next gate (project root). The
+		// point is that it gets PAST issue resolution: it must NOT fail
+		// "issue not found" even though the worker store is empty.
+		_, err := server.processStartRunCore(emptyStore, "", opts)
+		if err == nil {
+			t.Fatal("expected error at the project-root gate")
+		}
+		if strings.Contains(err.Error(), "issue not found") {
+			t.Fatalf("worker must use opts.IssueSnapshot, not read its empty store; got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "no project root available") {
+			t.Fatalf("expected to reach 'no project root available', got: %v", err)
+		}
+	})
+}
+
+// TestMasterFailsFastOnMissingIssueBeforeDelegation verifies that the master
+// (issue-store SSOT) rejects start/continue with an explicit "issue not found"
+// BEFORE delegating to a worker. This keeps the error on the master (where the
+// store lives) instead of on a worker that may run on a different host and have
+// no issue store at all. No worker is registered, so reaching delegation would
+// hang/fail differently; the assertion is that we never get there.
+func TestMasterFailsFastOnMissingIssueBeforeDelegation(t *testing.T) {
+	cleanup := setupXDGTestEnv(t)
+	defer cleanup()
+
+	st := &mockStore{
+		runs:   make(map[string]*model.Run),
+		issues: make(map[string]*model.Issue), // empty: issue does not exist on master
+	}
+	server := newTestServer(t, st)
+
+	t.Run("start_run", func(t *testing.T) {
+		resp := server.handleProtoStartRun(&orchpb.StartRunRequest{
+			IssueId: "missing-issue",
+			RunId:   "run-x",
+			Context: &orchpb.RequestContext{ProjectId: testProjectID},
+		})
+		if resp.Ok {
+			t.Fatalf("expected failure for missing issue, got ok response: %+v", resp)
+		}
+		if !strings.Contains(resp.Error, "issue not found: missing-issue") {
+			t.Fatalf("expected explicit 'issue not found: missing-issue', got: %q", resp.Error)
+		}
+	})
+
+	t.Run("continue_run", func(t *testing.T) {
+		resp := server.handleProtoContinueRun(&orchpb.ContinueRunRequest{
+			IssueId: "missing-issue",
+			RunId:   "run-x",
+			Branch:  "feature-branch",
+			Context: &orchpb.RequestContext{ProjectId: testProjectID},
+		})
+		if resp.Ok {
+			t.Fatalf("expected failure for missing issue, got ok response: %+v", resp)
+		}
+		if !strings.Contains(resp.Error, "issue not found: missing-issue") {
+			t.Fatalf("expected explicit 'issue not found: missing-issue', got: %q", resp.Error)
+		}
+	})
+
+	t.Run("continue_run short_id with no matching run fails fast on master", func(t *testing.T) {
+		// The short-id mode derives the issue ID from the referenced run; if the run
+		// is unknown to the master, fail fast here instead of delegating with an
+		// empty issue ID (which would mislead on the wrong host).
+		resp := server.handleProtoContinueRun(&orchpb.ContinueRunRequest{
+			ShortId: "deadbe",
+			Context: &orchpb.RequestContext{ProjectId: testProjectID},
+		})
+		if resp.Ok {
+			t.Fatalf("expected failure for unknown short id, got ok response: %+v", resp)
+		}
+		if !strings.Contains(resp.Error, "run not found: deadbe") {
+			t.Fatalf("expected explicit 'run not found: deadbe', got: %q", resp.Error)
+		}
+	})
 }
 
 func TestBootstrapOpenCodeRunSessionFailsFastOnCreateSessionError(t *testing.T) {
@@ -5764,6 +5881,59 @@ func TestProcessContinueRunCoreValidation(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "'orch restart-from' only supports failed, canceled, or unknown runs") {
 			t.Fatalf("expected restart-from terminal-state guidance, got: %s", err.Error())
+		}
+	})
+
+	t.Run("branch path uses payload issue snapshot without reading worker store", func(t *testing.T) {
+		// A worker pinned to a different host than the master has no issue store.
+		// The master carries the resolved issue in opts.IssueSnapshot; the worker
+		// must consume it and never read its own store for the run's issue.
+		emptyStore := &mockStore{
+			runs:   make(map[string]*model.Run),
+			issues: make(map[string]*model.Issue), // intentionally empty: worker has no issue
+		}
+		opts := &ContinueRunOptions{
+			Branch:  "feature-branch",
+			IssueID: "remote-issue",
+			IssueSnapshot: &model.Issue{
+				ID:     "remote-issue",
+				Title:  "Remote",
+				Body:   "do the thing",
+				Status: model.IssueStatusOpen,
+			},
+		}
+		// projectRoot="" makes the core fail at the next gate (project root). The
+		// point is that it gets PAST the branch-path issue validation: it must NOT
+		// fail "issue not found" even though the worker store is empty.
+		_, err := server.processContinueRunCore(emptyStore, "", opts)
+		if err == nil {
+			t.Fatal("expected error at the project-root gate")
+		}
+		if strings.Contains(err.Error(), "issue not found") {
+			t.Fatalf("worker must use opts.IssueSnapshot, not read its empty store; got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "no project root available") {
+			t.Fatalf("expected to reach 'no project root available', got: %v", err)
+		}
+	})
+
+	t.Run("branch path fails fast on missing issue when no snapshot", func(t *testing.T) {
+		emptyStore := &mockStore{
+			runs:   make(map[string]*model.Run),
+			issues: make(map[string]*model.Issue),
+		}
+		opts := &ContinueRunOptions{
+			Branch:  "feature-branch",
+			IssueID: "remote-issue",
+			// No IssueSnapshot: a non-delegated direct call falls back to the local
+			// store and must fail fast (never silently swallow a missing issue).
+		}
+		_, err := server.processContinueRunCore(emptyStore, "/project", opts)
+		if err == nil {
+			t.Fatal("expected 'issue not found' error")
+		}
+		if !strings.Contains(err.Error(), "issue not found") {
+			t.Fatalf("expected 'issue not found', got: %v", err)
 		}
 	})
 }

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -599,7 +599,11 @@ func SummaryAliveInfo(s *RunSummary) (alive bool, known bool) {
 }
 
 type StartRunOptions struct {
-	IssueID        model.IssueID
+	IssueID model.IssueID
+	// IssueSnapshot is the issue resolved by the MASTER (the issue-store SSOT) and
+	// carried in the worker payload so the worker never reads its own issue from a
+	// local store it may not have (e.g. a worker pinned to a different host than the
+	// master). The worker-delegation path in handleProtoStartRun always sets this.
 	IssueSnapshot  *model.Issue
 	RunID          model.RunID
 	Agent          string
@@ -651,7 +655,12 @@ type StartRunResult struct {
 }
 
 type ContinueRunOptions struct {
-	IssueID        model.IssueID
+	IssueID model.IssueID
+	// IssueSnapshot is the issue resolved by the MASTER (the issue-store SSOT) and
+	// carried in the worker payload so the worker never reads its own issue from a
+	// local store it may not have (e.g. a worker pinned to a different host than the
+	// master). The worker-delegation path in handleProtoContinueRun always sets this.
+	IssueSnapshot  *model.Issue
 	RunID          model.RunID
 	ShortID        model.ShortID
 	Branch         string

--- a/internal/daemon/worker_plane_test.go
+++ b/internal/daemon/worker_plane_test.go
@@ -196,3 +196,71 @@ targets:
 		t.Fatalf("worktree path = %q, want local project-root-based path", result.StartRunResult.WorktreePath)
 	}
 }
+
+// TestProcessStartRunCoreUsesSnapshotWithEmptyWorkerIssueStore is the authoritative
+// regression for the cross-machine worker bug: a worker pinned to a different host
+// than the master has an EMPTY issue store. The master (issue-store SSOT) resolves a
+// non-GitHub issue and carries it in opts.IssueSnapshot. processStartRunCore must get
+// PAST issue resolution AND past st.CreateRun (which previously called ResolveIssue
+// internally and failed "issue not found") by using CreateRunForExistingIssue, then
+// reach worktree creation / booting. The run document must land even though the
+// worker's issue store has no issue file.
+func TestProcessStartRunCoreUsesSnapshotWithEmptyWorkerIssueStore(t *testing.T) {
+	// Real git repo so worktree creation (which happens AFTER st.CreateRun) can run.
+	projectRoot := createGitRepoWithOrigin(t, "https://github.com/example/snapshot-worker.git")
+
+	// FileStore with an EMPTY issues store: the worker has no issue file at all.
+	issuesRoot := filepath.Join(projectRoot, "issues-store")
+	if err := os.MkdirAll(filepath.Join(issuesRoot, "issues"), 0o755); err != nil {
+		t.Fatalf("mkdir issues root: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".orch"), 0o755); err != nil {
+		t.Fatalf("mkdir .orch: %v", err)
+	}
+	configBody := "issues:\n  path: " + issuesRoot + "\nworktree_dir: worktrees\n"
+	if err := os.WriteFile(filepath.Join(projectRoot, ".orch", "config.yaml"), []byte(configBody), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	st, err := filestore.New(issuesRoot)
+	if err != nil {
+		t.Fatalf("filestore.New() error = %v", err)
+	}
+	// Sanity: the issue genuinely does not exist on the worker store.
+	if _, err := st.ResolveIssue("remote-issue"); err == nil {
+		t.Fatal("precondition failed: worker store unexpectedly has the issue")
+	}
+
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+
+	const issueID model.IssueID = "remote-issue" // non-gh id: CreateRun would verify it
+	const runID model.RunID = "20231220-101010"
+	opts := &StartRunOptions{
+		IssueID:     issueID,
+		RunID:       runID,
+		Agent:       "custom",
+		AgentCmd:    "true",
+		Multiplexer: "tmux",
+		// Master-resolved snapshot: this is what the worker must consume.
+		IssueSnapshot: &model.Issue{
+			ID:     issueID,
+			Title:  "Remote",
+			Body:   "do the thing",
+			Status: model.IssueStatusOpen,
+		},
+	}
+
+	// The call may still fail LATER (multiplexer/session launch is environment
+	// dependent), but it must NOT fail at issue resolution or at st.CreateRun.
+	_, err = server.processStartRunCore(st, projectRoot, opts)
+	if err != nil && strings.Contains(err.Error(), "issue not found") {
+		t.Fatalf("worker must use opts.IssueSnapshot and CreateRunForExistingIssue, not verify against its empty store; got: %v", err)
+	}
+
+	// The run document must have landed coherently under runs/<issueID>/<runID>.md,
+	// proving st.CreateRun's verification gate was bypassed without an issue file.
+	runDoc := filepath.Join(issuesRoot, "runs", string(issueID), string(runID)+".md")
+	if _, statErr := os.Stat(runDoc); statErr != nil {
+		t.Fatalf("expected run document at %q (CreateRun gate must be bypassed); stat err=%v; core err=%v", runDoc, statErr, err)
+	}
+}

--- a/internal/store/file/file.go
+++ b/internal/store/file/file.go
@@ -656,7 +656,9 @@ func (s *FileStore) ListIssues() ([]*model.Issue, error) {
 	return issues, nil
 }
 
-// CreateRun creates a new run for an issue
+// CreateRun creates a new run for an issue, verifying the issue exists in this
+// store first (for non-GitHub issues). Use this on the co-located/master path
+// where this store owns the issue.
 func (s *FileStore) CreateRun(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
 	// Skip verification for GitHub issues - they're not local files
 	if !strings.HasPrefix(string(issueID), "gh-") && !strings.HasPrefix(string(issueID), "gh#") {
@@ -667,6 +669,24 @@ func (s *FileStore) CreateRun(issueID model.IssueID, runID model.RunID, metadata
 
 	}
 
+	return s.createRunDocument(issueID, runID, metadata)
+}
+
+// CreateRunForExistingIssue creates a run WITHOUT verifying the issue against
+// this store. It is for worker-delegated execution: a worker may run on a
+// different host than the master and therefore have no issue store at all, yet
+// the master (the issue-store SSOT) has already resolved and verified the issue
+// before delegating. The run document layout (runs/<issueID>/<runID>.md under
+// this store's root) does not depend on the issue file being present; the runs
+// directory is created as needed.
+func (s *FileStore) CreateRunForExistingIssue(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
+	return s.createRunDocument(issueID, runID, metadata)
+}
+
+// createRunDocument writes the run document and returns the run. It assumes the
+// issue has already been verified by the caller (or intentionally skipped for a
+// worker-delegated run / GitHub issue).
+func (s *FileStore) createRunDocument(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
 	// Create runs directory for issue if needed
 	runsDir := s.runsDir(issueID)
 	if err := os.MkdirAll(runsDir, 0755); err != nil {

--- a/internal/store/file/file_test.go
+++ b/internal/store/file/file_test.go
@@ -288,6 +288,57 @@ func TestCreateRunDuplicate(t *testing.T) {
 	}
 }
 
+// TestCreateRunForExistingIssueSkipsIssueVerification proves the worker-delegation
+// path: a worker may have NO issue store (it can run on a different host than the
+// master), yet must still be able to create the run document because the master
+// (issue-store SSOT) already verified the issue. CreateRun must reject a missing
+// non-GitHub issue, while CreateRunForExistingIssue must succeed and land the run
+// document coherently at runs/<issueID>/<runID>.md even though the issue file is
+// absent.
+func TestCreateRunForExistingIssueSkipsIssueVerification(t *testing.T) {
+	vault, cleanup := setupTestVault(t)
+	defer cleanup()
+
+	s, _ := New(vault)
+
+	// No issue created on this store: the worker has no issue store.
+	const issueID model.IssueID = "remote-local-issue" // non-gh id (would normally be verified)
+	const runID model.RunID = "20231220-100000"
+
+	// Verifying CreateRun must fail fast: the worker would have broken here before
+	// this fix (the old st.CreateIssue hack masked it).
+	if _, err := s.CreateRun(issueID, runID, nil); err == nil {
+		t.Fatal("expected CreateRun to fail for missing non-gh issue")
+	}
+
+	// CreateRunForExistingIssue bypasses verification and writes the run document.
+	run, err := s.CreateRunForExistingIssue(issueID, runID, map[string]string{"agent": "custom"})
+	if err != nil {
+		t.Fatalf("CreateRunForExistingIssue() error = %v", err)
+	}
+	if run.IssueID != issueID || run.RunID != runID {
+		t.Fatalf("run identity = %s#%s, want %s#%s", run.IssueID, run.RunID, issueID, runID)
+	}
+
+	// Run document must land coherently under runs/<issueID>/<runID>.md.
+	wantPath := filepath.Join(vault, "runs", string(issueID), string(runID)+".md")
+	if run.Path != wantPath {
+		t.Fatalf("run.Path = %q, want %q", run.Path, wantPath)
+	}
+	if _, err := os.Stat(run.Path); err != nil {
+		t.Fatalf("run document not created at %q: %v", run.Path, err)
+	}
+
+	// And it must be retrievable without the issue file present.
+	loaded, err := s.GetRun(run.Ref())
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if loaded.Agent != "custom" {
+		t.Fatalf("Agent = %q, want custom", loaded.Agent)
+	}
+}
+
 func TestAppendEvent(t *testing.T) {
 	vault, cleanup := setupTestVault(t)
 	defer cleanup()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -36,8 +36,15 @@ type Store interface {
 	// SetIssueStatus updates an issue's status in frontmatter
 	SetIssueStatus(issueID model.IssueID, status model.IssueStatus) error
 
-	// CreateRun creates a new run for an issue
+	// CreateRun creates a new run for an issue, verifying the issue exists in this
+	// store first (non-GitHub issues). Use on the co-located/master path.
 	CreateRun(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error)
+
+	// CreateRunForExistingIssue creates a run WITHOUT verifying the issue against
+	// this store. It is for worker-delegated execution where the master (issue-store
+	// SSOT) has already resolved the issue and the worker may have no issue store of
+	// its own (e.g. pinned to a different host than the master).
+	CreateRunForExistingIssue(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error)
 
 	// AppendEvent appends an event to a run
 	AppendEvent(ref *model.RunRef, event *model.Event) error

--- a/internal/testutil/mock_store.go
+++ b/internal/testutil/mock_store.go
@@ -28,6 +28,9 @@ var _ store.Store = &StoreMock{}
 //			CreateRunFunc: func(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
 //				panic("mock out the CreateRun method")
 //			},
+//			CreateRunForExistingIssueFunc: func(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
+//				panic("mock out the CreateRunForExistingIssue method")
+//			},
 //			DeleteRunFunc: func(ref *model.RunRef) error {
 //				panic("mock out the DeleteRun method")
 //			},
@@ -82,6 +85,9 @@ type StoreMock struct {
 
 	// CreateRunFunc mocks the CreateRun method.
 	CreateRunFunc func(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error)
+
+	// CreateRunForExistingIssueFunc mocks the CreateRunForExistingIssue method.
+	CreateRunForExistingIssueFunc func(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error)
 
 	// DeleteRunFunc mocks the DeleteRun method.
 	DeleteRunFunc func(ref *model.RunRef) error
@@ -138,6 +144,15 @@ type StoreMock struct {
 		}
 		// CreateRun holds details about calls to the CreateRun method.
 		CreateRun []struct {
+			// IssueID is the issueID argument value.
+			IssueID model.IssueID
+			// RunID is the runID argument value.
+			RunID model.RunID
+			// Metadata is the metadata argument value.
+			Metadata map[string]string
+		}
+		// CreateRunForExistingIssue holds details about calls to the CreateRunForExistingIssue method.
+		CreateRunForExistingIssue []struct {
 			// IssueID is the issueID argument value.
 			IssueID model.IssueID
 			// RunID is the runID argument value.
@@ -211,22 +226,23 @@ type StoreMock struct {
 			Content string
 		}
 	}
-	lockAppendEvent        sync.RWMutex
-	lockCreateIssue        sync.RWMutex
-	lockCreateRun          sync.RWMutex
-	lockDeleteRun          sync.RWMutex
-	lockGetLatestRun       sync.RWMutex
-	lockGetRun             sync.RWMutex
-	lockGetRunByShortID    sync.RWMutex
-	lockListIssues         sync.RWMutex
-	lockListRuns           sync.RWMutex
-	lockReadAgentPrompt    sync.RWMutex
-	lockResolveIssue       sync.RWMutex
-	lockRootPath           sync.RWMutex
-	lockSetIssueStatus     sync.RWMutex
-	lockUpdateIssue        sync.RWMutex
-	lockValidateIssueFiles sync.RWMutex
-	lockWriteAgentPrompt   sync.RWMutex
+	lockAppendEvent               sync.RWMutex
+	lockCreateIssue               sync.RWMutex
+	lockCreateRun                 sync.RWMutex
+	lockCreateRunForExistingIssue sync.RWMutex
+	lockDeleteRun                 sync.RWMutex
+	lockGetLatestRun              sync.RWMutex
+	lockGetRun                    sync.RWMutex
+	lockGetRunByShortID           sync.RWMutex
+	lockListIssues                sync.RWMutex
+	lockListRuns                  sync.RWMutex
+	lockReadAgentPrompt           sync.RWMutex
+	lockResolveIssue              sync.RWMutex
+	lockRootPath                  sync.RWMutex
+	lockSetIssueStatus            sync.RWMutex
+	lockUpdateIssue               sync.RWMutex
+	lockValidateIssueFiles        sync.RWMutex
+	lockWriteAgentPrompt          sync.RWMutex
 }
 
 // AppendEvent calls AppendEventFunc.
@@ -334,6 +350,46 @@ func (mock *StoreMock) CreateRunCalls() []struct {
 	mock.lockCreateRun.RLock()
 	calls = mock.calls.CreateRun
 	mock.lockCreateRun.RUnlock()
+	return calls
+}
+
+// CreateRunForExistingIssue calls CreateRunForExistingIssueFunc.
+func (mock *StoreMock) CreateRunForExistingIssue(issueID model.IssueID, runID model.RunID, metadata map[string]string) (*model.Run, error) {
+	if mock.CreateRunForExistingIssueFunc == nil {
+		panic("StoreMock.CreateRunForExistingIssueFunc: method is nil but Store.CreateRunForExistingIssue was just called")
+	}
+	callInfo := struct {
+		IssueID  model.IssueID
+		RunID    model.RunID
+		Metadata map[string]string
+	}{
+		IssueID:  issueID,
+		RunID:    runID,
+		Metadata: metadata,
+	}
+	mock.lockCreateRunForExistingIssue.Lock()
+	mock.calls.CreateRunForExistingIssue = append(mock.calls.CreateRunForExistingIssue, callInfo)
+	mock.lockCreateRunForExistingIssue.Unlock()
+	return mock.CreateRunForExistingIssueFunc(issueID, runID, metadata)
+}
+
+// CreateRunForExistingIssueCalls gets all the calls that were made to CreateRunForExistingIssue.
+// Check the length with:
+//
+//	len(mockedStore.CreateRunForExistingIssueCalls())
+func (mock *StoreMock) CreateRunForExistingIssueCalls() []struct {
+	IssueID  model.IssueID
+	RunID    model.RunID
+	Metadata map[string]string
+} {
+	var calls []struct {
+		IssueID  model.IssueID
+		RunID    model.RunID
+		Metadata map[string]string
+	}
+	mock.lockCreateRunForExistingIssue.RLock()
+	calls = mock.calls.CreateRunForExistingIssue
+	mock.lockCreateRunForExistingIssue.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
## Problem

orch is master(issue SSOT) + worker. Worker delegation runs `processStartRunCore`/`processContinueRunCore` **on the worker**, which read the issue store for the run's OWN issue — directly via `st.ResolveIssue` and transitively via `FileStore.CreateRun`'s verification gate. On a **cross-machine worker** (e.g. a `company` codex run pinned to the `mac` worker while the master is `zeus`) the worker has no issue store, so it failed with `issue not found` even though the issue exists on the master. This never surfaced before because every run executed on zeus where master+worker are co-located.

```
BEFORE:  master delegates → worker processStartRunCore → st.ResolveIssue (worker store) ✗
                                                        → st.CreateRun → ResolveIssue gate ✗  "issue not found"
AFTER:   master ResolveIssue (fail-fast) → opts.IssueSnapshot in payload → worker consumes snapshot
                                                        → CreateRunForExistingIssue (no gate) ✓
```

## Fix (master is the issue SSOT; the worker must not read it)

- **Master resolves the issue** (fail-fast `issue not found: <id>` BEFORE delegating) and carries it as `opts.IssueSnapshot` in the worker payload — on the **start** path and all **three continue modes** (branch / issue+run / short-id).
- **Worker consumes `opts.IssueSnapshot`** and never reads the issue store for its own issue (direct `ResolveIssue` calls are snapshot-guarded).
- **`Store.CreateRunForExistingIssue`** (new) skips the issue-verification gate on the delegated path. `FileStore` split into `createRunDocument` (shared) + `CreateRun` (verifies; co-located/direct) + `CreateRunForExistingIssue` (skips). `runsDir` is `<root>/runs/<issueID>` — independent of the issue `.md`, so the run doc lands coherently with no issue file present.
- Removed a **master-SSOT-violating hack** where the worker wrote the issue into its OWN store via `st.CreateIssue`, plus a master-side resolve error-swallow.
- **short-id continue** now fails fast `run not found` instead of delegating an empty issueID.

## Tests
- `TestProcessStartRunCoreUsesSnapshotWithEmptyWorkerIssueStore`: real `FileStore` worker with an **empty issue store** + snapshot reaches past `CreateRun` (run doc lands at `runs/<issueID>/`).
- store-layer `CreateRunForExistingIssue` skip test; master fail-fast-before-delegation on all 3 modes; `mockStore.CreateRun` made faithful (verifies against issues) so routing regressions can't hide.

## Review
Two fresh-eyes rounds (off-context subagents). Round 1 caught a remaining worker-side own-issue store read (`FileStore.CreateRun`'s gate) — now closed via `CreateRunForExistingIssue`. Final: LGTM, per-path verified.

## Verification
`go build ./...`, `go test ./internal/daemon ./internal/store/...`, `go test -race ./internal/daemon ./internal/monitor ./internal/cli`, `make lint` — all green. (Pre-existing `test/integration` opencode-500 failure is unrelated — identical on base.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)