### PR TITLE
[codex] Monitor queued orphaned runs

### DIFF
--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -75,8 +75,8 @@ Facts the daemon can notice about a run, with their sources:
 ## 3. Current transition matrix (monitor plane)
 
 States: `queued, booting, running, waiting, rate_limited, pr_open, unknown`
-(active) and `done, failed, canceled` (terminal). The monitor only lists
-non-terminal runs **except `queued`** (see I6).
+(active) and `done, failed, canceled` (terminal). The monitor lists every
+non-terminal run, including `queued` (see I6).
 
 Per tick, observations are evaluated in this order; the first terminal
 transition ends the tick:
@@ -133,14 +133,14 @@ O8 launch progress           (launch ladder W2–W5)                 queued → 
 | I3 | `PromptStreak >= 2` required before `waiting` (debounce); reset on feedback | holds (W6 + `noteRunFeedback`) |
 | I4 | duplicate status events must not accumulate | enforced only in W1 (same-status no-op); W2–W9 rely on transition legality alone |
 | I5 | `PRRecorded` dedupes `pr` artifacts | holds across restarts since D-C1 (§7, 2026-06-12): derived from existing `pr` artifacts at registration |
-| I6 | every non-terminal run is eventually observed | **violated for `queued`**: `monitorAll` does not list `queued`, so a run orphaned before `booting` (e.g. daemon crash mid-launch) is never monitored again |
+| I6 | every non-terminal run is eventually observed | holds since `monitorAll` lists `queued` as well as the other non-terminal states, so a run orphaned before `booting` still reaches the monitor plane |
 | I7 | a gone session must eventually produce a verdict | holds since L3' (§7 D-C3, 2026-06-12): both planes conclude `unknown` after the never-alive grace |
 | I8 | status-change listeners observe every transition | violated: only the O4 agent-inference path fires `fireStatusChange` |
 
-I2, I5 (via D-C1) and I7 (via D-C3) were resolved on 2026-06-12. I4's
-broader guarantee arrives with the Phase B write-surface consolidation;
-I6 and I8 are tracked as coupling-core roadmap issues
-(`inv-monitor-queued-orphans`, `inv-fire-status-change-all`).
+I2, I5 (via D-C1), I7 (via D-C3), and I6
+(`inv-monitor-queued-orphans`) were resolved on 2026-06-12. I4's broader
+guarantee arrives with the Phase B write-surface consolidation; I8 is tracked
+as the coupling-core roadmap issue `inv-fire-status-change-all`.
 
 ## 5. `step()` v1 — scope and design decisions
 
@@ -285,6 +285,6 @@ after the change:
 |-----|-----------|
 | L3' grace (revised) | a never-alive run within `neverAliveVerdictGrace` never receives an `unknown`/`failed` verdict; after the grace, any plane concludes `unknown` on the standing evidence |
 
