### PR TITLE
docs: align beta prerequisites and examples

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,10 +20,10 @@ When using a remote daemon, configure the client target in
 ```yaml
 # ~/.config/orch/client.yaml
 remote:
-  default: zeus
+  default: primary
   hosts:
-    zeus:
-      addr: zeus:7777
+    primary:
+      addr: master-host:7777
     cloud:
       addr: 10.0.0.5:7777
 ```
@@ -48,8 +48,8 @@ On the server side, expose the daemon over TCP and register the repository URL:
 orch daemon start --listen tcp://0.0.0.0:7777
 
 # From client machine
-orch --remote zeus:7777 daemon repo register https://github.com/your-org/your-project.git
-orch --remote zeus:7777 daemon repo list
+orch --remote master-host:7777 daemon repo register https://github.com/your-org/your-project.git
+orch --remote master-host:7777 daemon repo list
 ```
 
 In remote mode, orch resolves project identity from `--project`/`ORCH_PROJECT`
@@ -257,7 +257,7 @@ All settings can be configured via environment variables:
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `ORCH_PROJECT` | Project identity (repo ID or URL) | `your-org-your-repo` |
-| `ORCH_REMOTE` | Remote daemon address | `zeus:7777` |
+| `ORCH_REMOTE` | Remote daemon address | `master-host:7777` |
 | `ORCH_AGENT` | Default agent | `claude` |
 | `ORCH_BACKEND` | Backend type | `file` |
 | `ORCH_MODEL` | Default model | `anthropic/claude-opus-4-5` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ This guide will take you from zero to your first working agent run in about 5 mi
 
 Before installing orch, ensure you have:
 
-1. **Go 1.22+** - For building orch from source (or use pre-built binaries)
+1. **Go 1.25+** - For building orch from source (or use pre-built binaries)
 2. **tmux** or **zellij** - Terminal multiplexer for agent sessions
 3. **An LLM CLI** - At least one of:
    - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`claude`)
@@ -14,6 +14,8 @@ Before installing orch, ensure you have:
    - [Codex](https://github.com/openai/codex) (`codex`)
    - [Gemini CLI](https://github.com/google/gemini-cli) (`gemini`)
 4. **Git** - For worktree management
+5. **GitHub CLI** (`gh`) - Required for the PR workflow. Run `gh auth login` before creating PRs.
+6. **uv** - Required only when installing or developing the Python TUI (`orch-monitor`)
 
 ### Quick prerequisite check
 
@@ -26,6 +28,9 @@ tmux -V
 
 # Verify your LLM CLI (example with claude)
 claude --version
+
+# Verify GitHub CLI authentication for PR workflows
+gh auth status
 ```
 
 ## Installation
@@ -53,6 +58,22 @@ sudo mv orch /usr/local/bin/
 
 ```bash
 go install github.com/proboscis/orch/cmd/orch@latest
+```
+
+### Option 3: Build from a local checkout
+
+For the CLI and daemon only:
+
+```bash
+make build
+make install-cli
+```
+
+The default `make` target installs both the CLI and the Python TUI. It requires
+`uv` because it runs the TUI installer:
+
+```bash
+make
 ```
 
 ### Verify installation

--- a/docs/remote-usage.md
+++ b/docs/remote-usage.md
@@ -10,11 +10,11 @@ daemon is the source of truth for runs/issues state and resolves project
 identity through repo mappings.
 
 ```text
-Local client                  Remote host
-┌──────────────────────┐      ┌────────────────────────────────────┐
-│ orch CLI / monitor   │ TCP  │ orch daemon (--listen)            │
-│ --remote zeus:7777   │─────▶│ repo mapping: repoid -> path      │
-└──────────────────────┘      └────────────────────────────────────┘
+Local client                         Remote host
+┌──────────────────────────────┐      ┌────────────────────────────────────┐
+│ orch CLI / monitor           │ TCP  │ orch daemon (--listen)            │
+│ --remote master-host:7777    │─────▶│ repo mapping: repoid -> path      │
+└──────────────────────────────┘      └────────────────────────────────────┘
 ```
 
 ## Prerequisites
@@ -46,8 +46,8 @@ orch daemon start --listen tcp://0.0.0.0:7777
 
 ```bash
 # From client (or server), point to remote daemon
-orch --remote zeus:7777 daemon repo register https://github.com/your-org/your-project.git
-orch --remote zeus:7777 daemon repo list
+orch --remote master-host:7777 daemon repo register https://github.com/your-org/your-project.git
+orch --remote master-host:7777 daemon repo list
 ```
 
 If repo mappings are missing, remote commands fail with a store/project mapping
@@ -58,13 +58,13 @@ error.
 ### Option A: per-command remote flag
 
 ```bash
-orch --remote zeus:7777 ps
+orch --remote master-host:7777 ps
 ```
 
 ### Option B: environment variable
 
 ```bash
-export ORCH_REMOTE=zeus:7777
+export ORCH_REMOTE=master-host:7777
 orch ps
 ```
 
@@ -73,10 +73,10 @@ orch ps
 ```yaml
 # ~/.config/orch/client.yaml
 remote:
-  default: zeus
+  default: primary
   hosts:
-    zeus:
-      addr: zeus:7777
+    primary:
+      addr: master-host:7777
 ```
 
 ```bash
@@ -94,15 +94,15 @@ orch --remote "" ps
 
 ```bash
 # Start a run remotely
