### PR TITLE
feat(monitor): TUI StopRun via daemon verb + v2 dispositions (coupling-core Phase B)

### DIFF
--- a/docs/design/coupling-core-roadmap.md
+++ b/docs/design/coupling-core-roadmap.md
@@ -185,13 +185,18 @@ run-state-machine.md と同じ playbook を適用する。
 
 | # | core | 4層の状態 | 守り | 閉鎖フェーズ |
 |---|------|----------|------|------------|
-| 1 | run status 遷移 | ADR✓ law✓(tested) runtime△ static✗ | A1 ルール | A1→B |
-| 2 | RunState vs event log(導出状態) | I2 open(doc に明記) | なし | C1 |
-| 3 | worker lease 所有権/ライフサイクル | 未文書化 | なし | E |
+| 1 | run status 遷移 | ADR✓ law✓(tested) runtime△ **static✓ (A1, 2026-06-12)** | `run-status-write-surface` ルール + 凍結 whitelist | B で whitelist→0 |
+| 2 | RunState vs event log(導出状態) | 決定済み **D-C1**(run-state-machine.md §7): 導出可能フィールドは fold、収束カウンタは ephemeral-by-law (L7) | なし(実装待ち) | C1 実装 |
+| 3 | worker lease 所有権/ライフサイクル | 調査完了(E1 doc)、law 候補 5 件ドラフト | なし | E2/E3 |
 | 4 | identity(typed IDs) | 型✓ + lint✓ | `.semgrep/typed-id-rules` | 完了 |
 | 5 | client/daemon 境界(読み取り) | semgrep ~60 ルール✓ | `make lint` + CI | 完了 |
