### PR TITLE
feat(lint): close the run-status write surface (coupling-core Phase A)

### DIFF
--- a/.semgrep/run-status-write-surface/run_status_write_surface.go
+++ b/.semgrep/run-status-write-surface/run_status_write_surface.go
@@ -1,0 +1,50 @@
+//go:build semgrepfixture
+
+// Semgrep test fixture for run-status-write-surface rules.
+// Parsed by `semgrep test`, never compiled.
+package fixture
+
+func badConstructStatusEvent() {
+	// ruleid: run-status-write-surface
+	_ = model.NewStatusEvent(model.StatusRunning)
+}
+
+func badConstructViaNewEvent() {
+	// ruleid: run-status-write-surface
+	_ = model.NewEvent(model.EventTypeStatus, "done", nil)
+}
+
+func badConstructViaNewEventStringLiteral() {
+	// ruleid: run-status-write-surface
+	_ = model.NewEvent("status", "done", nil)
+}
+
+func badClientStatusLiteral() {
+	ev := &orchapi.Event{
+		// ruleid: run-status-write-surface
+		Type: "status",
+		Name: "done",
+	}
+	_ = ev
+}
+
+func badIgnoredAppendResult(api API, ctx Ctx, ref Ref, ev *Event) {
+	// ruleid: no-ignored-status-append
+	_, _ = api.AppendEvent(ctx, ref, ev)
+}
+
+func okReadStatusEventType(e Event) bool {
+	// ok: run-status-write-surface
+	return e.Type == "status"
+}
+
+func okArtifactAppend(st Store, ref Ref) error {
+	// ok: run-status-write-surface
+	return st.AppendEvent(ref, model.NewArtifactEvent("pr", nil))
+}
+
+func okGuardedAppendErrorHandled(api API, ctx Ctx, ref Ref, ev *Event) error {
+	// ok: no-ignored-status-append
+	_, err := api.AppendEvent(ctx, ref, ev)
+	return err
+}

--- a/.semgrep/run-status-write-surface/run_status_write_surface.yaml
+++ b/.semgrep/run-status-write-surface/run_status_write_surface.yaml
@@ -1,0 +1,52 @@
+rules:
+  - id: run-status-write-surface
+    pattern-either:
+      - pattern: model.NewStatusEvent(...)
+      - pattern: model.NewEvent(model.EventTypeStatus, ...)
+      - pattern: model.NewEvent("status", ...)
+      - pattern-regex: 'Type:\s*"status"'
+      - pattern-regex: 'Type:\s*(model\.)?EventTypeStatus\b'
+    paths:
+      include:
+        - /internal/
+        - /.semgrep/run-status-write-surface/
+      exclude:
+        - /internal/model/
+    message: >
+      Run status transitions must flow through the step() executor
+      (Daemon.updateStatus in internal/daemon/monitor.go). Constructing or
+      appending a run status event anywhere else bypasses the transition
+      policy encoded in step() — debounce, grace windows, terminality, and
+      duplicate suppression (docs/design/run-state-machine.md). Existing
+      writers are frozen with `nosemgrep: run-status-write-surface`
+      annotations and shrink toward zero (docs/design/coupling-core-roadmap.md
+      Phase B). Do not add a new writer: extend step() with a new observation
+      or effect instead.
+    severity: ERROR
+    languages: [go]
+    metadata:
+      category: invariant
+      violation: run-status-write-outside-step
+
+  - id: no-ignored-status-append
+    pattern-either:
+      - pattern: _ = $ST.AppendEvent($REF, model.NewStatusEvent(...))
+      - pattern: _ = $ST.AppendEvent($REF, model.NewEvent(model.EventTypeStatus, ...))
+      - pattern: _, _ = $API.AppendEvent(...)
+    paths:
+      include:
+        - /internal/
+        - /.semgrep/run-status-write-surface/
+      exclude:
+        - /internal/model/
+    message: >
+      Do not discard the error from a status-event append. A swallowed append
+      means the daemon believes a transition happened while the store
+      disagrees — silent divergence between the event log (store of record)
+      and in-memory state. Propagate the error (fail-fast), or on
+      error-recording paths log it explicitly with run context.
+    severity: ERROR
+    languages: [go]
+    metadata:
+      category: fail-fast
+      violation: ignored-status-append-error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,53 @@ Examples:
 - Bad: `orch send` reports success when the remote control path was never reached.
 - Good: `orch send` fails with the exact host/session/opencode error and the next diagnostic step.
 