-orch --remote zeus:7777 --project yourorg-yourrepo run my-issue
+orch --remote master-host:7777 --project yourorg-yourrepo run my-issue
 
 # Monitor runs
-orch --remote zeus:7777 --project yourorg-yourrepo ps
+orch --remote master-host:7777 --project yourorg-yourrepo ps
 
 # Attach/send/capture as usual
-orch --remote zeus:7777 --project yourorg-yourrepo attach my-issue
-orch --remote zeus:7777 --project yourorg-yourrepo send my-issue "please include tests"
-orch --remote zeus:7777 --project yourorg-yourrepo capture my-issue
+orch --remote master-host:7777 --project yourorg-yourrepo attach my-issue
+orch --remote master-host:7777 --project yourorg-yourrepo send my-issue "please include tests"
+orch --remote master-host:7777 --project yourorg-yourrepo capture my-issue
 ```
 
 ## Important Behavior in Remote Mode
@@ -115,7 +115,7 @@ orch --remote zeus:7777 --project yourorg-yourrepo capture my-issue
 ### Cannot connect to daemon
 
 ```bash
-orch --remote zeus:7777 daemon status
+orch --remote master-host:7777 daemon status
 ```
 
 Verify listener and network path to the remote host.
@@ -123,19 +123,19 @@ Verify listener and network path to the remote host.
 ### "No store available" / project mapping errors
 
 ```bash
-orch --remote zeus:7777 daemon repo list
+orch --remote master-host:7777 daemon repo list
 ```
 
 If missing, register the repository URL on the remote daemon:
 
 ```bash
-orch --remote zeus:7777 daemon repo register https://github.com/your-org/your-project.git
+orch --remote master-host:7777 daemon repo register https://github.com/your-org/your-project.git
 ```
 
 Then scope runtime commands by project identity (repo ID):
 
 ```bash
-orch --remote zeus:7777 --project yourorg-yourrepo ps --json
+orch --remote master-host:7777 --project yourorg-yourrepo ps --json
 ```
 
 ### "Issue not found" during `run` with remote master + external worker
@@ -149,11 +149,11 @@ Checklist:
 
 ```bash
 # master-side mapping exists
-orch --remote zeus:7777 daemon repo list
+orch --remote master-host:7777 daemon repo list
 
 # run this on the worker host; it reports the local background process plus
 # that worker's registration state on the configured master
-orch --remote zeus:7777 worker status --json
+orch --remote master-host:7777 worker status --json
 ```
 
 Then confirm worker host project/config alignment (`--project`, `.orch/config.yaml`,


### PR DESCRIPTION
## Summary

- Align Getting Started prerequisites with `go.mod` (`go 1.25.3`) and document `gh auth login` plus TUI-only `uv` usage.
- Document the local checkout build paths: `make build` / `make install-cli` for CLI-only, and plain `make` for CLI + Python TUI.
- Replace author-specific remote examples in user-facing docs with neutral placeholders such as `master-host:7777` and `primary`.

## Evidence

- Issue: `beta-docs-prereqs`
- Module path / Go version verified:

```text
module: module github.com/proboscis/orch
go: go 1.25.3
README.md:14:go install github.com/proboscis/orch/cmd/orch@latest
docs/getting-started.md:60:go install github.com/proboscis/orch/cmd/orch@latest
```

- Getting Started prerequisites and build paths verified:

```text
docs/getting-started.md:9:1. **Go 1.25+** - For building orch from source (or use pre-built binaries)
docs/getting-started.md:17:5. **GitHub CLI** (`gh`) - Required for the PR workflow. Run `gh auth login` before creating PRs.
docs/getting-started.md:18:6. **uv** - Required only when installing or developing the Python TUI (`orch-monitor`)
docs/getting-started.md:68:make build
docs/getting-started.md:69:make install-cli
docs/getting-started.md:72:The default `make` target installs both the CLI and the Python TUI. It requires
```

- E2E instruction links are repo-relative:

```text
AGENTS.md:187:- [docs/e2e-master-worker-client.md](docs/e2e-master-worker-client.md)
AGENTS.md:188:- [docs/e2e-backend-matrix.md](docs/e2e-backend-matrix.md)
AGENTS.md:189:- [docs/e2e-automation-plan.md](docs/e2e-automation-plan.md)
```

- User-facing docs grep proof for removed author-specific examples:

```text
$ rg -n 'zeus|CA-20035844|/Users/s22625' README.md docs/getting-started.md docs/configuration.md docs/remote-usage.md docs/daily-workflow.md
# no matches
```

- Checks:

```text
$ git diff --check
# passed

$ make lint
# passed; internal semgrep, TUI semgrep, and fixture tests completed with 0 blocking findings in scanned source

$ ORCH_SAFE_CLI_TEST=1 go test -p 1 -parallel 1 $(go list ./... | rg -v '/test/integration$')
# passed
```

## Test note

`make test-fast` was also attempted. It reached `test/integration` and failed in `TestRunWithBuiltInAgents` because `opencode` session creation returned an external server 500:

```text
failed to create opencode session: create session returned status 500
```

The changed files are documentation-only and do not touch integration runtime behavior.
