### PR TITLE
[codex] Consolidate ResolveRun daemon verb

### DIFF
--- a/internal/cli/query_test.go
+++ b/internal/cli/query_test.go
@@ -85,6 +85,9 @@ func (m *mockQueryAPI) CreateRun(ctx context.Context, req *orchapi.CreateRunRequ
 	return nil, nil
 }
 func (m *mockQueryAPI) StopRun(ctx context.Context, ref orchapi.RunRef) error { return nil }
+func (m *mockQueryAPI) MarkRunResolved(ctx context.Context, ref orchapi.RunRef) error {
+	return nil
+}
 func (m *mockQueryAPI) AppendEvent(ctx context.Context, ref orchapi.RunRef, event *orchapi.Event) (*orchapi.AppendEventResult, error) {
 	return nil, nil
 }

--- a/internal/daemon/proto_client.go
+++ b/internal/daemon/proto_client.go
@@ -772,6 +772,33 @@ func (c *ProtoClient) StopRun(issueID, runID string, force bool) (*StopRunRespon
 	}, nil
 }
 
+func (c *ProtoClient) ResolveRun(issueID, runID string) (*ResolveRunResponse, error) {
+	req := &orchpb.Request{
+		Request: &orchpb.Request_ResolveRun{
+			ResolveRun: &orchpb.ResolveRunRequest{
+				IssueId: issueID,
+				RunId:   runID,
+				Context: c.requestContext(c.projectRoot),
+			},
+		},
+	}
+
+	resp, err := c.sendRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.Ok {
+		return nil, fmt.Errorf("daemon error: %s", resp.Error)
+	}
+
+	if resp.GetResolveRun() == nil {
+		return nil, fmt.Errorf("unexpected response type")
+	}
+
+	return &ResolveRunResponse{OK: true}, nil
+}
+
 func (c *ProtoClient) ResolveIssue(issueID string, force bool) (*ResolveIssueResponse, error) {
 	req := &orchpb.Request{
 		Request: &orchpb.Request_ResolveIssue{

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -1851,16 +1851,26 @@ func (s *SocketServer) handleProtoStopRun(req *orchpb.StopRunRequest) *orchpb.Re
 }
 
 func (s *SocketServer) handleProtoResolveRun(req *orchpb.ResolveRunRequest) *orchpb.Response {
+	projectID := projectIDFromContext(req.Context)
 	st := s.resolveStoreFromContextOrProto(req.Context, "")
 	if st == nil {
-		if projectID := projectIDFromContext(req.Context); projectID != "" {
+		if projectID != "" {
 			return errorResponse(fmt.Sprintf("no store available for project_id %q (register daemon project mapping)", projectID))
 		}
 		return errorResponse("no store available")
 	}
 
-	if err := st.SetIssueStatus(model.IssueID(req.IssueId), model.IssueStatusResolved); err != nil {
-		return errorResponse("store_error")
+	run, err := resolveRunForMutation(st, req.IssueId, req.RunId, "")
+	if err != nil || run == nil {
+		return errorResponse(masterRunNotFoundError(projectID, req.IssueId, req.RunId, "", err))
+	}
+
+	if err := appendRunResolvedByUser(st, run); err != nil {
+		return errorResponse(fmt.Sprintf("failed to mark run done in master store for project %q: %v", projectID, err))
+	}
+
+	if err := st.SetIssueStatus(run.IssueID, model.IssueStatusResolved); err != nil {
+		return errorResponse(fmt.Sprintf("failed to resolve issue %s: %v", run.IssueID, err))
 	}
 
 	return &orchpb.Response{

--- a/internal/daemon/proto_handler_test.go
+++ b/internal/daemon/proto_handler_test.go
@@ -22,6 +22,57 @@ type waitForRunsStatusStore struct {
 	calls int
 }
 
+type resolveRunTestStore struct {
+	mockStore
+	appendErr          error
+	setIssueErr        error
+	latestRun          *model.Run
+	appendCalls        []resolveRunAppendCall
+	setIssueStatusCall []resolveRunSetIssueStatusCall
+}
+
+type resolveRunAppendCall struct {
+	ref   model.RunRef
+	event *model.Event
+}
+
+type resolveRunSetIssueStatusCall struct {
+	issueID model.IssueID
+	status  model.IssueStatus
+}
+
+func (s *resolveRunTestStore) GetRun(ref *model.RunRef) (*model.Run, error) {
+	if ref == nil {
+		return nil, fmt.Errorf("run reference required")
+	}
+	if ref.IsLatest() {
+		return s.GetLatestRun(ref.IssueID)
+	}
+	return s.mockStore.GetRun(ref)
+}
+
+func (s *resolveRunTestStore) GetLatestRun(issueID model.IssueID) (*model.Run, error) {
+	if s.latestRun != nil && s.latestRun.IssueID == issueID {
+		return s.latestRun, nil
+	}
+	return nil, fmt.Errorf("no runs found for issue: %s", issueID)
+}
+
+func (s *resolveRunTestStore) AppendEvent(ref *model.RunRef, event *model.Event) error {
+	if ref != nil && event != nil {
+		s.appendCalls = append(s.appendCalls, resolveRunAppendCall{ref: *ref, event: event})
+	}
+	if s.appendErr != nil {
+		return s.appendErr
+	}
+	return s.mockStore.AppendEvent(ref, event)
+}
+
+func (s *resolveRunTestStore) SetIssueStatus(issueID model.IssueID, status model.IssueStatus) error {
+	s.setIssueStatusCall = append(s.setIssueStatusCall, resolveRunSetIssueStatusCall{issueID: issueID, status: status})
+	return s.setIssueErr
+}
+
 func (s *waitForRunsStatusStore) GetRun(ref *model.RunRef) (*model.Run, error) {
 	if s.run == nil || ref == nil || ref.String() != s.run.Ref().String() {
 		return nil, fmt.Errorf("run not found")
@@ -42,6 +93,143 @@ func (l *timingTestLogger) Printf(format string, v ...interface{}) {
 
 func (l *timingTestLogger) String() string {
 	return l.buf.String()
+}
+
+func newResolveRunHandlerTestServer(t *testing.T, st *resolveRunTestStore) (*SocketServer, *orchpb.RequestContext) {
+	t.Helper()
+
+	server := NewSocketServer(nil, nil)
+	registerRepoContextForTest(t, server, "project-resolve-run", t.TempDir(), st)
+	return server, &orchpb.RequestContext{ProjectId: "project-resolve-run"}
+}
+
+func TestHandleProtoResolveRunAppendsDoneAndResolvesIssue(t *testing.T) {
+	run := &model.Run{IssueID: "orch-1", RunID: "run-1", Status: model.StatusRunning}
+	st := &resolveRunTestStore{
+		mockStore: mockStore{runs: map[string]*model.Run{run.Ref().String(): run}},
+	}
+	server, ctx := newResolveRunHandlerTestServer(t, st)
+
+	resp := server.handleProtoResolveRun(&orchpb.ResolveRunRequest{
+		IssueId: string(run.IssueID),
+		RunId:   string(run.RunID),
+		Context: ctx,
+	})
+
+	if !resp.Ok {
+		t.Fatalf("handleProtoResolveRun() ok=false error=%q", resp.Error)
+	}
+	if run.Status != model.StatusDone {
+		t.Fatalf("run.Status = %q, want %q", run.Status, model.StatusDone)
+	}
+	if len(st.appendCalls) != 1 {
+		t.Fatalf("append call count = %d, want 1", len(st.appendCalls))
+	}
+	call := st.appendCalls[0]
+	if call.ref.IssueID != run.IssueID || call.ref.RunID != run.RunID {
+		t.Fatalf("append ref = %s, want %s", call.ref.String(), run.Ref().String())
+	}
+	if call.event.Type != model.EventTypeStatus || call.event.Name != string(model.StatusDone) {
+		t.Fatalf("append event = %s/%s, want status/done", call.event.Type, call.event.Name)
+	}
+	if got := call.event.Attrs["source"]; got != string(model.EventSourceUser) {
+		t.Fatalf("append event source = %q, want %q", got, model.EventSourceUser)
+	}
+	if len(st.setIssueStatusCall) != 1 {
+		t.Fatalf("set issue status call count = %d, want 1", len(st.setIssueStatusCall))
+	}
+	if got := st.setIssueStatusCall[0]; got.issueID != run.IssueID || got.status != model.IssueStatusResolved {
+		t.Fatalf("set issue status = %s/%s, want %s/%s", got.issueID, got.status, run.IssueID, model.IssueStatusResolved)
+	}
+}
+
+func TestHandleProtoResolveRunTerminalOnlyResolvesIssue(t *testing.T) {
+	run := &model.Run{IssueID: "orch-2", RunID: "run-2", Status: model.StatusDone}
+	st := &resolveRunTestStore{
+		mockStore: mockStore{runs: map[string]*model.Run{run.Ref().String(): run}},
+	}
+	server, ctx := newResolveRunHandlerTestServer(t, st)
+
+	resp := server.handleProtoResolveRun(&orchpb.ResolveRunRequest{
+		IssueId: string(run.IssueID),
+		RunId:   string(run.RunID),
+		Context: ctx,
+	})
+
+	if !resp.Ok {
+		t.Fatalf("handleProtoResolveRun() ok=false error=%q", resp.Error)
+	}
+	if len(st.appendCalls) != 0 {
+		t.Fatalf("append call count = %d, want 0 for terminal run", len(st.appendCalls))
+	}
+	if len(st.setIssueStatusCall) != 1 {
+		t.Fatalf("set issue status call count = %d, want 1", len(st.setIssueStatusCall))
+	}
+	if got := st.setIssueStatusCall[0]; got.issueID != run.IssueID || got.status != model.IssueStatusResolved {
+		t.Fatalf("set issue status = %s/%s, want %s/%s", got.issueID, got.status, run.IssueID, model.IssueStatusResolved)
+	}
+}
+
+func TestHandleProtoResolveRunAppendFailureFailsResponse(t *testing.T) {
+	run := &model.Run{IssueID: "orch-3", RunID: "run-3", Status: model.StatusRunning}
+	st := &resolveRunTestStore{
+		mockStore: mockStore{runs: map[string]*model.Run{run.Ref().String(): run}},
+		appendErr: errors.New("append boom"),
+	}
+	server, ctx := newResolveRunHandlerTestServer(t, st)
+
+	resp := server.handleProtoResolveRun(&orchpb.ResolveRunRequest{
+		IssueId: string(run.IssueID),
+		RunId:   string(run.RunID),
+		Context: ctx,
+	})
+
+	if resp.Ok {
+		t.Fatal("handleProtoResolveRun() ok=true, want failure")
+	}
+	if !strings.Contains(resp.Error, "failed to mark run done") || !strings.Contains(resp.Error, "append boom") {
+		t.Fatalf("error = %q, want append failure detail", resp.Error)
+	}
+	if len(st.setIssueStatusCall) != 0 {
+		t.Fatalf("set issue status call count = %d, want 0 after append failure", len(st.setIssueStatusCall))
+	}
+	if run.Status != model.StatusRunning {
+		t.Fatalf("run.Status = %q, want unchanged %q", run.Status, model.StatusRunning)
+	}
+}
+
+func TestHandleProtoResolveRunEmptyRunIDResolvesLatestRun(t *testing.T) {
+	older := &model.Run{IssueID: "orch-4", RunID: "run-1", Status: model.StatusRunning}
+	latest := &model.Run{IssueID: "orch-4", RunID: "run-2", Status: model.StatusWaiting}
+	st := &resolveRunTestStore{
+		mockStore: mockStore{runs: map[string]*model.Run{
+			older.Ref().String():  older,
+			latest.Ref().String(): latest,
+		}},
+		latestRun: latest,
+	}
+	server, ctx := newResolveRunHandlerTestServer(t, st)
+
+	resp := server.handleProtoResolveRun(&orchpb.ResolveRunRequest{
+		IssueId: string(latest.IssueID),
+		Context: ctx,
+	})
+
+	if !resp.Ok {
+		t.Fatalf("handleProtoResolveRun() ok=false error=%q", resp.Error)
+	}
+	if latest.Status != model.StatusDone {
+		t.Fatalf("latest.Status = %q, want %q", latest.Status, model.StatusDone)
+	}
+	if older.Status != model.StatusRunning {
+		t.Fatalf("older.Status = %q, want unchanged %q", older.Status, model.StatusRunning)
+	}
+	if len(st.appendCalls) != 1 || st.appendCalls[0].ref.RunID != latest.RunID {
+		t.Fatalf("append calls = %+v, want exactly latest run %s", st.appendCalls, latest.RunID)
+	}
+	if len(st.setIssueStatusCall) != 1 || st.setIssueStatusCall[0].issueID != latest.IssueID {
+		t.Fatalf("set issue status calls = %+v, want latest issue %s", st.setIssueStatusCall, latest.IssueID)
+	}
 }
 
 func TestDaemonListRunsTimingEnabled(t *testing.T) {

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -4967,6 +4967,24 @@ func appendRunCanceledByUser(st store.Store, run *model.Run) error {
 	return st.AppendEvent(ref, event)
 }
 
+func appendRunResolvedByUser(st store.Store, run *model.Run) error {
+	if st == nil {
+		return fmt.Errorf("store required")
+	}
+	if run == nil {
+		return fmt.Errorf("run required")
+	}
+	if run.Status == model.StatusDone || run.Status == model.StatusFailed || run.Status == model.StatusCanceled {
+		return nil
+	}
+
+	ref := &model.RunRef{IssueID: run.IssueID, RunID: run.RunID}
+	event := model.NewEvent(model.EventTypeStatus, string(model.StatusDone), map[string]string{ // nosemgrep: run-status-write-surface
+		"source": string(model.EventSourceUser),
+	})
+	return st.AppendEvent(ref, event)
+}
+
 func (s *SocketServer) handleResolveIssue(req SendRequest, encoder *json.Encoder) {
 	if req.IssueID == "" {
 		encoder.Encode(ResolveIssueResponse{OK: false, Error: "invalid_request: issue_id required"})

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -766,6 +766,11 @@ type StopRunResponse struct {
 	StoppedCount int      `json:"stopped_count"`
 }
 
+type ResolveRunResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
 type ResolveIssueResponse struct {
 	OK      bool   `json:"ok"`
 	Error   string `json:"error,omitempty"`

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -738,16 +738,8 @@ func (m *Monitor) ResolveRun(run *model.Run) error {
 	ctx := context.Background()
 	ref := orchapi.RunRef{IssueID: run.IssueID, RunID: run.RunID}
 
-	if !run.Status.IsTerminal() {
-		// Frozen client-plane status writer: scheduled to become a daemon API
-		// verb (coupling-core roadmap Phase B3). Do not copy this pattern.
-		if _, err := m.api.AppendEvent(ctx, ref, &orchapi.Event{Type: "status", Name: string(model.StatusDone)}); err != nil { // nosemgrep: run-status-write-surface
-			return fmt.Errorf("failed to mark run as done: %w", err)
-		}
-	}
-
-	if err := m.api.SetIssueStatus(ctx, run.IssueID, orchapi.IssueStatusResolved); err != nil {
-		return fmt.Errorf("failed to resolve issue: %w", err)
+	if err := m.api.MarkRunResolved(ctx, ref); err != nil {
+		return fmt.Errorf("failed to resolve run: %w", err)
 	}
 
 	return nil

--- a/internal/monitor/monitor_test.go
+++ b/internal/monitor/monitor_test.go
@@ -85,6 +85,8 @@ func TestBuildIssueDisplayMap(t *testing.T) {
 }
 
 func TestSessionNameForProject(t *testing.T) {
+	t.Setenv("ZELLIJ_SOCKET_DIR", "/tmp/zellij-test")
+
 	tests := []struct {
 		name        string
 		projectPath string

--- a/internal/orchapi/api.go
+++ b/internal/orchapi/api.go
@@ -101,6 +101,9 @@ type OrchAPI interface {
 	// Sends interrupt to the agent and records cancel status.
 	StopRun(ctx context.Context, ref RunRef) error
 
+	// MarkRunResolved marks a run done when it is non-terminal and resolves its issue.
+	MarkRunResolved(ctx context.Context, ref RunRef) error
+
 	// AppendEvent appends an event to a run's event log.
 	AppendEvent(ctx context.Context, ref RunRef, event *Event) (*AppendEventResult, error)
 

--- a/internal/orchapi/daemon_client.go
+++ b/internal/orchapi/daemon_client.go
@@ -310,6 +310,15 @@ func (c *DaemonClient) StopRun(ctx context.Context, ref RunRef) error {
 	return err
 }
 
+func (c *DaemonClient) MarkRunResolved(ctx context.Context, ref RunRef) error {
+	run, err := c.ResolveRun(ctx, ref)
+	if err != nil {
+		return err
+	}
+	_, err = c.proto.ResolveRun(string(run.IssueID), string(run.RunID))
+	return err
+}
+
 func (c *DaemonClient) AppendEvent(ctx context.Context, ref RunRef, event *Event) (*AppendEventResult, error) {
 	run, err := c.ResolveRun(ctx, ref)
 	if err != nil {

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -83,6 +83,9 @@ func (m *mockAPI) CreateRun(ctx context.Context, req *orchapi.CreateRunRequest) 
 	return nil, nil
 }
 func (m *mockAPI) StopRun(ctx context.Context, ref orchapi.RunRef) error { return nil }
+func (m *mockAPI) MarkRunResolved(ctx context.Context, ref orchapi.RunRef) error {
+	return nil
+}
 func (m *mockAPI) AppendEvent(ctx context.Context, ref orchapi.RunRef, event *orchapi.Event) (*orchapi.AppendEventResult, error) {
 	return nil, nil
 }

--- a/internal/testutil/mock_orchapi.go
+++ b/internal/testutil/mock_orchapi.go
@@ -86,6 +86,9 @@ var _ orchapi.OrchAPI = &OrchAPIMock{}
 //			ListRunsFunc: func(ctx context.Context, filter *orchapi.ListRunsFilter) (*orchapi.ListRunsResult, error) {
 //				panic("mock out the ListRuns method")
 //			},
+//			MarkRunResolvedFunc: func(ctx context.Context, ref orchapi.RunRef) error {
+//				panic("mock out the MarkRunResolved method")
+//			},
 //			PingFunc: func(ctx context.Context) error {
 //				panic("mock out the Ping method")
 //			},
@@ -209,6 +212,9 @@ type OrchAPIMock struct {
 
 	// ListRunsFunc mocks the ListRuns method.
 	ListRunsFunc func(ctx context.Context, filter *orchapi.ListRunsFilter) (*orchapi.ListRunsResult, error)
+
+	// MarkRunResolvedFunc mocks the MarkRunResolved method.
+	MarkRunResolvedFunc func(ctx context.Context, ref orchapi.RunRef) error
 
 	// PingFunc mocks the Ping method.
 	PingFunc func(ctx context.Context) error
@@ -421,6 +427,13 @@ type OrchAPIMock struct {
 			// Filter is the filter argument value.
 			Filter *orchapi.ListRunsFilter
 		}
+		// MarkRunResolved holds details about calls to the MarkRunResolved method.
+		MarkRunResolved []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Ref is the ref argument value.
+			Ref orchapi.RunRef
+		}
 		// Ping holds details about calls to the Ping method.
 		Ping []struct {
 			// Ctx is the ctx argument value.
@@ -579,6 +592,7 @@ type OrchAPIMock struct {
 	lockInjectInitialPrompt  sync.RWMutex
 	lockListIssues           sync.RWMutex
 	lockListRuns             sync.RWMutex
+	lockMarkRunResolved      sync.RWMutex
 	lockPing                 sync.RWMutex
 	lockQueryOpenCodeServer  sync.RWMutex
 	lockReadAgentPrompt      sync.RWMutex
@@ -1395,6 +1409,42 @@ func (mock *OrchAPIMock) ListRunsCalls() []struct {
 	mock.lockListRuns.RLock()
 	calls = mock.calls.ListRuns
 	mock.lockListRuns.RUnlock()
+	return calls
+}
+
+// MarkRunResolved calls MarkRunResolvedFunc.
+func (mock *OrchAPIMock) MarkRunResolved(ctx context.Context, ref orchapi.RunRef) error {
+	if mock.MarkRunResolvedFunc == nil {
+		panic("OrchAPIMock.MarkRunResolvedFunc: method is nil but OrchAPI.MarkRunResolved was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		Ref orchapi.RunRef
+	}{
+		Ctx: ctx,
+		Ref: ref,
+	}
+	mock.lockMarkRunResolved.Lock()
+	mock.calls.MarkRunResolved = append(mock.calls.MarkRunResolved, callInfo)
+	mock.lockMarkRunResolved.Unlock()
+	return mock.MarkRunResolvedFunc(ctx, ref)
+}
+
+// MarkRunResolvedCalls gets all the calls that were made to MarkRunResolved.
+// Check the length with:
+//
+//	len(mockedOrchAPI.MarkRunResolvedCalls())
+func (mock *OrchAPIMock) MarkRunResolvedCalls() []struct {
+	Ctx context.Context
+	Ref orchapi.RunRef
+} {
+	var calls []struct {
+		Ctx context.Context
+		Ref orchapi.RunRef
+	}
+	mock.lockMarkRunResolved.RLock()
+	calls = mock.calls.MarkRunResolved
+	mock.lockMarkRunResolved.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
## Summary

- Moves `ResolveRun` run-status mutation into the daemon: non-terminal runs get `done(source=user)` before the issue is marked resolved.
- Adds `ProtoClient.ResolveRun` and `OrchAPI.MarkRunResolved`, then updates the Go TUI to call the daemon verb instead of appending status client-side.
- Adds focused handler tests for non-terminal, terminal, append-failure, and empty-`RunId` latest-run behavior.
- Updates generated and hand-written test mocks for the new API method.
- Stabilizes `TestSessionNameForProject` by fixing its socket-dir environment; long zellij socket paths remain covered by the dedicated regression test.

Reference: `inv-resolve-run-verb`

## Acceptance Evidence

- `ResolveRun(issue, run)` now appends `done(source=user)` for non-terminal runs and then resolves the issue in daemon handler tests.
- Terminal runs skip the append and still resolve the issue.
- Append failure returns an error response and does not partially resolve the issue.
- Empty `RunId` resolves the latest run for the issue.
- No proto file changes.
- `nosemgrep: run-status-write-surface` total did not increase: diff is one new sanctioned daemon helper annotation and one removed TUI client-writer annotation; current total command result is `48`.

## Verification

- `go build ./...` passed.
- `go test ./internal/daemon/ ./internal/monitor/` passed.
- `make lint` passed.
- `go test ./internal/cli ./internal/query` passed after updating hand-written mocks.

Additional full-suite note: `go test ./...` compiles and passes ordinary packages, but `test/integration` still fails in `TestRunWithBuiltInAgents` because OpenCode session creation returns HTTP 500 from the OpenCode server (`failed to create opencode session: create session returned status 500`).