+### Coupling Cores and Change Routing
+
+Some clusters of design decisions in this codebase are mutually constraining:
+changing one silently invalidates the others' premises. These coupling cores
+are inventoried in [docs/design/coupling-core-roadmap.md](docs/design/coupling-core-roadmap.md)
+(the watchlist table). The run-status transition core is specified in
+[docs/design/run-state-machine.md](docs/design/run-state-machine.md).
+
+**Routing rule.** Work that touches a core goes to a frontier model plus a
+human reviewer, and ships its law/spec/invariant revision in the same change
+set. Work outside the cores can be delegated to sub-frontier agents as a
+verified issue. Core surfaces today:
+
+- `internal/daemon/step.go`, `internal/daemon/monitor.go` (transition policy
+  and its executor)
+- `internal/daemon/socket.go`, `internal/daemon/proto_handler.go` launch
+  ladders (frozen status writers, Phase B consolidation)
+- `internal/daemon/worker_plane.go` (worker lease ownership and heartbeats)
+- `internal/model/event.go`, `internal/model/run.go` (event fold = store of
+  record)
+
+**Status write surface.** Run status events are appended in exactly one
+sanctioned place: `Daemon.updateStatus`. The semgrep rule
+`run-status-write-surface` enforces this; the `nosemgrep` annotations on
+existing writers are frozen legacy and may only shrink. Never add a new
+writer or a new `nosemgrep` annotation — extend `step()` with a new
+observation or effect instead.
+
+**Tripwire checklist for reviewing delegated PRs.** Any single hit means
+stop and re-route to frontier + human:
+
+- a new ID type for something that previously had no identity
+- a new registry / lookup side-table mapping an id to a live object
+- a shared mutable flag synchronizing two copies of state
+- a clone/copy of something conceptually move-only or single-owner
+- a cache or accumulated field mirroring live state
+- a "keep in sync" comment between two representations
+- a new `nosemgrep` annotation on any architecture rule
+
+**Choice-space gate.** Do not delegate work near a core until the choice
+space is closed: enumerate the options as explicit equations/laws and fill
+the spec holes first. A delegate fills any open classification space with
+the cheapest compliant answer.
+
+**Burn-in loop.** When the same review comment repeats about three times,
+encode it as a semgrep rule or convention here instead of repeating it.
+
 ## Working with Conflicting PRs
 
 When your PR has conflicts with main after other PRs are merged:

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ test-compile:
 lint: lint-fixtures
 	@test -x "$(SEMGREP)" || uv tool install semgrep
 	$(SEMGREP) test .semgrep/typed-id-rules
+	$(SEMGREP) test .semgrep/run-status-write-surface
 	$(SEMGREP) --error --config .semgrep/ ./internal/ --exclude='*_test.go'
 	$(MAKE) -C orch-monitor-tui lint
 	$(MAKE) -C orch-monitor-tui lint-test

