### PR TITLE
feat(lint): lease-mutation fence + roadmap progress log (coupling-core E3)

### DIFF
--- a/.semgrep/worker-lease-mutation/worker_lease_mutation.go
+++ b/.semgrep/worker-lease-mutation/worker_lease_mutation.go
@@ -1,0 +1,39 @@
+//go:build semgrepfixture
+
+// Semgrep test fixture for worker-lease-mutation-surface.
+// Parsed by `semgrep test`, never compiled.
+package fixture
+
+func badLeaseMapWrite(s Server, lease Lease) {
+	// ruleid: worker-lease-mutation-surface
+	s.workerLeases[lease.LeaseID] = lease
+}
+
+func badLeaseMapDelete(s Server, id string) {
+	// ruleid: worker-lease-mutation-surface
+	delete(s.workerLeases, id)
+}
+
+func badWorkerMapWrite(s Server, w Worker) {
+	// ruleid: worker-lease-mutation-surface
+	s.workers[w.ID] = w
+}
+
+func badWorkerMapDelete(s Server, id string) {
+	// ruleid: worker-lease-mutation-surface
+	delete(s.workers, id)
+}
+
+func okReadLease(s Server, id string) Lease {
+	// ok: worker-lease-mutation-surface
+	return s.workerLeases[id]
+}
+
+func okIterateWorkers(s Server) int {
+	n := 0
+	// ok: worker-lease-mutation-surface
+	for range s.workers {
+		n++
+	}
+	return n
+}

--- a/.semgrep/worker-lease-mutation/worker_lease_mutation.yaml
+++ b/.semgrep/worker-lease-mutation/worker_lease_mutation.yaml
@@ -1,0 +1,25 @@
+rules:
+  - id: worker-lease-mutation-surface
+    pattern-either:
+      - pattern: $S.workerLeases[$K] = $V
+      - pattern: delete($S.workerLeases, $K)
+      - pattern: $S.workers[$K] = $V
+      - pattern: delete($S.workers, $K)
+    paths:
+      include:
+        - /internal/
+        - /.semgrep/worker-lease-mutation/
+      exclude:
+        - /internal/daemon/worker_plane.go
+    message: >
+      Worker and lease registry mutations are confined to
+      internal/daemon/worker_plane.go (write surface LW1-LW5 in
+      docs/design/worker-lease.md). Mutating s.workers or s.workerLeases
+      anywhere else bypasses the locking discipline and the
+      ownership/lifecycle rules of the worker-lease coupling core. Add a
+      function to worker_plane.go instead.
+    severity: ERROR
+    languages: [go]
+    metadata:
+      category: invariant
+      violation: lease-mutation-outside-worker-plane

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ lint: lint-fixtures
 	@test -x "$(SEMGREP)" || uv tool install semgrep
 	$(SEMGREP) test .semgrep/typed-id-rules
 	$(SEMGREP) test .semgrep/run-status-write-surface
+	$(SEMGREP) test .semgrep/worker-lease-mutation
 	$(SEMGREP) --error --config .semgrep/ ./internal/ --exclude='*_test.go'
 	$(MAKE) -C orch-monitor-tui lint
 	$(MAKE) -C orch-monitor-tui lint-test

--- a/docs/design/coupling-core-roadmap.md
+++ b/docs/design/coupling-core-roadmap.md
@@ -197,6 +197,10 @@ run-state-machine.md と同じ playbook を適用する。
 - 2026-06-12 Phase A 完了(PR #463): A1 ルール+46 サイト凍結 / A2 fail-fast 化 / A3 AGENTS.md routing。
 - 2026-06-12 Phase B 部分完了: B2 disposition 決定(run-state-machine.md §6)、B3 StopRun 動詞化(TUI のローカル mux kill + client append を撤去 — リモート run の stop が壊れていたバグも同時修正)。B3 ResolveRun は §6 の式で choice space を閉じ、verified issue 化。
 - 2026-06-12 C1/C3 の選択空間を閉鎖(run-state-machine.md §7 D-C1/D-C3、L7/L3' 制定)。実装は C フェーズ。
+- 2026-06-12 Phase C 実装完了(PR #467): C3 = L3' 対称化(I7 解消)、C1 = initialRunCore で fold 導出(I2/I5 解消)。C2/C4 は issue 委譲済み(inv-monitor-queued-orphans / inv-fire-status-change-all)。
+- 2026-06-12 Phase D1 完了(PR #466): step_sim_test.go 観測スクリプト replay、5 シナリオで matrix と実装の一致を検証。D2(過去 issue の観測語彙カバレッジ)は未着手。
+- 2026-06-12 Phase E1+E3 完了(PR #465 / #468): docs/design/worker-lease.md(LW1-LW5、LL1-LL5 draft)+ `.semgrep/worker-lease-mutation/` ルール(lease map 変異を worker_plane.go に限定、現状違反ゼロの純粋な柵)。残: E2(LL1-LL5 の property test 化)。
+- 残作業: B1(launch ladder 統合 — whitelist 45→0、フル文脈の frontier 箱)、E2、D2、issue 4 件の消化。
 
 ## 推奨順序と箱
 


### PR DESCRIPTION
Stacked on #467. Phase E3 of the coupling-core roadmap: the static guard for the worker-lease core.

- New semgrep rule `worker-lease-mutation-surface`: entry writes/deletes on `s.workers` / `s.workerLeases` are confined to `internal/daemon/worker_plane.go` (write surface LW1–LW5 in `docs/design/worker-lease.md`, PR #465).
- Zero current violations — a pure fence with no frozen whitelist, unlike the status-write rule.
- Fixture tests (4 ruleid + 2 ok) wired into `make lint`; negative-tested with a synthetic `delete(s.workerLeases, …)` in socket.go (1 finding, reverted).
- Roadmap progress log updated for Phases C/D/E (F1 living-document maintenance).

Remaining for the lease core: E2 — promote LL1–LL5 draft laws to property tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)