### PR TITLE
Group CLI help surface

### DIFF
--- a/docs/orch-monitor.md
+++ b/docs/orch-monitor.md
@@ -2,6 +2,11 @@
 
 orch-monitor is a terminal user interface (TUI) for managing orch issues and runs visually. It provides a dashboard view of your workflow and integrates with the control agent for chat-based management.
 
+`orch monitor` and `orch-monitor` are separate frontends. `orch monitor` is the
+built-in Go TUI shipped as an `orch` subcommand, while `orch-monitor` is the
+optional standalone Python TUI installed from `orch-monitor-tui`. Both read the
+same daemon state, but they have separate binaries, launch flows, and docs.
+
 ## Installation
 
 The TUI is packaged separately and can be installed with uv:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -704,7 +704,7 @@ orch log [flags]
 
 ## orch models
 
-List available models for opencode.
+List opencode provider models.
 
 ```bash
 orch models

--- a/internal/cli/master_worker.go
+++ b/internal/cli/master_worker.go
@@ -20,10 +20,11 @@ func newMasterCmd() *cobra.Command {
 	cmd := newDaemonCmd()
 	cmd.Use = "master"
 	cmd.Short = "Manage orch-master control plane"
+	cmd.Hidden = true
 	cmd.Long = `Manage orch-master control plane.
 
-This command is the preferred cluster terminology. It is behaviorally equivalent
-to 'orch daemon'.`
+The canonical command name is 'orch daemon'. 'orch master' is kept as a hidden
+compatibility alias for existing deployments.`
 	return cmd
 }
 