--- a/docs/design/coupling-core-roadmap.md
+++ b/docs/design/coupling-core-roadmap.md
@@ -1,0 +1,208 @@
+# Coupling-Core Roadmap — orch
+
+Status: living document
+Date: 2026-06-12
+Basis: /coupling-core 診断 (2026-06-12)。`docs/design/run-state-machine.md`
+(step() v1, PR #460) を「結晶化完了扱い・S4 委譲開放」とする所有者判断を
+前提に、S4 を安全にするための残作業を全フェーズ列挙する。
+このファイルは watchlist を兼ねる(skill の生きた成果物)。
+
+## 現状サマリ
+
+- step() v1 マージ済み。law L1–L6 は `internal/daemon/step_test.go` の
+  9 本の property test で機械検証済み。
+- **未閉鎖**: status イベント書き込み面が step 実行器の外に 15+ 箇所
+  (socket.go ×10, proto_handler.go ×4, internal/monitor/monitor.go ×2,
+  cli/tick.go, cli/repair.go)。これを守る semgrep ルールが無い。
+- proto_handler.go の 4 箇所が `_ = st.AppendEvent(...)` でエラー握り潰し。
+- I2(再起動透過性)・I5–I8 は doc 自身が違反と明記。
+- worker lease は churn(PR #457/#461, c5aba240)があるのに ADR/law 無し。
+- CI: `.github/workflows/quality.yaml` が `make lint`(semgrep)を実行済み
+  → `.semgrep/` に足したルールはそのまま delegate PR のゲートになる。
+
+## フェーズ依存関係
+
+```
+A 柵を立てる ──────────────► S4 が安全になる(最優先・即日)
+│
+├─► B step() v2 統合 ──► C I2/fold + 不変条件完済 ──► D シミュレータ
+│        (書き込み面→1)        (状態=イベントの畳み込み)     (完全性チェック)
+│
+├─► E worker lease 結晶化(並行・独立)
+│
+└─► F S4 運用レジーム(A と同日に開始、以後継続)
+```
+
+---
+
+## Phase A — 委譲の柵(最優先、~1 日箱)
+
+S4 入場条件「watchlist 全項目が 4 層固定 or 明示隔離」の最小充足。
+コア委譲が既に進行中なので、これだけは他の何よりも先。
+
+### A1. status 書き込み面の semgrep 閉鎖【frontier、2–4h】
+- 成果物: `.semgrep/run-status-write-surface.yaml`
+- 内容: step 実行器(`internal/daemon/monitor.go` updateStatus)以外での
+  `model.NewStatusEvent` / `Type: "status"` の AppendEvent を禁止。
+  既存 15+ 箇所は明示 whitelist(`paths` 除外 or `nosemgrep` 注記)で
+  「凍結された負債」として列挙 — 新規追加だけが落ちる。
+- exit: 16 箇所目の writer を足した PR が `make lint` で落ちる。
+
+### A2. AppendEvent エラー握り潰しの根絶【決定=frontier / 実装=codex】
+- 対象: `proto_handler.go:1513,1564,1606,1657` の `_ = st.AppendEvent(...)`
+- 決定事項(frontier): 失敗時の伝播先 — リクエスト失敗にするか、
+  error artifact + ログにするか。fail-fast 原則に従い前者を既定とする。
+- 成果物: 4 箇所の修正 + `.semgrep/` ルール `no-ignored-append-event`
+  (`_ = $ST.AppendEvent(...)` パターン禁止)。
+- exit: 握り潰しが lint で再発不能。
+
+### A3. routing rule の明文化【frontier、1h】
+- 成果物: `AGENTS.md` に追記 — コア面
+  (`internal/daemon/{step,monitor,socket,proto_handler}.go`、lease 系)
+  を触る issue は frontier + human、それ以外は codex 委譲可。
+  delegate PR レビュー時のトリップワイヤ(新 ID 型・registry・共有フラグ・
+  状態ミラー・手動同期コメント)を checklist 化。
+
+---
+
+## Phase B — step() v2: 書き込み面を 1 に縮める(2–3 日箱)
+
+run-state-machine.md が「v2 候補」と明記した W2–W10 の統合。
+A1 の whitelist がフェーズの進捗メーター(縮んで空になったら完了)。
+
+### B1. launch ladder W2–W5 → step 統合【frontier】
+- `socket.go` / `proto_handler.go` の起動段階遷移
+  (queued → booting → running/failed)を launch-progress 観測(O8)として
+  step に流す。imperative bootstrap は効果(effect)として残し、
+  遷移の決定だけを step に移す。
+- 対象: socket.go:1896,2970,3459,3474,3487,3516,3564,3593,4321,4340 /
+  proto_handler.go:1513,1564,1606,1657
+- exit: whitelist から daemon 内の該当行が消える。
+
+### B2. W6 feedback / W8 stop / W9 master projection / W10 external append【frontier 判断 → codex 実装可】
+- 各サイトを「step の観測に統合する」か「明示隔離(理由を
+  run-state-machine.md に追記)」のどちらかに決定する。
+  どちらでもよいが、**未決定のまま残すことだけが禁止**。
+- W10(external append、`socket.go handleAppendEvent`)は外界橋
+  (law 境界)として隔離が妥当な候補 — `CanTransitionStatus` が唯一の守り
+  であることを明記。
+
+### B3. クライアント面からの status 書き込み撤去【API 設計=frontier / 移植=codex】
+- 対象: `internal/monitor/monitor.go:594`(canceled), `:749`(done)、
+  `cli/tick.go:163`、`cli/repair.go:207`
+- クライアントが status イベントを組み立てるのをやめ、意味のある
+  daemon API 動詞(CancelRun / ResolveRun / Repair)に置き換える。
+  「状態計算は daemon」の境界の書き込み版。
+- 成果物: API 動詞 + `.semgrep/` ルール `client-no-status-append`
+  (internal/cli, internal/monitor での Type:"status" append 禁止)。
+- exit: status イベントの append 箇所が正確に 1(step 実行器)。
+
+---
+
+## Phase C — 再起動透過性(I2)+ 不変条件の完済(2–3 日箱)
+
+### C1. RunState = fold(event log)【frontier — store-of-record vs derived の核】
+- 意味カウンタ(WasAlive / DeadCheckCount / PromptStreak / PRRecorded /
+  OutputHash)を daemon 再起動で失わない構造に。選択肢を式で閉じる:
+  (a) 起動時に event log を replay して導出、
+  (b) カウンタ変化をイベントとして永続化、
+  (c) 周期スナップショット + replay。
+- 新 law(再起動透過性): 任意の時点で daemon を再起動しても、
+  同じ観測列に対する step の遷移列は不変。property test 化。
+- exit: I2 が doc の表で "holds" になり、test が守る。
+
+### C2. I6 — queued 孤児の監視【codex(verified issue)】
+- `monitorAll` が `queued` を列挙しないため、起動途中の daemon クラッシュで
+  孤児化した run が二度と観測されない問題。queued を監視対象に含め、
+  「すべての非 terminal run はいつか観測される」を test 化。
+
+### C3. I7 — local/remote verdict 非対称の解消【law 改定=frontier】
+- never-alive run への verdict が remote は grace 後 `unknown`、
+  local は永遠に沈黙という非対称(L3 補項で pinned)を、単一意味論に統一
+  (推奨: local も grace 後 `unknown`)。L3 を改定し test 更新。
+
+### C4. I8 — fireStatusChange の全遷移発火【codex】
+- 通知発火を step の効果実行器に移し、O4 経路だけでなく
+  すべての遷移で listener が発火することを test 化。B 完了後は自然に
+  落ちてくる作業。
+
+### C5. I5 — PR artifact dedup の永続化【C1 から従属】
+- `PRRecorded` を event log からの導出に置き換え(C1 の系)。
+  再起動後の重複 `pr` artifact が出ないことを test 化。
+
+- Phase C exit: run-state-machine.md §4 の I1–I8 が全行 "holds"。
+
+---
+
+## Phase D — 決定論シミュレータ + 完全性チェック(1–2 日箱)
+
+### D1. 観測スクリプト replay ハーネス【frontier 設計 / codex 拡充】
+- step + fake 効果実行器 + fake store で観測列を流す決定論シミュレータ。
+- 過去の実障害(5,830 重複イベント、PR #458 の推論バグ、queued 孤児)を
+  観測スクリプトとして再現・回帰固定。
+- exit(skill の完全性チェック): 外界橋ハンドラの差し替え**だけ**で
+  シミュレータが組めること。組めない箇所 = コアが葉に漏れている箇所。
+
+### D2. 代数カバレッジ検査【転記=codex / 判定=frontier】
+- 過去の run ライフサイクル系バグ・issue ~20 件を観測語彙
+  (O1–O8)で書き直す。70% 未満しか表現できなければ観測タクソノミを
+  見直す(分解の妥当性検査)。
+
+---
+
+## Phase E — worker lease 核の結晶化(並行可、2–3 日箱)
+
+第 2 の核。痛点申告(lease / remote)+ churn(PR #457 snapshot SSOT、
+#461 lease fail-fast、c5aba240 race 修正)があるのに ADR/law が無い。
+run-state-machine.md と同じ playbook を適用する。
+
+### E1. 調査ドキュメント【frontier】
+- `docs/design/worker-lease.md`: lease の書き込み面の全列挙、
+  所有権/ライフサイクル(誰が取得・更新・解放するか、master/worker
+  再起動時の挙動)、heartbeat 意味論 — run-state-machine.md §1–4 の鏡。
+
+### E2. laws + property tests【frontier】
+- 候補: lease 排他性(同時 active holder ≤ 1)、heartbeat 単調性、
+  failover 収束、lease 喪失 × run status の相互作用
+  (lease が消えた run はどの遷移を受けるか — run 状態機械との結合点)。
+
+### E3. 静的ガード【frontier 定義 → 以後 CI】
+- lease 変異面の semgrep ルール(A1 と同型)。
+
+---
+
+## Phase F — S4 運用レジーム(A と同日開始、以後継続)
+
+- F1. このファイルを watchlist として維持(下表)。新しい churn クラスタ
+  が出たら行を足す。大規模 rework が起きたら postmortem → 全層更新。
+- F2. choice-space gate: 核近傍の issue は、選択肢を式として列挙し
+  spec の穴を埋めてからでないと codex に出さない
+  (delegate は開いた分類空間を最安の答えで埋める)。
+- F3. メンテループ: frontier のレビュー指摘が ~3 回繰り返されたら
+  semgrep ルール/規約に焼き込む。
+
+## Watchlist(生きた表 — 状態が変わったら更新)
+
+| # | core | 4層の状態 | 守り | 閉鎖フェーズ |
+|---|------|----------|------|------------|
+| 1 | run status 遷移 | ADR✓ law✓(tested) runtime△ static✗ | A1 ルール | A1→B |
+| 2 | RunState vs event log(導出状態) | I2 open(doc に明記) | なし | C1 |
+| 3 | worker lease 所有権/ライフサイクル | 未文書化 | なし | E |
+| 4 | identity(typed IDs) | 型✓ + lint✓ | `.semgrep/typed-id-rules` | 完了 |
+| 5 | client/daemon 境界(読み取り) | semgrep ~60 ルール✓ | `make lint` + CI | 完了 |
+| 6 | cancellation/stop 意味論(W7/W8, PR close terminal) | step に部分統合 | terminal guard のみ | B2 |
+| 7 | エラー伝播 × append(fail-fast) | 4 箇所違反 | なし | A2 |
+
+## 推奨順序と箱
+
+```
+Day 0       : A1 + A2 + A3 + F1   (柵。これが終わるまでコア委譲は控える)
+Day 1–3     : B1 → B3 → B2        (whitelist が空になるまで)
+Day 4–6     : C1 → C3 → C2/C4/C5  (C2/C4 は codex 並行可)
+Day 7–8     : D1 → D2
+並行(任意) : E1 → E2 → E3        (次に lease を触る前に E1 だけでも)
+```
+
+codex に切り出せる verified issue 候補: A2 実装、B3 の機械的移植、
+C2、C4、D2 転記。それ以外(A1, B1, B2 判断, C1, C3, D1 設計, E 全部)は
+frontier + human。

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -203,8 +203,10 @@ func repairStaleRunsAPI(ctx context.Context, api orchapi.OrchAPI, opts *repairOp
 		}
 
 		ref := orchapi.RunRef{IssueID: run.IssueID, RunID: run.RunID}
+		// Frozen client-plane status writer: scheduled to become a daemon API
+		// verb (coupling-core roadmap Phase B3). Do not copy this pattern.
 		event := &orchapi.Event{
-			Type: "status",
+			Type: "status", // nosemgrep: run-status-write-surface
 			Name: string(newStatus),
 		}
 		if _, err := api.AppendEvent(ctx, ref, event); err != nil {

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -529,7 +529,12 @@ func (d *Daemon) updateStatus(run *model.Run, status model.Status, st store.Stor
 		}
 	}
 
-	event := model.NewStatusEvent(status)
+	// The sanctioned single writer for monitor-plane status transitions:
+	// every transition decided by step() is committed here, and only here
+	// (docs/design/run-state-machine.md). All other status writers are
+	// frozen legacy, enumerated by `nosemgrep: run-status-write-surface`
+	// annotations, and shrink toward zero (coupling-core roadmap Phase B).
+	event := model.NewStatusEvent(status) // nosemgrep: run-status-write-surface
 	if err := st.AppendEvent(ref, event); err != nil {
 		return err
 	}

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -1510,7 +1510,9 @@ func (s *SocketServer) syncStartRunResultToMasterStore(st store.Store, req *orch
 		if run == nil {
 			return fmt.Errorf("store returned nil run for %s#%s", req.IssueId, result.RunID)
 		}
-		_ = st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued))
+		if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued)); err != nil { // nosemgrep: run-status-write-surface
+			return fmt.Errorf("failed to record queued status for %s#%s: %w", req.IssueId, result.RunID, err)
+		}
 	}
 	if run == nil {
 		return fmt.Errorf("run unavailable for %s#%s", req.IssueId, result.RunID)
@@ -1561,7 +1563,9 @@ func (s *SocketServer) syncStartRunResultToMasterStore(st store.Store, req *orch
 	if err != nil {
 		return fmt.Errorf("invalid start_run worker result status for %s#%s: %w", req.IssueId, result.RunID, err)
 	}
-	_ = st.AppendEvent(run.Ref(), model.NewStatusEvent(status))
+	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(status)); err != nil { // nosemgrep: run-status-write-surface
+		return fmt.Errorf("failed to record status %s for %s#%s: %w", status, req.IssueId, result.RunID, err)
+	}
 
 	return nil
 }
