### PR TITLE
feat(daemon): machine-readable reason on unknown verdicts (k8s phase+reason pattern)

### DIFF
--- a/.semgrep/run-status-write-surface/run_status_write_surface.go
+++ b/.semgrep/run-status-write-surface/run_status_write_surface.go
@@ -9,6 +9,11 @@ func badConstructStatusEvent() {
 	_ = model.NewStatusEvent(model.StatusRunning)
 }
 
+func badConstructStatusEventWithReason() {
+	// ruleid: run-status-write-surface
+	_ = model.NewStatusEventWithReason(model.StatusUnknown, model.StatusReasonNeverAlive)
+}
+
 func badConstructViaNewEvent() {
 	// ruleid: run-status-write-surface
 	_ = model.NewEvent(model.EventTypeStatus, "done", nil)

--- a/.semgrep/run-status-write-surface/run_status_write_surface.yaml
+++ b/.semgrep/run-status-write-surface/run_status_write_surface.yaml
@@ -2,6 +2,7 @@ rules:
   - id: run-status-write-surface
     pattern-either:
       - pattern: model.NewStatusEvent(...)
+      - pattern: model.NewStatusEventWithReason(...)
       - pattern: model.NewEvent(model.EventTypeStatus, ...)
       - pattern: model.NewEvent("status", ...)
       - pattern-regex: 'Type:\s*"status"'
@@ -31,6 +32,7 @@ rules:
   - id: no-ignored-status-append
     pattern-either:
       - pattern: _ = $ST.AppendEvent($REF, model.NewStatusEvent(...))
+      - pattern: _ = $ST.AppendEvent($REF, model.NewStatusEventWithReason(...))
       - pattern: _ = $ST.AppendEvent($REF, model.NewEvent(model.EventTypeStatus, ...))
       - pattern: _, _ = $API.AppendEvent(...)
     paths:

--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -209,6 +209,22 @@ distinction the law tests themselves forced:
 | L5 verdict requires evidence | `obsSessionGone` never emits a status directly; it requests git evidence exactly when the dead-check threshold is reached |
 | L6 debounce | `waiting` via prompt requires ≥ `waitingPromptStreakThreshold` consecutive prompt observations; any busy capture resets the streak |
 
+### Status reasons (verdict payload)
+
+The status vocabulary is a closed set; *why* an `unknown` verdict was reached
+travels as a machine-readable `reason` attribute on the status event
+(`model.AttrStatusReason` — the k8s `phase`+`reason` pattern). Every
+`unknown` verdict emitted by `step()` carries one:
+
+| reason | emitted by | operator response |
+|--------|-----------|-------------------|
+| `never_alive` | L3' grace expiry, either plane | infrastructure problem (binary/auth/mux env); fix the host before retrying |
+| `session_lost` | opencode session not found after dead checks | backend lost observability; backend-specific triage |
+| `agent_exited` | capture verdict: process exited, shell prompt showing | check transcript/worktree; retry plausible |
+
+`orch ps` renders the reason inline (`unknown(never_alive)`); the event log
+carries it as `reason=…`; `StatusChangeEvent.Reason` exposes it to listeners.
+
 L1/L4 fix the 5,830-duplicate-event class structurally; L2 is the law the
 PR #458 inference fixes were converging toward; restart transparency (I2)
 remains an open law until monitor state is derived from the event log

--- a/internal/cli/ps.go
+++ b/internal/cli/ps.go
@@ -519,7 +519,7 @@ func outputJSONWithIssueInfo(
 			ModelVariant:      r.ModelVariant,
 			Target:            target,
 			TargetHost:        targetHost,
-			Status:            string(r.Status),
+			Status:            statusWithReason(r),
 			AgentStatus:       shortAgentStatus(r.Status),
 			BranchStatus:      branchStatus,
 			PRStatus:          prStatusFromRun(r, branchStateByRun[runKey]),
@@ -841,6 +841,16 @@ func shortAgentStatus(status model.Status) string {
 	default:
 		return "?"
 	}
+}
+
+// statusWithReason renders the run status with its machine-readable verdict
+// reason when one was recorded, e.g. "unknown(never_alive)" — so triage from
+// `orch ps` does not require opening the run record.
+func statusWithReason(r *model.Run) string {
+	if reason := r.StatusReason(); reason != "" {
+		return fmt.Sprintf("%s(%s)", r.Status, reason)
+	}
+	return string(r.Status)
 }
 
 func prStatusFromRun(r *model.Run, gitState string) string {

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -206,7 +206,7 @@ func (d *Daemon) applyRunEffects(run *model.Run, st store.Store, oldCore, core r
 				return core, err
 			}
 		case effectSetStatus:
-			if err := d.updateStatus(run, e.Status, st); err != nil {
+			if err := d.updateStatus(run, e.Status, e.Reason, st); err != nil {
 				statusWriteFailed = true
 				if firstErr == nil {
 					firstErr = err
@@ -220,6 +220,7 @@ func (d *Daemon) applyRunEffects(run *model.Run, st store.Store, oldCore, core r
 				Run:        run,
 				From:       e.From,
 				To:         e.Status,
+				Reason:     e.Reason,
 				Source:     model.EventSourceDaemon,
 				LastOutput: e.Output,
 				Store:      st,
@@ -510,7 +511,9 @@ func isConnectionRefusedError(err error) bool {
 // updateStatus is the single executor for status transitions (effectSetStatus).
 // It re-checks the authoritative store state beneath the stepRun matrix:
 // terminal protection, transition legality, and the same-status no-op.
-func (d *Daemon) updateStatus(run *model.Run, status model.Status, st store.Store) error {
+// reason, when non-empty, is recorded on the status event as the
+// machine-readable verdict reason (model.AttrStatusReason).
+func (d *Daemon) updateStatus(run *model.Run, status model.Status, reason string, st store.Store) error {
 	ref := &model.RunRef{IssueID: run.IssueID, RunID: run.RunID}
 
 	// Check current status - daemon cannot overwrite terminal states
@@ -534,7 +537,7 @@ func (d *Daemon) updateStatus(run *model.Run, status model.Status, st store.Stor
 	// (docs/design/run-state-machine.md). All other status writers are
 	// frozen legacy, enumerated by `nosemgrep: run-status-write-surface`
 	// annotations, and shrink toward zero (coupling-core roadmap Phase B).
-	event := model.NewStatusEvent(status) // nosemgrep: run-status-write-surface
+	event := model.NewStatusEventWithReason(status, reason) // nosemgrep: run-status-write-surface
 	if err := st.AppendEvent(ref, event); err != nil {
 		return err
 	}

--- a/internal/daemon/monitor_publish_test.go
+++ b/internal/daemon/monitor_publish_test.go
@@ -57,7 +57,7 @@ func TestUpdateStatus_PublishesTransitionToBus(t *testing.T) {
 		t.Fatalf("seeded status not running: %q", current.Status)
 	}
 
-	if err := d.updateStatus(current, model.StatusWaiting, st); err != nil {
+	if err := d.updateStatus(current, model.StatusWaiting, "", st); err != nil {
 		t.Fatalf("updateStatus: %v", err)
 	}
 
@@ -121,7 +121,7 @@ func TestUpdateStatus_SkipsRedundantPublish(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetRun: %v", err)
 	}
-	if err := d.updateStatus(current, model.StatusPROpen, st); err != nil {
+	if err := d.updateStatus(current, model.StatusPROpen, "", st); err != nil {
 		t.Fatalf("updateStatus: %v", err)
 	}
 

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -134,6 +134,7 @@ type mockStoreForUpdate struct {
 		status  model.IssueStatus
 	}
 	appendEventCalls int
+	lastAppendedEvent *model.Event
 }
 
 func (m *mockStoreForUpdate) ResolveIssue(issueID model.IssueID) (*model.Issue, error) {
@@ -153,6 +154,7 @@ func (m *mockStoreForUpdate) SetIssueStatus(issueID model.IssueID, status model.
 
 func (m *mockStoreForUpdate) AppendEvent(ref *model.RunRef, event *model.Event) error {
 	m.appendEventCalls++
+	m.lastAppendedEvent = event
 	return m.appendEventErr
 }
 
@@ -194,18 +196,50 @@ func TestUpdateStatusSameStatusIsNoOp(t *testing.T) {
 		run:                run,
 	}
 
-	if err := d.updateStatus(run, model.StatusUnknown, st); err != nil {
+	if err := d.updateStatus(run, model.StatusUnknown, "", st); err != nil {
 		t.Fatalf("updateStatus() error = %v", err)
 	}
 	if st.appendEventCalls != 0 {
 		t.Fatalf("re-affirming the current status must not append events, got %d", st.appendEventCalls)
 	}
 
-	if err := d.updateStatus(run, model.StatusPROpen, st); err != nil {
+	if err := d.updateStatus(run, model.StatusPROpen, "", st); err != nil {
 		t.Fatalf("updateStatus() error = %v", err)
 	}
 	if st.appendEventCalls != 1 {
 		t.Fatalf("expected a real transition to append one event, got %d", st.appendEventCalls)
+	}
+}
+
+// updateStatus persists the verdict reason as the status event's
+// model.AttrStatusReason attribute (run-state-machine.md §5 "Status reasons").
+func TestUpdateStatusPersistsReason(t *testing.T) {
+	d := newTestDaemon()
+	run := &model.Run{IssueID: "i1", RunID: "r1", Status: model.StatusRunning}
+	st := &mockStoreWithRun{
+		mockStoreForUpdate: mockStoreForUpdate{issue: &model.Issue{ID: "i1", Status: model.IssueStatusOpen}},
+		run:                run,
+	}
+
+	if err := d.updateStatus(run, model.StatusUnknown, model.StatusReasonNeverAlive, st); err != nil {
+		t.Fatalf("updateStatus() error = %v", err)
+	}
+	ev := st.lastAppendedEvent
+	if ev == nil || ev.Type != model.EventTypeStatus {
+		t.Fatalf("expected a status event append, got %+v", ev)
+	}
+	if got := ev.Attrs[model.AttrStatusReason]; got != model.StatusReasonNeverAlive {
+		t.Fatalf("status event reason = %q, want %q", got, model.StatusReasonNeverAlive)
+	}
+
+	// An empty reason must not introduce an attrs map entry.
+	run2 := &model.Run{IssueID: "i1", RunID: "r2", Status: model.StatusRunning}
+	st.run = run2
+	if err := d.updateStatus(run2, model.StatusWaiting, "", st); err != nil {
+		t.Fatalf("updateStatus() error = %v", err)
+	}
+	if _, ok := st.lastAppendedEvent.Attrs[model.AttrStatusReason]; ok {
+		t.Fatalf("empty reason must not write a reason attribute, got %+v", st.lastAppendedEvent.Attrs)
 	}
 }
 
@@ -298,7 +332,7 @@ func TestUpdateStatusAutoResolve(t *testing.T) {
 			}
 			run := &model.Run{IssueID: "test-issue", RunID: "run-1"}
 
-			err := d.updateStatus(run, tt.status, st)
+			err := d.updateStatus(run, tt.status, "", st)
 			if err != nil {
 				t.Fatalf("updateStatus() error = %v", err)
 			}
@@ -327,7 +361,7 @@ func TestUpdateStatusSetIssueStatusErrorSwallowed(t *testing.T) {
 	}
 	run := &model.Run{IssueID: "test-issue", RunID: "run-1"}
 
-	err := d.updateStatus(run, model.StatusDone, st)
+	err := d.updateStatus(run, model.StatusDone, "", st)
 	if err != nil {
 		t.Fatalf("updateStatus() should not fail when SetIssueStatus fails, got error = %v", err)
 	}
@@ -344,7 +378,7 @@ func TestUpdateStatusAppendEventError(t *testing.T) {
 	}
 	run := &model.Run{IssueID: "test-issue", RunID: "run-1"}
 
-	err := d.updateStatus(run, model.StatusDone, st)
+	err := d.updateStatus(run, model.StatusDone, "", st)
 	if err == nil {
 		t.Fatal("updateStatus() should fail when AppendEvent fails")
 	}

--- a/internal/daemon/step.go
+++ b/internal/daemon/step.go
@@ -188,6 +188,7 @@ type runEffect struct {
 	PRURL  string       // effectRecordPR / effectRecordPRClosed
 	Output string       // effectFireStatusChange
 	Msg    string       // effectLog / effectDebugLog
+	Reason string       // effectSetStatus / effectFireStatusChange: machine-readable verdict reason
 }
 
 func logEffect(format string, args ...interface{}) runEffect {
@@ -200,6 +201,12 @@ func debugEffect(format string, args ...interface{}) runEffect {
 
 func setStatusEffect(status model.Status) runEffect {
 	return runEffect{Kind: effectSetStatus, Status: status}
+}
+
+// setStatusReasonEffect is setStatusEffect with a machine-readable reason
+// attached to the resulting status event (model.AttrStatusReason).
+func setStatusReasonEffect(status model.Status, reason string) runEffect {
+	return runEffect{Kind: effectSetStatus, Status: status, Reason: reason}
 }
 
 // stepRun is the single transition function for the monitor plane:
@@ -328,7 +335,7 @@ func stepGitEvidence(view runView, core runCore, obs runObservation, now time.Ti
 			if view.Status != model.StatusUnknown {
 				effects = append(effects, logEffect("%s#%s: remote agent never confirmed alive after %d checks, marking unknown", view.IssueID, view.RunID, core.DeadCheckCount))
 			}
-			effects = append(effects, setStatusEffect(model.StatusUnknown))
+			effects = append(effects, setStatusReasonEffect(model.StatusUnknown, model.StatusReasonNeverAlive))
 			return core, effects
 		}
 		effects = append(effects, logEffect("%s#%s: remote agent confirmed dead after %d checks, marking failed", view.IssueID, view.RunID, core.DeadCheckCount))
@@ -352,13 +359,13 @@ func stepGitEvidence(view runView, core runCore, obs runObservation, now time.Ti
 		if view.Status != model.StatusUnknown {
 			effects = append(effects, logEffect("%s#%s: agent never confirmed alive after %d checks, marking unknown", view.IssueID, view.RunID, core.DeadCheckCount))
 		}
-		effects = append(effects, setStatusEffect(model.StatusUnknown))
+		effects = append(effects, setStatusReasonEffect(model.StatusUnknown, model.StatusReasonNeverAlive))
 		return core, effects
 	}
 
 	if view.Agent == "opencode" {
 		effects = append(effects, logEffect("%s#%s: opencode session not found after %d checks, marking unknown", view.IssueID, view.RunID, core.DeadCheckCount))
-		effects = append(effects, setStatusEffect(model.StatusUnknown))
+		effects = append(effects, setStatusReasonEffect(model.StatusUnknown, model.StatusReasonSessionLost))
 		return core, effects
 	}
 	effects = append(effects, logEffect("%s#%s: agent confirmed dead after %d checks, marking failed", view.IssueID, view.RunID, core.DeadCheckCount))
@@ -465,12 +472,12 @@ func stepCaptured(view runView, core runCore, obs runObservation, now time.Time)
 		return core, effects
 	}
 
-	newStatus := agentVerdict(view, obs.Signal, outputChanged, hasStablePrompt)
+	newStatus, reason := agentVerdict(view, obs.Signal, outputChanged, hasStablePrompt)
 	if newStatus != "" && newStatus != view.Status {
 		effects = append(effects,
 			logEffect("%s#%s: status change %s -> %s", view.IssueID, view.RunID, view.Status, newStatus),
-			setStatusEffect(newStatus),
-			runEffect{Kind: effectFireStatusChange, From: view.Status, Status: newStatus, Output: obs.Output},
+			setStatusReasonEffect(newStatus, reason),
+			runEffect{Kind: effectFireStatusChange, From: view.Status, Status: newStatus, Output: obs.Output, Reason: reason},
 		)
 	}
 
@@ -480,25 +487,27 @@ func stepCaptured(view runView, core runCore, obs runObservation, now time.Time)
 // agentVerdict applies the agent-specific reading of a captured output. For
 // resolved signals (opencode) the gatherer already produced the verdict; for
 // mux agents the historical MuxManager.GetStatus precedence applies.
-func agentVerdict(view runView, sig agentSignal, outputChanged, hasStablePrompt bool) model.Status {
+// The second return value is the machine-readable reason for the verdict
+// (model.AttrStatusReason); empty for self-explanatory statuses.
+func agentVerdict(view runView, sig agentSignal, outputChanged, hasStablePrompt bool) (model.Status, string) {
 	if sig.Resolved {
-		return sig.Status
+		return sig.Status, ""
 	}
 	switch {
 	case sig.Exited:
-		return model.StatusUnknown
+		return model.StatusUnknown, model.StatusReasonAgentExited
 	case sig.Completed:
-		return model.StatusDone
+		return model.StatusDone, ""
 	case sig.APILimited:
-		return model.StatusRateLimited
+		return model.StatusRateLimited, ""
 	case sig.Failed:
-		return model.StatusFailed
+		return model.StatusFailed, ""
 	case hasStablePrompt:
-		return model.StatusWaiting
+		return model.StatusWaiting, ""
 	case outputChanged:
-		return model.StatusRunning
+		return model.StatusRunning, ""
 	default:
-		return ""
+		return "", ""
 	}
 }
 

--- a/internal/daemon/step_test.go
+++ b/internal/daemon/step_test.go
@@ -341,6 +341,64 @@ func TestStepNeverAliveVerdictAfterGrace(t *testing.T) {
 	}
 }
 
+// Status-reason payload (run-state-machine.md §5 "Status reasons"): every
+// unknown verdict emitted by step() carries a machine-readable reason.
+func TestStepUnknownVerdictsCarryReason(t *testing.T) {
+	now := time.Now()
+	startedAt := now.Add(-2 * neverAliveVerdictGrace)
+
+	unknownReason := func(view runView, core runCore, remote bool) string {
+		t.Helper()
+		for i := 0; i < deadChecksBeforeFailed+1; i++ {
+			var effects []runEffect
+			core, effects = stepRun(view, core, runObservation{Kind: obsSessionGone, Remote: remote}, now)
+			if reason, ok := unknownReasonOf(effects); ok {
+				return reason
+			}
+			view = foldStatus(view, effects)
+			if effectsContain(effects, effectGatherGitEvidence) {
+				core, effects = stepRun(view, core, runObservation{Kind: obsGitEvidence, Remote: remote, Evidence: gitEvidence{RepoRootFound: true}}, now)
+				if reason, ok := unknownReasonOf(effects); ok {
+					return reason
+				}
+				view = foldStatus(view, effects)
+			}
+		}
+		t.Fatalf("no unknown verdict emitted (remote=%t agent=%s)", remote, view.Agent)
+		return ""
+	}
+
+	// L3' never-alive arms, both planes.
+	if got := unknownReason(stepTestView(model.StatusBooting, "codex", startedAt), runCore{}, true); got != model.StatusReasonNeverAlive {
+		t.Fatalf("remote never-alive reason = %q, want %q", got, model.StatusReasonNeverAlive)
+	}
+	if got := unknownReason(stepTestView(model.StatusBooting, "codex", startedAt), runCore{}, false); got != model.StatusReasonNeverAlive {
+		t.Fatalf("local never-alive reason = %q, want %q", got, model.StatusReasonNeverAlive)
+	}
+
+	// opencode session-lost arm (was alive, local plane).
+	if got := unknownReason(stepTestView(model.StatusRunning, "opencode", startedAt), runCore{WasAlive: true}, false); got != model.StatusReasonSessionLost {
+		t.Fatalf("opencode session-lost reason = %q, want %q", got, model.StatusReasonSessionLost)
+	}
+
+	// Capture verdict: agent exited, shell prompt showing.
+	status, reason := agentVerdict(stepTestView(model.StatusRunning, "codex", startedAt), agentSignal{Exited: true}, false, false)
+	if status != model.StatusUnknown || reason != model.StatusReasonAgentExited {
+		t.Fatalf("exited verdict = (%s, %q), want (unknown, %q)", status, reason, model.StatusReasonAgentExited)
+	}
+}
+
+// unknownReasonOf returns the Reason of the first effectSetStatus carrying
+// StatusUnknown, if any.
+func unknownReasonOf(effects []runEffect) (string, bool) {
+	for _, e := range effects {
+		if e.Kind == effectSetStatus && e.Status == model.StatusUnknown {
+			return e.Reason, true
+		}
+	}
+	return "", false
+}
+
 // D-C1 (run-state-machine.md §7): the fold-derivable runCore fields are
 // reconstructed from the event log at monitor registration; the ephemeral
 // counters start at zero.

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -249,6 +249,36 @@ func NewStatusEvent(status Status) *Event {
 	return NewEvent(EventTypeStatus, string(status), nil)
 }
 
+// AttrStatusReason is the event attribute carrying the machine-readable
+// reason for a status verdict. The status vocabulary itself is a closed set;
+// discrimination of *why* a verdict was reached travels as payload, the way
+// Kubernetes keeps `phase` tiny and puts `reason` beside it.
+const AttrStatusReason = "reason"
+
+// Reasons attached to StatusUnknown verdicts (docs/design/run-state-machine.md §5).
+const (
+	// StatusReasonNeverAlive: the agent was never observed alive and the boot
+	// grace expired — an infrastructure problem (binary/auth/mux env); retry
+	// is futile until the host is fixed.
+	StatusReasonNeverAlive = "never_alive"
+	// StatusReasonSessionLost: the agent was alive but the backend lost
+	// observability of its session.
+	StatusReasonSessionLost = "session_lost"
+	// StatusReasonAgentExited: the agent process exited without a verdict,
+	// shell prompt showing — check the transcript/worktree; retry plausible.
+	StatusReasonAgentExited = "agent_exited"
+)
+
+// NewStatusEventWithReason creates a status change event carrying a
+// machine-readable reason attribute. An empty reason degrades to
+// NewStatusEvent.
+func NewStatusEventWithReason(status Status, reason string) *Event {
+	if reason == "" {
+		return NewStatusEvent(status)
+	}
+	return NewEvent(EventTypeStatus, string(status), map[string]string{AttrStatusReason: reason})
+}
+
 // NewPhaseEvent creates a phase change event
 func NewPhaseEvent(phase Phase) *Event {
 	return NewEvent(EventTypePhase, string(phase), nil)

--- a/internal/model/run.go
+++ b/internal/model/run.go
@@ -144,6 +144,19 @@ func (r *Run) GetStatus() (Status, error) {
 	return StatusQueued, nil
 }
 
+// StatusReason derives the machine-readable reason attached to the run's
+// most recent status event (same derivation rule as GetStatus: last status
+// event wins). Empty when the verdict carried no reason.
+func (r *Run) StatusReason() string {
+	for i := len(r.Events) - 1; i >= 0; i-- {
+		e := r.Events[i]
+		if e.Type == EventTypeStatus {
+			return e.Attrs[AttrStatusReason]
+		}
+	}
+	return ""
+}
+
 // GetPhase derives phase from events (last phase event wins).
 func (r *Run) GetPhase() Phase {
 	for i := len(r.Events) - 1; i >= 0; i-- {

--- a/internal/runevents/listener.go
+++ b/internal/runevents/listener.go
@@ -24,6 +24,7 @@ type StatusChangeEvent struct {
 	Run        *model.Run
 	From       model.Status
 	To         model.Status
+	Reason     string // machine-readable verdict reason (model.AttrStatusReason); may be empty
 	Source     model.EventSource
 	LastOutput string
 	Store      store.Store


### PR DESCRIPTION
Implements the owner-approved design from [#467 review comment](https://github.com/proboscis/orch/pull/467#issuecomment-4691874306): a bare `unknown` is uninformative — the verdict now carries a machine-readable `reason` attribute, while the status vocabulary itself stays closed (it is the coupling core; discrimination is payload, exactly as k8s keeps `phase` tiny and puts `reason` beside it).

## What

| reason | emitted by | operator response |
|--------|-----------|-------------------|
| `never_alive` | L3' grace expiry, both planes | infra problem (binary/auth/mux env); fix host before retry |
| `session_lost` | opencode session not found after dead checks | backend observability triage |
| `agent_exited` | capture verdict: exited, shell prompt showing | check transcript/worktree; retry plausible |

- `runEffect.Reason` threads from the step() arms to the sanctioned writer; `updateStatus` records it via the new `model.NewStatusEventWithReason` (empty reason degrades to the plain event — no attrs entry)
- `StatusChangeEvent.Reason` exposes it to listeners (Slack notifications become self-explanatory)
- `orch ps` renders `unknown(never_alive)` inline; `orch show`'s event list already prints `reason=…` via the generic attr format
- The decision sites already logged the reason in prose — this wires the same information into the event log (SSOT) instead of throwing it away

## Fence self-extension

`run-status-write-surface` and `no-ignored-status-append` now also ban `NewStatusEventWithReason` outside the sanctioned writer — adding the constructor without extending the fence would have opened a bypass. Fixture case added; negative-tested with a synthetic writer in internal/cli (1 finding, reverted).

## Law doc

run-state-machine.md §5 gains a "Status reasons" table tied to L3'.

## Verification

- `go build ./...` clean; `go test ./internal/...`: daemon/model/cli green incl. 2 new tests (`TestStepUnknownVerdictsCarryReason` covering all four arms, `TestUpdateStatusPersistsReason`)
- `make lint`: 106 rules, 0 findings; semgrep fixtures pass (10 guardrails matched)
- Pre-existing, unrelated failures on clean main too: internal/monitor TestSessionNameForProject, test/integration tmux-dependent tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)