@@ -34,8 +35,8 @@ func newWorkerCmd() *cobra.Command {
 		Long: `Manage orch-worker execution plane.
 
 Workers run as long-lived host managers and execute work assigned by
-orch-master via worker protocol APIs. Zeus single-host mode is implemented as
-co-located master+worker with the same semantics as distributed mode.`,
+orch-master via worker protocol APIs. Single-host mode is implemented as
+co-located daemon+worker with the same semantics as distributed mode.`,
 	}
 
 	cmd.AddCommand(newWorkerStatusCmd())

--- a/internal/cli/master_worker_test.go
+++ b/internal/cli/master_worker_test.go
@@ -14,12 +14,16 @@ func TestRootRegistersMasterAndWorkerCommands(t *testing.T) {
 		t.Fatal("expected root commands to be initialized")
 	}
 
+	var masterCmdLong string
+	masterHidden := false
 	hasMaster := false
 	hasWorker := false
 	for _, cmd := range rootCmd.Commands() {
 		switch cmd.Name() {
 		case "master":
 			hasMaster = true
+			masterHidden = cmd.Hidden
+			masterCmdLong = cmd.Long
 		case "worker":
 			hasWorker = true
 		}
@@ -27,6 +31,12 @@ func TestRootRegistersMasterAndWorkerCommands(t *testing.T) {
 
 	if !hasMaster {
 		t.Fatal("expected root command to include 'master'")
+	}
+	if !masterHidden {
+		t.Fatal("expected 'master' command to be hidden from help")
+	}
+	if !strings.Contains(masterCmdLong, "canonical command name is 'orch daemon'") {
+		t.Fatalf("expected master help to point at canonical daemon command, got: %s", masterCmdLong)
 	}
 	if !hasWorker {
 		t.Fatal("expected root command to include 'worker'")

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -25,7 +25,7 @@ func newModelsCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "models",
-		Short: "List available models for opencode",
+		Short: "List opencode provider models",
 		Long: `List available models and variants for the opencode agent.
 
 Requires a running opencode server. If no server is running, start one with:

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -45,6 +45,12 @@ type GlobalOptions struct {
 var globalOpts = &GlobalOptions{}
 var remoteFlagWasSet bool
 
+const (
+	commandGroupCore     = "core"
+	commandGroupSetupOps = "setup-ops"
+	commandGroupAdvanced = "advanced"
+)
+
 var noDaemonCommands = map[string]bool{
 	"show":                 true,
 	"daemon":               true,
@@ -121,41 +127,58 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&globalOpts.Quiet, "quiet", false, "Suppress human-readable output")
 	rootCmd.PersistentFlags().StringVar(&globalOpts.LogLevel, "log-level", "warn", "Log level (error|warn|info|debug)")
 
+	rootCmd.AddGroup(
+		&cobra.Group{ID: commandGroupCore, Title: "Core Commands:"},
+		&cobra.Group{ID: commandGroupSetupOps, Title: "Setup & Ops Commands:"},
+		&cobra.Group{ID: commandGroupAdvanced, Title: "Advanced Commands:"},
+	)
+	rootCmd.SetHelpCommandGroupID(commandGroupCore)
+	rootCmd.SetCompletionCommandGroupID(commandGroupAdvanced)
+
 	// Add subcommands
-	rootCmd.AddCommand(newIssueCmd())
-	rootCmd.AddCommand(newPsCmd())
-	rootCmd.AddCommand(newRunCmd())
-	rootCmd.AddCommand(newRestartFromCmd())
-	rootCmd.AddCommand(newShowCmd())
-	rootCmd.AddCommand(newDiffCmd())
-	rootCmd.AddCommand(newAttachCmd())
-	rootCmd.AddCommand(newTickCmd())
-	rootCmd.AddCommand(newOpenCmd())
-	rootCmd.AddCommand(newStopCmd())
-	rootCmd.AddCommand(newWaitCmd())
-	rootCmd.AddCommand(newMonitorCmd())
-	rootCmd.AddCommand(newResolveCmd())
-	rootCmd.AddCommand(newDaemonCmd())
-	rootCmd.AddCommand(newMasterCmd())
-	rootCmd.AddCommand(newWorkerCmd())
-	rootCmd.AddCommand(newDaemonRestartCmd())
-	rootCmd.AddCommand(newRepairCmd())
-	rootCmd.AddCommand(newCleanCmd())
-	rootCmd.AddCommand(newDeleteCmd())
-	rootCmd.AddCommand(newExecCmd())
-	rootCmd.AddCommand(newSendCmd())
-	rootCmd.AddCommand(newCaptureCmd())
-	rootCmd.AddCommand(newCaptureAllCmd())
-	rootCmd.AddCommand(newModelsCmd())
-	rootCmd.AddCommand(newNotifyCmd())
-	rootCmd.AddCommand(newLogCmd())
-	rootCmd.AddCommand(newEventsCmd())
-	rootCmd.AddCommand(newDebugCmd())
-	rootCmd.AddCommand(newQueryCmd())
-	rootCmd.AddCommand(newSchemaCmd())
-	rootCmd.AddCommand(newTutorialCmd())
-	rootCmd.AddCommand(newAgentCmd())
-	rootCmd.AddCommand(newValidateIssueFilesCmd())
+	rootCmd.AddCommand(
+		withCommandGroup(newIssueCmd(), commandGroupCore),
+		withCommandGroup(newPsCmd(), commandGroupCore),
+		withCommandGroup(newRunCmd(), commandGroupCore),
+		withCommandGroup(newShowCmd(), commandGroupCore),
+		withCommandGroup(newDiffCmd(), commandGroupCore),
+		withCommandGroup(newAttachCmd(), commandGroupCore),
+		withCommandGroup(newOpenCmd(), commandGroupCore),
+		withCommandGroup(newStopCmd(), commandGroupCore),
+		withCommandGroup(newWaitCmd(), commandGroupCore),
+		withCommandGroup(newMonitorCmd(), commandGroupCore),
+		withCommandGroup(newResolveCmd(), commandGroupCore),
+		withCommandGroup(newSendCmd(), commandGroupCore),
+		withCommandGroup(newCaptureCmd(), commandGroupCore),
+
+		withCommandGroup(newDaemonCmd(), commandGroupSetupOps),
+		withCommandGroup(newMasterCmd(), commandGroupSetupOps),
+		withCommandGroup(newWorkerCmd(), commandGroupSetupOps),
+		withCommandGroup(newDaemonRestartCmd(), commandGroupSetupOps),
+		withCommandGroup(newRepairCmd(), commandGroupSetupOps),
+		withCommandGroup(newTutorialCmd(), commandGroupSetupOps),
+		withCommandGroup(newCleanCmd(), commandGroupSetupOps),
+		withCommandGroup(newDeleteCmd(), commandGroupSetupOps),
+		withCommandGroup(newNotifyCmd(), commandGroupSetupOps),
+
+		withCommandGroup(newTickCmd(), commandGroupAdvanced),
+		withCommandGroup(newRestartFromCmd(), commandGroupAdvanced),
+		withCommandGroup(newExecCmd(), commandGroupAdvanced),
+		withCommandGroup(newCaptureAllCmd(), commandGroupAdvanced),
+		withCommandGroup(newModelsCmd(), commandGroupAdvanced),
+		withCommandGroup(newLogCmd(), commandGroupAdvanced),
+		withCommandGroup(newEventsCmd(), commandGroupAdvanced),
+		withCommandGroup(newDebugCmd(), commandGroupAdvanced),
+		withCommandGroup(newQueryCmd(), commandGroupAdvanced),
+		withCommandGroup(newSchemaCmd(), commandGroupAdvanced),
+		withCommandGroup(newAgentCmd(), commandGroupAdvanced),
+		withCommandGroup(newValidateIssueFilesCmd(), commandGroupAdvanced),
+	)
+}
+
+func withCommandGroup(cmd *cobra.Command, groupID string) *cobra.Command {
+	cmd.GroupID = groupID
+	return cmd
 }
 
 // Execute runs the root command

--- a/internal/cli/root_help_test.go
+++ b/internal/cli/root_help_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRootHelpRendersGroupedCommands(t *testing.T) {
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+	})
+
+	if err := rootCmd.Help(); err != nil {
+		t.Fatalf("root help failed: %v", err)
+	}
+
+	help := out.String()
+	for _, section := range []string{
+		"\nCore Commands:\n",
+		"\nSetup & Ops Commands:\n",
+		"\nAdvanced Commands:\n",
+	} {
+		if !strings.Contains(help, section) {
+			t.Fatalf("expected grouped help section %q in:\n%s", section, help)
+		}
+	}
+	if strings.Contains(help, "\nAdditional Commands:\n") {
+		t.Fatalf("expected all visible commands to be grouped, got:\n%s", help)
+	}
+	if strings.Contains(help, "\n  master ") {
+		t.Fatalf("expected hidden master command to be omitted from help, got:\n%s", help)
+	}
+}
+
+func TestVisibleRootCommandsBelongToGroups(t *testing.T) {
+	rootCmd.InitDefaultHelpCmd()
+	rootCmd.InitDefaultCompletionCmd()
+
+	groupIDs := make(map[string]bool)
+	for _, group := range rootCmd.Groups() {
+		groupIDs[group.ID] = true
+	}
+
+	for _, cmd := range rootCmd.Commands() {
+		if !cmd.IsAvailableCommand() && cmd.Name() != "help" {
+			continue
+		}
+		if cmd.GroupID == "" {
+			t.Fatalf("visible root command %q has no group", cmd.Name())
+		}
+		if !groupIDs[cmd.GroupID] {
+			t.Fatalf("visible root command %q uses unknown group %q", cmd.Name(), cmd.GroupID)
+		}
+	}
+}