@@ -1603,7 +1607,9 @@ func (s *SocketServer) syncContinueRunResultToMasterStore(st store.Store, req *o
 		if run == nil {
 			return fmt.Errorf("store returned nil run for %s#%s", result.IssueID, result.RunID)
 		}
-		_ = st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued))
+		if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued)); err != nil { // nosemgrep: run-status-write-surface
+			return fmt.Errorf("failed to record queued status for %s#%s: %w", result.IssueID, result.RunID, err)
+		}
 	}
 	if run == nil {
 		return fmt.Errorf("run unavailable for %s#%s", result.IssueID, result.RunID)
@@ -1654,7 +1660,9 @@ func (s *SocketServer) syncContinueRunResultToMasterStore(st store.Store, req *o
 	if err != nil {
 		return fmt.Errorf("invalid continue_run worker result status for %s#%s: %w", result.IssueID, result.RunID, err)
 	}
-	_ = st.AppendEvent(run.Ref(), model.NewStatusEvent(status))
+	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(status)); err != nil { // nosemgrep: run-status-write-surface
+		return fmt.Errorf("failed to record status %s for %s#%s: %w", status, result.IssueID, result.RunID, err)
+	}
 	return nil
 }
 

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -1892,8 +1892,14 @@ func (s *SocketServer) failOpenCodeRunBootstrap(st store.Store, run *model.Run, 
 	msg := err.Error()
 	s.logger.Printf(msg)
 	if st != nil && run != nil {
-		_ = st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(msg))
-		_ = st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+		// Error-recording path: the original bootstrap error must be returned,
+		// so append failures are surfaced in the log instead of swallowed.
+		if appendErr := st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(msg)); appendErr != nil {
+			s.logger.Printf("%s#%s: failed to record error artifact: %v", run.IssueID, run.RunID, appendErr)
+		}
+		if appendErr := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)); appendErr != nil { // nosemgrep: run-status-write-surface
+			s.logger.Printf("%s#%s: failed to record failed status: %v", run.IssueID, run.RunID, appendErr)
+		}
 	}
 	return err
 }