-I6 (queued runs are never monitored) remains a behavior fix tracked by the
-coupling-core roadmap Phase C2: `monitorAll` must include `queued` so that
-"every non-terminal run is eventually observed" holds.
+I6 is resolved by listing `queued` runs in `monitorAll`: a run orphaned before
+`booting` enters the same monitor plane and follows L3' (no verdict within
+`neverAliveVerdictGrace`; `unknown` after grace on standing dead evidence).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -355,7 +355,7 @@ func (d *Daemon) monitorAll() {
 			continue
 		}
 		runs, err := ctx.Store.ListRuns(&store.ListRunsFilter{
-			Status: []model.Status{model.StatusRunning, model.StatusBooting, model.StatusWaiting, model.StatusRateLimited, model.StatusPROpen, model.StatusUnknown},
+			Status: []model.Status{model.StatusQueued, model.StatusRunning, model.StatusBooting, model.StatusWaiting, model.StatusRateLimited, model.StatusPROpen, model.StatusUnknown},
 		})
 		if err != nil {
 			d.logger.Printf("error listing runs for %s: %v", ctx.RepoID, err)

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -772,6 +772,37 @@ func (m *mockStoreRecordingEvents) AppendEvent(ref *model.RunRef, event *model.E
 	return m.mockStoreForUpdate.AppendEvent(ref, event)
 }
 
+type mockStoreForMonitorAll struct {
+	mockStoreRecordingEvents
+	listRunsFilters []*store.ListRunsFilter
+}
+
+func (m *mockStoreForMonitorAll) ListRuns(filter *store.ListRunsFilter) ([]*model.Run, error) {
+	if filter == nil {
+		filter = &store.ListRunsFilter{}
+	}
+	filterCopy := *filter
+	filterCopy.Status = append([]model.Status(nil), filter.Status...)
+	m.listRunsFilters = append(m.listRunsFilters, &filterCopy)
+
+	if m.run == nil {
+		return nil, nil
+	}
+	if len(filter.Status) > 0 && !statusListContains(filter.Status, m.run.Status) {
+		return nil, nil
+	}
+	return []*model.Run{m.run}, nil
+}
+
+func statusListContains(statuses []model.Status, status model.Status) bool {
+	for _, candidate := range statuses {
+		if candidate == status {
+			return true
+		}
+	}
+	return false
+}
+
 func newRemoteTestRun(status model.Status) *model.Run {
 	return &model.Run{
 		IssueID:        "ISSUE-REMOTE-1",
@@ -783,6 +814,84 @@ func newRemoteTestRun(status model.Status) *model.Run {
 		TargetWorkerID: "host-CA-1",
 		SessionName:    "run-ISSUE-REMOTE-1-run-1",
 		Multiplexer:    "tmux",
+	}
+}
+
+func TestMonitorAllObservesQueuedNeverAliveRun(t *testing.T) {
+	cases := []struct {
+		name        string
+		startedAt   time.Time
+		wantUnknown bool
+	}{
+		{
+			name:      "inside grace",
+			startedAt: time.Now(),
+		},
+		{
+			name:        "after grace",
+			startedAt:   time.Now().Add(-2 * neverAliveVerdictGrace),
+			wantUnknown: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newTestDaemon()
+			d.socketServer = NewSocketServer(func(string) (store.Store, error) {
+				return nil, nil
+			}, d.logger)
+			d.socketServer.currentWorkerID = "host-local"
+
+			run := newRemoteTestRun(model.StatusQueued)
+			run.IssueID = "ISSUE-QUEUED-1"
+			run.RunID = model.RunID("run-" + strings.ReplaceAll(tc.name, " ", "-"))
+			run.StartedAt = tc.startedAt
+			run.Branch = ""
+			run.PRUrl = ""
+
+			st := &mockStoreForMonitorAll{
+				mockStoreRecordingEvents: mockStoreRecordingEvents{
+					mockStoreForUpdate: mockStoreForUpdate{
+						issue: &model.Issue{ID: run.IssueID, Status: model.IssueStatusOpen},
+					},
+					run: run,
+				},
+			}
+			registerRepoContextForTest(t, d.socketServer, "project-queued", "", st)
+
+			captures := 0
+			d.remoteCaptureFn = func(*model.Run, string, string, int) (string, error) {
+				captures++
+				return "", errors.New("session_not_found")
+			}
+
+			for i := 0; i < deadChecksBeforeFailed; i++ {
+				d.monitorAll()
+				if state := d.runStates[run.Ref().String()]; state != nil {
+					state.RemoteCaptureAt = time.Time{}
+				}
+			}
+
+			if len(st.listRunsFilters) == 0 {
+				t.Fatal("monitorAll must list runs from the repo store")
+			}
+			if !statusListContains(st.listRunsFilters[0].Status, model.StatusQueued) {
+				t.Fatalf("monitorAll status filter = %v, want queued included", st.listRunsFilters[0].Status)
+			}
+			if captures != deadChecksBeforeFailed {
+				t.Fatalf("queued run must be observed each dead check, got %d captures want %d", captures, deadChecksBeforeFailed)
+			}
+
+			gotUnknown := false
+			for _, event := range st.events {
+				if event.Type == model.EventTypeStatus && event.Name == string(model.StatusUnknown) {
+					gotUnknown = true
+				}
+			}
+			if gotUnknown != tc.wantUnknown {
+				t.Fatalf("unknown status event = %t, want %t", gotUnknown, tc.wantUnknown)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Include `queued` runs in `monitorAll`'s non-terminal run listing so pre-boot orphaned runs enter the monitor plane.
- Add a `monitorAll` regression test for queued never-alive runs: no verdict inside `neverAliveVerdictGrace`, and `unknown` after grace on standing session-not-found evidence.
- Update `docs/design/run-state-machine.md` so invariant I6 reflects the implemented behavior.

## Root Cause

`monitorAll` listed active run statuses but omitted `queued`. If the daemon crashed mid-launch before a run reached `booting`, the run could stay `queued` forever because it was never handed back to the monitor plane.

```
Before:
queued --not listed--> monitorAll never observes it

After:
queued --listed--> monitorAll -> existing L3' never-alive ladder
                         | within grace: no verdict
                         | after grace: unknown
```

## Acceptance Criteria Evidence

- `queued` is included in the `ListRunsFilter.Status` used by `monitorAll`.
- `TestMonitorAllObservesQueuedNeverAliveRun/inside_grace` verifies a queued never-alive run is observed but receives no `unknown` event before grace expires.
- `TestMonitorAllObservesQueuedNeverAliveRun/after_grace` verifies the same monitor path reaches `unknown` after `neverAliveVerdictGrace`.
- No queued-specific `step()` policy was added; the test drives the existing gone-session and git-evidence path.

## Validation

- `go test ./internal/daemon -run 'TestMonitorAllObservesQueuedNeverAliveRun|TestStepNeverAliveVerdictAfterGrace|TestStepLawNeverAliveGrace|TestSimNeverAliveRemoteGraceThenUnknown' -count=1` passed.
- `go test ./internal/daemon/ -count=1` passed.
- `make lint` passed.
- `go build ./...` passed.
- `go test ./...` ran to completion but failed in an unrelated existing test: `internal/monitor/TestSessionNameForProject` expects prefixes like `orch-myproject-`, while current output is abbreviated such as `orch-myp-f9a700`. This PR does not touch `internal/monitor`.