--- a/internal/cli/tutorial.go
+++ b/internal/cli/tutorial.go
@@ -18,7 +18,7 @@ This tutorial covers:
   - Basic workflow commands
   - Run statuses and what they mean
   - Troubleshooting tips
-  - orch-monitor TUI workflow and keybindings`,
+  - Monitoring options and TUI keybindings`,
 		Run: func(cmd *cobra.Command, args []string) {
 			printTutorial()
 		},
@@ -122,6 +122,11 @@ Interact with the agent:
 	orch restart-from <run> Restart from a failed/canceled/unknown run
     orch capture <run>      Capture agent session to markdown
 
+Note: 'orch monitor' is the built-in Go TUI shipped with the orch CLI.
+'orch-monitor' is the optional standalone Python TUI installed from
+orch-monitor-tui; both inspect the same daemon state, but they are separate
+frontends.
+
 --------------------------------------------------------------------------------
 5. RUN STATUSES
 --------------------------------------------------------------------------------
@@ -184,7 +189,9 @@ Capture all completed runs:
 8. ORCH-MONITOR TUI
 --------------------------------------------------------------------------------
 
-orch-monitor is a terminal UI for managing issue-driven development.
+orch-monitor is the optional standalone Python terminal UI for managing
+issue-driven development. It is separate from the built-in 'orch monitor'
+command.
 
 Launch the TUI:
 
@@ -244,7 +251,7 @@ Point every command at a shared master daemon via client.yaml
 (global: ~/.config/orch/client.yaml, or per-repo: .orch/client.yaml):
 
     remote:
-      default: "zeus:7777"
+      default: "<master-host>:7777"
 
 Each host that should execute runs needs a local worker registered to the
 master:


### PR DESCRIPTION
## Summary

- Group top-level `orch --help` commands into Core, Setup & Ops, and Advanced sections with all visible commands assigned to a Cobra group.
- Hide the legacy `orch master` duplicate while keeping it functional and documenting `orch daemon` as the canonical name.
- Tighten opencode model help text and replace CLI tutorial host-specific examples with `<master-host>:7777`.
- Clarify `orch monitor` vs `orch-monitor` in the tutorial and monitor docs.

## Issue

Refs beta-cli-surface.

## Verification

- `go run ./cmd/orch --help`
  - Renders `Core Commands:`, `Setup & Ops Commands:`, and `Advanced Commands:`.
  - Does not render `master` or `Additional Commands:`.
  - Renders `models               List opencode provider models`.
- `go run ./cmd/orch master --help`
  - Still works and says the canonical command name is `orch daemon`.
- `go run ./cmd/orch tutorial | rg '<master-host>|zeus:7777|orch monitor|orch-monitor'`
  - Shows `default: "<master-host>:7777"` and the `orch monitor` / `orch-monitor` distinction.
  - No `zeus:7777` CLI tutorial hit.
- `go build ./...` passed.
- `go test ./internal/cli` passed.
- `go test $(go list ./... | grep -v '/test/integration$')` passed.
- `TMUX= go test ./test/integration -run TestAgentClaude -count=1` passed, per dispatcher note for known tmux false failures.
- `make lint` passed.

## Residual Test Note

- `go test ./...` did not pass on this host because `test/integration` is currently failing outside this change:
  - One run failed in `TestRunWithBuiltInAgents` when the external `opencode` path returned HTTP 500 while creating/sending a session.
  - A later `TMUX= go test ./...` run failed in integration `TestMain` with `panic: daemon did not start in time`.
- The changed code is CLI help/docs presentation only; the failing integration paths are external agent/daemon startup paths and were not modified here.