@@ -2967,7 +2973,7 @@ func (s *SocketServer) markRunFeedbackSent(st store.Store, run *model.Run) {
 	if st == nil || run == nil || !feedbackResumesRun(run.Status) {
 		return
 	}
-	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)); err != nil {
+	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)); err != nil { // nosemgrep: run-status-write-surface
 		s.logger.Printf("%s#%s: failed to mark run running after feedback: %v", run.IssueID, run.RunID, err)
 		return
 	}
@@ -3456,7 +3462,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		return
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued))
+	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued)) // nosemgrep: run-status-write-surface
 
 	baseBranch := resolveBaseBranch(req.BaseBranch, issue, cfg)
 
@@ -3471,7 +3477,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 	})
 	if err != nil {
 		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 		encoder.Encode(StartRunResponse{OK: false, Error: "failed to create worktree: " + err.Error()})
 		return
 	}
@@ -3484,7 +3490,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 	promptPath := filepath.Join(worktreeResult.WorktreePath, "ORCH_PROMPT.md")
 	if err := os.WriteFile(promptPath, []byte(agentPrompt), 0644); err != nil {
 		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 		encoder.Encode(StartRunResponse{OK: false, Error: "failed to write prompt file: " + err.Error()})
 		return
 	}
@@ -3513,12 +3519,12 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 	agentCmd, err := adapter.LaunchCommand(launchCfg)
 	if err != nil {
 		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 		encoder.Encode(StartRunResponse{OK: false, Error: "failed to build agent command: " + err.Error()})
 		return
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting))
+	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting)) // nosemgrep: run-status-write-surface
 
 	muxType, _ := multiplexer.ParseType(req.Multiplexer)
 
