### PR TITLE
feat(daemon): lease completion finality guard + LL law tests (coupling-core E2)

### DIFF
--- a/docs/design/coupling-core-roadmap.md
+++ b/docs/design/coupling-core-roadmap.md
@@ -200,7 +200,9 @@ run-state-machine.md と同じ playbook を適用する。
 - 2026-06-12 Phase C 実装完了(PR #467): C3 = L3' 対称化(I7 解消)、C1 = initialRunCore で fold 導出(I2/I5 解消)。C2/C4 は issue 委譲済み(inv-monitor-queued-orphans / inv-fire-status-change-all)。
 - 2026-06-12 Phase D1 完了(PR #466): step_sim_test.go 観測スクリプト replay、5 シナリオで matrix と実装の一致を検証。D2(過去 issue の観測語彙カバレッジ)は未着手。
 - 2026-06-12 Phase E1+E3 完了(PR #465 / #468): docs/design/worker-lease.md(LW1-LW5、LL1-LL5 draft)+ `.semgrep/worker-lease-mutation/` ルール(lease map 変異を worker_plane.go に限定、現状違反ゼロの純粋な柵)。残: E2(LL1-LL5 の property test 化)。
-- 残作業: B1(launch ladder 統合 — whitelist 45→0、フル文脈の frontier 箱)、E2、D2、issue 4 件の消化。
+- 2026-06-12 Phase E2 完了(PR #469): LL 法テスト一式 + **LL3 実バグ修正**(acknowledgeWorkerLease が確定済み判定を無条件上書きしていた → first-verdict-wins の冪等 no-op に)。LL1/LL5 は既存テストでカバー済みと判定。
+- 2026-06-12 Phase D2 完了(PR #470): docs/design/observation-coverage.md — 過去 21 修正の転記で完全表現 61.9% + 補語彙で 100%。判定: 語彙は健全、欠落はすべて infrastructure 面(意図的スコープ境界)。O11–O14 拡張バックログを記録。
+- 残作業: **B1 のみ**(launch ladder W2–W5 統合 — whitelist 45→0。socket.go の 4 重 ladder 解体なのでフル文脈の新セッションで着手すること)+ issue 4 件の消化(inv-never-alive-local-unknown は PR #467 で解決済み、run 起動不要)。
 
 ## 推奨順序と箱
 

--- a/internal/daemon/worker_plane.go
+++ b/internal/daemon/worker_plane.go
@@ -898,6 +898,15 @@ func (s *SocketServer) acknowledgeWorkerLease(workerID, leaseID string, success 
 		return fmt.Errorf("lease worker mismatch")
 	}
 
+	if lease.Completed {
+		// LL3 completion finality (docs/design/worker-lease.md §7): the first
+		// verdict wins. A late or duplicate ack — an at-least-once RPC retry,
+		// or a re-dispatched executor finishing after its successor — must
+		// not rewrite a committed verdict; acknowledging a completed lease is
+		// an idempotent no-op.
+		return nil
+	}
+
 	lease.Completed = true
 	lease.CompletedAt = time.Now()
 	lease.Success = success

--- a/internal/daemon/worker_plane_law_test.go
+++ b/internal/daemon/worker_plane_law_test.go
@@ -1,0 +1,187 @@
+package daemon
+
+// Law tests for the worker-lease core (LL1–LL5 drafted in
+// docs/design/worker-lease.md; Phase E2 of the coupling-core roadmap).
+// LL1 (liveness fail-fast) is covered by
+// TestWaitForWorkerLeaseCompletionFailsFastWhenWorkerLost; LL5 (snapshot
+// sufficiency) by the executeLeaseEffect snapshot tests.
+
+import (
+	"io"
+	"log"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/s22625/orch/internal/store"
+	filestore "github.com/s22625/orch/internal/store/file"
+)
+
+func newLeaseLawServer(t *testing.T, workerID string, effects []string) *SocketServer {
+	t.Helper()
+	server := NewSocketServer(func(issuesRoot string) (store.Store, error) {
+		return filestore.New(issuesRoot)
+	}, log.New(io.Discard, "", 0))
+	if _, ttl := server.registerWorker(workerID, "external", "localhost", "external", effects); ttl <= 0 {
+		t.Fatal("expected positive heartbeat ttl for test worker")
+	}
+	return server
+}
+
+func leaseRecord(t *testing.T, server *SocketServer, leaseID string) WorkerLease {
+	t.Helper()
+	server.workerLeasesMu.RLock()
+	defer server.workerLeasesMu.RUnlock()
+	lease, ok := server.workerLeases[leaseID]
+	if !ok {
+		t.Fatalf("lease %s not found", leaseID)
+	}
+	return *lease
+}
+
+// LL3 completion finality: the first verdict wins; a late or duplicate ack
+// is an idempotent no-op and never rewrites Success/Error/ResultJSON.
+func TestLeaseLawCompletionFinality(t *testing.T) {
+	server := newLeaseLawServer(t, "worker-ll3", []string{"stop_run"})
+	lease, err := server.acquireWorkerLease("project-test", "stop_run", "orch-1", "run-1", nil)
+	if err != nil {
+		t.Fatalf("acquireWorkerLease() error = %v", err)
+	}
+	if dispatched := server.leaseWorkForWorker("worker-ll3"); dispatched == nil {
+		t.Fatal("expected initial dispatch")
+	}
+
+	if err := server.acknowledgeWorkerLease("worker-ll3", lease.LeaseID, true, "", `{"r":1}`); err != nil {
+		t.Fatalf("first ack error = %v", err)
+	}
+	first := leaseRecord(t, server, lease.LeaseID)
+
+	if err := server.acknowledgeWorkerLease("worker-ll3", lease.LeaseID, false, "late failure", `{"r":2}`); err != nil {
+		t.Fatalf("late ack must be an idempotent no-op, got error %v", err)
+	}
+	rec := leaseRecord(t, server, lease.LeaseID)
+	if !rec.Completed || rec.Success != first.Success || rec.Error != first.Error ||
+		rec.ResultJSON != first.ResultJSON || !rec.CompletedAt.Equal(first.CompletedAt) {
+		t.Fatalf("late ack rewrote the verdict: first=%+v now=%+v", first, rec)
+	}
+}
+
+// LL2 dispatch exclusivity: a dispatched lease is not handed out again
+// before its dispatch TTL expires; after expiry it re-dispatches with a
+// monotonically increased DispatchCount.
+func TestLeaseLawDispatchExclusiveUntilExpiry(t *testing.T) {
+	server := newLeaseLawServer(t, "worker-ll2", []string{"capture_session"})
+	lease, err := server.acquireWorkerLease("project-test", "capture_session", "orch-2", "run-2", nil)
+	if err != nil {
+		t.Fatalf("acquireWorkerLease() error = %v", err)
+	}
+
+	first := server.leaseWorkForWorker("worker-ll2")
+	if first == nil || first.DispatchCount != 1 {
+		t.Fatalf("first dispatch = %+v, want DispatchCount 1", first)
+	}
+	if redispatch := server.leaseWorkForWorker("worker-ll2"); redispatch != nil {
+		t.Fatalf("lease re-dispatched before expiry: %+v", redispatch)
+	}
+
+	server.workerLeasesMu.Lock()
+	server.workerLeases[lease.LeaseID].ExpiresAt = time.Now().Add(-time.Second)
+	server.workerLeasesMu.Unlock()
+
+	second := server.leaseWorkForWorker("worker-ll2")
+	if second == nil || second.DispatchCount != 2 {
+		t.Fatalf("expected re-dispatch with DispatchCount 2 after expiry, got %+v", second)
+	}
+}
+
+// LL2/LL3 corollary: a completed lease is never dispatched again, even
+// after its dispatch TTL has expired.
+func TestLeaseLawNoDispatchAfterCompletion(t *testing.T) {
+	server := newLeaseLawServer(t, "worker-ll23", []string{"stop_run"})
+	lease, err := server.acquireWorkerLease("project-test", "stop_run", "orch-3", "run-3", nil)
+	if err != nil {
+		t.Fatalf("acquireWorkerLease() error = %v", err)
+	}
+	if dispatched := server.leaseWorkForWorker("worker-ll23"); dispatched == nil {
+		t.Fatal("expected initial dispatch")
+	}
+	if err := server.acknowledgeWorkerLease("worker-ll23", lease.LeaseID, true, "", ""); err != nil {
+		t.Fatalf("ack error = %v", err)
+	}
+
+	server.workerLeasesMu.Lock()
+	server.workerLeases[lease.LeaseID].ExpiresAt = time.Now().Add(-time.Second)
+	server.workerLeasesMu.Unlock()
+
+	if redispatch := server.leaseWorkForWorker("worker-ll23"); redispatch != nil {
+		t.Fatalf("completed lease was re-dispatched: %+v", redispatch)
+	}
+}
+
+// LL4 restart amnesia is safe: leases are memory-only by design, so a
+// caller holding a pre-restart lease ID observes an immediate "not found"
+// failure, never a hang until the lease timeout.
+func TestLeaseLawRestartAmnesiaFailsFast(t *testing.T) {
+	server := newLeaseLawServer(t, "worker-ll4", []string{"stop_run"}) // fresh maps = post-restart state
+
+	start := time.Now()
+	_, err := server.waitForWorkerLeaseCompletion("lease-from-before-restart", time.Minute)
+	if err == nil || !strings.Contains(err.Error(), "lease not found") {
+		t.Fatalf("error = %v, want lease-not-found", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("amnesia failure took %s, want immediate", elapsed)
+	}
+}
+
+// Random walk over dispatch/expire/ack interleavings: DispatchCount is
+// monotone, a completed lease never dispatches, and the first verdict is
+// never rewritten — for any operation order.
+func TestLeaseLawRandomWalkInvariants(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	for trial := 0; trial < 25; trial++ {
+		server := newLeaseLawServer(t, "worker-walk", []string{"stop_run"})
+		lease, err := server.acquireWorkerLease("project-test", "stop_run", "orch-w", "run-w", nil)
+		if err != nil {
+			t.Fatalf("trial %d: acquireWorkerLease() error = %v", trial, err)
+		}
+
+		prevDispatch := 0
+		var verdict *WorkerLease
+		for op := 0; op < 40; op++ {
+			switch rng.Intn(3) {
+			case 0: // dispatch attempt
+				got := server.leaseWorkForWorker("worker-walk")
+				rec := leaseRecord(t, server, lease.LeaseID)
+				if rec.DispatchCount < prevDispatch {
+					t.Fatalf("trial %d op %d: DispatchCount decreased %d -> %d", trial, op, prevDispatch, rec.DispatchCount)
+				}
+				if got != nil && rec.Completed {
+					t.Fatalf("trial %d op %d: dispatched a completed lease", trial, op)
+				}
+				prevDispatch = rec.DispatchCount
+			case 1: // age the dispatch TTL past expiry
+				server.workerLeasesMu.Lock()
+				server.workerLeases[lease.LeaseID].ExpiresAt = time.Now().Add(-time.Millisecond)
+				server.workerLeasesMu.Unlock()
+			case 2: // ack with a random verdict
+				success := rng.Intn(2) == 0
+				errMsg := ""
+				if !success {
+					errMsg = "boom"
+				}
+				if err := server.acknowledgeWorkerLease("worker-walk", lease.LeaseID, success, errMsg, ""); err != nil {
+					t.Fatalf("trial %d op %d: ack error = %v", trial, op, err)
+				}
+				rec := leaseRecord(t, server, lease.LeaseID)
+				if verdict == nil {
+					v := rec
+					verdict = &v
+				} else if rec.Success != verdict.Success || rec.Error != verdict.Error {
+					t.Fatalf("trial %d op %d: verdict rewritten: first=%+v now=%+v", trial, op, verdict, rec)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Stacked on #468. Phase E2 of the coupling-core roadmap: the worker-lease draft laws (LL1–LL5, `docs/design/worker-lease.md` in #465) become executable, and the one law the code violated gets its fix.

## The LL3 bug

```
before                                        after
──────                                        ─────
ack #1: success, result A  → committed        ack #1: success, result A → committed
ack #2 (late/duplicate):                      ack #2: idempotent no-op —
  Success/Error/ResultJSON                      first verdict wins
  OVERWRITTEN unconditionally
```

A re-dispatched executor finishing after its successor, or an at-least-once RPC retry, could rewrite a verdict the master had already acted on.

## Law test coverage

| Law | Test |
|-----|------|
| LL1 liveness fail-fast | existing `TestWaitForWorkerLeaseCompletionFailsFastWhenWorkerLost` |
| LL2 dispatch exclusivity + monotone DispatchCount | `TestLeaseLawDispatchExclusiveUntilExpiry`, `TestLeaseLawNoDispatchAfterCompletion` |
| LL3 completion finality | `TestLeaseLawCompletionFinality` |
| LL4 restart amnesia is safe | `TestLeaseLawRestartAmnesiaFailsFast` |
| LL5 snapshot sufficiency | existing `executeLeaseEffect` snapshot tests |
| all interleavings | `TestLeaseLawRandomWalkInvariants` (seeded random walk) |

## Verification
- `go test ./internal/daemon` — full suite + 5 new law tests pass
- LL3 doc table in `worker-lease.md` (#465) notes the guard was missing; it can flip to "holds" once both PRs merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)