### PR TITLE
feat(daemon): launch ladders → step() O8 observations (coupling-core B1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,12 +62,14 @@ verified issue. Core surfaces today:
 - `internal/model/event.go`, `internal/model/run.go` (event fold = store of
   record)
 
-**Status write surface.** Run status events are appended in exactly one
-sanctioned place: `Daemon.updateStatus`. The semgrep rule
+**Status write surface.** Run status events are constructed in exactly one
+sanctioned place: `commitRunStatus` (`internal/daemon/status_commit.go`),
+driven by its two executors — `Daemon.updateStatus` (monitor plane) and
+`SocketServer.reportLaunchProgress` (launch plane, O8). The semgrep rule
 `run-status-write-surface` enforces this; the `nosemgrep` annotations on
-existing writers are frozen legacy and may only shrink. Never add a new
-writer or a new `nosemgrep` annotation — extend `step()` with a new
-observation or effect instead.
+the remaining legacy writers (W6/W8/W9/W10/ResolveRun) are frozen and may
+only shrink. Never add a new writer or a new `nosemgrep` annotation —
+extend `step()` with a new observation or effect instead.
 
 **Tripwire checklist for reviewing delegated PRs.** Any single hit means
 stop and re-route to frontier + human:

--- a/docs/design/coupling-core-roadmap.md
+++ b/docs/design/coupling-core-roadmap.md
@@ -71,13 +71,16 @@ run-state-machine.md が「v2 候補」と明記した W2–W10 の統合。
 A1 の whitelist がフェーズの進捗メーター(縮んで空になったら完了)。
 
 ### B1. launch ladder W2–W5 → step 統合【frontier】
-- `socket.go` / `proto_handler.go` の起動段階遷移
-  (queued → booting → running/failed)を launch-progress 観測(O8)として
-  step に流す。imperative bootstrap は効果(effect)として残し、
-  遷移の決定だけを step に移す。
-- 対象: socket.go:1896,2970,3459,3474,3487,3516,3564,3593,4321,4340 /
-  proto_handler.go:1513,1564,1606,1657
-- exit: whitelist から daemon 内の該当行が消える。
+- 実装済み(2026-06-13, run-state-machine.md §7 D-B1): W2–W5/W7 の全 37
+  append サイトを O8 観測(`launchSignal`)化。遷移決定は純粋な
+  `stepLaunchProgress`、実行は `reportLaunchProgress`(worker プロセスでも
+  動く launch 面実行器)。updateStatus の guard/append 核は
+  `commitRunStatus`(status_commit.go)へ抽出され、status イベント構築点は
+  文字通り 1 箇所になった。失敗 verdict は `launch_<step>` reason を獲得
+  (L9)。whitelist 47 → 10。
+- proto_handler.go の 4 サイトは §6 の W9 disposition(quarantine — law
+  boundary)に従い対象外(本節の旧記述は disposition 決定前のもの)。
+- 残 v2: 4 重 imperative bootstrap の制御フロー自体の統合。
 
 ### B2. W6 feedback / W8 stop / W9 master projection / W10 external append【frontier 判断 → codex 実装可】
 - 各サイトを「step の観測に統合する」か「明示隔離(理由を
@@ -190,12 +193,12 @@ run-state-machine.md と同じ playbook を適用する。
 
 | # | core | 4層の状態 | 守り | 閉鎖フェーズ |
 |---|------|----------|------|------------|
-| 1 | run status 遷移 | ADR✓ law✓(tested) runtime△ **static✓ (A1, 2026-06-12)** | `run-status-write-surface` ルール + 凍結 whitelist | B で whitelist→0 |
+| 1 | run status 遷移 | ADR✓ law✓(tested) runtime△ **static✓ (A1, 2026-06-12)** | `run-status-write-surface` ルール + 凍結 whitelist | **B1 済(47→10, 2026-06-13)**; 残は v2(W6/W8)+ 法境界(W9/W10) |
 | 2 | RunState vs event log(導出状態) | 決定済み **D-C1**(run-state-machine.md §7): 導出可能フィールドは fold、収束カウンタは ephemeral-by-law (L7) | なし(実装待ち) | C1 実装 |
 | 3 | worker lease 所有権/ライフサイクル | 調査完了(E1 doc)、law 候補 5 件ドラフト | なし | E2/E3 |
 | 4 | identity(typed IDs) | 型✓ + lint✓ | `.semgrep/typed-id-rules` | 完了 |
 | 5 | client/daemon 境界(読み取り) | semgrep ~60 ルール✓ | `make lint` + CI | 完了 |
-| 6 | cancellation/stop 意味論(W7/W8, PR close terminal) | **disposition 決定済み**(run-state-machine.md §6): W7=ladder と統合、W8=v2 統合 | terminal guard + A1 凍結 | B1 後 |
+| 6 | cancellation/stop 意味論(W7/W8, PR close terminal) | **disposition 決定済み**(run-state-machine.md §6): W7=ladder と統合、W8=v2 統合 | terminal guard + A1 凍結 | W7 統合済(D-B1); W8 は v2 |
 | 7 | エラー伝播 × append(fail-fast) | **修正済み (A2, 2026-06-12)** | `no-ignored-status-append` ルール | 完了 |
 
 進捗ログ:
@@ -207,7 +210,9 @@ run-state-machine.md と同じ playbook を適用する。
 - 2026-06-12 Phase E1+E3 完了(PR #465 / #468): docs/design/worker-lease.md(LW1-LW5、LL1-LL5 draft)+ `.semgrep/worker-lease-mutation/` ルール(lease map 変異を worker_plane.go に限定、現状違反ゼロの純粋な柵)。残: E2(LL1-LL5 の property test 化)。
 - 2026-06-12 Phase E2 完了(PR #469): LL 法テスト一式 + **LL3 実バグ修正**(acknowledgeWorkerLease が確定済み判定を無条件上書きしていた → first-verdict-wins の冪等 no-op に)。LL1/LL5 は既存テストでカバー済みと判定。
 - 2026-06-12 Phase D2 完了(PR #470): docs/design/observation-coverage.md — 過去 21 修正の転記で完全表現 61.9% + 補語彙で 100%。判定: 語彙は健全、欠落はすべて infrastructure 面(意図的スコープ境界)。O11–O14 拡張バックログを記録。
-- 残作業: **B1 のみ**(launch ladder W2–W5 統合 — whitelist 45→0。socket.go の 4 重 ladder 解体なのでフル文脈の新セッションで着手すること)+ issue 4 件の消化(inv-never-alive-local-unknown は PR #467 で解決済み、run 起動不要)。
+- 2026-06-12 委譲 3 issue 完遂: inv-resolve-run-verb(PR #473)/ inv-monitor-queued-orphans(PR #471, I6 解消)/ inv-fire-status-change-all(PR #472, I8 解消 + L8 制定)。全 merge・issue resolved。
+- 2026-06-13 **Phase B1 完了**: W2–W5/W7 の 37 サイトを O8 観測化(stepLaunchProgress + reportLaunchProgress)、`commitRunStatus` 抽出で status イベント構築点が正確に 1 箇所に。launch 失敗 verdict に `launch_<step>` reason(L9 制定)。whitelist 47 → 10(残 = W6/W8/ResolveRun/W9×4/W10 repair — 全て §6 disposition 済み)。run-state-machine.md §1/§2/§3/§5/§6/§7 D-B1 同梱。
+- 残作業: v2(4 重 bootstrap 制御フローの統合、W6/W8 の step 統合)。whitelist のさらなる縮小はそこで。
 
 ## 推奨順序と箱
 

--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -27,21 +27,27 @@ windows, inference — lives in the writers:
 
 | # | Site | Transitions written | Guards |
 |---|------|---------------------|--------|
-| W1 | `monitor.go updateStatus` (sole monitor-plane writer) | all monitor inferences | terminal check, `CanTransitionStatus`, same-status no-op, auto-resolve issue on `done`, `publishRunEvent`, `fireStatusChange` after append |
-| W2 | `socket.go handleStartRun` (legacy JSON path) | `queued` → (`failed` per setup step) → `booting` → `failed`/`running` | store-level only; append errors ignored |
-| W3 | `socket.go processStartRunCore` (worker/master core) | same ladder as W2 | same |
-| W4 | `socket.go processContinueRunCore` | same ladder | same |
-| W5 | `socket.go handleContinueRun` (legacy JSON path) | same ladder | same |
+| W1 | `monitor.go updateStatus` (monitor-plane executor over `commitRunStatus`) | all monitor inferences | `commitRunStatus` guards; auto-resolve issue on `done`, `publishRunEvent`, `fireStatusChange` after commit |
+| W2–W5 | launch ladders (`handleStartRun` / `processStartRunCore` / `processContinueRunCore` / `handleContinueRun`) | **no direct writes since D-B1 (2026-06-13)**: milestones/failures are O8 observations; `stepLaunchProgress` decides, `reportLaunchProgress` executes via `commitRunStatus` | `commitRunStatus` guards (policy-level same-status no-op on top) |
 | W6 | `socket.go markRunFeedbackSent` | `waiting/pr_open/rate_limited/unknown` → `running` | `feedbackResumesRun` predicate; fires `onRunFeedback` (PromptStreak reset), `fireStatusChange`, `PublishRunEvent` after append |
-| W7 | `socket.go failOpenCodeRunBootstrap` | → `failed` | none |
+| W7 | `socket.go failOpenCodeRunBootstrap` | **no direct writes since D-B1**: routes `launchFailed("opencode_bootstrap")` through O8 | same as W2–W5 |
 | W8 | `socket.go appendRunCanceledByUser` (`orch stop`) | → `canceled` (`source=user`) | skip if terminal |
 | W9 | `proto_handler.go syncStartRunResultToMasterStore` / `syncContinueRunResultToMasterStore` | `queued` (if record missing) + result status (default `running`) | store-level only |
 | W10 | `socket.go handleAppendEvent` (external append API; agent self-report) | arbitrary, caller-supplied source | `CanTransitionStatus` with caller source |
 
 Notes:
 
-- W2–W5 are four near-copies of the same launch ladder (legacy + core ×
-  start/continue) — the "same pattern repeated" crystallization signal.
+- Status events are **constructed in exactly one place**: `commitRunStatus`
+  (`status_commit.go`), which owns the terminal check, `CanTransitionStatus`,
+  the same-status no-op, and the append. Its two sanctioned executors are
+  W1 (`updateStatus`, monitor plane) and `reportLaunchProgress`
+  (launch plane, usable in the worker process where no `Daemon` exists).
+  The remaining annotated writers (W6, W8, W9, W10, `ResolveRun`) are the
+  frozen legacy / law-boundary set.
+- W2–W5 remain four near-copies of the same *imperative bootstrap* (legacy +
+  core × start/continue), but since D-B1 they carry no transition policy:
+  every status decision flows through `stepLaunchProgress`. Collapsing the
+  four control flows themselves is the remaining v2 work.
 - Worker-hosted runs are dual-written: the worker executes W3/W4/W6 against
   its **local** store (`worker_plane.go executeLeaseEffect`), while the master
   store receives a projection (W9) and is then maintained by the master's
@@ -69,7 +75,7 @@ Facts the daemon can notice about a run, with their sources:
 | O5 | git evidence (PR info, ahead count, uncommitted changes) | gh cache + git, gathered only after a dead verdict is near | subprocess |
 | O6 | user feedback delivered (`orch send` without `--no-enter`) | send paths | — |
 | O7 | user stop | stop path | — |
-| O8 | launch lifecycle progress (worktree created, session created, …) | launch ladders | — |
+| O8 | launch lifecycle progress (`launchSignal`: stage milestone or failed step) | launch ladders via `reportLaunchProgress` | — |
 | O9 | time | `now` vs `StartedAt` (boot grace), tick cadence, backoff timers | — |
 | O10 | agent self-report | `handleAppendEvent` | — |
 
@@ -122,7 +128,13 @@ O4 captured + agent verdict:     (mux: 優先順位順)
 O6 feedback delivered        status ∈ {waiting,pr_open,            → running (+PromptStreak reset)
                              rate_limited,unknown}
 O7 user stop                 非terminal                            → canceled (source=user)
-O8 launch progress           (launch ladder W2–W5)                 queued → booting → running / failed
+O8 launch progress           stageRunCreated                       → queued
+   (W2–W5/W7 →               stageLaunchReady                      → booting
+    stepLaunchProgress)      stageWorkspaceOnly / stageAgentStarted → running
+                             bootstrap step failed                 → failed
+                               (reason launch_<step>; error artifact first)
+   terminal view は L4 で吸収(store guard が拒否していた旧挙動と同値)。
+   同値 status への再到達は無発行(L1a — 暗黙の初期 queued は二重化しない)。
 ```
 
 ## 4. Implicit invariants of in-memory monitor state (`RunState`)
@@ -212,6 +224,7 @@ distinction the law tests themselves forced:
 | L5 verdict requires evidence | `obsSessionGone` never emits a status directly; it requests git evidence exactly when the dead-check threshold is reached |
 | L6 debounce | `waiting` via prompt requires ≥ `waitingPromptStreakThreshold` consecutive prompt observations; any busy capture resets the streak |
 | L8 listener commit point | every committed W1 status transition fires exactly one status-change listener event after `AppendEvent` succeeds; duplicate-status no-ops and failed appends fire none |
+| L9 launch failure reason | a launch-failure verdict (O8) always carries the machine-readable reason `launch_<step>`, preceded by an error artifact recording the bootstrap error; launch milestones on a terminal or already-reached status emit nothing |
 
 ### Status reasons (verdict payload)
 
@@ -225,6 +238,7 @@ travels as a machine-readable `reason` attribute on the status event
 | `never_alive` | L3' grace expiry, either plane | infrastructure problem (binary/auth/mux env); fix the host before retrying |
 | `session_lost` | opencode session not found after dead checks | backend lost observability; backend-specific triage |
 | `agent_exited` | capture verdict: process exited, shell prompt showing | check transcript/worktree; retry plausible |
+| `launch_<step>` | O8 bootstrap failure (`failed` verdict); `<step>` ∈ worktree, prompt, agent_command, multiplexer, opencode_server, session, opencode_bootstrap, bootstrap | the named bootstrap step broke; the paired error artifact carries the detail |
 
 `orch ps` renders the reason inline (`unknown(never_alive)`); the event log
 carries it as `reason=…`; `StatusChangeEvent.Reason` exposes it to listeners.
@@ -244,8 +258,8 @@ rationale. *Undecided* is no longer a legal state for a status writer.
 
 | # | Site | Disposition | Rationale |
 |---|------|-------------|-----------|
-| W2–W5 | launch ladders (socket.go ×4) | **integrate — v2, first** | Four near-copies of one ladder; interleaves with monitor-plane transitions (booting/running races). Becomes launch-progress observations (O8) decided in `step()`, with the imperative bootstrap steps as effects. |
-| W7 | `failOpenCodeRunBootstrap` → failed | **integrate — with W2–W5** | The failure arm of the same ladder. |
+| W2–W5 | launch ladders (socket.go ×4) | **integrated — D-B1 (2026-06-13)** | Transition policy moved to `stepLaunchProgress` (O8); ladders report milestones/failures via `reportLaunchProgress`, commits go through `commitRunStatus`. The four imperative control flows remain to be collapsed in v2. |
+| W7 | `failOpenCodeRunBootstrap` → failed | **integrated — D-B1 (2026-06-13)** | Routes `launchFailed("opencode_bootstrap")` through the same O8 path. |
 | W6 | feedback → running | **integrate — v2** | Already mutates `runCore` (PromptStreak reset, O6). Core state must change only through `step()`. Until then, the legacy writer emits `fireStatusChange` after its append to preserve listener coverage. |
 | W8 | `appendRunCanceledByUser` (`orch stop`) | **integrate — v2, after the ladder** | O7 (user stop) exists in the observation taxonomy; terminality (L4) should observe it. Single guarded site until then. |
 | W9 | master projections (proto_handler.go) | **quarantine — law boundary** | Replicates transitions already decided on the worker plane; carries no local policy. Guards: `CanTransitionStatus` + fail-fast appends (Phase A2). Law: a projection is status-preserving — it must never add inference in flight. |
@@ -325,3 +339,46 @@ W6 feedback resume is still a legacy writer until O6 enters `step()` v2, so
 it bridges into the same listener fanout immediately after its append. This
 keeps `orch send` resume notifications consistent with W1 without changing
 the transition policy matrix.
+
+### D-B1 — launch ladders integrated as O8 observations (implemented 2026-06-13)
+
+The four launch ladders (W2–W5) and their failure arm (W7) no longer write
+status events. Each milestone or failure is reported as an O8 observation
+(`launchSignal`) to `reportLaunchProgress`, which feeds it through the pure
+policy `stepLaunchProgress` and executes the effects. The imperative
+bootstrap (worktree, prompt file, multiplexer, server, session) stays where
+it was — only the transition *decisions* moved, exactly the
+mechanism/policy split of D2 in §5.
+
+Decisions taken:
+
+- **Single constructor.** `Daemon.updateStatus` no longer owns the append:
+  its guard/append core was extracted to `commitRunStatus`
+  (`status_commit.go`), the one place that constructs status events. The
+  launch executor calls the same function, so the worker process (which has
+  a `SocketServer` but no `Daemon`) commits through the identical guards.
+- **Stage vocabulary, not statuses, in the observation.** The ladders report
+  `stageRunCreated / stageLaunchReady / stageWorkspaceOnly /
+  stageAgentStarted` or `launchFailed(step, err)`; the stage→status mapping
+  is policy. `stageWorkspaceOnly` is the `--tmux=false` arm: workspace
+  prepared, no agent launched, run handed to the monitor plane as `running`.
+- **Terminal absorption replaces guard reliance.** A launch observation on a
+  terminal view is absorbed by the stepRun L4 guard. Previously those
+  appends were silently *rejected* by the store guard (daemon source on a
+  terminal run); the fold outcome is identical, but the no-write is now a
+  policy decision instead of a discarded error. All ladders operate on
+  freshly created runs (continue creates a new run linked by
+  `continued_from`), so this arm only fires when a user cancels mid-boot.
+- **The implicit initial `queued` is no longer materialized.** A fresh run's
+  fold already yields `queued` (the `GetStatus` default); the policy-level
+  same-status no-op therefore skips the event the ladders used to append
+  right after `CreateRun`. One less redundant event, no fold change.
+- **Failure verdicts gained machine-readable reasons** (`launch_<step>`,
+  L9) and keep the error-artifact-then-verdict order of the old ladders.
+- **Listener scope unchanged.** `reportLaunchProgress` does not fire
+  `fireStatusChange` / `publishRunEvent`: launch transitions were never
+  listener-visible, and widening I8's scope is a separate decision from
+  removing the write surface. The asymmetry is recorded in §1 notes.
+
+Whitelist meter: 47 → 10 annotations (socket.go 40 → 3; the remaining three
+are W6, W8 and `appendRunResolvedByUser`, all with §6 dispositions).

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -204,6 +204,10 @@ func (d *Daemon) applyRunEffects(run *model.Run, st store.Store, oldCore, core r
 			if err := d.recordPRClosedEvent(run, e.PRURL, st); err != nil {
 				return core, err
 			}
+		case effectRecordError:
+			if err := st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(e.Msg)); err != nil {
+				d.logger.Printf("%s#%s: failed to record error artifact: %v", run.IssueID, run.RunID, err)
+			}
 		case effectSetStatus:
 			if err := d.updateStatus(run, e.Status, e.Reason, st, e.Output); err != nil {
 				if firstErr == nil {
@@ -493,39 +497,20 @@ func isConnectionRefusedError(err error) bool {
 	return strings.Contains(msg, "connection refused") || strings.Contains(msg, "econnrefused")
 }
 
-// updateStatus is the single executor for status transitions (effectSetStatus).
-// It re-checks the authoritative store state beneath the stepRun matrix:
-// terminal protection, transition legality, and the same-status no-op.
+// updateStatus is the monitor-plane executor for status transitions
+// (effectSetStatus): commitRunStatus owns the store-level guards and the
+// append itself; this wrapper adds the monitor-plane consequences (event-bus
+// publish, issue auto-resolve, status-change listeners).
 // reason, when non-empty, is recorded on the status event as the
 // machine-readable verdict reason (model.AttrStatusReason).
 // lastOutput rides along as the listener notification payload.
 func (d *Daemon) updateStatus(run *model.Run, status model.Status, reason string, st store.Store, lastOutput string) error {
-	ref := &model.RunRef{IssueID: run.IssueID, RunID: run.RunID}
-
-	// Check current status - daemon cannot overwrite terminal states
-	var fromStatus model.Status
-	if currentRun, err := st.GetRun(ref); err == nil && currentRun != nil {
-		fromStatus = currentRun.Status
-		// Re-affirming the current status is a no-op: appending duplicate
-		// status events bloats the run record and churns UpdatedAt, which
-		// breaks recency display/sorting for every client.
-		if fromStatus == status {
-			return nil
-		}
-		if !model.CanTransitionStatus(currentRun.Status, status, model.EventSourceDaemon) {
-			d.debug("%s#%s: daemon cannot transition from %s to %s", run.IssueID, run.RunID, currentRun.Status, status)
-			return nil
-		}
-	}
-
-	// The sanctioned single writer for monitor-plane status transitions:
-	// every transition decided by step() is committed here, and only here
-	// (docs/design/run-state-machine.md). All other status writers are
-	// frozen legacy, enumerated by `nosemgrep: run-status-write-surface`
-	// annotations, and shrink toward zero (coupling-core roadmap Phase B).
-	event := model.NewStatusEventWithReason(status, reason) // nosemgrep: run-status-write-surface
-	if err := st.AppendEvent(ref, event); err != nil {
+	fromStatus, committed, err := commitRunStatus(st, run, status, reason, d.debug)
+	if err != nil {
 		return err
+	}
+	if !committed {
+		return nil
 	}
 
 	d.publishRunEvent(run, fromStatus, status, model.EventSourceDaemon)

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -1891,21 +1891,49 @@ func (s *SocketServer) getOpenCodeServerPort(projectRoot string) int {
 	return 0
 }
 
+// reportLaunchProgress feeds one launch-ladder observation (O8) through the
+// pure transition policy (stepLaunchProgress) and executes its effects
+// against st. It is the launch-plane executor — the counterpart of
+// Daemon.applyRunEffects — shared by the master socket handlers and the
+// worker plane, which runs without a Daemon. Commit failures are logged,
+// never fatal to the bootstrap: the monitor plane re-converges the status
+// fold on its next observation (run-state-machine.md L1b).
+func (s *SocketServer) reportLaunchProgress(st store.Store, run *model.Run, sig launchSignal) {
+	if st == nil || run == nil {
+		return
+	}
+	// Policy reads the store-derived view, not the caller's in-hand run,
+	// which goes stale between milestones. commitRunStatus re-checks the
+	// store again beneath the policy as defense in depth.
+	view := runViewOf(run)
+	if current, err := st.GetRun(run.Ref()); err == nil && current != nil {
+		view = runViewOf(current)
+	}
+	_, effects := stepRun(view, runCore{}, runObservation{Kind: obsLaunchProgress, Launch: sig}, time.Now())
+	for _, e := range effects {
+		switch e.Kind {
+		case effectRecordError:
+			if err := st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(e.Msg)); err != nil {
+				s.logger.Printf("%s#%s: failed to record error artifact: %v", run.IssueID, run.RunID, err)
+			}
+		case effectSetStatus:
+			if _, _, err := commitRunStatus(st, run, e.Status, e.Reason, nil); err != nil {
+				s.logger.Printf("%s#%s: failed to record %s status: %v", run.IssueID, run.RunID, e.Status, err)
+			}
+		case effectLog:
+			s.logger.Printf("%s", e.Msg)
+		}
+	}
+}
+
 func (s *SocketServer) failOpenCodeRunBootstrap(st store.Store, run *model.Run, err error) error {
 	if err == nil {
 		return nil
 	}
-	msg := err.Error()
-	s.logger.Printf(msg)
 	if st != nil && run != nil {
-		// Error-recording path: the original bootstrap error must be returned,
-		// so append failures are surfaced in the log instead of swallowed.
-		if appendErr := st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(msg)); appendErr != nil {
-			s.logger.Printf("%s#%s: failed to record error artifact: %v", run.IssueID, run.RunID, appendErr)
-		}
-		if appendErr := st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)); appendErr != nil { // nosemgrep: run-status-write-surface
-			s.logger.Printf("%s#%s: failed to record failed status: %v", run.IssueID, run.RunID, appendErr)
-		}
+		s.reportLaunchProgress(st, run, launchFailed("opencode_bootstrap", err))
+	} else {
+		s.logger.Printf(err.Error())
 	}
 	return err
 }
@@ -3478,7 +3506,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		return
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued)) // nosemgrep: run-status-write-surface
+	s.reportLaunchProgress(st, run, launchReached(stageRunCreated))
 
 	baseBranch := resolveBaseBranch(req.BaseBranch, issue, cfg)
 
@@ -3492,8 +3520,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		Branch:      branch,
 	})
 	if err != nil {
-		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchFailed("worktree", err))
 		encoder.Encode(StartRunResponse{OK: false, Error: "failed to create worktree: " + err.Error()})
 		return
 	}
@@ -3505,8 +3532,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 	agentPrompt := s.buildRunPrompt(issue, st.RootPath(), req.NoPR, req.PromptTemplate, prTargetBranch)
 	promptPath := filepath.Join(worktreeResult.WorktreePath, "ORCH_PROMPT.md")
 	if err := os.WriteFile(promptPath, []byte(agentPrompt), 0644); err != nil {
-		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchFailed("prompt", err))
 		encoder.Encode(StartRunResponse{OK: false, Error: "failed to write prompt file: " + err.Error()})
 		return
 	}
@@ -3534,13 +3560,12 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 
 	agentCmd, err := adapter.LaunchCommand(launchCfg)
 	if err != nil {
-		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchFailed("agent_command", err))
 		encoder.Encode(StartRunResponse{OK: false, Error: "failed to build agent command: " + err.Error()})
 		return
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting)) // nosemgrep: run-status-write-surface
+	s.reportLaunchProgress(st, run, launchReached(stageLaunchReady))
 
 	muxType, _ := multiplexer.ParseType(req.Multiplexer)
 
@@ -3552,8 +3577,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 	}
 
 	if mux == nil {
-		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent("no multiplexer available"))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchFailed("multiplexer", fmt.Errorf("no multiplexer available")))
 		encoder.Encode(StartRunResponse{OK: false, Error: "no terminal multiplexer available"})
 		return
 	}
@@ -3562,8 +3586,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 	if adapter.PromptInjection() == agent.InjectionHTTP {
 		resp, err := s.ensureOpenCodeServerRunning(worktreeResult.WorktreePath)
 		if err != nil {
-			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+			s.reportLaunchProgress(st, run, launchFailed("opencode_server", err))
 			encoder.Encode(StartRunResponse{OK: false, Error: "failed to start opencode server: " + err.Error()})
 			return
 		}
@@ -3582,8 +3605,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 			Env:         env,
 		})
 		if err != nil {
-			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+			s.reportLaunchProgress(st, run, launchFailed("session", err))
 			encoder.Encode(StartRunResponse{OK: false, Error: "failed to create session: " + err.Error()})
 			return
 		}
@@ -3612,7 +3634,7 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		}
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)) // nosemgrep: run-status-write-surface
+	s.reportLaunchProgress(st, run, launchReached(stageAgentStarted))
 
 	s.logger.Printf("started run: %s#%s (agent=%s, worktree=%s)", req.IssueID, runID, agentName, worktreeResult.WorktreePath)
 
@@ -3828,7 +3850,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 		return nil, fmt.Errorf("failed to create run: %w", err)
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued)) // nosemgrep: run-status-write-surface
+	s.reportLaunchProgress(st, run, launchReached(stageRunCreated))
 
 	baseBranch := resolveBaseBranch(opts.BaseBranch, issue, cfg)
 
@@ -3842,8 +3864,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 		Branch:      branch,
 	}, runExecutor)
 	if err != nil {
-		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchFailed("worktree", err))
 		return nil, fmt.Errorf("failed to create worktree: %w", err)
 	}
 
@@ -3864,8 +3885,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 	agentPrompt := s.buildRunPrompt(issue, st.RootPath(), opts.NoPR, opts.PromptTemplate, prTargetBranch)
 	promptPath := filepath.Join(worktreeResult.WorktreePath, "ORCH_PROMPT.md")
 	if err := writeFileWithExecutor(runExecutor, promptPath, []byte(agentPrompt), 0644); err != nil {
-		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchFailed("prompt", err))
 		return nil, fmt.Errorf("failed to write prompt file: %w", err)
 	}
 
@@ -3896,12 +3916,11 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 
 	agentCmd, err := adapter.LaunchCommand(launchCfg)
 	if err != nil {
-		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchFailed("agent_command", err))
 		return nil, fmt.Errorf("failed to build agent command: %w", err)
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting)) // nosemgrep: run-status-write-surface
+	s.reportLaunchProgress(st, run, launchReached(stageLaunchReady))
 
 	if opts.NoSession {
 		// --tmux=false: the workspace (run record, worktree, branch, prompt
@@ -3909,7 +3928,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 		// agent is launched. SessionName stays empty so no session artifact
 		// is recorded anywhere and attach/send fail with a clear
 		// session-not-found error instead of pointing at a ghost session.
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchReached(stageWorkspaceOnly))
 		s.logger.Printf("started run without session: %s#%s (agent=%s, worktree=%s)", opts.IssueID, runID, agentName, worktreeResult.WorktreePath)
 		return &StartRunResult{
 			RunID:        runID,
@@ -3948,8 +3967,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 	}
 
 	if mux == nil {
-		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent("no multiplexer available"))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchFailed("multiplexer", fmt.Errorf("no multiplexer available")))
 		return nil, fmt.Errorf("no terminal multiplexer available")
 	}
 
@@ -3957,8 +3975,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 	if adapter.PromptInjection() == agent.InjectionHTTP {
 		resp, err := s.ensureOpenCodeServerRunning(worktreeResult.WorktreePath)
 		if err != nil {
-			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+			s.reportLaunchProgress(st, run, launchFailed("opencode_server", err))
 			return nil, fmt.Errorf("failed to start opencode server: %w", err)
 		}
 		serverAlreadyRunning = true
@@ -3976,8 +3993,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 			Env:         env,
 		})
 		if err != nil {
-			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+			s.reportLaunchProgress(st, run, launchFailed("session", err))
 			return nil, fmt.Errorf("failed to create session: %w", err)
 		}
 
@@ -4005,7 +4021,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 		}
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)) // nosemgrep: run-status-write-surface
+	s.reportLaunchProgress(st, run, launchReached(stageAgentStarted))
 
 	s.logger.Printf("started run: %s#%s (agent=%s, worktree=%s)", opts.IssueID, runID, agentName, worktreeResult.WorktreePath)
 
@@ -4242,7 +4258,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		return nil, fmt.Errorf("failed to create run: %w", err)
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued)) // nosemgrep: run-status-write-surface
+	s.reportLaunchProgress(st, run, launchReached(stageRunCreated))
 	st.AppendEvent(run.Ref(), model.NewArtifactEvent("worktree", map[string]string{"path": worktreePath}))
 	st.AppendEvent(run.Ref(), model.NewArtifactEvent("branch", map[string]string{"name": branch}))
 	if targetName := strings.TrimSpace(opts.Target); targetName != "" {
@@ -4260,8 +4276,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 	if _, err := os.Stat(promptPath); os.IsNotExist(err) {
 		agentPrompt := s.buildRunPrompt(issue, st.RootPath(), opts.NoPR, opts.PromptTemplate, opts.PRTargetBranch)
 		if err := os.WriteFile(promptPath, []byte(agentPrompt), 0644); err != nil {
-			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+			s.reportLaunchProgress(st, run, launchFailed("prompt", err))
 			return nil, fmt.Errorf("failed to write prompt file: %w", err)
 		}
 	}
@@ -4293,12 +4308,11 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 
 	agentCmd, err := adapter.LaunchCommand(launchCfg)
 	if err != nil {
-		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchFailed("agent_command", err))
 		return nil, fmt.Errorf("failed to build agent command: %w", err)
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting)) // nosemgrep: run-status-write-surface
+	s.reportLaunchProgress(st, run, launchReached(stageLaunchReady))
 
 	if opts.NoSession {
 		// --tmux=false: the workspace (run record, worktree, branch, prompt
@@ -4306,7 +4320,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		// agent is launched. SessionName stays empty so no session artifact
 		// is recorded anywhere and attach/send fail with a clear
 		// session-not-found error instead of pointing at a ghost session.
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchReached(stageWorkspaceOnly))
 		s.logger.Printf("continued run without session: %s#%s from %s (agent=%s, worktree=%s)", issueID, runID, continuedFrom, agentName, worktreePath)
 		return &ContinueRunResult{
 			RunID:         runID,
@@ -4330,8 +4344,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 	}
 
 	if mux == nil {
-		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent("no multiplexer available"))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchFailed("multiplexer", fmt.Errorf("no multiplexer available")))
 		return nil, fmt.Errorf("no terminal multiplexer available")
 	}
 
@@ -4339,8 +4352,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 	if adapter.PromptInjection() == agent.InjectionHTTP {
 		resp, err := s.ensureOpenCodeServerRunning(worktreePath)
 		if err != nil {
-			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+			s.reportLaunchProgress(st, run, launchFailed("opencode_server", err))
 			return nil, fmt.Errorf("failed to start opencode server: %w", err)
 		}
 		serverAlreadyRunning = true
@@ -4358,8 +4370,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 			Env:         env,
 		})
 		if err != nil {
-			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+			s.reportLaunchProgress(st, run, launchFailed("session", err))
 			return nil, fmt.Errorf("failed to create session: %w", err)
 		}
 
@@ -4389,7 +4400,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		}
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)) // nosemgrep: run-status-write-surface
+	s.reportLaunchProgress(st, run, launchReached(stageAgentStarted))
 
 	s.logger.Printf("continued run: %s#%s from %s (agent=%s, worktree=%s)", issueID, runID, continuedFrom, agentName, worktreePath)
 
@@ -4633,7 +4644,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 		return
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusQueued)) // nosemgrep: run-status-write-surface
+	s.reportLaunchProgress(st, run, launchReached(stageRunCreated))
 	st.AppendEvent(run.Ref(), model.NewArtifactEvent("worktree", map[string]string{"path": worktreePath}))
 	st.AppendEvent(run.Ref(), model.NewArtifactEvent("branch", map[string]string{"name": branch}))
 
@@ -4641,8 +4652,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 	if _, err := os.Stat(promptPath); os.IsNotExist(err) {
 		agentPrompt := s.buildRunPrompt(issue, st.RootPath(), req.NoPR, req.PromptTemplate, req.PRTargetBranch)
 		if err := os.WriteFile(promptPath, []byte(agentPrompt), 0644); err != nil {
-			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+			s.reportLaunchProgress(st, run, launchFailed("prompt", err))
 			encoder.Encode(ContinueRunResponse{OK: false, Error: "failed to write prompt file: " + err.Error()})
 			return
 		}
@@ -4671,13 +4681,12 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 
 	agentCmd, err := adapter.LaunchCommand(launchCfg)
 	if err != nil {
-		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchFailed("agent_command", err))
 		encoder.Encode(ContinueRunResponse{OK: false, Error: "failed to build agent command: " + err.Error()})
 		return
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusBooting)) // nosemgrep: run-status-write-surface
+	s.reportLaunchProgress(st, run, launchReached(stageLaunchReady))
 
 	muxType, _ := multiplexer.ParseType(req.Multiplexer)
 
@@ -4689,8 +4698,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 	}
 
 	if mux == nil {
-		st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent("no multiplexer available"))
-		st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+		s.reportLaunchProgress(st, run, launchFailed("multiplexer", fmt.Errorf("no multiplexer available")))
 		encoder.Encode(ContinueRunResponse{OK: false, Error: "no terminal multiplexer available"})
 		return
 	}
@@ -4699,8 +4707,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 	if adapter.PromptInjection() == agent.InjectionHTTP {
 		resp, err := s.ensureOpenCodeServerRunning(worktreePath)
 		if err != nil {
-			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+			s.reportLaunchProgress(st, run, launchFailed("opencode_server", err))
 			encoder.Encode(ContinueRunResponse{OK: false, Error: "failed to start opencode server: " + err.Error()})
 			return
 		}
@@ -4719,8 +4726,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 			Env:         env,
 		})
 		if err != nil {
-			st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(err.Error()))
-			st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusFailed)) // nosemgrep: run-status-write-surface
+			s.reportLaunchProgress(st, run, launchFailed("session", err))
 			encoder.Encode(ContinueRunResponse{OK: false, Error: "failed to create session: " + err.Error()})
 			return
 		}
@@ -4752,7 +4758,7 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 		}
 	}
 
-	st.AppendEvent(run.Ref(), model.NewStatusEvent(model.StatusRunning)) // nosemgrep: run-status-write-surface
+	s.reportLaunchProgress(st, run, launchReached(stageAgentStarted))
 
 	s.logger.Printf("continued run: %s#%s from %s (agent=%s, worktree=%s)", issueID, runID, continuedFrom, agentName, worktreePath)
 

--- a/internal/daemon/status_commit.go
+++ b/internal/daemon/status_commit.go
@@ -1,0 +1,51 @@
+package daemon
+
+import (
+	"github.com/s22625/orch/internal/model"
+	"github.com/s22625/orch/internal/store"
+)
+
+// commitRunStatus is the single constructor-and-append site for run status
+// events in the daemon (docs/design/run-state-machine.md §1). Every status
+// transition decided by stepRun — monitor plane (Daemon.updateStatus) and
+// launch plane (SocketServer.reportLaunchProgress) — is committed here, and
+// only here. All other status writers are frozen legacy, enumerated by
+// `nosemgrep: run-status-write-surface` annotations, and shrink toward zero
+// (coupling-core roadmap Phase B).
+//
+// It re-checks the authoritative store state beneath the stepRun matrix:
+// terminal protection, transition legality, and the same-status no-op.
+// reason, when non-empty, is recorded on the status event as the
+// machine-readable verdict reason (model.AttrStatusReason).
+//
+// Returns the store-derived from-status and whether a transition was
+// committed. committed == false with a nil error means the write was
+// absorbed (same-status no-op, or illegal for the daemon source); the
+// caller must not publish or notify in that case.
+func commitRunStatus(st store.Store, run *model.Run, status model.Status, reason string, debugf func(format string, args ...interface{})) (model.Status, bool, error) {
+	ref := &model.RunRef{IssueID: run.IssueID, RunID: run.RunID}
+
+	// Check current status - daemon cannot overwrite terminal states
+	var fromStatus model.Status
+	if currentRun, err := st.GetRun(ref); err == nil && currentRun != nil {
+		fromStatus = currentRun.Status
+		// Re-affirming the current status is a no-op: appending duplicate
+		// status events bloats the run record and churns UpdatedAt, which
+		// breaks recency display/sorting for every client.
+		if fromStatus == status {
+			return fromStatus, false, nil
+		}
+		if !model.CanTransitionStatus(currentRun.Status, status, model.EventSourceDaemon) {
+			if debugf != nil {
+				debugf("%s#%s: daemon cannot transition from %s to %s", run.IssueID, run.RunID, currentRun.Status, status)
+			}
+			return fromStatus, false, nil
+		}
+	}
+
+	event := model.NewStatusEventWithReason(status, reason) // nosemgrep: run-status-write-surface
+	if err := st.AppendEvent(ref, event); err != nil {
+		return fromStatus, false, err
+	}
+	return fromStatus, true, nil
+}

--- a/internal/daemon/step.go
+++ b/internal/daemon/step.go
@@ -104,6 +104,11 @@ const (
 	// obsGitEvidence is the response to effectGatherGitEvidence: the raw
 	// PR/git facts needed for a dead-session verdict.
 	obsGitEvidence
+	// obsLaunchProgress reports a launch-ladder milestone or bootstrap
+	// failure (O8). The bootstrap shells (socket.go start/continue handlers)
+	// stay imperative, but every status transition they used to write
+	// directly is decided here instead (run-state-machine.md §7 D-B1).
+	obsLaunchProgress
 )
 
 // agentSignal is the agent-specific reading of a captured output, gathered
@@ -137,6 +142,53 @@ type gitEvidence struct {
 	HasUncommitted  bool
 }
 
+// launchStage is the launch-ladder milestone vocabulary (O8). The stages are
+// facts about how far the bootstrap got; mapping a stage to a run status is
+// transition policy and lives in stepLaunchProgress, not at the call sites.
+type launchStage int
+
+const (
+	// stageRunCreated: the run record was created (or re-targeted by a
+	// continue) and the launch was accepted.
+	stageRunCreated launchStage = iota
+	// stageLaunchReady: the agent launch command is fully resolved and the
+	// imperative bootstrap (multiplexer, server, session) is about to run.
+	stageLaunchReady
+	// stageWorkspaceOnly: the workspace (run record, worktree, branch,
+	// prompt file) was prepared and, by request (NoSession), no multiplexer
+	// session or agent was launched. The run still counts as running: the
+	// monitor plane owns it from here.
+	stageWorkspaceOnly
+	// stageAgentStarted: the session exists and the initial prompt was
+	// handed to the agent.
+	stageAgentStarted
+)
+
+// launchSignal is one O8 observation: either a milestone reached or a
+// bootstrap failure. Step is the machine-readable name of the failed
+// bootstrap step; it becomes the status reason `launch_<step>`. Err is the
+// human-readable detail, recorded as an error artifact.
+type launchSignal struct {
+	Stage  launchStage
+	Failed bool
+	Step   string
+	Err    string
+}
+
+// launchReached builds the milestone form of a launch observation.
+func launchReached(stage launchStage) launchSignal {
+	return launchSignal{Stage: stage}
+}
+
+// launchFailed builds the failure form of a launch observation.
+func launchFailed(step string, err error) launchSignal {
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	return launchSignal{Failed: true, Step: step, Err: msg}
+}
+
 type runObservation struct {
 	Kind obsKind
 
@@ -154,6 +206,9 @@ type runObservation struct {
 
 	// obsGitEvidence
 	Evidence gitEvidence
+
+	// obsLaunchProgress
+	Launch launchSignal
 }
 
 type effectKind int
@@ -172,6 +227,10 @@ const (
 	// it back as an obsGitEvidence observation. The policy decides when
 	// evidence is needed; the shell never does.
 	effectGatherGitEvidence
+	// effectRecordError appends an error artifact (Msg carries the detail).
+	// Emitted before the failed-status effect so the artifact order matches
+	// the historical ladder behavior.
+	effectRecordError
 	// effectLog / effectDebugLog emit an operator log line.
 	effectLog
 	effectDebugLog
@@ -238,9 +297,68 @@ func stepRun(view runView, core runCore, obs runObservation, now time.Time) (run
 		return stepCaptured(view, core, obs, now)
 	case obsGitEvidence:
 		return stepGitEvidence(view, core, obs, now)
+	case obsLaunchProgress:
+		return stepLaunchProgress(view, core, obs)
 	default:
 		return core, nil
 	}
+}
+
+// stepLaunchProgress decides the launch-plane transitions (O8):
+//
+//	stageRunCreated    → queued
+//	stageLaunchReady   → booting
+//	stageWorkspaceOnly → running
+//	stageAgentStarted  → running
+//	failure            → failed (reason launch_<step>, error artifact first)
+//
+// The policy depends only on view.Status and the signal — never on the
+// monitor core, which the launch shells do not hold. Terminal views never
+// reach here (L4 guard in stepRun): a (re)launch against a terminal run
+// leaves the fold untouched, matching the store-level guard that already
+// rejected those appends. Re-affirming the current status emits nothing
+// (L1a), so the implicit initial `queued` (the fold default) is never
+// duplicated as an event.
+func stepLaunchProgress(view runView, core runCore, obs runObservation) (runCore, []runEffect) {
+	sig := obs.Launch
+
+	if sig.Failed {
+		step := sig.Step
+		if step == "" {
+			step = "bootstrap"
+		}
+		var effects []runEffect
+		if sig.Err != "" {
+			effects = append(effects, runEffect{Kind: effectRecordError, Msg: sig.Err})
+		}
+		effects = append(effects,
+			setStatusReasonEffect(model.StatusFailed, launchFailureReason(step)),
+			logEffect("%s#%s: launch failed at %s: %s", view.IssueID, view.RunID, step, sig.Err),
+		)
+		return core, effects
+	}
+
+	var target model.Status
+	switch sig.Stage {
+	case stageRunCreated:
+		target = model.StatusQueued
+	case stageLaunchReady:
+		target = model.StatusBooting
+	case stageWorkspaceOnly, stageAgentStarted:
+		target = model.StatusRunning
+	default:
+		return core, nil
+	}
+	if target == view.Status {
+		return core, nil
+	}
+	return core, []runEffect{setStatusEffect(target)}
+}
+
+// launchFailureReason is the machine-readable reason family for launch
+// failures: `launch_<step>` (run-state-machine.md §5 status reasons).
+func launchFailureReason(step string) string {
+	return "launch_" + step
 }
 
 func stepPRState(view runView, core runCore, obs runObservation) (runCore, []runEffect) {

--- a/internal/daemon/step_test.go
+++ b/internal/daemon/step_test.go
@@ -6,6 +6,7 @@ package daemon
 // are documented in docs/design/run-state-machine.md §5.
 
 import (
+	"fmt"
 	"math/rand"
 	"reflect"
 	"testing"
@@ -75,6 +76,13 @@ func stepTestObservations(now time.Time) []runObservation {
 		runObservation{Kind: obsCaptured, Output: "exited", Signal: agentSignal{Exited: true}},
 		runObservation{Kind: obsCaptured, Output: "busy", Signal: agentSignal{Resolved: true, Status: model.StatusRunning}},
 		runObservation{Kind: obsCaptured, Output: "idle", Signal: agentSignal{Resolved: true, Status: model.StatusWaiting}},
+	)
+	obs = append(obs,
+		runObservation{Kind: obsLaunchProgress, Launch: launchReached(stageRunCreated)},
+		runObservation{Kind: obsLaunchProgress, Launch: launchReached(stageLaunchReady)},
+		runObservation{Kind: obsLaunchProgress, Launch: launchReached(stageWorkspaceOnly)},
+		runObservation{Kind: obsLaunchProgress, Launch: launchReached(stageAgentStarted)},
+		runObservation{Kind: obsLaunchProgress, Launch: launchFailed("session", fmt.Errorf("session create failed"))},
 	)
 	return obs
 }
@@ -150,7 +158,7 @@ func TestStepLawDeterminism(t *testing.T) {
 // repetition legitimately advances debounce/dead counters.
 func isFactObservation(obs runObservation) bool {
 	switch obs.Kind {
-	case obsPRState, obsGitEvidence, obsSessionAlive:
+	case obsPRState, obsGitEvidence, obsSessionAlive, obsLaunchProgress:
 		return true
 	default:
 		return false
@@ -569,5 +577,71 @@ func TestStepRandomWalkTerminalAbsorption(t *testing.T) {
 				terminalAt = i
 			}
 		}
+	}
+}
+
+// O8 launch progress: stages map to exactly the ladder statuses, and
+// re-affirming the current status is silent — the implicit initial `queued`
+// (the fold default) is never duplicated as an event
+// (run-state-machine.md §7 D-B1).
+func TestStepLaunchProgressStageMapping(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		stage launchStage
+		want  model.Status
+	}{
+		{stageRunCreated, model.StatusQueued},
+		{stageLaunchReady, model.StatusBooting},
+		{stageWorkspaceOnly, model.StatusRunning},
+		{stageAgentStarted, model.StatusRunning},
+	}
+	for _, tc := range cases {
+		// waiting stands in for any non-terminal, non-target status: the
+		// reuse path relaunches waiting runs through the same ladder.
+		view := stepTestView(model.StatusWaiting, "codex", now.Add(-time.Minute))
+		obs := runObservation{Kind: obsLaunchProgress, Launch: launchReached(tc.stage)}
+		_, effects := stepRun(view, runCore{}, obs, now)
+		got, ok := statusEffectOf(effects)
+		if !ok || got != tc.want {
+			t.Fatalf("stage %d: status effect = %v (present=%t), want %s", tc.stage, got, ok, tc.want)
+		}
+
+		view.Status = tc.want
+		_, effects = stepRun(view, runCore{}, obs, now)
+		if len(effects) != 0 {
+			t.Fatalf("stage %d at %s: re-affirmation produced effects %+v", tc.stage, tc.want, effects)
+		}
+	}
+}
+
+// O8 launch failure: the error artifact precedes the failed verdict, the
+// verdict carries the machine-readable reason launch_<step>, and an unnamed
+// step falls back to launch_bootstrap.
+func TestStepLaunchFailureCarriesReason(t *testing.T) {
+	now := time.Now()
+	view := stepTestView(model.StatusBooting, "codex", now.Add(-time.Minute))
+
+	obs := runObservation{Kind: obsLaunchProgress, Launch: launchFailed("session", fmt.Errorf("tmux exploded"))}
+	_, effects := stepRun(view, runCore{}, obs, now)
+	if len(effects) != 3 {
+		t.Fatalf("expected [recordError, setStatus, log], got %+v", effects)
+	}
+	if effects[0].Kind != effectRecordError || effects[0].Msg != "tmux exploded" {
+		t.Fatalf("first effect = %+v, want error artifact carrying the bootstrap error", effects[0])
+	}
+	if effects[1].Kind != effectSetStatus || effects[1].Status != model.StatusFailed || effects[1].Reason != "launch_session" {
+		t.Fatalf("second effect = %+v, want failed with reason launch_session", effects[1])
+	}
+	if effects[2].Kind != effectLog {
+		t.Fatalf("third effect = %+v, want log", effects[2])
+	}
+
+	// No detail → no artifact; no step name → the bootstrap fallback reason.
+	_, effects = stepRun(view, runCore{}, runObservation{Kind: obsLaunchProgress, Launch: launchSignal{Failed: true}}, now)
+	if len(effects) != 2 {
+		t.Fatalf("expected [setStatus, log], got %+v", effects)
+	}
+	if effects[0].Kind != effectSetStatus || effects[0].Status != model.StatusFailed || effects[0].Reason != "launch_bootstrap" {
+		t.Fatalf("first effect = %+v, want failed with reason launch_bootstrap", effects[0])
 	}
 }


### PR DESCRIPTION
## What

Phase B1 of the coupling-core roadmap: the four launch ladders (W2 `handleStartRun`, W3 `processStartRunCore`, W4 `processContinueRunCore`, W5 `handleContinueRun`) and the failure arm (W7 `failOpenCodeRunBootstrap`) no longer write run status events. All 37 ladder append sites are replaced by O8 launch observations decided in the pure transition core.

```
ladder (imperative bootstrap, unchanged control flow)
  │  reportLaunchProgress(st, run, launchSignal)      ← launch-plane executor
  ▼
stepLaunchProgress (pure policy, step.go)
  stageRunCreated → queued      stageLaunchReady → booting
  stageWorkspaceOnly/stageAgentStarted → running
  failure → [error artifact, failed(reason=launch_<step>), log]
  │  effectSetStatus
  ▼
commitRunStatus (status_commit.go) ← THE single status-event constructor
  ▲
  └─ Daemon.updateStatus (monitor plane: +publish +auto-resolve +listeners)
```

## Key decisions (run-state-machine.md §7 D-B1)

- **`commitRunStatus` extraction**: `updateStatus`'s guard/append core is now a process-neutral function, so the worker plane (which runs `SocketServer` without a `Daemon`) commits through identical guards. Status events are constructed in exactly one place.
- **Stage vocabulary in the observation, statuses in the policy** — the ladders report facts; the mapping is `stepLaunchProgress`'s.
- **Terminal absorption == old store-guard behavior**: launch appends on terminal runs were already silently rejected (daemon source); now the no-write is a policy decision (L4), not a discarded error.
- **Launch failures carry `launch_<step>` reasons** (new law L9), rendered by `orch ps` as `failed(launch_session)` etc.
- **The implicit initial `queued`** (fold default) is no longer materialized as a redundant event.
- **Listener scope unchanged**: launch transitions stay listener-invisible (widening I8 is a separate decision).

## Whitelist meter

`nosemgrep: run-status-write-surface`: **47 → 10** (socket.go 40 → 3). Every survivor has a §6 disposition: W6/W8 (integrate v2), W9 ×4 / W10 (quarantined law boundaries), `appendRunResolvedByUser` (B3 verb), plus the sanctioned constructor itself.

## Tests

- O8 added to the law-sweep observation set → L4 terminality, determinism, L1a idempotent convergence, and stream fixed-point laws now cover launch observations automatically.
- New: `TestStepLaunchProgressStageMapping` (stage→status + re-affirmation silence), `TestStepLaunchFailureCarriesReason` (artifact order, `launch_<step>`, `launch_bootstrap` fallback).
- `go build ./...`, `go test ./internal/daemon` (19.4s ok), `make lint` (all semgrep fixtures pass, 0 findings), full `go test ./...` — only the two pre-existing tmux-environment integration failures (`TestAgentClaudeCreatesMultiplexerSession`, `TestAgentStatePersistence`), reproduced identically on main @ f39a19b1.

## Docs in the same change set

run-state-machine.md §1 (writer table + single-constructor note), §2 (O8), §3 (O8 matrix rows), §5 (L9 + `launch_<step>` reason family), §6 (W2–W5/W7 → integrated), §7 (D-B1); AGENTS.md status-write-surface; roadmap B1 + watchlist rows 1/6.

Per the routing rule this is a core change: frontier + human review — please review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)