@@ -3531,7 +3537,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 
 	if mux == nil {
 		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent("no multiplexer available"))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 		encoder.Encode(StartRunResponse{OK: false, Error: "no terminal multiplexer available"})
 		return
 	}
@@ -3541,7 +3547,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		resp, err := s.ensureOpenCodeServerRunning(worktreeResult.WorktreePath)
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 			encoder.Encode(StartRunResponse{OK: false, Error: "failed to start opencode server: " + err.Error()})
 			return
 		}
@@ -3561,7 +3567,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		})
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 			encoder.Encode(StartRunResponse{OK: false, Error: "failed to create session: " + err.Error()})
 			return
 		}
@@ -3590,7 +3596,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		}
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning))
+	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)) // nosemgrep: run-status-write-surface
 
 	s.logger.Printf("started run: %s#%s (agent=%s, worktree=%s)", req.IssueID, runID, agentName, worktreeResult.WorktreePath)
 
@@ -3806,7 +3812,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 		return nil, fmt.Errorf("failed to create run: %w", err)
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued))
+	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued)) // nosemgrep: run-status-write-surface
 
 	baseBranch := resolveBaseBranch(opts.BaseBranch, issue, cfg)
 
@@ -3821,7 +3827,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 	}, runExecutor)
 	if err != nil {
 		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 		return nil, fmt.Errorf("failed to create worktree: %w", err)
 	}
 
@@ -3843,7 +3849,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 	promptPath := filepath.Join(worktreeResult.WorktreePath, "ORCH_PROMPT.md")
 	if err := writeFileWithExecutor(runExecutor, promptPath, []byte(agentPrompt), 0644); err != nil {
 		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 		return nil, fmt.Errorf("failed to write prompt file: %w", err)
 	}
 
@@ -3875,11 +3881,11 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 	agentCmd, err := adapter.LaunchCommand(launchCfg)
 	if err != nil {
 		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 		return nil, fmt.Errorf("failed to build agent command: %w", err)
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting))
+	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting)) // nosemgrep: run-status-write-surface
 
 	if opts.NoSession {
 		// --tmux=false: the workspace (run record, worktree, branch, prompt
@@ -3887,7 +3893,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 		// agent is launched. SessionName stays empty so no session artifact
 		// is recorded anywhere and attach/send fail with a clear
 		// session-not-found error instead of pointing at a ghost session.
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)) // nosemgrep: run-status-write-surface
 		s.logger.Printf("started run without session: %s#%s (agent=%s, worktree=%s)", opts.IssueID, runID, agentName, worktreeResult.WorktreePath)
 		return &StartRunResult{
 			RunID:        runID,
@@ -3927,7 +3933,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 
 	if mux == nil {
 		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent("no multiplexer available"))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 		return nil, fmt.Errorf("no terminal multiplexer available")
 	}
 
