### PR TITLE
docs(design): worker-lease survey + draft laws (coupling-core Phase E1)

### DIFF
--- a/docs/design/coupling-core-roadmap.md
+++ b/docs/design/coupling-core-roadmap.md
@@ -185,13 +185,18 @@ run-state-machine.md と同じ playbook を適用する。
 
 | # | core | 4層の状態 | 守り | 閉鎖フェーズ |
 |---|------|----------|------|------------|
-| 1 | run status 遷移 | ADR✓ law✓(tested) runtime△ static✗ | A1 ルール | A1→B |
-| 2 | RunState vs event log(導出状態) | I2 open(doc に明記) | なし | C1 |
-| 3 | worker lease 所有権/ライフサイクル | 未文書化 | なし | E |
+| 1 | run status 遷移 | ADR✓ law✓(tested) runtime△ **static✓ (A1, 2026-06-12)** | `run-status-write-surface` ルール + 凍結 whitelist | B で whitelist→0 |
+| 2 | RunState vs event log(導出状態) | 決定済み **D-C1**(run-state-machine.md §7): 導出可能フィールドは fold、収束カウンタは ephemeral-by-law (L7) | なし(実装待ち) | C1 実装 |
+| 3 | worker lease 所有権/ライフサイクル | 調査完了(E1 doc)、law 候補 5 件ドラフト | なし | E2/E3 |
 | 4 | identity(typed IDs) | 型✓ + lint✓ | `.semgrep/typed-id-rules` | 完了 |
 | 5 | client/daemon 境界(読み取り) | semgrep ~60 ルール✓ | `make lint` + CI | 完了 |
