### PR TITLE
[codex] Fire status listeners at commit point

### DIFF
--- a/docs/design/coupling-core-roadmap.md
+++ b/docs/design/coupling-core-roadmap.md
@@ -122,9 +122,14 @@ A1 の whitelist がフェーズの進捗メーター(縮んで空になった�
   (推奨: local も grace 後 `unknown`)。L3 を改定し test 更新。
 
 ### C4. I8 — fireStatusChange の全遷移発火【codex】
-- 通知発火を step の効果実行器に移し、O4 経路だけでなく
-  すべての遷移で listener が発火することを test 化。B 完了後は自然に
-  落ちてくる作業。
+- 実装済み(2026-06-12, inv-fire-status-change-all): 通知発火を
+  O4 固有効果から W1 commit point (`Daemon.updateStatus`) に移し、
+  append 成功後に一回だけ listener が発火することを test 化。
+  PR close / dead verdict / agent inference / duplicate no-op / append 失敗を
+  検証対象に含める。
+- W6 feedback resume は v2 統合までの橋渡しとして legacy append 成功後に
+  同じ listener fanout を呼ぶ。W2–W5/W8 は Phase B/v2 の書き込み面統合で
+  W1/O7/O8 に吸収する。
 
 ### C5. I5 — PR artifact dedup の永続化【C1 から従属】
 - `PRRecorded` を event log からの導出に置き換え(C1 の系)。

--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -27,12 +27,12 @@ windows, inference — lives in the writers:
 
 | # | Site | Transitions written | Guards |
 |---|------|---------------------|--------|
-| W1 | `monitor.go updateStatus` (sole monitor-plane writer) | all monitor inferences | terminal check, `CanTransitionStatus`, same-status no-op, auto-resolve issue on `done`, `publishRunEvent` |
+| W1 | `monitor.go updateStatus` (sole monitor-plane writer) | all monitor inferences | terminal check, `CanTransitionStatus`, same-status no-op, auto-resolve issue on `done`, `publishRunEvent`, `fireStatusChange` after append |
 | W2 | `socket.go handleStartRun` (legacy JSON path) | `queued` → (`failed` per setup step) → `booting` → `failed`/`running` | store-level only; append errors ignored |
 | W3 | `socket.go processStartRunCore` (worker/master core) | same ladder as W2 | same |
 | W4 | `socket.go processContinueRunCore` | same ladder | same |
 | W5 | `socket.go handleContinueRun` (legacy JSON path) | same ladder | same |
-| W6 | `socket.go markRunFeedbackSent` | `waiting/pr_open/rate_limited/unknown` → `running` | `feedbackResumesRun` predicate; fires `onRunFeedback` (PromptStreak reset), `PublishRunEvent` |
+| W6 | `socket.go markRunFeedbackSent` | `waiting/pr_open/rate_limited/unknown` → `running` | `feedbackResumesRun` predicate; fires `onRunFeedback` (PromptStreak reset), `fireStatusChange`, `PublishRunEvent` after append |
 | W7 | `socket.go failOpenCodeRunBootstrap` | → `failed` | none |
 | W8 | `socket.go appendRunCanceledByUser` (`orch stop`) | → `canceled` (`source=user`) | skip if terminal |
 | W9 | `proto_handler.go syncStartRunResultToMasterStore` / `syncContinueRunResultToMasterStore` | `queued` (if record missing) + result status (default `running`) | store-level only |
@@ -47,9 +47,10 @@ Notes:
   store receives a projection (W9) and is then maintained by the master's
   monitor (W1 via capture leases). There is no synchronization invariant
   between the two stores; the master store is the client-visible SSOT.
-- `fireStatusChange` (Slack listeners) is invoked **only** for the
-  agent-inference transition inside `processRunOutput` — not for PR
-  merged/closed, dead-session verdicts, launch, feedback, or stop.
+- `fireStatusChange` (Slack listeners) is invoked after committed W1
+  monitor-plane transitions in `updateStatus`, so O1/O3/O4/O5 transitions
+  share the same listener fanout. W6 feedback resume bridges into the same
+  fanout after its legacy append until O6 is integrated into `step()` v2.
 
 ## 2. Observation taxonomy
 
@@ -116,7 +117,7 @@ O4 captured + agent verdict:     (mux: 優先順位順)
    output changed                                                  → running
    (opencode: busy→running, idle→waiting, retry→rate_limited,
     gone→unknown; booting/queued→running)
-   上記の遷移時のみ fireStatusChange (Slack等)
+   status append 成功後に updateStatus が fireStatusChange (Slack等)
 
 O6 feedback delivered        status ∈ {waiting,pr_open,            → running (+PromptStreak reset)
                              rate_limited,unknown}
@@ -135,12 +136,14 @@ O8 launch progress           (launch ladder W2–W5)                 queued → 
 | I5 | `PRRecorded` dedupes `pr` artifacts | holds across restarts since D-C1 (§7, 2026-06-12): derived from existing `pr` artifacts at registration |
 | I6 | every non-terminal run is eventually observed | holds since `monitorAll` lists `queued` as well as the other non-terminal states, so a run orphaned before `booting` still reaches the monitor plane |
 | I7 | a gone session must eventually produce a verdict | holds since L3' (§7 D-C3, 2026-06-12): both planes conclude `unknown` after the never-alive grace |
-| I8 | status-change listeners observe every transition | violated: only the O4 agent-inference path fires `fireStatusChange` |
+| I8 | status-change listeners observe every committed W1 transition | holds since D-C4 (§7, 2026-06-12): `updateStatus` fires once after a successful status append; same-status no-ops and append failures fire nothing |
 
-I2, I5 (via D-C1), I7 (via D-C3), and I6
-(`inv-monitor-queued-orphans`) were resolved on 2026-06-12. I4's broader
-guarantee arrives with the Phase B write-surface consolidation; I8 is tracked
-as the coupling-core roadmap issue `inv-fire-status-change-all`.
+I2, I5 (via D-C1), I7 (via D-C3), I6 (`inv-monitor-queued-orphans`) and
+I8 (D-C4, `inv-fire-status-change-all`) were resolved on 2026-06-12. I4's
+broader guarantee arrives with the Phase B write-surface consolidation.
+W6 feedback resume also fires the listener after its committed append; the
+remaining launch/stop legacy writers stay in the v2 disposition table until
+they are integrated into `step()`.
 
 ## 5. `step()` v1 — scope and design decisions
 
@@ -208,6 +211,7 @@ distinction the law tests themselves forced:
 | L4 terminality | from a terminal status, `step` emits no effect and no core change for any observation |
 | L5 verdict requires evidence | `obsSessionGone` never emits a status directly; it requests git evidence exactly when the dead-check threshold is reached |
 | L6 debounce | `waiting` via prompt requires ≥ `waitingPromptStreakThreshold` consecutive prompt observations; any busy capture resets the streak |
+| L8 listener commit point | every committed W1 status transition fires exactly one status-change listener event after `AppendEvent` succeeds; duplicate-status no-ops and failed appends fire none |
 
 ### Status reasons (verdict payload)
 
@@ -242,7 +246,7 @@ rationale. *Undecided* is no longer a legal state for a status writer.
 |---|------|-------------|-----------|
 | W2–W5 | launch ladders (socket.go ×4) | **integrate — v2, first** | Four near-copies of one ladder; interleaves with monitor-plane transitions (booting/running races). Becomes launch-progress observations (O8) decided in `step()`, with the imperative bootstrap steps as effects. |
 | W7 | `failOpenCodeRunBootstrap` → failed | **integrate — with W2–W5** | The failure arm of the same ladder. |
-| W6 | feedback → running | **integrate — v2** | Already mutates `runCore` (PromptStreak reset, O6). Core state must change only through `step()`. |
+| W6 | feedback → running | **integrate — v2** | Already mutates `runCore` (PromptStreak reset, O6). Core state must change only through `step()`. Until then, the legacy writer emits `fireStatusChange` after its append to preserve listener coverage. |
 | W8 | `appendRunCanceledByUser` (`orch stop`) | **integrate — v2, after the ladder** | O7 (user stop) exists in the observation taxonomy; terminality (L4) should observe it. Single guarded site until then. |
 | W9 | master projections (proto_handler.go) | **quarantine — law boundary** | Replicates transitions already decided on the worker plane; carries no local policy. Guards: `CanTransitionStatus` + fail-fast appends (Phase A2). Law: a projection is status-preserving — it must never add inference in flight. |
 | W10 | external append API (`handleAppendEvent`) | **quarantine — law boundary** | User/agent escape hatch with caller-supplied source. Guard: `CanTransitionStatus` with caller source. `orch repair` (cli/repair.go) is its sanctioned client and stays. |
@@ -304,3 +308,20 @@ after the change:
 I6 is resolved by listing `queued` runs in `monitorAll`: a run orphaned before
 `booting` enters the same monitor plane and follows L3' (no verdict within
 `neverAliveVerdictGrace`; `unknown` after grace on standing dead evidence).
