### PR TITLE
fix(multiplexer): zellij dump-screen uses --path flag (0.44+)

### DIFF
--- a/internal/multiplexer/zellij.go
+++ b/internal/multiplexer/zellij.go
@@ -316,7 +316,9 @@ func (z *ZellijMultiplexer) CapturePane(session string, lines int) (string, erro
 	tmpFile.Close()
 	defer os.Remove(tmpPath)
 
-	args := []string{"--session", session, "action", "dump-screen", tmpPath}
+	// zellij 0.44+ takes the dump path via the --path flag; the old positional
+	// form (`dump-screen <path>`) is rejected ("argument ... wasn't expected").
+	args := []string{"--session", session, "action", "dump-screen", "--path", tmpPath}
 	if err := z.run(args...); err != nil {
 		return "", err
 	}

--- a/internal/multiplexer/zellij_test.go
+++ b/internal/multiplexer/zellij_test.go
@@ -639,3 +639,32 @@ func TestShortenSessionName_UniqueForDifferentInputs(t *testing.T) {
 		t.Errorf("different inputs produced same output: %q", result1)
 	}
 }
+
+func TestZellijMultiplexer_CapturePane_UsesPathFlag(t *testing.T) {
+	exec := &fakeExecutor{calls: []fakeCall{{exitCode: 0}}}
+	orig := execCommand
+	execCommand = exec.Command
+	t.Cleanup(func() { execCommand = orig })
+
+	zm := NewZellijMultiplexer()
+	if _, err := zm.CapturePane("sess", 10); err != nil {
+		t.Fatalf("CapturePane error: %v", err)
+	}
+
+	call := exec.recorded[0]
+	idx := -1
+	for i, a := range call.args {
+		if a == "dump-screen" {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatalf("expected dump-screen action; got args: %v", call.args)
+	}
+	// zellij 0.44+ rejects a positional path; the dump path must be passed via
+	// the --path flag immediately after the action (regression guard).
+	if idx+1 >= len(call.args) || call.args[idx+1] != "--path" {
+		t.Fatalf("dump-screen must be followed by --path flag (zellij 0.44+), not a positional path; got args: %v", call.args)
+	}
+}


### PR DESCRIPTION
## Problem
zellij 0.44 changed `action dump-screen <path>` to `action dump-screen --path <path>`. The positional form is now rejected:
```
error: Found argument '/tmp/...' which wasn't expected, or isn't valid in this context
USAGE: zellij action dump-screen [OPTIONS]
```
So `ZellijMultiplexer.CapturePane` → `orch capture` failed with **exit status 2** on any host with zellij 0.44+. This broke **host-routed capture/review** of runs executing on a worker with a modern zellij — surfaced when a `company` codex run was delegated to a mac worker.

## Fix
- `CapturePane`: pass the dump path via `--path <tmpPath>` (zellij.go:319).
- Regression test: `dump-screen` must be followed by the `--path` flag.

`write-chars` / `write` (the send path) are unaffected — their args remain positional in 0.44, so SendKeys/sendKey need no change (verified via `--help`).

## Verification
`go test ./internal/multiplexer/` ok, `go build ./...` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)