### PR TITLE
Fix run state detection reliability for orch ps / orch wait

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -482,6 +482,17 @@ func IsWaitingForInput(output string) bool {
 			return true
 		}
 	}
+
+	// Recent codex builds render an idle footer with no shortcut hints
+	// (just "branch · cwd"), so none of the patterns above can match. The
+	// composer line — "› ..." with U+203A — is the stable idle marker.
+	// Echoed user messages share the prefix, but the busy markers above
+	// already returned false while the agent is actively working.
+	for _, line := range strings.Split(lines, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "›") {
+			return true
+		}
+	}
 	return false
 }
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -228,6 +228,34 @@ func TestIsWaitingForInput(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "codex idle composer without footer hints",
+			// Recent codex builds show only "branch · cwd" in the footer —
+			// the composer line is the only idle marker (captured from a
+			// live run-...-20260610-201733 session).
+			output: strings.Join([]string{
+				"• 完了しました。pr_open の PR が CLOSED の場合に pr_closed event を記録して",
+				"  canceled へ遷移するようにし、draft PR を作成しました。",
+				"",
+				"────────────────────────────────",
+				"",
+				"› Summarize recent commits",
+				"",
+				"  issue/prwatch-closed-pr-terminal-transition/run-20260610-201733 · ~/repos/orc…",
+			}, "\n"),
+			want: true,
+		},
+		{
+			name: "codex working with echoed message and bare footer",
+			output: strings.Join([]string{
+				"› Status check: please run 'git log --oneline -1'",
+				"",
+				"• Working (7s • esc to interrupt)",
+				"",
+				"  issue/prwatch-closed-pr-terminal-transition/run-20260610-201733 · ~/repos/orc…",
+			}, "\n"),
+			want: false,
+		},
+		{
 			name:   "no prompt",
 			output: "Just some regular output\nwith no prompts",
 			want:   false,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -195,6 +195,7 @@ func (d *Daemon) Run() error {
 	if d.listenAddr != "" {
 		d.socketServer.SetTCPListenAddr(d.listenAddr)
 	}
+	d.socketServer.runLiveness = d.runLiveness
 	d.socketServer.SetGitHubBackend(d.githubBackend)
 	if err := d.socketServer.Start(); err != nil {
 		d.logger.Printf("warning: failed to start socket server: %v", err)
@@ -433,6 +434,28 @@ func (d *Daemon) cleanupStates(activeRuns []*model.Run) {
 			delete(d.runStates, key)
 		}
 	}
+}
+
+// runLiveness reports the monitor's current view of a run's liveness.
+// alive means the last observation (local IsAlive or worker-lease capture)
+// succeeded; known means the monitor has actually observed the run at least
+// once — infra failures (worker offline) leave liveness unknown rather than
+// reporting a healthy session as dead.
+func (d *Daemon) runLiveness(run *model.Run) (alive, known bool) {
+	if run == nil {
+		return false, false
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	state, ok := d.runStates[run.Ref().String()]
+	if !ok {
+		return false, false
+	}
+	if !state.WasAlive && state.DeadCheckCount == 0 {
+		return false, false
+	}
+	return state.WasAlive && state.DeadCheckCount == 0, true
 }
 
 // getOrCreateState gets or creates run state tracking

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -196,6 +196,7 @@ func (d *Daemon) Run() error {
 		d.socketServer.SetTCPListenAddr(d.listenAddr)
 	}
 	d.socketServer.runLiveness = d.runLiveness
+	d.socketServer.onRunFeedback = d.noteRunFeedback
 	d.socketServer.SetGitHubBackend(d.githubBackend)
 	if err := d.socketServer.Start(); err != nil {
 		d.logger.Printf("warning: failed to start socket server: %v", err)
@@ -456,6 +457,22 @@ func (d *Daemon) runLiveness(run *model.Run) (alive, known bool) {
 		return false, false
 	}
 	return state.WasAlive && state.DeadCheckCount == 0, true
+}
+
+// noteRunFeedback resets a run's prompt debounce when feedback is delivered
+// to its agent session: the idle prompt may still be on screen for the next
+// capture or two, and must not flip the run straight back to waiting before
+// the agent starts working on the feedback.
+func (d *Daemon) noteRunFeedback(run *model.Run) {
+	if run == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if state, ok := d.runStates[run.Ref().String()]; ok {
+		state.PromptStreak = 0
+	}
 }
 
 // getOrCreateState gets or creates run state tracking

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -34,6 +34,17 @@ const (
 	remoteCaptureInterval     = 15 * time.Second
 	remoteCaptureLeaseTimeout = 15 * time.Second
 	remoteCaptureLines        = 200
+
+	// A run that was never observed alive gets this long from StartedAt
+	// before dead checks may conclude a verdict (unknown/failed): worker
+	// delegation, worktree setup, and agent boot all happen before the
+	// session becomes observable, and a premature verdict makes
+	// `orch wait` fire spuriously on a run that is still booting.
+	neverAliveVerdictGrace = 3 * time.Minute
+
+	// How often to re-log the "never confirmed alive" wait for a run whose
+	// session has not appeared (once per ~10 minutes at 5s ticks).
+	neverAliveLogEvery = 120
 )
 
 func (d *Daemon) monitorRun(run *model.Run, st store.Store, projectID, projectRoot string) error {
@@ -79,37 +90,46 @@ func (d *Daemon) monitorRun(run *model.Run, st store.Store, projectID, projectRo
 			}
 		}
 		if !state.WasAlive {
-			// Agent was never confirmed alive. For opencode runs, check if there are
-			// clear completion signals (merged PR, clean worktree) before giving up.
-			// This handles cases where the daemon started after the agent finished.
-			if run.Agent == "opencode" && state.DeadCheckCount >= deadChecksBeforeFailed {
-				inferredStatus := d.inferStatusFromGitState(run, st, false)
+			// Agent was never confirmed alive. Check for clear completion
+			// signals (merged/open PR, commits) before giving up — the daemon
+			// may have started after the agent finished. A gone session must
+			// never mask completed work, regardless of agent.
+			if state.DeadCheckCount >= deadChecksBeforeFailed {
+				inferredStatus := d.inferStatusFromGitState(run, st, false, projectRoot)
 				if inferredStatus != "" {
-					if opencodeLogPath != "" {
-						d.logger.Printf("%s#%s: agent never confirmed alive, but inferred status from git state: %s (opencode logs: %s)", run.IssueID, run.RunID, inferredStatus, opencodeLogPath)
-					} else {
-						d.logger.Printf("%s#%s: agent never confirmed alive, but inferred status from git state: %s", run.IssueID, run.RunID, inferredStatus)
+					if inferredStatus != run.Status {
+						if opencodeLogPath != "" {
+							d.logger.Printf("%s#%s: agent never confirmed alive, but inferred status from git state: %s (opencode logs: %s)", run.IssueID, run.RunID, inferredStatus, opencodeLogPath)
+						} else {
+							d.logger.Printf("%s#%s: agent never confirmed alive, but inferred status from git state: %s", run.IssueID, run.RunID, inferredStatus)
+						}
 					}
 					return d.updateStatus(run, inferredStatus, st)
 				}
 			}
-			d.logger.Printf("%s#%s: agent not alive yet (never confirmed alive), waiting", run.IssueID, run.RunID)
+			if state.DeadCheckCount <= deadChecksBeforeFailed || state.DeadCheckCount%neverAliveLogEvery == 0 {
+				d.logger.Printf("%s#%s: agent not alive yet (never confirmed alive), waiting", run.IssueID, run.RunID)
+			} else {
+				d.debug("%s#%s: agent not alive yet (never confirmed alive), waiting", run.IssueID, run.RunID)
+			}
 			return nil
 		}
 		if state.DeadCheckCount < deadChecksBeforeFailed {
 			d.logger.Printf("%s#%s: agent not alive (%d/%d checks), waiting", run.IssueID, run.RunID, state.DeadCheckCount, deadChecksBeforeFailed)
 			return nil
 		}
-		if run.Agent == "opencode" {
-			inferredStatus := d.inferStatusFromGitState(run, st, true)
-			if inferredStatus != "" {
+		inferredStatus := d.inferStatusFromGitState(run, st, true, projectRoot)
+		if inferredStatus != "" {
+			if inferredStatus != run.Status {
 				if opencodeLogPath != "" {
-					d.logger.Printf("%s#%s: opencode session gone, inferred status from git state: %s (opencode logs: %s)", run.IssueID, run.RunID, inferredStatus, opencodeLogPath)
+					d.logger.Printf("%s#%s: agent session gone, inferred status from git state: %s (opencode logs: %s)", run.IssueID, run.RunID, inferredStatus, opencodeLogPath)
 				} else {
-					d.logger.Printf("%s#%s: opencode session gone, inferred status from git state: %s", run.IssueID, run.RunID, inferredStatus)
+					d.logger.Printf("%s#%s: agent session gone, inferred status from git state: %s", run.IssueID, run.RunID, inferredStatus)
 				}
-				return d.updateStatus(run, inferredStatus, st)
 			}
+			return d.updateStatus(run, inferredStatus, st)
+		}
+		if run.Agent == "opencode" {
 			if opencodeLogPath != "" {
 				d.logger.Printf("%s#%s: opencode session not found after %d checks, marking unknown (opencode logs: %s)", run.IssueID, run.RunID, state.DeadCheckCount, opencodeLogPath)
 			} else {
@@ -251,13 +271,32 @@ func (d *Daemon) monitorRemoteRun(run *model.Run, st store.Store, projectID, pro
 	output, err := capture(run, projectID, projectRoot, remoteCaptureLines)
 	if err != nil {
 		if isRemoteSessionGone(err) {
+			// The worker answered authoritatively: the lease round-trip
+			// completed, so pace re-checks like successful captures instead
+			// of retrying every monitor tick.
+			state.RemoteCaptureAt = now
 			state.DeadCheckCount++
 			if state.DeadCheckCount < deadChecksBeforeFailed {
 				d.logger.Printf("%s#%s: remote session not found on worker (check %d/%d): %v", run.IssueID, run.RunID, state.DeadCheckCount, deadChecksBeforeFailed, err)
 				return nil
 			}
+			// The session is gone on the execution host. Same rule as local
+			// runs: a gone session must never mask completed work, so infer
+			// from PR/git state before falling back to unknown/failed.
+			if inferred := d.inferStatusFromGitState(run, st, state.WasAlive, projectRoot); inferred != "" {
+				if inferred != run.Status {
+					d.logger.Printf("%s#%s: remote session gone, inferred status from git state: %s", run.IssueID, run.RunID, inferred)
+				}
+				return d.updateStatus(run, inferred, st)
+			}
 			if !state.WasAlive {
-				d.logger.Printf("%s#%s: remote agent never confirmed alive after %d checks, marking unknown", run.IssueID, run.RunID, state.DeadCheckCount)
+				if withinNeverAliveGrace(run) {
+					d.debug("%s#%s: remote session not observable yet (within boot grace), waiting", run.IssueID, run.RunID)
+					return nil
+				}
+				if run.Status != model.StatusUnknown {
+					d.logger.Printf("%s#%s: remote agent never confirmed alive after %d checks, marking unknown", run.IssueID, run.RunID, state.DeadCheckCount)
+				}
 				return d.updateStatus(run, model.StatusUnknown, st)
 			}
 			d.logger.Printf("%s#%s: remote agent confirmed dead after %d checks, marking failed", run.IssueID, run.RunID, state.DeadCheckCount)
@@ -474,6 +513,12 @@ func (d *Daemon) updateStatus(run *model.Run, status model.Status, st store.Stor
 	var fromStatus model.Status
 	if currentRun, err := st.GetRun(ref); err == nil && currentRun != nil {
 		fromStatus = currentRun.Status
+		// Re-affirming the current status is a no-op: appending duplicate
+		// status events bloats the run record and churns UpdatedAt, which
+		// breaks recency display/sorting for every client.
+		if fromStatus == status {
+			return nil
+		}
 		if !model.CanTransitionStatus(currentRun.Status, status, model.EventSourceDaemon) {
 			d.debug("%s#%s: daemon cannot transition from %s to %s", run.IssueID, run.RunID, currentRun.Status, status)
 			return nil
@@ -625,45 +670,58 @@ func (d *Daemon) checkPRMergedWithURL(run *model.Run, st store.Store) (merged bo
 // is no longer reachable. wasAlive indicates whether the agent was ever confirmed running.
 // When wasAlive is false and no work was done (0 commits, clean worktree), returns
 // StatusFailed rather than StatusDone — the agent never started, not "completed."
-func (d *Daemon) inferStatusFromGitState(run *model.Run, st store.Store, wasAlive bool) model.Status {
-	if run.Branch == "" || run.WorktreePath == "" {
+//
+// projectRoot is the repo root registered with the daemon for the run's
+// project; it is the lookup root for worker-hosted runs whose worktree lives
+// on the execution host and is not visible from this machine.
+func (d *Daemon) inferStatusFromGitState(run *model.Run, st store.Store, wasAlive bool, projectRoot string) model.Status {
+	if run.Branch == "" {
 		d.debug("%s#%s: infer: skipping - branch=%q worktree=%q", run.IssueID, run.RunID, run.Branch, run.WorktreePath)
 		return ""
 	}
 
-	repoRoot, err := git.FindMainRepoRoot(run.WorktreePath)
-	if err != nil {
-		d.logger.Printf("%s#%s: infer: cannot find repo root: %v", run.IssueID, run.RunID, err)
-		return ""
+	repoRoot := ""
+	if run.WorktreePath != "" {
+		if root, err := git.FindMainRepoRoot(run.WorktreePath); err == nil {
+			repoRoot = root
+		}
+	}
+	if repoRoot == "" && projectRoot != "" {
+		if root, err := git.FindMainRepoRoot(projectRoot); err == nil {
+			repoRoot = root
+		}
 	}
 
-	d.debug("%s#%s: infer: checking PR for branch %s", run.IssueID, run.RunID, run.Branch)
-	prInfo, err := pr.LookupCachedInfo(repoRoot, run.Branch)
-	if err == nil && prInfo != nil && prInfo.URL != "" {
-		d.logger.Printf("%s#%s: infer: found PR %s (state=%s)", run.IssueID, run.RunID, prInfo.URL, prInfo.State)
-		if run.PRUrl == "" {
-			if err := d.recordPRArtifact(run, prInfo.URL, st); err != nil {
-				d.logger.Printf("%s#%s: infer: failed to record PR: %v", run.IssueID, run.RunID, err)
+	if repoRoot != "" {
+		d.debug("%s#%s: infer: checking PR for branch %s", run.IssueID, run.RunID, run.Branch)
+		prInfo, err := pr.LookupCachedInfo(repoRoot, run.Branch)
+		if err == nil && prInfo != nil && prInfo.URL != "" {
+			d.debug("%s#%s: infer: found PR %s (state=%s)", run.IssueID, run.RunID, prInfo.URL, prInfo.State)
+			if run.PRUrl == "" {
+				if err := d.recordPRArtifact(run, prInfo.URL, st); err != nil {
+					d.logger.Printf("%s#%s: infer: failed to record PR: %v", run.IssueID, run.RunID, err)
+				}
 			}
+			if prInfo.State == "MERGED" {
+				return model.StatusDone
+			}
+			return model.StatusPROpen
 		}
-		if prInfo.State == "MERGED" {
-			return model.StatusDone
+		if err != nil {
+			d.debug("%s#%s: infer: PR lookup error: %v", run.IssueID, run.RunID, err)
+		} else {
+			d.debug("%s#%s: infer: no PR found", run.IssueID, run.RunID)
 		}
-		return model.StatusPROpen
-	}
-	if err != nil {
-		d.debug("%s#%s: infer: PR lookup error: %v", run.IssueID, run.RunID, err)
-	} else {
-		d.debug("%s#%s: infer: no PR found", run.IssueID, run.RunID)
 	}
 
-	// If branch-based lookup failed but run already has a PR URL, check PR status by URL
-	// This handles cases where the local branch was deleted/rebased but PR still exists
+	// If branch-based lookup failed but run already has a PR URL, check PR status by URL.
+	// This handles cases where the local branch was deleted/rebased but PR still exists,
+	// and worker-hosted runs whose worktree/repo is not visible from this host.
 	if run.PRUrl != "" {
 		d.debug("%s#%s: infer: branch lookup failed, checking existing PR URL: %s", run.IssueID, run.RunID, run.PRUrl)
 		prInfo, err := pr.LookupCachedInfoByURL(run.PRUrl)
 		if err == nil && prInfo != nil {
-			d.logger.Printf("%s#%s: infer: PR %s state=%s (via URL lookup)", run.IssueID, run.RunID, prInfo.URL, prInfo.State)
+			d.debug("%s#%s: infer: PR %s state=%s (via URL lookup)", run.IssueID, run.RunID, prInfo.URL, prInfo.State)
 			if prInfo.State == "MERGED" {
 				return model.StatusDone
 			}
@@ -677,6 +735,11 @@ func (d *Daemon) inferStatusFromGitState(run *model.Run, st store.Store, wasAliv
 		return model.StatusPROpen
 	}
 
+	if repoRoot == "" {
+		d.debug("%s#%s: infer: cannot find repo root (worktree=%q project_root=%q)", run.IssueID, run.RunID, run.WorktreePath, projectRoot)
+		return ""
+	}
+
 	baseBranch := "origin/main"
 	if d.config != nil && d.config.BaseBranch != "" {
 		remote, branch := git.ParseRemoteBranch(d.config.BaseBranch)
@@ -685,20 +748,40 @@ func (d *Daemon) inferStatusFromGitState(run *model.Run, st store.Store, wasAliv
 
 	aheadCount, err := git.GetAheadCount(repoRoot, run.Branch, baseBranch)
 	if err != nil {
-		d.logger.Printf("%s#%s: infer: cannot get ahead count: %v", run.IssueID, run.RunID, err)
+		d.debug("%s#%s: infer: cannot get ahead count: %v", run.IssueID, run.RunID, err)
 		return ""
 	}
 
 	hasUncommitted := git.HasUncommittedChanges(run.WorktreePath)
 
-	d.logger.Printf("%s#%s: infer: commits ahead=%d, uncommitted=%v", run.IssueID, run.RunID, aheadCount, hasUncommitted)
+	d.debug("%s#%s: infer: commits ahead=%d, uncommitted=%v", run.IssueID, run.RunID, aheadCount, hasUncommitted)
 
 	if aheadCount > 0 || hasUncommitted {
 		return model.StatusWaiting
 	}
 
+	// No positive signals (no PR, no commits, clean worktree). The verdict
+	// depends on agent lifecycle: opencode exits when finished, so a gone
+	// session with no work means the run produced nothing. Interactive
+	// agents (codex, claude) keep their session open while idle, so a gone
+	// session with no work is not a completion signal — leave the verdict
+	// to the caller.
+	if run.Agent != "opencode" {
+		return ""
+	}
 	if !wasAlive {
+		if withinNeverAliveGrace(run) {
+			d.debug("%s#%s: infer: within boot grace, no verdict yet", run.IssueID, run.RunID)
+			return ""
+		}
 		return model.StatusFailed
 	}
 	return model.StatusDone
+}
+
+// withinNeverAliveGrace reports whether a run that has never been observed
+// alive is still inside its boot grace window, during which dead checks must
+// not conclude a verdict.
+func withinNeverAliveGrace(run *model.Run) bool {
+	return !run.StartedAt.IsZero() && time.Since(run.StartedAt) < neverAliveVerdictGrace
 }

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -208,6 +208,24 @@ func TestUpdateStatusSameStatusIsNoOp(t *testing.T) {
 	}
 }
 
+func TestNoteRunFeedbackResetsPromptDebounce(t *testing.T) {
+	d := newTestDaemon()
+	run := &model.Run{IssueID: "i1", RunID: "r1"}
+
+	state := d.getOrCreateState(run)
+	state.PromptStreak = 5 // idle at prompt for several captures
+
+	d.noteRunFeedback(run)
+
+	if state.PromptStreak != 0 {
+		t.Fatalf("expected prompt streak reset after feedback, got %d", state.PromptStreak)
+	}
+	// A lingering prompt on the very next capture must not be "stable" yet.
+	if state.recordPromptSignal(true) {
+		t.Fatal("single post-feedback prompt capture must not count as a stable prompt")
+	}
+}
+
 func TestRunLivenessFromMonitorState(t *testing.T) {
 	d := newTestDaemon()
 	run := &model.Run{IssueID: "i1", RunID: "r1"}

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -176,6 +176,62 @@ func (m *mockStoreForUpdate) WriteAgentPrompt(ref *model.RunRef, content string)
 func (m *mockStoreForUpdate) ReadAgentPrompt(ref *model.RunRef) (string, error)        { return "", nil }
 func (m *mockStoreForUpdate) CreateIssue(issue *model.Issue) error                     { return nil }
 
+// mockStoreWithRun returns a fixed run from GetRun so updateStatus can see
+// the current persisted status.
+type mockStoreWithRun struct {
+	mockStoreForUpdate
+	run *model.Run
+}
+
+func (m *mockStoreWithRun) GetRun(*model.RunRef) (*model.Run, error) { return m.run, nil }
+
+func TestUpdateStatusSameStatusIsNoOp(t *testing.T) {
+	d := newTestDaemon()
+	run := &model.Run{IssueID: "i1", RunID: "r1", Status: model.StatusUnknown}
+	st := &mockStoreWithRun{
+		mockStoreForUpdate: mockStoreForUpdate{issue: &model.Issue{ID: "i1", Status: model.IssueStatusOpen}},
+		run:                run,
+	}
+
+	if err := d.updateStatus(run, model.StatusUnknown, st); err != nil {
+		t.Fatalf("updateStatus() error = %v", err)
+	}
+	if st.appendEventCalls != 0 {
+		t.Fatalf("re-affirming the current status must not append events, got %d", st.appendEventCalls)
+	}
+
+	if err := d.updateStatus(run, model.StatusPROpen, st); err != nil {
+		t.Fatalf("updateStatus() error = %v", err)
+	}
+	if st.appendEventCalls != 1 {
+		t.Fatalf("expected a real transition to append one event, got %d", st.appendEventCalls)
+	}
+}
+
+func TestRunLivenessFromMonitorState(t *testing.T) {
+	d := newTestDaemon()
+	run := &model.Run{IssueID: "i1", RunID: "r1"}
+
+	if alive, known := d.runLiveness(run); alive || known {
+		t.Fatalf("unobserved run must be unknown, got alive=%v known=%v", alive, known)
+	}
+
+	state := d.getOrCreateState(run)
+	if alive, known := d.runLiveness(run); alive || known {
+		t.Fatalf("run with no observations yet must stay unknown, got alive=%v known=%v", alive, known)
+	}
+
+	state.WasAlive = true
+	if alive, known := d.runLiveness(run); !alive || !known {
+		t.Fatalf("observed-alive run must report alive, got alive=%v known=%v", alive, known)
+	}
+
+	state.DeadCheckCount = 1
+	if alive, known := d.runLiveness(run); alive || !known {
+		t.Fatalf("run failing dead checks must report not alive, got alive=%v known=%v", alive, known)
+	}
+}
+
 func TestUpdateStatusAutoResolve(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -630,6 +686,9 @@ func TestMonitorRemoteRunSessionGoneNeverAliveMarksUnknown(t *testing.T) {
 	mgr := agent.GetManager(run)
 
 	for i := 0; i < deadChecksBeforeFailed; i++ {
+		// A session-gone reply is a completed worker round-trip and is paced
+		// like a successful capture; rewind the pacing clock between checks.
+		state.RemoteCaptureAt = time.Now().Add(-2 * remoteCaptureInterval)
 		if err := d.monitorRemoteRun(run, st, "proj", "/root", state, mgr); err != nil {
 			t.Fatalf("monitorRemoteRun() call %d error = %v", i+1, err)
 		}
@@ -640,6 +699,87 @@ func TestMonitorRemoteRunSessionGoneNeverAliveMarksUnknown(t *testing.T) {
 	}
 	if st.appendEventCalls != 1 {
 		t.Fatalf("expected exactly one status event after dead checks, got %d", st.appendEventCalls)
+	}
+}
+
+func TestMonitorRemoteRunSessionGonePacesLeaseRoundTrips(t *testing.T) {
+	d := newTestDaemon()
+	captures := 0
+	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (string, error) {
+		captures++
+		return "", errors.New("session run-ISSUE-REMOTE-1-run-1 not found (run may not be active)")
+	}
+
+	run := newRemoteTestRun(model.StatusRunning)
+	st := &mockStoreForUpdate{issue: &model.Issue{ID: "ISSUE-REMOTE-1", Status: model.IssueStatusOpen}}
+	state := d.getOrCreateState(run)
+	mgr := agent.GetManager(run)
+
+	for i := 0; i < 3; i++ {
+		if err := d.monitorRemoteRun(run, st, "proj", "/root", state, mgr); err != nil {
+			t.Fatalf("monitorRemoteRun() call %d error = %v", i+1, err)
+		}
+	}
+
+	if captures != 1 {
+		t.Fatalf("dead-session checks must be paced by the remote capture interval, got %d lease round-trips", captures)
+	}
+	if state.DeadCheckCount != 1 {
+		t.Fatalf("expected a single dead check within one interval, got %d", state.DeadCheckCount)
+	}
+}
+
+func TestMonitorRemoteRunSessionGoneWithRecordedPRInfersPROpen(t *testing.T) {
+	d := newTestDaemon()
+	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (string, error) {
+		return "", errors.New("session run-ISSUE-REMOTE-1-run-1 not found (run may not be active)")
+	}
+
+	run := newRemoteTestRun(model.StatusRunning)
+	run.Branch = "issue/ISSUE-REMOTE-1/run-1"
+	// Non-GitHub URL keeps the lookup offline; the recorded PR itself is the
+	// completion evidence and must preserve pr_open.
+	run.PRUrl = "https://gitlab.com/org/repo/merge_requests/9"
+	st := &mockStoreRecordingEvents{mockStoreForUpdate: mockStoreForUpdate{issue: &model.Issue{ID: "ISSUE-REMOTE-1", Status: model.IssueStatusOpen}}}
+	state := d.getOrCreateState(run)
+	mgr := agent.GetManager(run)
+
+	for i := 0; i < deadChecksBeforeFailed; i++ {
+		state.RemoteCaptureAt = time.Now().Add(-2 * remoteCaptureInterval)
+		if err := d.monitorRemoteRun(run, st, "proj", "/root", state, mgr); err != nil {
+			t.Fatalf("monitorRemoteRun() call %d error = %v", i+1, err)
+		}
+	}
+
+	if len(st.events) != 1 {
+		t.Fatalf("expected exactly one status event, got %d", len(st.events))
+	}
+	if got := st.events[0].Name; got != string(model.StatusPROpen) {
+		t.Fatalf("expected pr_open inferred from recorded PR, got %s", got)
+	}
+}
+
+func TestMonitorRemoteRunSessionGoneNeverAliveWithinGraceWaits(t *testing.T) {
+	d := newTestDaemon()
+	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (string, error) {
+		return "", errors.New("session run-ISSUE-REMOTE-1-run-1 not found (run may not be active)")
+	}
+
+	run := newRemoteTestRun(model.StatusBooting)
+	run.StartedAt = time.Now() // just booted: worker has not created the session yet
+	st := &mockStoreForUpdate{issue: &model.Issue{ID: "ISSUE-REMOTE-1", Status: model.IssueStatusOpen}}
+	state := d.getOrCreateState(run)
+	mgr := agent.GetManager(run)
+
+	for i := 0; i < deadChecksBeforeFailed+2; i++ {
+		state.RemoteCaptureAt = time.Now().Add(-2 * remoteCaptureInterval)
+		if err := d.monitorRemoteRun(run, st, "proj", "/root", state, mgr); err != nil {
+			t.Fatalf("monitorRemoteRun() call %d error = %v", i+1, err)
+		}
+	}
+
+	if st.appendEventCalls != 0 {
+		t.Fatalf("a booting run must not get an unknown verdict within the grace window, got %d status events", st.appendEventCalls)
 	}
 }
 
@@ -656,6 +796,7 @@ func TestMonitorRemoteRunSessionGoneAfterAliveMarksFailed(t *testing.T) {
 	mgr := agent.GetManager(run)
 
 	for i := 0; i < deadChecksBeforeFailed; i++ {
+		state.RemoteCaptureAt = time.Now().Add(-2 * remoteCaptureInterval)
 		if err := d.monitorRemoteRun(run, st, "proj", "/root", state, mgr); err != nil {
 			t.Fatalf("monitorRemoteRun() call %d error = %v", i+1, err)
 		}

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -897,6 +897,7 @@ func (s *SocketServer) handleProtoListRuns(req *orchpb.ListRunsRequest) *orchpb.
 	protoRuns := make([]*orchpb.Run, len(paginatedRuns))
 	protoRuns = enrichRunsParallel(paginatedRuns, protoRuns)
 	applyIssueMetadataToRunEntries(paginatedEntries, protoRuns)
+	s.applyRunLiveness(paginatedRuns, protoRuns)
 	enrichDuration := time.Since(enrichStart)
 
 	s.maybeLogListRunsTiming(req, len(paginatedRuns), storeDuration, enrichDuration, time.Since(requestStart), nil)
@@ -1022,6 +1023,24 @@ func (s *SocketServer) maybeLogListRunsTiming(
 		hasOlderThan,
 		slow,
 	)
+}
+
+// applyRunLiveness stamps the monitor's liveness view onto proto runs. The
+// monitor is the single source of truth for liveness: it observes local runs
+// via the multiplexer and worker-hosted runs via capture leases, so this is
+// correct regardless of which host a run executes on.
+func (s *SocketServer) applyRunLiveness(runs []*model.Run, protoRuns []*orchpb.Run) {
+	if s.runLiveness == nil {
+		return
+	}
+	for i, run := range runs {
+		if i >= len(protoRuns) || protoRuns[i] == nil {
+			continue
+		}
+		alive, known := s.runLiveness(run)
+		protoRuns[i].Alive = alive
+		protoRuns[i].AliveKnown = known
+	}
 }
 
 func enrichRunProto(pr *orchpb.Run, run *model.Run, runner git.Runner) {
@@ -1263,6 +1282,7 @@ func (s *SocketServer) handleProtoGetRun(req *orchpb.GetRunRequest) *orchpb.Resp
 
 	pr := modelRunToProto(run)
 	enrichRunProto(pr, run, s.gitRunner)
+	s.applyRunLiveness([]*model.Run{run}, []*orchpb.Run{pr})
 
 	return &orchpb.Response{
 		Ok: true,

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -2312,6 +2312,11 @@ func (s *SocketServer) handleProtoSendMessage(req *orchpb.SendMessageRequest) *o
 		if _, err := s.withWorkerLease(runCtx.projectID, "send_message", string(runCtx.run.IssueID), string(runCtx.run.RunID), payload); err != nil {
 			return errorResponse(err.Error())
 		}
+		// --no-enter only types into the input box without submitting; the
+		// agent has not received anything, so the run is not resumed.
+		if !req.NoEnter {
+			s.markRunFeedbackSent(runCtx.store, runCtx.run)
+		}
 		return &orchpb.Response{
 			Ok:       true,
 			Response: &orchpb.Response_SendMessage{SendMessage: &orchpb.SendMessageResponse{}},

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -328,6 +328,13 @@ type SocketServer struct {
 	// list/get responses can report ALIVE for both local and worker-hosted
 	// runs. Wired by Daemon at startup.
 	runLiveness func(run *model.Run) (alive, known bool)
+
+	// onRunFeedback, when set, notifies the daemon monitor that feedback
+	// was just delivered to a run's agent session, so it can reset its
+	// prompt debounce: the idle prompt still on screen must not flip the
+	// run straight back to waiting before the agent starts working. Wired
+	// by Daemon at startup.
+	onRunFeedback func(run *model.Run)
 }
 
 type managedServer struct {
@@ -2911,9 +2918,60 @@ func (s *SocketServer) processSendMessage(st store.Store, params *SendMessagePar
 	}
 
 	if run.Agent == string(agent.AgentOpenCode) {
-		return s.processSendOpenCode(st, ref, run, params.Message)
+		if err := s.processSendOpenCode(st, ref, run, params.Message); err != nil {
+			return err
+		}
+	} else if err := s.processSendTmux(run, params.Message, params.NoEnter); err != nil {
+		return err
 	}
-	return s.processSendTmux(run, params.Message, params.NoEnter)
+
+	// --no-enter only types into the input box without submitting; the agent
+	// has not received anything, so the run is not resumed.
+	if !params.NoEnter {
+		s.markRunFeedbackSent(st, run)
+	}
+	return nil
+}
+
+// feedbackResumesRun reports whether a run in this status goes back to work
+// when the user sends feedback to its agent session. Boot statuses are
+// excluded (the boot flow owns the transition to running) and terminal
+// statuses stay terminal.
+func feedbackResumesRun(status model.Status) bool {
+	switch status {
+	case model.StatusWaiting, model.StatusPROpen, model.StatusRateLimited, model.StatusUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// markRunFeedbackSent transitions an idle/parked run back to running after
+// feedback was successfully delivered to its agent session. Send is the
+// running edge of the running ⟷ waiting lifecycle: without this transition
+// `orch wait` called right after `orch send` would see the stale pre-send
+// status (waiting/pr_open) and return immediately instead of blocking until
+// the agent next goes idle or the PR state changes.
+func (s *SocketServer) markRunFeedbackSent(st store.Store, run *model.Run) {
+	if st == nil || run == nil || !feedbackResumesRun(run.Status) {
+		return
+	}
+	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)); err != nil {
+		s.logger.Printf("%s#%s: failed to mark run running after feedback: %v", run.IssueID, run.RunID, err)
+		return
+	}
+	if s.onRunFeedback != nil {
+		s.onRunFeedback(run)
+	}
+	s.PublishRunEvent(&orchpb.RunEventFrame{
+		RunId:           string(run.RunID),
+		IssueId:         string(run.IssueID),
+		ShortId:         string(model.GenerateShortID(run.IssueID, run.RunID)),
+		FromStatus:      modelStatusToProto(run.Status),
+		ToStatus:        modelStatusToProto(model.StatusRunning),
+		TimestampUnixMs: time.Now().UnixMilli(),
+		Source:          string(model.EventSourceUser),
+	})
 }
 
 func (s *SocketServer) handleListRuns(req SendRequest, encoder *json.Encoder) {

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -322,6 +322,12 @@ type SocketServer struct {
 	currentWorkerHost string
 
 	runEventBus *RunEventBus
+
+	// runLiveness, when set, exposes the daemon monitor's liveness view
+	// (last observation succeeded / run has been observed at all) so that
+	// list/get responses can report ALIVE for both local and worker-hosted
+	// runs. Wired by Daemon at startup.
+	runLiveness func(run *model.Run) (alive, known bool)
 }
 
 type managedServer struct {
@@ -845,8 +851,29 @@ func (s *SocketServer) GetAllRepoContexts() []*RepoContext {
 	s.reposMu.RLock()
 	defer s.reposMu.RUnlock()
 
+	// s.repos can alias one store under two keys: the repo ID and the
+	// issuesRoot cache key used by getOrCreateStore. Callers treat the
+	// result as "each repo once" (the monitor would otherwise observe every
+	// run twice per tick, double-counting dead checks and duplicating
+	// events), so collapse aliases to a single context, preferring the
+	// entry that carries project metadata.
 	contexts := make([]*RepoContext, 0, len(s.repos))
+	byStore := make(map[store.Store]int, len(s.repos))
 	for _, ctx := range s.repos {
+		if ctx == nil {
+			continue
+		}
+		if ctx.Store == nil {
+			contexts = append(contexts, ctx)
+			continue
+		}
+		if i, ok := byStore[ctx.Store]; ok {
+			if contexts[i].ProjectRoot == "" && ctx.ProjectRoot != "" {
+				contexts[i] = ctx
+			}
+			continue
+		}
+		byStore[ctx.Store] = len(contexts)
 		contexts = append(contexts, ctx)
 	}
 	return contexts

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -4103,6 +4103,7 @@ func TestSendMessageRemoteTargetUsesWorkerLease(t *testing.T) {
 				Agent:       string(agent.AgentClaude),
 				Target:      "mac",
 				TargetHost:  "mac-host",
+				Status:      model.StatusPROpen,
 			},
 		},
 		issues: map[string]*model.Issue{},
@@ -4131,7 +4132,7 @@ func TestSendMessageRemoteTargetUsesWorkerLease(t *testing.T) {
 				return
 			}
 			payload := lease.Payload.SendMessage
-			if payload.Message != "hello remote" || !payload.NoEnter || payload.TargetWorkerID != workerID {
+			if payload.Message != "hello remote" || payload.NoEnter || payload.TargetWorkerID != workerID {
 				_ = server.acknowledgeWorkerLease(workerID, lease.LeaseID, false, "unexpected send payload", "")
 				return
 			}
@@ -4144,11 +4145,52 @@ func TestSendMessageRemoteTargetUsesWorkerLease(t *testing.T) {
 		IssueId: "issue-remote",
 		RunId:   "run-remote",
 		Message: "hello remote",
-		NoEnter: true,
+		NoEnter: false,
 		Context: &orchpb.RequestContext{},
 	})
 	if !resp.Ok {
 		t.Fatalf("expected send_message to succeed, got error: %s", resp.Error)
+	}
+
+	// Feedback resumes the run: a pr_open run that just received input is
+	// working again, so `orch wait` blocks until the agent next goes idle.
+	if got := st.runs["issue-remote#run-remote"].Status; got != model.StatusRunning {
+		t.Fatalf("expected run marked running after feedback, got %s", got)
+	}
+}
+
+func TestMarkRunFeedbackSentTransitions(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	server := NewSocketServer(nil, logger)
+
+	cases := []struct {
+		status model.Status
+		want   model.Status
+	}{
+		{model.StatusWaiting, model.StatusRunning},
+		{model.StatusPROpen, model.StatusRunning},
+		{model.StatusRateLimited, model.StatusRunning},
+		{model.StatusUnknown, model.StatusRunning},
+		{model.StatusRunning, model.StatusRunning}, // no duplicate event
+		{model.StatusBooting, model.StatusBooting}, // boot flow owns running
+		{model.StatusDone, model.StatusDone},       // terminal stays terminal
+		{model.StatusFailed, model.StatusFailed},
+	}
+
+	for _, tc := range cases {
+		run := &model.Run{IssueID: "i", RunID: "r", Status: tc.status}
+		st := &mockStore{runs: map[string]*model.Run{"i#r": run}, issues: map[string]*model.Issue{}}
+		feedbackNoted := false
+		server.onRunFeedback = func(*model.Run) { feedbackNoted = true }
+
+		server.markRunFeedbackSent(st, run)
+
+		if got := st.runs["i#r"].Status; got != tc.want {
+			t.Errorf("markRunFeedbackSent from %s: status = %s, want %s", tc.status, got, tc.want)
+		}
+		if wantNoted := tc.want == model.StatusRunning && tc.status != model.StatusRunning; feedbackNoted != wantNoted {
+			t.Errorf("markRunFeedbackSent from %s: feedback noted = %v, want %v", tc.status, feedbackNoted, wantNoted)
+		}
 	}
 }
 

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -263,6 +263,30 @@ func TestLegacySocketFilePath(t *testing.T) {
 	}
 }
 
+func TestGetAllRepoContextsCollapsesStoreAliases(t *testing.T) {
+	shared := &mockStoreForUpdate{}
+	other := &mockStoreForUpdate{}
+	s := &SocketServer{
+		repos: map[string]*RepoContext{
+			// getOrCreateStore caches the same store under its issuesRoot
+			// path and under the repo ID; the monitor must see it once.
+			"/home/u/repos/orch-issues": {Store: shared},
+			"proboscis-orch":            {Store: shared, RepoID: "proboscis-orch", ProjectRoot: "/home/u/repos/orch"},
+			"other-repo":                {Store: other, RepoID: "other-repo", ProjectRoot: "/home/u/repos/other"},
+		},
+	}
+
+	contexts := s.GetAllRepoContexts()
+	if len(contexts) != 2 {
+		t.Fatalf("expected aliases collapsed to 2 contexts, got %d", len(contexts))
+	}
+	for _, ctx := range contexts {
+		if ctx.Store == store.Store(shared) && ctx.ProjectRoot != "/home/u/repos/orch" {
+			t.Fatalf("expected the alias with project metadata to win, got %+v", ctx)
+		}
+	}
+}
+
 func randomID() string {
 	return time.Now().Format("150405") + "-" + randomString(4)
 }


### PR DESCRIPTION
## Problem

`orch wait` had become unreliable because the daemon was not reliably detecting run/PR state:

- Worker-hosted runs that finished days ago (PR open) showed agent `?` (unknown) with UPDATED "just now"
- One stuck run accumulated **5,830 duplicate `unknown` status events**, appended 2× every 5s
- `orch wait` returned `status=unknown` for runs that completed work and opened PRs
- ALIVE showed `-` for every run
- The `orch send` → `orch wait` review cycle didn't work: wait returned immediately with the stale pre-send status
- Idle codex agents were never detected (stuck `run` forever) — recent codex builds have no shortcut hints in the footer
- zeus daemon.log had grown to **6.3 GB** from monitor spam

## Root causes & fixes

### Commit 1 — monitor state detection

```
master daemon                                 worker host
┌──────────────────────────────┐              ┌────────────────────┐
│ monitorAll (5s tick)         │              │ tmux session       │
│  ├ repos["<repo-id>"]     ───┼─┐            │ (gone after agent  │
│  └ repos["<issues-root>"] ───┼─┴─ same store│  finished)         │
│       → every run monitored 2× per tick (4) └────────────────────┘
│ monitorRemoteRun, session gone:
│   never-alive → unknown   ← even with recorded PR (1)
│   was-alive   → failed    ← even with recorded PR (1)
│   no boot grace → spurious unknown ~15s after start (2)
│ updateStatus(same status) → event appended every cycle (3)
│ proto list path: Alive/AliveKnown never computed (5)
└──────────────────────────────┘
```

1. **Session-gone classification now infers from PR/git state for all agents and hosts.** `inferStatusFromGitState` falls back to the daemon-registered project root when the run's worktree lives on another host, and consults the recorded PR URL even when no repo root resolves. Open PR → `pr_open`, merged → `done`. The no-signal verdict stays opencode-only (interactive agents don't exit on completion).
2. **3-minute boot grace for never-alive verdicts** — no spurious `unknown` while worker delegation + worktree setup + agent boot are in progress.
3. **`updateStatus` is a no-op when status is unchanged** — stops event-record bloat and UpdatedAt churn.
4. **`GetAllRepoContexts` collapses store aliases** (repo-ID key vs issuesRoot cache key), same as `listStores` — no more double monitoring.
5. **ALIVE is stamped from monitor state** on the proto list/get path — correct for local and worker-hosted runs.

### Commit 2 — `orch send` resumes the run

`orch send` never touched run status, so a `pr_open`/`waiting` run that just received feedback kept its stale status and `orch wait` returned immediately instead of blocking until the agent next went idle. Send is the running edge of the `running ⟷ waiting` lifecycle: after feedback is delivered (and actually submitted — `--no-enter` only types), the daemon appends `running` for idle/parked runs (`waiting`/`pr_open`/`rate_limited`/`unknown`), on both the local and worker-delegated paths. The monitor's prompt debounce resets on feedback so the lingering idle prompt can't flip the run straight back to waiting.

### Commit 3 — codex idle detection

Recent codex builds render the idle footer as just `branch · cwd` — none of the `IsWaitingForInput` patterns exist on the idle screen, so codex runs could never transition `running → waiting` (observed live: an idle run stuck as `run`, `orch wait` timing out). The composer line (`› …` U+203A) is the stable idle marker; busy markers are checked first so working screens stay busy.

## Verification (live, deployed to zeus master + both workers)

- Dead worker runs with open PRs: `?`/unknown → **`pr`**, ALIVE `no`, UPDATED stable (no churn)
- Live runs: PRs #456/#457 detected via worker capture within one cycle; ALIVE `yes`
- `orch send <pr_open run>` → status flips to **`run` synchronously**; `orch wait` blocks; agent idles → wait returns in 14s with `{"status":"pr_open","pr_url":...}`
- Idle codex runs across hosts flipped `running/pr_open → waiting` within one capture cycle of deploy
- Send to a gone session still fails fast with the exact session error and no status change
- `go test ./internal/daemon ./internal/agent` all pass; `make lint` 0 findings; remaining `go test ./...` failures are pre-existing (reproduced identically on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)