+
+### D-C4 — listener dispatch moved to the commit point (implemented 2026-06-12)
+
+`fireStatusChange` is no longer a separate `step()` effect emitted only by
+O4 agent inference. W1 (`Daemon.updateStatus`) now dispatches listeners
+after the status event append succeeds, using the store-derived `from`
+status and the requested `to` status. This makes listener delivery follow
+the event log: if the append fails, no listener fires; if the transition is a
+same-status no-op, no listener fires; otherwise exactly one listener event is
+emitted for the committed W1 transition. The event carries the verdict
+`reason` (model.AttrStatusReason) alongside `from`/`to`, so listeners (Slack…)
+can render `unknown(never_alive)` without reading the run record.
+
+W6 feedback resume is still a legacy writer until O6 enters `step()` v2, so
+it bridges into the same listener fanout immediately after its append. This
+keeps `orch send` resume notifications consistent with W1 without changing
+the transition policy matrix.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -201,6 +201,7 @@ func (d *Daemon) Run() error {
 	}
 	d.socketServer.runLiveness = d.runLiveness
 	d.socketServer.onRunFeedback = d.noteRunFeedback
+	d.socketServer.onStatusChange = d.fireStatusChange
 	d.socketServer.SetGitHubBackend(d.githubBackend)
 	if err := d.socketServer.Start(); err != nil {
 		d.logger.Printf("warning: failed to start socket server: %v", err)

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -187,7 +187,6 @@ func (d *Daemon) applyStep(run *model.Run, st store.Store, state *RunState, obs 
 // is a shell-loop concern (applyGoneObservation) and is skipped here.
 func (d *Daemon) applyRunEffects(run *model.Run, st store.Store, oldCore, core runCore, effects []runEffect) (runCore, error) {
 	var firstErr error
-	statusWriteFailed := false
 	for _, e := range effects {
 		switch e.Kind {
 		case effectLog:
@@ -206,25 +205,11 @@ func (d *Daemon) applyRunEffects(run *model.Run, st store.Store, oldCore, core r
 				return core, err
 			}
 		case effectSetStatus:
-			if err := d.updateStatus(run, e.Status, e.Reason, st); err != nil {
-				statusWriteFailed = true
+			if err := d.updateStatus(run, e.Status, e.Reason, st, e.Output); err != nil {
 				if firstErr == nil {
 					firstErr = err
 				}
 			}
-		case effectFireStatusChange:
-			if statusWriteFailed {
-				continue
-			}
-			d.fireStatusChange(&runevents.StatusChangeEvent{
-				Run:        run,
-				From:       e.From,
-				To:         e.Status,
-				Reason:     e.Reason,
-				Source:     model.EventSourceDaemon,
-				LastOutput: e.Output,
-				Store:      st,
-			})
 		case effectGatherGitEvidence:
 			// handled by applyGoneObservation
 		}
@@ -513,7 +498,8 @@ func isConnectionRefusedError(err error) bool {
 // terminal protection, transition legality, and the same-status no-op.
 // reason, when non-empty, is recorded on the status event as the
 // machine-readable verdict reason (model.AttrStatusReason).
-func (d *Daemon) updateStatus(run *model.Run, status model.Status, reason string, st store.Store) error {
+// lastOutput rides along as the listener notification payload.
+func (d *Daemon) updateStatus(run *model.Run, status model.Status, reason string, st store.Store, lastOutput string) error {
 	ref := &model.RunRef{IssueID: run.IssueID, RunID: run.RunID}
 
 	// Check current status - daemon cannot overwrite terminal states
@@ -562,6 +548,16 @@ func (d *Daemon) updateStatus(run *model.Run, status model.Status, reason string
 			}
 		}
 	}
+
+	d.fireStatusChange(&runevents.StatusChangeEvent{
+		Run:        run,
+		From:       fromStatus,
+		To:         status,
+		Reason:     reason,
+		Source:     model.EventSourceDaemon,
+		LastOutput: lastOutput,
+		Store:      st,
+	})
 
 	return nil
 }

--- a/internal/daemon/monitor_publish_test.go
+++ b/internal/daemon/monitor_publish_test.go
@@ -57,7 +57,7 @@ func TestUpdateStatus_PublishesTransitionToBus(t *testing.T) {
 		t.Fatalf("seeded status not running: %q", current.Status)
 	}
 
-	if err := d.updateStatus(current, model.StatusWaiting, "", st); err != nil {
+	if err := d.updateStatus(current, model.StatusWaiting, "", st, ""); err != nil {
 		t.Fatalf("updateStatus: %v", err)
 	}
 
@@ -121,7 +121,7 @@ func TestUpdateStatus_SkipsRedundantPublish(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetRun: %v", err)
 	}
-	if err := d.updateStatus(current, model.StatusPROpen, "", st); err != nil {
+	if err := d.updateStatus(current, model.StatusPROpen, "", st, ""); err != nil {
 		t.Fatalf("updateStatus: %v", err)
 	}
 

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/s22625/orch/internal/agent"
 	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/pr"
+	"github.com/s22625/orch/internal/runevents"
 	"github.com/s22625/orch/internal/store"
 )
 
@@ -195,19 +196,125 @@ func TestUpdateStatusSameStatusIsNoOp(t *testing.T) {
 		mockStoreForUpdate: mockStoreForUpdate{issue: &model.Issue{ID: "i1", Status: model.IssueStatusOpen}},
 		run:                run,
 	}
+	listenerCalls := 0
+	d.AddStatusChangeListener(runevents.StatusChangeListenerFunc(func(_ *runevents.StatusChangeEvent) {
+		listenerCalls++
+	}))
 
-	if err := d.updateStatus(run, model.StatusUnknown, "", st); err != nil {
+	if err := d.updateStatus(run, model.StatusUnknown, "", st, "ignored"); err != nil {
 		t.Fatalf("updateStatus() error = %v", err)
 	}
 	if st.appendEventCalls != 0 {
 		t.Fatalf("re-affirming the current status must not append events, got %d", st.appendEventCalls)
 	}
+	if listenerCalls != 0 {
+		t.Fatalf("re-affirming the current status must not fire listeners, got %d", listenerCalls)
+	}
 
-	if err := d.updateStatus(run, model.StatusPROpen, "", st); err != nil {
+	if err := d.updateStatus(run, model.StatusPROpen, "", st, ""); err != nil {
 		t.Fatalf("updateStatus() error = %v", err)
 	}
 	if st.appendEventCalls != 1 {
 		t.Fatalf("expected a real transition to append one event, got %d", st.appendEventCalls)
+	}
+	if listenerCalls != 1 {
+		t.Fatalf("expected a real transition to fire one listener event, got %d", listenerCalls)
+	}
+}
+
+func TestStatusChangeListenersFireOnceForMonitorTransitionPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		run        *model.Run
+		setupState func(*RunState)
+		obs        runObservation
+		wantFrom   model.Status
+		wantTo     model.Status
+		wantOutput string
+	}{
+		{
+			name: "agent inference",
+			run:  &model.Run{IssueID: "i-infer", RunID: "r1", Agent: "opencode", Status: model.StatusRunning},
+			obs: runObservation{
+				Kind:   obsCaptured,
+				Output: "agent is idle and waiting",
+				Signal: agentSignal{Resolved: true, Status: model.StatusWaiting},
+			},
+			wantFrom:   model.StatusRunning,
+			wantTo:     model.StatusWaiting,
+			wantOutput: "agent is idle and waiting",
+		},
+		{
+			name: "PR closed terminal",
+			run: &model.Run{
+				IssueID: "i-pr",
+				RunID:   "r1",
+				Status:  model.StatusPROpen,
+				PRUrl:   "https://github.com/org/repo/pull/7",
+			},
+			obs: runObservation{
+				Kind:      obsPRState,
+				PROutcome: prOutcomeClosed,
+				PRURL:     "https://github.com/org/repo/pull/7",
+			},
+			wantFrom: model.StatusPROpen,
+			wantTo:   model.StatusCanceled,
+		},
+		{
+			name: "dead-session verdict",
+			run:  &model.Run{IssueID: "i-dead", RunID: "r1", Agent: "codex", Status: model.StatusRunning, StartedAt: time.Now().Add(-time.Hour)},
+			setupState: func(state *RunState) {
+				state.WasAlive = true
+				state.DeadCheckCount = deadChecksBeforeFailed
+			},
+			obs:      runObservation{Kind: obsGitEvidence},
+			wantFrom: model.StatusRunning,
+			wantTo:   model.StatusFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := newTestDaemon()
+			st := &mockStoreRecordingEvents{
+				mockStoreForUpdate: mockStoreForUpdate{issue: &model.Issue{ID: tt.run.IssueID, Status: model.IssueStatusOpen}},
+				run:                tt.run,
+			}
+			state := d.getOrCreateState(tt.run)
+			if tt.setupState != nil {
+				tt.setupState(state)
+			}
+
+			var events []*runevents.StatusChangeEvent
+			d.AddStatusChangeListener(runevents.StatusChangeListenerFunc(func(ev *runevents.StatusChangeEvent) {
+				copy := *ev
+				events = append(events, &copy)
+			}))
+
+			if _, err := d.applyStep(tt.run, st, state, tt.obs, ""); err != nil {
+				t.Fatalf("applyStep() error = %v", err)
+			}
+
+			if len(events) != 1 {
+				t.Fatalf("expected exactly one status listener event, got %d", len(events))
+			}
+			ev := events[0]
+			if ev.Run != tt.run {
+				t.Fatal("listener received the wrong run pointer")
+			}
+			if ev.From != tt.wantFrom || ev.To != tt.wantTo {
+				t.Fatalf("listener transition = %s -> %s, want %s -> %s", ev.From, ev.To, tt.wantFrom, tt.wantTo)
+			}
+			if ev.Source != model.EventSourceDaemon {
+				t.Fatalf("listener source = %s, want %s", ev.Source, model.EventSourceDaemon)
+			}
+			if ev.Store != st {
+				t.Fatal("listener received the wrong store")
+			}
+			if ev.LastOutput != tt.wantOutput {
+				t.Fatalf("listener LastOutput = %q, want %q", ev.LastOutput, tt.wantOutput)
+			}
+		})
 	}
 }
 
@@ -221,7 +328,7 @@ func TestUpdateStatusPersistsReason(t *testing.T) {
 		run:                run,
 	}
 
-	if err := d.updateStatus(run, model.StatusUnknown, model.StatusReasonNeverAlive, st); err != nil {
+	if err := d.updateStatus(run, model.StatusUnknown, model.StatusReasonNeverAlive, st, ""); err != nil {
 		t.Fatalf("updateStatus() error = %v", err)
 	}
 	ev := st.lastAppendedEvent
@@ -235,7 +342,7 @@ func TestUpdateStatusPersistsReason(t *testing.T) {
 	// An empty reason must not introduce an attrs map entry.
 	run2 := &model.Run{IssueID: "i1", RunID: "r2", Status: model.StatusRunning}
 	st.run = run2
-	if err := d.updateStatus(run2, model.StatusWaiting, "", st); err != nil {
+	if err := d.updateStatus(run2, model.StatusWaiting, "", st, ""); err != nil {
 		t.Fatalf("updateStatus() error = %v", err)
 	}
 	if _, ok := st.lastAppendedEvent.Attrs[model.AttrStatusReason]; ok {
@@ -332,7 +439,7 @@ func TestUpdateStatusAutoResolve(t *testing.T) {
 			}
 			run := &model.Run{IssueID: "test-issue", RunID: "run-1"}
 
-			err := d.updateStatus(run, tt.status, "", st)
+			err := d.updateStatus(run, tt.status, "", st, "")
 			if err != nil {
 				t.Fatalf("updateStatus() error = %v", err)
 			}
@@ -361,7 +468,7 @@ func TestUpdateStatusSetIssueStatusErrorSwallowed(t *testing.T) {
 	}
 	run := &model.Run{IssueID: "test-issue", RunID: "run-1"}
 
-	err := d.updateStatus(run, model.StatusDone, "", st)
+	err := d.updateStatus(run, model.StatusDone, "", st, "")
 	if err != nil {
 		t.Fatalf("updateStatus() should not fail when SetIssueStatus fails, got error = %v", err)
 	}
@@ -377,8 +484,12 @@ func TestUpdateStatusAppendEventError(t *testing.T) {
 		appendEventErr: io.ErrUnexpectedEOF,
 	}
 	run := &model.Run{IssueID: "test-issue", RunID: "run-1"}
+	listenerCalls := 0
+	d.AddStatusChangeListener(runevents.StatusChangeListenerFunc(func(_ *runevents.StatusChangeEvent) {
+		listenerCalls++
+	}))
 
-	err := d.updateStatus(run, model.StatusDone, "", st)
+	err := d.updateStatus(run, model.StatusDone, "", st, "")
 	if err == nil {
 		t.Fatal("updateStatus() should fail when AppendEvent fails")
 	}
@@ -386,6 +497,9 @@ func TestUpdateStatusAppendEventError(t *testing.T) {
 	// SetIssueStatus should not be called if AppendEvent fails
 	if len(st.setIssueStatusCalls) != 0 {
 		t.Errorf("expected SetIssueStatus not to be called when AppendEvent fails, got %d calls", len(st.setIssueStatusCalls))
+	}
+	if listenerCalls != 0 {
+		t.Fatalf("expected listener not to fire when AppendEvent fails, got %d calls", listenerCalls)
 	}
 }
 

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -27,6 +27,7 @@ import (
 	"github.com/s22625/orch/internal/github"
 	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/multiplexer"
+	"github.com/s22625/orch/internal/runevents"
 	"github.com/s22625/orch/internal/store"
 	"github.com/s22625/orch/internal/xdg"
 	"gopkg.in/yaml.v3"
@@ -335,6 +336,11 @@ type SocketServer struct {
 	// run straight back to waiting before the agent starts working. Wired
 	// by Daemon at startup.
 	onRunFeedback func(run *model.Run)
+
+	// onStatusChange, when set, fans committed non-monitor status
+	// transitions into the daemon's in-process listeners. Monitor-plane
+	// transitions are emitted by Daemon.updateStatus.
+	onStatusChange func(ev *runevents.StatusChangeEvent)
 }
 
 type managedServer struct {
@@ -2973,6 +2979,7 @@ func (s *SocketServer) markRunFeedbackSent(st store.Store, run *model.Run) {
 	if st == nil || run == nil || !feedbackResumesRun(run.Status) {
 		return
 	}
+	fromStatus := run.Status
 	if err := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)); err != nil { // nosemgrep: run-status-write-surface
 		s.logger.Printf("%s#%s: failed to mark run running after feedback: %v", run.IssueID, run.RunID, err)
 		return
@@ -2980,7 +2987,16 @@ func (s *SocketServer) markRunFeedbackSent(st store.Store, run *model.Run) {
 	if s.onRunFeedback != nil {
 		s.onRunFeedback(run)
 	}
-	fromProto, err := modelStatusToProto(run.Status)
+	if s.onStatusChange != nil {
+		s.onStatusChange(&runevents.StatusChangeEvent{
+			Run:    run,
+			From:   fromStatus,
+			To:     model.StatusRunning,
+			Source: model.EventSourceUser,
+			Store:  st,
+		})
+	}
+	fromProto, err := modelStatusToProto(fromStatus)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/s22625/orch/internal/git"
 	"github.com/s22625/orch/internal/model"
 	"github.com/s22625/orch/internal/multiplexer"
+	"github.com/s22625/orch/internal/runevents"
 	"github.com/s22625/orch/internal/store"
 	"github.com/s22625/orch/internal/xdg"
 	"google.golang.org/protobuf/proto"
@@ -4198,15 +4199,43 @@ func TestMarkRunFeedbackSentTransitions(t *testing.T) {
 		run := &model.Run{IssueID: "i", RunID: "r", Status: tc.status}
 		st := &mockStore{runs: map[string]*model.Run{"i#r": run}, issues: map[string]*model.Issue{}}
 		feedbackNoted := false
+		var statusChanges []*runevents.StatusChangeEvent
 		server.onRunFeedback = func(*model.Run) { feedbackNoted = true }
+		server.onStatusChange = func(ev *runevents.StatusChangeEvent) {
+			copy := *ev
+			statusChanges = append(statusChanges, &copy)
+		}
 
 		server.markRunFeedbackSent(st, run)
 
 		if got := st.runs["i#r"].Status; got != tc.want {
 			t.Errorf("markRunFeedbackSent from %s: status = %s, want %s", tc.status, got, tc.want)
 		}
-		if wantNoted := tc.want == model.StatusRunning && tc.status != model.StatusRunning; feedbackNoted != wantNoted {
-			t.Errorf("markRunFeedbackSent from %s: feedback noted = %v, want %v", tc.status, feedbackNoted, wantNoted)
+		wantTransition := tc.want == model.StatusRunning && tc.status != model.StatusRunning
+		if feedbackNoted != wantTransition {
+			t.Errorf("markRunFeedbackSent from %s: feedback noted = %v, want %v", tc.status, feedbackNoted, wantTransition)
+		}
+		if wantTransition {
+			if len(statusChanges) != 1 {
+				t.Fatalf("markRunFeedbackSent from %s: listener events = %d, want 1", tc.status, len(statusChanges))
+			}
+			ev := statusChanges[0]
+			if ev.Run != run {
+				t.Fatalf("markRunFeedbackSent from %s: listener received wrong run", tc.status)
+			}
+			if ev.From != tc.status || ev.To != model.StatusRunning {
+				t.Fatalf("markRunFeedbackSent from %s: listener transition = %s -> %s, want %s -> %s",
+					tc.status, ev.From, ev.To, tc.status, model.StatusRunning)
+			}
+			if ev.Source != model.EventSourceUser {
+				t.Fatalf("markRunFeedbackSent from %s: listener source = %s, want %s",
+					tc.status, ev.Source, model.EventSourceUser)
+			}
+			if ev.Store != st {
+				t.Fatalf("markRunFeedbackSent from %s: listener received wrong store", tc.status)
+			}
+		} else if len(statusChanges) != 0 {
+			t.Fatalf("markRunFeedbackSent from %s: listener events = %d, want 0", tc.status, len(statusChanges))
 		}
 	}
 }

--- a/internal/daemon/step.go
+++ b/internal/daemon/step.go
@@ -172,10 +172,6 @@ const (
 	// it back as an obsGitEvidence observation. The policy decides when
 	// evidence is needed; the shell never does.
 	effectGatherGitEvidence
-	// effectFireStatusChange dispatches the run-event listeners (Slack…).
-	// Emitted only on the agent-inference transition, matching historical
-	// behavior (see run-state-machine.md §4 I8).
-	effectFireStatusChange
 	// effectLog / effectDebugLog emit an operator log line.
 	effectLog
 	effectDebugLog
@@ -184,11 +180,10 @@ const (
 type runEffect struct {
 	Kind   effectKind
 	Status model.Status // effectSetStatus
-	From   model.Status // effectFireStatusChange
 	PRURL  string       // effectRecordPR / effectRecordPRClosed
-	Output string       // effectFireStatusChange
+	Output string       // effectSetStatus listener payload context
 	Msg    string       // effectLog / effectDebugLog
-	Reason string       // effectSetStatus / effectFireStatusChange: machine-readable verdict reason
+	Reason string       // effectSetStatus: machine-readable verdict reason (model.AttrStatusReason)
 }
 
 func logEffect(format string, args ...interface{}) runEffect {
@@ -207,6 +202,12 @@ func setStatusEffect(status model.Status) runEffect {
 // attached to the resulting status event (model.AttrStatusReason).
 func setStatusReasonEffect(status model.Status, reason string) runEffect {
 	return runEffect{Kind: effectSetStatus, Status: status, Reason: reason}
+}
+
+// setStatusEffectWithOutput is setStatusEffect carrying the captured output
+// as the listener notification payload.
+func setStatusEffectWithOutput(status model.Status, output string) runEffect {
+	return runEffect{Kind: effectSetStatus, Status: status, Output: output}
 }
 
 // stepRun is the single transition function for the monitor plane:
@@ -467,7 +468,7 @@ func stepCaptured(view runView, core runCore, obs runObservation, now time.Time)
 		effects = append(effects,
 			logEffect("%s#%s: PR created: %s", view.IssueID, view.RunID, prURL),
 			runEffect{Kind: effectRecordPR, PRURL: prURL},
-			setStatusEffect(model.StatusPROpen),
+			setStatusEffectWithOutput(model.StatusPROpen, obs.Output),
 		)
 		return core, effects
 	}
@@ -476,8 +477,7 @@ func stepCaptured(view runView, core runCore, obs runObservation, now time.Time)
 	if newStatus != "" && newStatus != view.Status {
 		effects = append(effects,
 			logEffect("%s#%s: status change %s -> %s", view.IssueID, view.RunID, view.Status, newStatus),
-			setStatusReasonEffect(newStatus, reason),
-			runEffect{Kind: effectFireStatusChange, From: view.Status, Status: newStatus, Output: obs.Output, Reason: reason},
+			runEffect{Kind: effectSetStatus, Status: newStatus, Output: obs.Output, Reason: reason},
 		)
 	}
 


### PR DESCRIPTION
## Summary

- Moves monitor-plane status listener dispatch from the old O4-only `effectFireStatusChange` path into `Daemon.updateStatus` after a successful status append.
- Preserves captured output context on O4-derived status effects so blocked/rate-limited listeners still receive `LastOutput`.
- Bridges feedback resume (`orch send` without `--no-enter`) into the same listener fanout after its legacy append, until O6 is folded into `step()` v2.
- Updates the C4/I8 design docs and roadmap with the new commit-point law.

## Root Cause

Status-change listeners were modeled as a separate `step()` effect that only `stepCaptured` emitted for agent inference. Other committed monitor transitions, such as PR closed/merged and dead-session verdicts, used `updateStatus` but never emitted that listener effect.

```
before:
  O4 capture -> setStatus + fireStatusChange
  O1/O5     -> setStatus only

after:
  any W1 setStatus -> updateStatus -> AppendEvent ok -> fireStatusChange once
  duplicate/no-op  -> no AppendEvent -> no listener
  append failure   -> error        -> no listener
```

## Verification

- `go test -count=1 ./internal/daemon/`
  - passed: validates daemon package including new listener tests.
- `go test ./internal/daemon/ -run 'TestStatusChangeListenersFireOnceForMonitorTransitionPaths|TestUpdateStatusSameStatusIsNoOp|TestUpdateStatusAppendEventError|TestMarkRunFeedbackSentTransitions'`
  - passed: covers agent inference, PR-close terminal transition, dead-session verdict, feedback resume, duplicate no-op, and append failure.
- `make lint`
  - passed: semgrep architecture rules and fixtures passed.
- `go build ./...`
  - passed.

## Additional Check

- `go test ./...` was run and failed outside this change:
  - `internal/monitor`: `TestSessionNameForProject` expects untruncated project-name prefixes, but current output uses shortened names such as `orch-myp-f9a700`.
  - `test/integration`: `TestRunWithBuiltInAgents` failed when opencode session creation returned HTTP 500 (`UnknownError`, ref `err_0c02feb6`).

Issue: `inv-fire-status-change-all`