-| 6 | cancellation/stop 意味論(W7/W8, PR close terminal) | step に部分統合 | terminal guard のみ | B2 |
-| 7 | エラー伝播 × append(fail-fast) | 4 箇所違反 | なし | A2 |
+| 6 | cancellation/stop 意味論(W7/W8, PR close terminal) | **disposition 決定済み**(run-state-machine.md §6): W7=ladder と統合、W8=v2 統合 | terminal guard + A1 凍結 | B1 後 |
+| 7 | エラー伝播 × append(fail-fast) | **修正済み (A2, 2026-06-12)** | `no-ignored-status-append` ルール | 完了 |
+
+進捗ログ:
+- 2026-06-12 Phase A 完了(PR #463): A1 ルール+46 サイト凍結 / A2 fail-fast 化 / A3 AGENTS.md routing。
+- 2026-06-12 Phase B 部分完了: B2 disposition 決定(run-state-machine.md §6)、B3 StopRun 動詞化(TUI のローカル mux kill + client append を撤去 — リモート run の stop が壊れていたバグも同時修正)。B3 ResolveRun は §6 の式で choice space を閉じ、verified issue 化。
+- 2026-06-12 C1/C3 の選択空間を閉鎖(run-state-machine.md §7 D-C1/D-C3、L7/L3' 制定)。実装は C フェーズ。
 
 ## 推奨順序と箱
 

--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -209,4 +209,80 @@ distinction the law tests themselves forced:
 
 L1/L4 fix the 5,830-duplicate-event class structurally; L2 is the law the
 PR #458 inference fixes were converging toward; restart transparency (I2)
-remains an open law until monitor state is derived from the event log.
+remains an open law until monitor state is derived from the event log
+(resolved by decision D-C1 in §7).
+
+## 6. v2 disposition of the remaining writers (decided 2026-06-12)
+
+Phase A of the coupling-core roadmap closed the write surface mechanically
+(semgrep rule `run-status-write-surface`; every existing writer carries a
+frozen `nosemgrep` annotation). Each frozen writer now has an explicit
+disposition — integrate into `step()` or quarantine with a recorded
+rationale. *Undecided* is no longer a legal state for a status writer.
+
+| # | Site | Disposition | Rationale |
+|---|------|-------------|-----------|
+| W2–W5 | launch ladders (socket.go ×4) | **integrate — v2, first** | Four near-copies of one ladder; interleaves with monitor-plane transitions (booting/running races). Becomes launch-progress observations (O8) decided in `step()`, with the imperative bootstrap steps as effects. |
+| W7 | `failOpenCodeRunBootstrap` → failed | **integrate — with W2–W5** | The failure arm of the same ladder. |
+| W6 | feedback → running | **integrate — v2** | Already mutates `runCore` (PromptStreak reset, O6). Core state must change only through `step()`. |
+| W8 | `appendRunCanceledByUser` (`orch stop`) | **integrate — v2, after the ladder** | O7 (user stop) exists in the observation taxonomy; terminality (L4) should observe it. Single guarded site until then. |
+| W9 | master projections (proto_handler.go) | **quarantine — law boundary** | Replicates transitions already decided on the worker plane; carries no local policy. Guards: `CanTransitionStatus` + fail-fast appends (Phase A2). Law: a projection is status-preserving — it must never add inference in flight. |
+| W10 | external append API (`handleAppendEvent`) | **quarantine — law boundary** | User/agent escape hatch with caller-supplied source. Guard: `CanTransitionStatus` with caller source. `orch repair` (cli/repair.go) is its sanctioned client and stays. |
+| — | TUI `Monitor.StopRun` (client plane) | **removed — B3** | Now calls the daemon `StopRun` verb (host-aware session kill + daemon-side canceled append). |
+| — | TUI `Monitor.ResolveRun` (client plane) | **pending — B3 issue** | Daemon `ResolveRun` verb gains run-done semantics; see the equation below. |
+
+B3 ResolveRun equation (spec for the pending issue — the daemon verb, not
+the orchapi lookup of the same name):
+
+```
+ResolveRun(issue, run) ≡  append(run, done, source=user)   if ¬terminal(run)
+                          ; SetIssueStatus(issue, resolved)
+```
+
+Today `handleProtoResolveRun` implements only the second conjunct; the TUI
+implements both client-side. After the issue lands, exactly one
+implementation exists (daemon), and the TUI client calls it.
+
+## 7. Open-law decisions (decided 2026-06-12)
+
+### D-C1 — restart transparency without new persistence
+
+`runCore` fields fall into two classes, and the restart story differs:
+
+- **Derivable (fold of the event log)** — must be re-derived at monitor
+  registration, never mirrored:
+  - `WasAlive := ∃ status event ∈ {running, waiting, rate_limited, done}`
+  - `PRRecorded := ∃ artifact event of type pr` (also resolves I5)
+  - boot grace: derivable from the persisted `StartedAt`
+- **Ephemeral by law (bounded re-convergence)** — deliberately reset on
+  restart; L1b guarantees they re-converge within bounded ticks, and the
+  reset direction is safe (verdicts/debounce are *delayed*, never wrong):
+  `DeadCheckCount`, `PromptStreak`, `OutputHash`, `LastOutput*`.
+
+Rejected alternatives: (a) full observation replay (observations are not
+events; would require recording per-tick captures), (b) persisting counter
+changes as events (OutputHash churn would spam the log), (c) periodic
+snapshots (a second store of record — exactly the mirror this design
+forbids).
+
+| Law | Statement |
+|-----|-----------|
+| L7 restart transparency | for any observation sequence and any restart point, the sequence of *transition targets* is identical with and without the restart; only their timing may differ, by at most `max(deadCheckThreshold, waitingPromptStreakThreshold)` ticks |
+
+### D-C3 — never-alive verdict asymmetry resolved
+
+L3's pinned complement ("after grace, remote concludes `unknown`; local
+keeps waiting") is revised: **local and remote both conclude `unknown`
+after `neverAliveVerdictGrace`**. Rationale: I7 (a gone session must
+eventually produce a verdict) is a liveness requirement; the local
+keep-waiting behavior violates it for never-alive non-opencode runs, and
+the asymmetry was pinned in v1 only for behavior preservation. L3 reads
+after the change:
+
+| Law | Statement |
+|-----|-----------|
+| L3' grace (revised) | a never-alive run within `neverAliveVerdictGrace` never receives an `unknown`/`failed` verdict; after the grace, any plane concludes `unknown` on the standing evidence |
+
+I6 (queued runs are never monitored) remains a behavior fix tracked by the
+coupling-core roadmap Phase C2: `monitorAll` must include `queued` so that
+"every non-terminal run is eventually observed" holds.

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -574,27 +574,18 @@ func (m *Monitor) Quit() error {
 	return m.mux.KillSession(m.session)
 }
 
-// StopRun kills the run session and marks the run canceled.
+// StopRun stops the run through the daemon StopRun verb: the daemon owns
+// the host-aware session kill (worker lease for remote runs) and records
+// the user-sourced canceled status. The TUI must not kill sessions via the
+// local multiplexer or write status events itself.
 func (m *Monitor) StopRun(run *model.Run) error {
 	if run.Status.IsTerminal() {
 		return nil
 	}
 
-	sessionName := run.SessionName
-	if sessionName == "" {
-		sessionName = model.GenerateSessionName(run.IssueID, run.RunID)
-	}
-
-	if m.mux.HasSession(sessionName) {
-		_ = m.mux.KillSession(sessionName)
-	}
-
 	ctx := context.Background()
 	ref := orchapi.RunRef{IssueID: run.IssueID, RunID: run.RunID}
-	// Frozen client-plane status writer: scheduled to become a daemon API
-	// verb (coupling-core roadmap Phase B3). Do not copy this pattern.
-	_, err := m.api.AppendEvent(ctx, ref, &orchapi.Event{Type: "status", Name: string(model.StatusCanceled)}) // nosemgrep: run-status-write-surface
-	return err
+	return m.api.StopRun(ctx, ref)
 }
 
 func (m *Monitor) StartRun(issueID string, agentType string) (string, error) {


### PR DESCRIPTION
## Summary

Stacked on #463 (Phase A). Phase B of [docs/design/coupling-core-roadmap.md](https://github.com/proboscis/orch/blob/feat/coupling-core-phase-b/docs/design/coupling-core-roadmap.md).

### B3 (partial) — TUI StopRun → daemon verb

```
before                                   after
──────                                   ─────
TUI: kill via LOCAL mux                  TUI: m.api.StopRun(ctx, ref)
   + append canceled client-side         daemon: host-aware kill (worker
→ broken for worker-hosted runs            lease for remote) + canceled
→ client-plane status writer               append with source=user
```

Whitelist meter: 46 → 45 frozen writers.

### B2 — dispositions recorded (run-state-machine.md §6)

| Writers | Disposition |
|---------|-------------|
| W2–W7 launch ladders + bootstrap-fail | integrate into step() (v2, first) |
| W6 feedback, W8 user stop | integrate (v2) |
| W9 master projections | quarantine — law boundary (status-preserving replication) |
| W10 external append | quarantine — law boundary (`orch repair` = sanctioned client) |
| TUI ResolveRun | pending issue; equation specified in §6 |

### §7 — open-law decisions

- **D-C1** restart transparency (L7): `WasAlive`/`PRRecorded` become fold-derivable; `DeadCheckCount`/`PromptStreak`/`OutputHash` declared ephemeral-by-law (bounded re-convergence). No new persistence mechanism.
- **D-C3** (L3'): never-alive verdict asymmetry resolved — both planes conclude `unknown` after grace (restores I7 liveness).

## Verification
- `go build` / `go vet` clean; write-surface semgrep scan: 0 findings
- No behavior tests existed for Monitor.StopRun; daemon StopRun path is covered by existing proto handler tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)