-| 6 | cancellation/stop 意味論(W7/W8, PR close terminal) | step に部分統合 | terminal guard のみ | B2 |
-| 7 | エラー伝播 × append(fail-fast) | 4 箇所違反 | なし | A2 |
+| 6 | cancellation/stop 意味論(W7/W8, PR close terminal) | **disposition 決定済み**(run-state-machine.md §6): W7=ladder と統合、W8=v2 統合 | terminal guard + A1 凍結 | B1 後 |
+| 7 | エラー伝播 × append(fail-fast) | **修正済み (A2, 2026-06-12)** | `no-ignored-status-append` ルール | 完了 |
+
+進捗ログ:
+- 2026-06-12 Phase A 完了(PR #463): A1 ルール+46 サイト凍結 / A2 fail-fast 化 / A3 AGENTS.md routing。
+- 2026-06-12 Phase B 部分完了: B2 disposition 決定(run-state-machine.md §6)、B3 StopRun 動詞化(TUI のローカル mux kill + client append を撤去 — リモート run の stop が壊れていたバグも同時修正)。B3 ResolveRun は §6 の式で choice space を閉じ、verified issue 化。
+- 2026-06-12 C1/C3 の選択空間を閉鎖(run-state-machine.md §7 D-C1/D-C3、L7/L3' 制定)。実装は C フェーズ。
 
 ## 推奨順序と箱
 

--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -209,4 +209,80 @@ distinction the law tests themselves forced:
 
 L1/L4 fix the 5,830-duplicate-event class structurally; L2 is the law the
 PR #458 inference fixes were converging toward; restart transparency (I2)
-remains an open law until monitor state is derived from the event log.
+remains an open law until monitor state is derived from the event log
+(resolved by decision D-C1 in §7).
+
+## 6. v2 disposition of the remaining writers (decided 2026-06-12)
+
+Phase A of the coupling-core roadmap closed the write surface mechanically
+(semgrep rule `run-status-write-surface`; every existing writer carries a
+frozen `nosemgrep` annotation). Each frozen writer now has an explicit
+disposition — integrate into `step()` or quarantine with a recorded
+rationale. *Undecided* is no longer a legal state for a status writer.
+
+| # | Site | Disposition | Rationale |
+|---|------|-------------|-----------|
+| W2–W5 | launch ladders (socket.go ×4) | **integrate — v2, first** | Four near-copies of one ladder; interleaves with monitor-plane transitions (booting/running races). Becomes launch-progress observations (O8) decided in `step()`, with the imperative bootstrap steps as effects. |
+| W7 | `failOpenCodeRunBootstrap` → failed | **integrate — with W2–W5** | The failure arm of the same ladder. |
+| W6 | feedback → running | **integrate — v2** | Already mutates `runCore` (PromptStreak reset, O6). Core state must change only through `step()`. |
+| W8 | `appendRunCanceledByUser` (`orch stop`) | **integrate — v2, after the ladder** | O7 (user stop) exists in the observation taxonomy; terminality (L4) should observe it. Single guarded site until then. |
+| W9 | master projections (proto_handler.go) | **quarantine — law boundary** | Replicates transitions already decided on the worker plane; carries no local policy. Guards: `CanTransitionStatus` + fail-fast appends (Phase A2). Law: a projection is status-preserving — it must never add inference in flight. |
+| W10 | external append API (`handleAppendEvent`) | **quarantine — law boundary** | User/agent escape hatch with caller-supplied source. Guard: `CanTransitionStatus` with caller source. `orch repair` (cli/repair.go) is its sanctioned client and stays. |
+| — | TUI `Monitor.StopRun` (client plane) | **removed — B3** | Now calls the daemon `StopRun` verb (host-aware session kill + daemon-side canceled append). |
+| — | TUI `Monitor.ResolveRun` (client plane) | **pending — B3 issue** | Daemon `ResolveRun` verb gains run-done semantics; see the equation below. |
+
+B3 ResolveRun equation (spec for the pending issue — the daemon verb, not
+the orchapi lookup of the same name):
+
+```
+ResolveRun(issue, run) ≡  append(run, done, source=user)   if ¬terminal(run)
+                          ; SetIssueStatus(issue, resolved)
+```
+
+Today `handleProtoResolveRun` implements only the second conjunct; the TUI
+implements both client-side. After the issue lands, exactly one
+implementation exists (daemon), and the TUI client calls it.
+
+## 7. Open-law decisions (decided 2026-06-12)
+
+### D-C1 — restart transparency without new persistence
+
+`runCore` fields fall into two classes, and the restart story differs:
+
+- **Derivable (fold of the event log)** — must be re-derived at monitor
+  registration, never mirrored:
+  - `WasAlive := ∃ status event ∈ {running, waiting, rate_limited, done}`
+  - `PRRecorded := ∃ artifact event of type pr` (also resolves I5)
+  - boot grace: derivable from the persisted `StartedAt`
+- **Ephemeral by law (bounded re-convergence)** — deliberately reset on
+  restart; L1b guarantees they re-converge within bounded ticks, and the
+  reset direction is safe (verdicts/debounce are *delayed*, never wrong):
+  `DeadCheckCount`, `PromptStreak`, `OutputHash`, `LastOutput*`.
+
+Rejected alternatives: (a) full observation replay (observations are not
+events; would require recording per-tick captures), (b) persisting counter
+changes as events (OutputHash churn would spam the log), (c) periodic
+snapshots (a second store of record — exactly the mirror this design
+forbids).
+
+| Law | Statement |
+|-----|-----------|
+| L7 restart transparency | for any observation sequence and any restart point, the sequence of *transition targets* is identical with and without the restart; only their timing may differ, by at most `max(deadCheckThreshold, waitingPromptStreakThreshold)` ticks |
+
+### D-C3 — never-alive verdict asymmetry resolved
+
+L3's pinned complement ("after grace, remote concludes `unknown`; local
+keeps waiting") is revised: **local and remote both conclude `unknown`
+after `neverAliveVerdictGrace`**. Rationale: I7 (a gone session must
+eventually produce a verdict) is a liveness requirement; the local
+keep-waiting behavior violates it for never-alive non-opencode runs, and
+the asymmetry was pinned in v1 only for behavior preservation. L3 reads
+after the change:
+
+| Law | Statement |
+|-----|-----------|
+| L3' grace (revised) | a never-alive run within `neverAliveVerdictGrace` never receives an `unknown`/`failed` verdict; after the grace, any plane concludes `unknown` on the standing evidence |
+
+I6 (queued runs are never monitored) remains a behavior fix tracked by the
+coupling-core roadmap Phase C2: `monitorAll` must include `queued` so that
+"every non-terminal run is eventually observed" holds.

--- a/docs/design/worker-lease.md
+++ b/docs/design/worker-lease.md
@@ -1,0 +1,131 @@
+# Worker Lease — Survey and Law Candidates
+
+Status: survey (E1); laws are DRAFT pending verification (E2)
+Date: 2026-06-12
+
+Mirror of `run-state-machine.md` §1–4 for the second coupling core: worker
+lease ownership, heartbeats, and their coupling to the run state machine.
+Sources: code as of `feat/coupling-core-phase-b`, commits 7bfbcf88
+(heartbeats during effects, fail leases fast) and 88ef7dc5 / PR #457
+(run snapshots as mutation SSOT).
+
+## 1. Lease write surface
+
+All lease state lives in `SocketServer.workerLeases` (map, RWMutex) and
+`SocketServer.workers` (map, RWMutex). Writers:
+
+| # | Site | Writes | Lock |
+|---|------|--------|------|
+| LW1 | `worker_plane.go:411-448 acquireWorkerLease` | new lease (LeaseID, WorkerID, LeasedAt; DispatchCount=0) | workerLeasesMu |
+| LW2 | `worker_plane.go:553-588 leaseWorkForWorker` | DispatchCount++, DispatchedAt, ExpiresAt=now+60s, PayloadJSON | workerLeasesMu |
+| LW3 | `worker_plane.go:883-907 acknowledgeWorkerLease` | Completed, CompletedAt, Success, Error, ResultJSON | workerLeasesMu |
+| LW4 | `worker_plane.go:240-256 heartbeatWorker` | worker.LastHeartbeat=now, Active=true | workersMu |
+| LW5 | `worker_plane.go:236 unregisterWorker` | delete from workers map | workersMu |
+
+Readers that decide policy: `waitForWorkerLeaseCompletion`
+(`worker_plane.go:831-881`; poll 100ms, deadline, and since 7bfbcf88 a
+per-iteration `workerIsActive` check that fails the wait early), and
+`selectActiveWorkerForEffect` (worker choice at acquire time).
+
+Entry points: every host-routed RPC goes through `withWorkerLease`
+(`worker_plane.go:909-921`, acquire + wait, 10min timeout) —
+start_run, continue_run, stop_run, capture_session, send_message,
+get_diff(-stats), get_branch_state (`proto_handler.go:1441,1757,1822,
+2339,2436,2489,2555,2665`), plus `captureRunOutputViaWorker`
+(`proto_handler.go:819-823`, 15s capture timeout per `monitor.go:42`).
+
+## 2. Ownership / lifecycle
+
+- **Master owns the lease record**: creates (LW1), dispatches (LW2),
+  observes completion (LW3 via worker ack), and times out. The worker owns
+  only the *execution*; it reports back via `handleProtoAcknowledgeEffect`.
+- **Master restart**: `workerLeases` and `workers` are reset in the
+  constructor — leases have no persistence (see §5). In-flight RPC waits
+  die with the process; workers re-register/heartbeat and the next
+  dispatch starts clean.
+- **Worker death**: heartbeat goes silent → `workerIsActive` false after
+  30s → `waitForWorkerLeaseCompletion` fails fast with
+  "worker lost while executing lease" (`worker_plane.go:871-876`,
+  7bfbcf88) instead of burning the full 10min timeout.
+- **Worker graceful shutdown**: UnregisterWorker RPC → removed from the
+  workers map → same observable outcome as heartbeat expiry.
+
+## 3. Heartbeat semantics
+
+| Constant | Value | Site |
+|----------|-------|------|
+| workerHeartbeatTTL | 30s | worker_plane.go:18 |
+| workerLeaseTTL (dispatch) | 60s | worker_plane.go:19 |
+| lease wait timeout | 10min | withWorkerLease |
+| remoteCaptureLeaseTimeout | 15s | monitor.go:42 |
+
+Since 7bfbcf88 the worker sends heartbeats from a dedicated goroutine, so
+a long-running effect (e.g. a hanging zellij call) no longer silences the
+heartbeat and masquerades as worker death; conversely the master checks
+liveness on every wait iteration, so a genuinely dead worker is detected
+in ≤30s rather than 10min.
+
+## 4. Coupling to the run state machine
+
+`step()` never sees leases directly — by design. Lease failures reach the
+run state machine only as *observations*:
+
+```
+lease failure (capture)        lease failure (start/continue/stop)
+        │                                    │
+        ▼                                    ▼
+ obsSessionGone et al. ──► step() ──►  RPC error to the caller; launch
+ (dead-check ladder,                   ladder writes failed (W2–W5) or
+  git-evidence verdict)                the caller retries
+```
+
+This is the correct mechanism/policy split and must be preserved by E2/E3:
+**a lease is infrastructure; only its observable consequences are policy.**
+
+## 5. Store-of-record
+
+- Lease records: **memory only**, by design (a lease is a short-lived
+  coordination token, not domain state). Master restart forgets them; the
+  bounded-timeout + heartbeat layers make this safe.
+- Run mutations during delegation: the master sends a `RunSnapshot`
+  (`run_snapshot.go`, PR #457) inside the lease payload; the worker
+  operates on the snapshot instead of reading its own local store. The
+  master store remains the client-visible SSOT, maintained via W9
+  projections + W1 monitoring (see run-state-machine.md §1 notes on
+  dual-write).
+
+## 6. Invariant candidates and tripwire observations
+
+- Copy-vs-pointer discipline: `acquireWorkerLease` returns a *copy* under
+  the lock because `leaseWorkForWorker` mutates the stored pointer
+  (comment at worker_plane.go:441). This is a documented manual-sync
+  point — tripwire-adjacent; E2 should either law it or remove the
+  aliasing.
+- `WorkerRegistration.Active` is written by LW4 but liveness decisions go
+  through `workerIsActive` (computed from LastHeartbeat) — the stored flag
+  is a near-mirror of a derivable value. Candidate for removal (derive,
+  don't mirror).
+- No invariant currently asserts **single active holder per run**: nothing
+  prevents two concurrent leases targeting the same run (e.g. a capture
+  lease racing a stop lease). Whether that is benign must be decided by
+  law, not by luck.
+
+## 7. Law candidates (DRAFT — verify in E2)
+
+| Law | Statement |
+|-----|-----------|
+| LL1 liveness detection | a dead worker is observed within workerHeartbeatTTL; no lease wait outlives a dead worker by more than one poll interval (7bfbcf88's contract) |
+| LL2 dispatch monotonicity | DispatchCount is monotone; re-dispatch happens only after ExpiresAt; (DispatchedAt, ExpiresAt] intervals of one lease never overlap |
+| LL3 completion finality | a completed lease never changes again (Completed is terminal; acks after completion are no-ops — currently unguarded, needs a check) |
+| LL4 restart amnesia is safe | master restart ⇒ all leases forgotten; every caller observes failure within its timeout; no run transition is *decided* by lease state alone (only via observations, §4) |
+| LL5 snapshot sufficiency | a worker executes any effect using only the lease payload (RunSnapshot); it never reads its local store for master-owned runs (PR #457's contract) |
+
+## Next (E2/E3)
+
+1. Verify LL1–LL5 against the code; promote to laws with property tests
+   (the `step_test.go` style: enumerate interleavings of heartbeat /
+   dispatch / ack / restart).
+2. Decide the single-holder-per-run question (LL candidate or explicit
+   non-goal with rationale).
+3. Static guard: semgrep rule confining lease-map mutation to
+   worker_plane.go (mirror of `run-status-write-surface`).

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -574,27 +574,18 @@ func (m *Monitor) Quit() error {
 	return m.mux.KillSession(m.session)
 }
 
-// StopRun kills the run session and marks the run canceled.
+// StopRun stops the run through the daemon StopRun verb: the daemon owns
+// the host-aware session kill (worker lease for remote runs) and records
+// the user-sourced canceled status. The TUI must not kill sessions via the
+// local multiplexer or write status events itself.
 func (m *Monitor) StopRun(run *model.Run) error {
 	if run.Status.IsTerminal() {
 		return nil
 	}
 
-	sessionName := run.SessionName
-	if sessionName == "" {
-		sessionName = model.GenerateSessionName(run.IssueID, run.RunID)
-	}
-
-	if m.mux.HasSession(sessionName) {
-		_ = m.mux.KillSession(sessionName)
-	}
-
 	ctx := context.Background()
 	ref := orchapi.RunRef{IssueID: run.IssueID, RunID: run.RunID}
-	// Frozen client-plane status writer: scheduled to become a daemon API
-	// verb (coupling-core roadmap Phase B3). Do not copy this pattern.
-	_, err := m.api.AppendEvent(ctx, ref, &orchapi.Event{Type: "status", Name: string(model.StatusCanceled)}) // nosemgrep: run-status-write-surface
-	return err
+	return m.api.StopRun(ctx, ref)
 }
 
 func (m *Monitor) StartRun(issueID string, agentType string) (string, error) {


### PR DESCRIPTION
Stacked on #464. Phase E1 of the coupling-core roadmap: the survey document for the worker-lease core (`docs/design/worker-lease.md`), structured as a mirror of `run-state-machine.md` — write surface LW1–LW5, ownership/lifecycle, heartbeat semantics, run-state-machine coupling (leases reach `step()` only as observations), store-of-record rationale, tripwire observations, and DRAFT laws LL1–LL5 for E2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)