@@ -3936,7 +3942,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 		resp, err := s.ensureOpenCodeServerRunning(worktreeResult.WorktreePath)
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 			return nil, fmt.Errorf("failed to start opencode server: %w", err)
 		}
 		serverAlreadyRunning = true
@@ -3955,7 +3961,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 		})
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 			return nil, fmt.Errorf("failed to create session: %w", err)
 		}
 
@@ -3983,7 +3989,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 		}
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning))
+	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)) // nosemgrep: run-status-write-surface
 
 	s.logger.Printf("started run: %s#%s (agent=%s, worktree=%s)", opts.IssueID, runID, agentName, worktreeResult.WorktreePath)
 
@@ -4220,7 +4226,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		return nil, fmt.Errorf("failed to create run: %w", err)
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued))
+	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued)) // nosemgrep: run-status-write-surface
 	st.AppendEvent(run.Ref(), model.NewArtifactEvent("worktree", map[string]string{"path": worktreePath}))
 	st.AppendEvent(run.Ref(), model.NewArtifactEvent("branch", map[string]string{"name": branch}))
 	if targetName := strings.TrimSpace(opts.Target); targetName != "" {
@@ -4239,7 +4245,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		agentPrompt := s.buildRunPrompt(issue, st.RootPath(), opts.NoPR, opts.PromptTemplate, opts.PRTargetBranch)
 		if err := os.WriteFile(promptPath, []byte(agentPrompt), 0644); err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 			return nil, fmt.Errorf("failed to write prompt file: %w", err)
 		}
 	}
@@ -4272,11 +4278,11 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 	agentCmd, err := adapter.LaunchCommand(launchCfg)
 	if err != nil {
 		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 		return nil, fmt.Errorf("failed to build agent command: %w", err)
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting))
+	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting)) // nosemgrep: run-status-write-surface
 
 	if opts.NoSession {
 		// --tmux=false: the workspace (run record, worktree, branch, prompt
@@ -4284,7 +4290,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		// agent is launched. SessionName stays empty so no session artifact
 		// is recorded anywhere and attach/send fail with a clear
 		// session-not-found error instead of pointing at a ghost session.
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)) // nosemgrep: run-status-write-surface
 		s.logger.Printf("continued run without session: %s#%s from %s (agent=%s, worktree=%s)", issueID, runID, continuedFrom, agentName, worktreePath)
 		return &ContinueRunResult{
 			RunID:         runID,
@@ -4309,7 +4315,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 
 	if mux == nil {
 		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent("no multiplexer available"))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 		return nil, fmt.Errorf("no terminal multiplexer available")
 	}
 
@@ -4318,7 +4324,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		resp, err := s.ensureOpenCodeServerRunning(worktreePath)
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 			return nil, fmt.Errorf("failed to start opencode server: %w", err)
 		}
 		serverAlreadyRunning = true
@@ -4337,7 +4343,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		})
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 			return nil, fmt.Errorf("failed to create session: %w", err)
 		}
 
@@ -4367,7 +4373,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		}
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning))
+	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)) // nosemgrep: run-status-write-surface
 
 	s.logger.Printf("continued run: %s#%s from %s (agent=%s, worktree=%s)", issueID, runID, continuedFrom, agentName, worktreePath)
 
@@ -4611,7 +4617,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 		return
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued))
+	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued)) // nosemgrep: run-status-write-surface
 	st.AppendEvent(run.Ref(), model.NewArtifactEvent("worktree", map[string]string{"path": worktreePath}))
 	st.AppendEvent(run.Ref(), model.NewArtifactEvent("branch", map[string]string{"name": branch}))
 
@@ -4620,7 +4626,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 		agentPrompt := s.buildRunPrompt(issue, st.RootPath(), req.NoPR, req.PromptTemplate, req.PRTargetBranch)
 		if err := os.WriteFile(promptPath, []byte(agentPrompt), 0644); err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 			encoder.Encode(ContinueRunResponse{OK: false, Error: "failed to write prompt file: " + err.Error()})
 			return
 		}
@@ -4650,12 +4656,12 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 	agentCmd, err := adapter.LaunchCommand(launchCfg)
 	if err != nil {
 		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 		encoder.Encode(ContinueRunResponse{OK: false, Error: "failed to build agent command: " + err.Error()})
 		return
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting))
+	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting)) // nosemgrep: run-status-write-surface
 
 	muxType, _ := multiplexer.ParseType(req.Multiplexer)
 
@@ -4668,7 +4674,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 
 	if mux == nil {
 		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent("no multiplexer available"))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 		encoder.Encode(ContinueRunResponse{OK: false, Error: "no terminal multiplexer available"})
 		return
 	}
@@ -4678,7 +4684,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 		resp, err := s.ensureOpenCodeServerRunning(worktreePath)
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 			encoder.Encode(ContinueRunResponse{OK: false, Error: "failed to start opencode server: " + err.Error()})
 			return
 		}
