### PR TITLE
feat(daemon): L3' verdict symmetry + fold-derived runCore (coupling-core Phase C)

### DIFF
--- a/docs/design/coupling-core-roadmap.md
+++ b/docs/design/coupling-core-roadmap.md
@@ -185,13 +185,18 @@ run-state-machine.md と同じ playbook を適用する。
 
 | # | core | 4層の状態 | 守り | 閉鎖フェーズ |
 |---|------|----------|------|------------|
-| 1 | run status 遷移 | ADR✓ law✓(tested) runtime△ static✗ | A1 ルール | A1→B |
-| 2 | RunState vs event log(導出状態) | I2 open(doc に明記) | なし | C1 |
-| 3 | worker lease 所有権/ライフサイクル | 未文書化 | なし | E |
+| 1 | run status 遷移 | ADR✓ law✓(tested) runtime△ **static✓ (A1, 2026-06-12)** | `run-status-write-surface` ルール + 凍結 whitelist | B で whitelist→0 |
+| 2 | RunState vs event log(導出状態) | 決定済み **D-C1**(run-state-machine.md §7): 導出可能フィールドは fold、収束カウンタは ephemeral-by-law (L7) | なし(実装待ち) | C1 実装 |
+| 3 | worker lease 所有権/ライフサイクル | 調査完了(E1 doc)、law 候補 5 件ドラフト | なし | E2/E3 |
 | 4 | identity(typed IDs) | 型✓ + lint✓ | `.semgrep/typed-id-rules` | 完了 |
 | 5 | client/daemon 境界(読み取り) | semgrep ~60 ルール✓ | `make lint` + CI | 完了 |