@@ -4698,7 +4704,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 		})
 		if err != nil {
 			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed))
+			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
 			encoder.Encode(ContinueRunResponse{OK: false, Error: "failed to create session: " + err.Error()})
 			return
 		}
@@ -4730,7 +4736,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 		}
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning))
+	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)) // nosemgrep: run-status-write-surface
 
 	s.logger.Printf("continued run: %s#%s from %s (agent=%s, worktree=%s)", issueID, runID, continuedFrom, agentName, worktreePath)
 
@@ -4955,7 +4961,7 @@ func appendRunCanceledByUser(st store.Store, run *model.Run) error {
 	}
 
 	ref := &model.RunRef{IssueID: run.IssueID, RunID: run.RunID}
-	event := model.NewEvent(model.EventTypeStatus, string(model.StatusCanceled), map[string]string{
+	event := model.NewEvent(model.EventTypeStatus, string(model.StatusCanceled), map[string]string{ // nosemgrep: run-status-write-surface
 		"source": string(model.EventSourceUser),
 	})
 	return st.AppendEvent(ref, event)

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -591,7 +591,9 @@ func (m *Monitor) StopRun(run *model.Run) error {
 
 	ctx := context.Background()
 	ref := orchapi.RunRef{IssueID: run.IssueID, RunID: run.RunID}
-	_, err := m.api.AppendEvent(ctx, ref, &orchapi.Event{Type: "status", Name: string(model.StatusCanceled)})
+	// Frozen client-plane status writer: scheduled to become a daemon API
+	// verb (coupling-core roadmap Phase B3). Do not copy this pattern.
+	_, err := m.api.AppendEvent(ctx, ref, &orchapi.Event{Type: "status", Name: string(model.StatusCanceled)}) // nosemgrep: run-status-write-surface
 	return err
 }
 
@@ -746,7 +748,9 @@ func (m *Monitor) ResolveRun(run *model.Run) error {
 	ref := orchapi.RunRef{IssueID: run.IssueID, RunID: run.RunID}
 
 	if !run.Status.IsTerminal() {
-		if _, err := m.api.AppendEvent(ctx, ref, &orchapi.Event{Type: "status", Name: string(model.StatusDone)}); err != nil {
+		// Frozen client-plane status writer: scheduled to become a daemon API
+		// verb (coupling-core roadmap Phase B3). Do not copy this pattern.
+		if _, err := m.api.AppendEvent(ctx, ref, &orchapi.Event{Type: "status", Name: string(model.StatusDone)}); err != nil { // nosemgrep: run-status-write-surface
 			return fmt.Errorf("failed to mark run as done: %w", err)
 		}
 	}


### PR DESCRIPTION
## Summary

Phase A of [docs/design/coupling-core-roadmap.md](docs/design/coupling-core-roadmap.md): make the run-status write surface machine-checked so that delegated PRs cannot silently add status writers that bypass the `step()` transition policy.

```
before                                    after
──────                                    ─────
step() decides transitions,               step() decides transitions,
but 46 sites in 5 files also              exactly 1 sanctioned writer
write status events directly              (Daemon.updateStatus);
→ nothing stops writer #47               46 frozen sites annotated,
                                          writer #47 = CI failure
```

### A1 — semgrep rule `run-status-write-surface`
- Bans `model.NewStatusEvent` / `model.NewEvent(EventTypeStatus, …)` / `Type: "status"` literals everywhere in `internal/` (except `internal/model/`).
- The 46 existing writers (socket.go ×39, proto_handler.go ×4 — now fixed, monitor TUI ×2, cli/repair.go ×1) are frozen with per-line `nosemgrep` annotations. **The whitelist may only shrink** — `grep -c 'nosemgrep: run-status-write-surface'` is the Phase B progress meter.
- `semgrep test` fixtures wired into `make lint`; CI picks it up via quality.yaml.

### A2 — fail-fast on status appends (`no-ignored-status-append`)
- The 4 `_ = st.AppendEvent(…NewStatusEvent…)` master-projection sites in proto_handler.go now propagate append failures with run context.
- `failOpenCodeRunBootstrap` (socket.go): error-recording path keeps returning the original bootstrap error, but append failures are now logged instead of swallowed.
- New rule bans the discard pattern from reappearing.

### A3 — routing rules in AGENTS.md
Coupling-core inventory, frontier/delegate routing rule, tripwire checklist for delegate PR review, choice-space gate, and the burn-in loop.

## Verification
- `make lint`: 0 findings (105 rules), new fixture tests 2/2 pass
- Synthetic 47th writer trips **both** new rules (negative test, reverted)
- `go build ./...` clean; `go test ./internal/daemon ./internal/cli` pass
- `internal/monitor` `TestSessionNameForProject` fails **identically on main** (environment-dependent session-name truncation) — pre-existing, untouched by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)