-| 6 | cancellation/stop 意味論(W7/W8, PR close terminal) | step に部分統合 | terminal guard のみ | B2 |
-| 7 | エラー伝播 × append(fail-fast) | 4 箇所違反 | なし | A2 |
+| 6 | cancellation/stop 意味論(W7/W8, PR close terminal) | **disposition 決定済み**(run-state-machine.md §6): W7=ladder と統合、W8=v2 統合 | terminal guard + A1 凍結 | B1 後 |
+| 7 | エラー伝播 × append(fail-fast) | **修正済み (A2, 2026-06-12)** | `no-ignored-status-append` ルール | 完了 |
+
+進捗ログ:
+- 2026-06-12 Phase A 完了(PR #463): A1 ルール+46 サイト凍結 / A2 fail-fast 化 / A3 AGENTS.md routing。
+- 2026-06-12 Phase B 部分完了: B2 disposition 決定(run-state-machine.md §6)、B3 StopRun 動詞化(TUI のローカル mux kill + client append を撤去 — リモート run の stop が壊れていたバグも同時修正)。B3 ResolveRun は §6 の式で choice space を閉じ、verified issue 化。
+- 2026-06-12 C1/C3 の選択空間を閉鎖(run-state-machine.md §7 D-C1/D-C3、L7/L3' 制定)。実装は C フェーズ。
 
 ## 推奨順序と箱
 

--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -99,7 +99,8 @@ O3 session gone, count ≥ 3   → O5 git evidence を収集して判定:
    O5: no signal, agent=opencode, never-alive, grace内             遷移なし
    O5: no signal, agent≠opencode:
        local,  was-alive                                           → failed
-       local,  never-alive                                         遷移なし (永遠に待つ — I7)
+       local,  never-alive, grace内                                 遷移なし
+       local,  never-alive, grace超過                               → unknown (L3', §7 D-C3)
        remote, was-alive                                           → failed
        remote, never-alive, grace内                                 遷移なし
        remote, never-alive, grace超過                               → unknown
@@ -128,17 +129,18 @@ O8 launch progress           (launch ladder W2–W5)                 queued → 
 | # | Invariant | Status |
 |---|-----------|--------|
 | I1 | `DeadCheckCount == 0` ⇔ last observation was alive; `>= 3` consecutive dead checks ⇒ verdict allowed | holds, but scattered across two paths |
-| I2 | `WasAlive` is monotone (never unset) **within one daemon process** | violated across restarts: RunState is in-memory, so a restart resets boot grace, dead counts, and prompt debounce |
+| I2 | `WasAlive` is monotone (never unset) | holds across restarts since D-C1 (§7, 2026-06-12): `WasAlive`/`PRRecorded` are re-derived from the event log at registration; the ephemeral counters reset by design and re-converge (L7) |
 | I3 | `PromptStreak >= 2` required before `waiting` (debounce); reset on feedback | holds (W6 + `noteRunFeedback`) |
 | I4 | duplicate status events must not accumulate | enforced only in W1 (same-status no-op); W2–W9 rely on transition legality alone |
-| I5 | `PRRecorded` dedupes `pr` artifacts | in-memory only: after a daemon restart, a PR URL still visible in the pane appends one duplicate `pr` artifact |
+| I5 | `PRRecorded` dedupes `pr` artifacts | holds across restarts since D-C1 (§7, 2026-06-12): derived from existing `pr` artifacts at registration |
 | I6 | every non-terminal run is eventually observed | **violated for `queued`**: `monitorAll` does not list `queued`, so a run orphaned before `booting` (e.g. daemon crash mid-launch) is never monitored again |
-| I7 | a gone session must eventually produce a verdict | **violated locally** for never-alive non-opencode runs: no unknown/failed verdict is ever issued (remote path issues `unknown` after grace — asymmetric) |
+| I7 | a gone session must eventually produce a verdict | holds since L3' (§7 D-C3, 2026-06-12): both planes conclude `unknown` after the never-alive grace |
 | I8 | status-change listeners observe every transition | violated: only the O4 agent-inference path fires `fireStatusChange` |
 
-I2 is the standing argument for deriving monitor state from the event log
-(state = fold) in a later phase; I5–I8 are candidate behavior fixes that are
-**not** part of the v1 behavior-preserving refactor.
+I2, I5 (via D-C1) and I7 (via D-C3) were resolved on 2026-06-12. I4's
+broader guarantee arrives with the Phase B write-surface consolidation;
+I6 and I8 are tracked as coupling-core roadmap issues
+(`inv-monitor-queued-orphans`, `inv-fire-status-change-all`).
 
 ## 5. `step()` v1 — scope and design decisions
 
@@ -202,7 +204,7 @@ distinction the law tests themselves forced:
 | L1a idempotency (facts) | re-applying a fact observation after its transition committed never yields a different target |
 | L1b fixed point (streams) | repeating one stream observation reaches a quiet fixed point after boundedly many steps (no oscillation) |
 | L2 order-independent convergence | {session gone ×3 + git evidence, PR merged/closed} in any interleaving converge to the same terminal status |
-| L3 grace | a never-alive run within `neverAliveVerdictGrace` never receives an `unknown`/`failed` verdict, on any observation sequence (complement: after grace, remote concludes `unknown`; local keeps waiting — the §3 asymmetry, pinned) |
+| L3' grace | a never-alive run within `neverAliveVerdictGrace` never receives an `unknown`/`failed` verdict, on any observation sequence; after the grace, any plane concludes `unknown` on the standing evidence (revised from v1's pinned asymmetry by §7 D-C3) |
 | L4 terminality | from a terminal status, `step` emits no effect and no core change for any observation |
 | L5 verdict requires evidence | `obsSessionGone` never emits a status directly; it requests git evidence exactly when the dead-check threshold is reached |
 | L6 debounce | `waiting` via prompt requires ≥ `waitingPromptStreakThreshold` consecutive prompt observations; any busy capture resets the streak |
@@ -245,7 +247,7 @@ implementation exists (daemon), and the TUI client calls it.
 
 ## 7. Open-law decisions (decided 2026-06-12)
 
-### D-C1 — restart transparency without new persistence
+### D-C1 — restart transparency without new persistence (implemented 2026-06-12)
 
 `runCore` fields fall into two classes, and the restart story differs:
 
@@ -269,7 +271,7 @@ forbids).
 |-----|-----------|
 | L7 restart transparency | for any observation sequence and any restart point, the sequence of *transition targets* is identical with and without the restart; only their timing may differ, by at most `max(deadCheckThreshold, waitingPromptStreakThreshold)` ticks |
 
-### D-C3 — never-alive verdict asymmetry resolved
+### D-C3 — never-alive verdict asymmetry resolved (implemented 2026-06-12)
 
 L3's pinned complement ("after grace, remote concludes `unknown`; local
 keeps waiting") is revised: **local and remote both conclude `unknown`

--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -209,4 +209,80 @@ distinction the law tests themselves forced:
 
 L1/L4 fix the 5,830-duplicate-event class structurally; L2 is the law the
 PR #458 inference fixes were converging toward; restart transparency (I2)
-remains an open law until monitor state is derived from the event log.
+remains an open law until monitor state is derived from the event log
+(resolved by decision D-C1 in §7).
+
+## 6. v2 disposition of the remaining writers (decided 2026-06-12)
+
+Phase A of the coupling-core roadmap closed the write surface mechanically
+(semgrep rule `run-status-write-surface`; every existing writer carries a
+frozen `nosemgrep` annotation). Each frozen writer now has an explicit
+disposition — integrate into `step()` or quarantine with a recorded
+rationale. *Undecided* is no longer a legal state for a status writer.
+
+| # | Site | Disposition | Rationale |
+|---|------|-------------|-----------|
+| W2–W5 | launch ladders (socket.go ×4) | **integrate — v2, first** | Four near-copies of one ladder; interleaves with monitor-plane transitions (booting/running races). Becomes launch-progress observations (O8) decided in `step()`, with the imperative bootstrap steps as effects. |
+| W7 | `failOpenCodeRunBootstrap` → failed | **integrate — with W2–W5** | The failure arm of the same ladder. |
+| W6 | feedback → running | **integrate — v2** | Already mutates `runCore` (PromptStreak reset, O6). Core state must change only through `step()`. |
+| W8 | `appendRunCanceledByUser` (`orch stop`) | **integrate — v2, after the ladder** | O7 (user stop) exists in the observation taxonomy; terminality (L4) should observe it. Single guarded site until then. |
+| W9 | master projections (proto_handler.go) | **quarantine — law boundary** | Replicates transitions already decided on the worker plane; carries no local policy. Guards: `CanTransitionStatus` + fail-fast appends (Phase A2). Law: a projection is status-preserving — it must never add inference in flight. |
+| W10 | external append API (`handleAppendEvent`) | **quarantine — law boundary** | User/agent escape hatch with caller-supplied source. Guard: `CanTransitionStatus` with caller source. `orch repair` (cli/repair.go) is its sanctioned client and stays. |
+| — | TUI `Monitor.StopRun` (client plane) | **removed — B3** | Now calls the daemon `StopRun` verb (host-aware session kill + daemon-side canceled append). |
+| — | TUI `Monitor.ResolveRun` (client plane) | **pending — B3 issue** | Daemon `ResolveRun` verb gains run-done semantics; see the equation below. |
+
+B3 ResolveRun equation (spec for the pending issue — the daemon verb, not
+the orchapi lookup of the same name):
+
+```
+ResolveRun(issue, run) ≡  append(run, done, source=user)   if ¬terminal(run)
+                          ; SetIssueStatus(issue, resolved)
+```
+
+Today `handleProtoResolveRun` implements only the second conjunct; the TUI
+implements both client-side. After the issue lands, exactly one
+implementation exists (daemon), and the TUI client calls it.
+
+## 7. Open-law decisions (decided 2026-06-12)
+
+### D-C1 — restart transparency without new persistence
+
+`runCore` fields fall into two classes, and the restart story differs:
+
+- **Derivable (fold of the event log)** — must be re-derived at monitor
+  registration, never mirrored:
+  - `WasAlive := ∃ status event ∈ {running, waiting, rate_limited, done}`
+  - `PRRecorded := ∃ artifact event of type pr` (also resolves I5)
+  - boot grace: derivable from the persisted `StartedAt`
+- **Ephemeral by law (bounded re-convergence)** — deliberately reset on
+  restart; L1b guarantees they re-converge within bounded ticks, and the
+  reset direction is safe (verdicts/debounce are *delayed*, never wrong):
+  `DeadCheckCount`, `PromptStreak`, `OutputHash`, `LastOutput*`.
+
+Rejected alternatives: (a) full observation replay (observations are not
+events; would require recording per-tick captures), (b) persisting counter
+changes as events (OutputHash churn would spam the log), (c) periodic
+snapshots (a second store of record — exactly the mirror this design
+forbids).
+
+| Law | Statement |
+|-----|-----------|
+| L7 restart transparency | for any observation sequence and any restart point, the sequence of *transition targets* is identical with and without the restart; only their timing may differ, by at most `max(deadCheckThreshold, waitingPromptStreakThreshold)` ticks |
+
+### D-C3 — never-alive verdict asymmetry resolved
+
+L3's pinned complement ("after grace, remote concludes `unknown`; local
+keeps waiting") is revised: **local and remote both conclude `unknown`
+after `neverAliveVerdictGrace`**. Rationale: I7 (a gone session must
+eventually produce a verdict) is a liveness requirement; the local
+keep-waiting behavior violates it for never-alive non-opencode runs, and
+the asymmetry was pinned in v1 only for behavior preservation. L3 reads
+after the change:
+
+| Law | Statement |
+|-----|-----------|
+| L3' grace (revised) | a never-alive run within `neverAliveVerdictGrace` never receives an `unknown`/`failed` verdict; after the grace, any plane concludes `unknown` on the standing evidence |
+
+I6 (queued runs are never monitored) remains a behavior fix tracked by the
+coupling-core roadmap Phase C2: `monitorAll` must include `queued` so that
+"every non-terminal run is eventually observed" holds.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -489,8 +489,10 @@ func (d *Daemon) getOrCreateState(run *model.Run) *RunState {
 	if !ok {
 		state = &RunState{
 			LastCheckAt: time.Now(),
-			// Assume output is fresh when we start tracking
-			runCore: runCore{LastOutputAt: time.Now()},
+			// Fold-derivable core fields come from the event log (D-C1/L7);
+			// ephemeral counters start at zero and re-converge (L1b). Output
+			// freshness is assumed at tracking start.
+			runCore: initialRunCore(run, time.Now()),
 		}
 		d.runStates[key] = state
 	}

--- a/internal/daemon/step.go
+++ b/internal/daemon/step.go
@@ -57,6 +57,33 @@ type runCore struct {
 	DeadCheckCount int
 }
 
+// initialRunCore derives the fold-derivable runCore fields from the run's
+// event log (run-state-machine.md §7 D-C1 / L7). WasAlive folds from any
+// alive-implying status event, PRRecorded from an existing pr artifact, so
+// neither survives only in daemon memory (the I2/I5 fix). The remaining
+// counters are ephemeral by law: they reset to zero and re-converge within
+// bounded ticks (L1b), delaying verdicts/debounce but never changing them.
+func initialRunCore(run *model.Run, now time.Time) runCore {
+	core := runCore{LastOutputAt: now}
+	for _, e := range run.Events {
+		if e == nil {
+			continue
+		}
+		switch e.Type {
+		case model.EventTypeStatus:
+			switch model.Status(e.Name) {
+			case model.StatusRunning, model.StatusWaiting, model.StatusRateLimited, model.StatusDone:
+				core.WasAlive = true
+			}
+		case model.EventTypeArtifact:
+			if e.Name == "pr" {
+				core.PRRecorded = true
+			}
+		}
+	}
+	return core
+}
+
 type obsKind int
 
 const (
@@ -310,13 +337,22 @@ func stepGitEvidence(view runView, core runCore, obs runObservation, now time.Ti
 	}
 
 	if !core.WasAlive {
-		// Locally a never-alive run gets no unknown/failed verdict: keep
-		// waiting for the session, with cadence-limited logging.
-		if core.DeadCheckCount <= deadChecksBeforeFailed || core.DeadCheckCount%neverAliveLogEvery == 0 {
-			effects = append(effects, logEffect("%s#%s: agent not alive yet (never confirmed alive), waiting", view.IssueID, view.RunID))
-		} else {
-			effects = append(effects, debugEffect("%s#%s: agent not alive yet (never confirmed alive), waiting", view.IssueID, view.RunID))
+		// L3' (run-state-machine.md §7 D-C3): a never-alive run gets no
+		// verdict within the boot grace; past it, the local plane concludes
+		// unknown exactly like the remote plane, so I7 (a gone session must
+		// eventually produce a verdict) holds locally too.
+		if withinNeverAliveGraceAt(view.StartedAt, now) {
+			if core.DeadCheckCount <= deadChecksBeforeFailed || core.DeadCheckCount%neverAliveLogEvery == 0 {
+				effects = append(effects, logEffect("%s#%s: agent not alive yet (never confirmed alive), waiting", view.IssueID, view.RunID))
+			} else {
+				effects = append(effects, debugEffect("%s#%s: agent not alive yet (never confirmed alive), waiting", view.IssueID, view.RunID))
+			}
+			return core, effects
 		}
+		if view.Status != model.StatusUnknown {
+			effects = append(effects, logEffect("%s#%s: agent never confirmed alive after %d checks, marking unknown", view.IssueID, view.RunID, core.DeadCheckCount))
+		}
+		effects = append(effects, setStatusEffect(model.StatusUnknown))
 		return core, effects
 	}
 

--- a/internal/daemon/step_test.go
+++ b/internal/daemon/step_test.go
@@ -311,9 +311,9 @@ func TestStepLawNeverAliveGrace(t *testing.T) {
 	}
 }
 
-// L3 complement: after the grace expires, the remote channel does conclude
-// unknown for a never-alive run with no git evidence, and the local channel
-// still waits (asymmetry documented in run-state-machine.md §3).
+// L3' complement (run-state-machine.md §7 D-C3): after the grace expires,
+// BOTH channels conclude unknown for a never-alive run with no git
+// evidence — v1's pinned local keep-waiting asymmetry is resolved.
 func TestStepNeverAliveVerdictAfterGrace(t *testing.T) {
 	now := time.Now()
 	startedAt := now.Add(-2 * neverAliveVerdictGrace)
@@ -336,8 +336,82 @@ func TestStepNeverAliveVerdictAfterGrace(t *testing.T) {
 	if status, transitioned := run(true); !transitioned || status != model.StatusUnknown {
 		t.Fatalf("remote never-alive after grace: status=%s, want unknown", status)
 	}
-	if _, transitioned := run(false); transitioned {
-		t.Fatalf("local never-alive run must keep waiting for its session (no verdict)")
+	if status, transitioned := run(false); !transitioned || status != model.StatusUnknown {
+		t.Fatalf("local never-alive after grace: status=%s, want unknown", status)
+	}
+}
+
+// D-C1 (run-state-machine.md §7): the fold-derivable runCore fields are
+// reconstructed from the event log at monitor registration; the ephemeral
+// counters start at zero.
+func TestInitialRunCoreDerivation(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name      string
+		events    []*model.Event
+		wantAlive bool
+		wantPRRec bool
+	}{
+		{"empty log", nil, false, false},
+		{"queued and booting only", []*model.Event{
+			model.NewStatusEvent(model.StatusQueued),
+			model.NewStatusEvent(model.StatusBooting),
+		}, false, false},
+		{"reached running", []*model.Event{
+			model.NewStatusEvent(model.StatusQueued),
+			model.NewStatusEvent(model.StatusRunning),
+		}, true, false},
+		{"pr artifact recorded", []*model.Event{
+			model.NewStatusEvent(model.StatusRunning),
+			model.NewArtifactEvent("pr", map[string]string{"url": "https://github.com/o/r/pull/1"}),
+		}, true, true},
+		{"failed while never alive", []*model.Event{
+			model.NewStatusEvent(model.StatusQueued),
+			model.NewStatusEvent(model.StatusFailed),
+		}, false, false},
+	}
+	for _, tc := range cases {
+		run := &model.Run{Events: tc.events}
+		core := initialRunCore(run, now)
+		if core.WasAlive != tc.wantAlive || core.PRRecorded != tc.wantPRRec {
+			t.Fatalf("%s: WasAlive=%t PRRecorded=%t, want %t/%t",
+				tc.name, core.WasAlive, core.PRRecorded, tc.wantAlive, tc.wantPRRec)
+		}
+		if core.DeadCheckCount != 0 || core.PromptStreak != 0 || core.OutputHash != "" {
+			t.Fatalf("%s: ephemeral counters must start at zero", tc.name)
+		}
+		if !core.LastOutputAt.Equal(now) {
+			t.Fatalf("%s: LastOutputAt = %v, want %v", tc.name, core.LastOutputAt, now)
+		}
+	}
+}
+
+// L7 restart transparency (the I2 fix): after a daemon restart, a run whose
+// log shows it was alive folds WasAlive back, so a gone session is judged a
+// real death (failed) rather than a never-alive boot (unknown).
+func TestInitialRunCoreRestoresLivenessAcrossRestart(t *testing.T) {
+	now := time.Now()
+	startedAt := now.Add(-2 * neverAliveVerdictGrace)
+
+	run := &model.Run{Events: []*model.Event{
+		model.NewStatusEvent(model.StatusQueued),
+		model.NewStatusEvent(model.StatusRunning),
+	}}
+	core := initialRunCore(run, now)
+
+	view := stepTestView(model.StatusRunning, "codex", startedAt)
+	var effects []runEffect
+	for i := 0; i < deadChecksBeforeFailed; i++ {
+		core, effects = stepRun(view, core, runObservation{Kind: obsSessionGone}, now)
+		view = foldStatus(view, effects)
+	}
+	if !effectsContain(effects, effectGatherGitEvidence) {
+		t.Fatalf("expected evidence request at the dead-check threshold")
+	}
+	_, effects = stepRun(view, core, runObservation{Kind: obsGitEvidence, Evidence: gitEvidence{RepoRootFound: true}}, now)
+	view = foldStatus(view, effects)
+	if view.Status != model.StatusFailed {
+		t.Fatalf("was-alive run after restart judged %s, want failed", view.Status)
 	}
 }
 

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -574,27 +574,18 @@ func (m *Monitor) Quit() error {
 	return m.mux.KillSession(m.session)
 }
 
-// StopRun kills the run session and marks the run canceled.
+// StopRun stops the run through the daemon StopRun verb: the daemon owns
+// the host-aware session kill (worker lease for remote runs) and records
+// the user-sourced canceled status. The TUI must not kill sessions via the
+// local multiplexer or write status events itself.
 func (m *Monitor) StopRun(run *model.Run) error {
 	if run.Status.IsTerminal() {
 		return nil
 	}
 
-	sessionName := run.SessionName
-	if sessionName == "" {
-		sessionName = model.GenerateSessionName(run.IssueID, run.RunID)
-	}
-
-	if m.mux.HasSession(sessionName) {
-		_ = m.mux.KillSession(sessionName)
-	}
-
 	ctx := context.Background()
 	ref := orchapi.RunRef{IssueID: run.IssueID, RunID: run.RunID}
-	// Frozen client-plane status writer: scheduled to become a daemon API
-	// verb (coupling-core roadmap Phase B3). Do not copy this pattern.
-	_, err := m.api.AppendEvent(ctx, ref, &orchapi.Event{Type: "status", Name: string(model.StatusCanceled)}) // nosemgrep: run-status-write-surface
-	return err
+	return m.api.StopRun(ctx, ref)
 }
 
 func (m *Monitor) StartRun(issueID string, agentType string) (string, error) {


### PR DESCRIPTION
Stacked on #464. Implements the two §7 open-law decisions that were doc-ahead-of-code:

### C3 — L3' (never-alive verdict symmetry)

```
before (v1, pinned)                       after (L3')
───────────────────                       ───────────
local,  never-alive → wait forever (I7✗)  local,  never-alive, ≤grace → wait
remote, never-alive, >grace → unknown     local,  never-alive, >grace → unknown
                                          remote: unchanged
```

`stepGitEvidence`'s local arm becomes the mirror of the remote arm. §3 matrix row, §5 law table (L3→L3'), and `TestStepNeverAliveVerdictAfterGrace` revised in the same PR. Closes issue `inv-never-alive-local-unknown`.

### C1 — D-C1 / L7 (restart transparency, the I2 fix)

`getOrCreateState` now builds `runCore` via `initialRunCore(run, now)`:
- `WasAlive` := ∃ status event ∈ {running, waiting, rate_limited, done} (fold)
- `PRRecorded` := ∃ `pr` artifact (fold — also fixes I5 duplicate artifacts)
- `DeadCheckCount`/`PromptStreak`/`OutputHash`: ephemeral by law, re-converge (L1b)

No new persistence mechanism. New tests: derivation table (5 cases) + restart-then-real-verdict (a was-alive run is judged `failed`, not grace-suppressed `unknown`, after restart).

Invariant table now: I2 ✓, I5 ✓, I7 ✓; I6/I8 tracked by `inv-monitor-queued-orphans` / `inv-fire-status-change-all`.

## Verification
- `go test ./internal/daemon` — all law tests + 2 new tests pass
- `go build ./...` clean; lint via pre-commit hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)