### PR TITLE
Remove runtime-reachable daemon panics on status-vocabulary drift (modelStatusToProto)

### DIFF
--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -382,3 +382,24 @@ Decisions taken:
 
 Whitelist meter: 47 → 10 annotations (socket.go 40 → 3; the remaining three
 are W6, W8 and `appendRunResolvedByUser`, all with §6 dispositions).
+
+## 8. Vocabulary drift at serialization boundaries (decided 2026-07-07)
+
+**Rule: vocabulary drift at serialization boundaries degrades to skip+log —
+never panics, never invents a status.**
+
+The status vocabulary can drift ahead of the proto map (newer binary wrote,
+older binary reads, or vice versa; there is no CLI/daemon version handshake).
+The conversion layer (`internal/daemon/proto_convert.go` —
+`modelStatusToProto` and friends) returns `(value, error)` for an unmapped
+status; it never panics. Callers at serialization boundaries (event-bus
+publish in `Daemon.publishRunEvent`, `SocketServer.publishFeedbackResume`)
+handle the error by logging an ERROR naming the run ref and the offending
+status, then skipping that run's notification for that tick. No status event
+is written, no synthetic status (e.g. `unknown`) is substituted, and the
+daemon stays alive — one drifted run must not stop monitoring for all runs.
+
+This does not weaken fail-fast elsewhere: recover wrappers still re-panic
+(`logAndRepanic`), the transition policy (`step()`) and the status write
+surface (`commitRunStatus`) are untouched, and discarding conversion errors
+remains banned by the `fail-fast-no-discard-status-parse-error` semgrep rule.

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -562,13 +562,18 @@ func (d *Daemon) publishRunEvent(run *model.Run, from, to model.Status, source m
 	if from == to {
 		return
 	}
+	// Vocabulary drift (a status with no proto mapping) degrades to skip+log
+	// per docs/design/run-state-machine.md §8: this run's publish is dropped
+	// for this tick, no status is invented, and the daemon stays alive.
 	fromProto, err := modelStatusToProto(from)
 	if err != nil {
-		panic(err)
+		d.logger.Printf("ERROR %s#%s: skipping run event publish: %v", run.IssueID, run.RunID, err)
+		return
 	}
 	toProto, err := modelStatusToProto(to)
 	if err != nil {
-		panic(err)
+		d.logger.Printf("ERROR %s#%s: skipping run event publish: %v", run.IssueID, run.RunID, err)
+		return
 	}
 	frame := &orchpb.RunEventFrame{
 		RunId:           string(run.RunID),

--- a/internal/daemon/monitor_publish_test.go
+++ b/internal/daemon/monitor_publish_test.go
@@ -1,10 +1,12 @@
 package daemon
 
 import (
+	"bytes"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -81,6 +83,61 @@ func TestUpdateStatus_PublishesTransitionToBus(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("no event received within timeout")
+	}
+}
+
+// TestPublishRunEvent_VocabularyDriftSkipsNotPanics feeds a status with no
+// proto mapping through the monitor-plane publish path (both the from and
+// the to arm) and asserts the drift rule of
+// docs/design/run-state-machine.md §8: no panic (the old behavior panicked
+// here and killed the daemon), an ERROR naming the run ref and the
+// offending status is logged, no frame is published for the drifted run,
+// and a subsequent healthy run's publish is unaffected.
+func TestPublishRunEvent_VocabularyDriftSkipsNotPanics(t *testing.T) {
+	var logBuf bytes.Buffer
+	srv := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	d := newTestDaemon()
+	d.logger = log.New(&logBuf, "", 0)
+	d.socketServer = srv
+
+	sub := srv.RunEventBus().Subscribe(RunEventFilter{})
+	defer sub.Close()
+
+	drifted := &model.Run{IssueID: "issue-drift", RunID: "run-drift"}
+	unmapped := model.Status("status-from-the-future")
+
+	// Old behavior: either of these calls panics and the test fails.
+	d.publishRunEvent(drifted, unmapped, model.StatusRunning, model.EventSourceDaemon)
+	d.publishRunEvent(drifted, model.StatusRunning, unmapped, model.EventSourceDaemon)
+
+	logged := logBuf.String()
+	if got := strings.Count(logged, "ERROR issue-drift#run-drift"); got != 2 {
+		t.Fatalf("ERROR log lines naming the run ref = %d, want 2; log:\n%s", got, logged)
+	}
+	if !strings.Contains(logged, "status-from-the-future") {
+		t.Fatalf("log does not name the offending status:\n%s", logged)
+	}
+
+	select {
+	case ev := <-sub.Events():
+		t.Fatalf("expected no event for drifted status, got %+v", ev)
+	case <-time.After(200 * time.Millisecond):
+		// expected: publish skipped
+	}
+
+	// Other runs' updates are unaffected on the same tick.
+	healthy := &model.Run{IssueID: "issue-healthy", RunID: "run-1"}
+	d.publishRunEvent(healthy, model.StatusRunning, model.StatusWaiting, model.EventSourceDaemon)
+	select {
+	case ev := <-sub.Events():
+		if ev.IssueId != "issue-healthy" || ev.RunId != "run-1" {
+			t.Fatalf("unexpected ids: %+v", ev)
+		}
+		if ev.FromStatus != orchpb.RunStatus_RUN_STATUS_RUNNING || ev.ToStatus != orchpb.RunStatus_RUN_STATUS_WAITING {
+			t.Fatalf("unexpected transition: %+v", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("healthy run publish blocked after drift skip")
 	}
 }
 

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -3024,13 +3024,24 @@ func (s *SocketServer) markRunFeedbackSent(st store.Store, run *model.Run) {
 			Store:  st,
 		})
 	}
+	s.publishFeedbackResume(run, fromStatus)
+}
+
+// publishFeedbackResume broadcasts the feedback-driven resume transition
+// (fromStatus -> running) on the run event bus. Vocabulary drift (a status
+// with no proto mapping) degrades to skip+log per
+// docs/design/run-state-machine.md §8: this run's publish is dropped for
+// this tick, no status is invented, and the daemon stays alive.
+func (s *SocketServer) publishFeedbackResume(run *model.Run, fromStatus model.Status) {
 	fromProto, err := modelStatusToProto(fromStatus)
 	if err != nil {
-		panic(err)
+		s.logger.Printf("ERROR %s#%s: skipping feedback resume publish: %v", run.IssueID, run.RunID, err)
+		return
 	}
 	toProto, err := modelStatusToProto(model.StatusRunning)
 	if err != nil {
-		panic(err)
+		s.logger.Printf("ERROR %s#%s: skipping feedback resume publish: %v", run.IssueID, run.RunID, err)
+		return
 	}
 	s.PublishRunEvent(&orchpb.RunEventFrame{
 		RunId:           string(run.RunID),

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -4240,6 +4240,59 @@ func TestMarkRunFeedbackSentTransitions(t *testing.T) {
 	}
 }
 
+// TestPublishFeedbackResume_VocabularyDriftSkipsNotPanics feeds a status
+// with no proto mapping through the socket-plane publish path and asserts
+// the drift rule of docs/design/run-state-machine.md §8: no panic (the old
+// behavior panicked here and killed the daemon), an ERROR naming the run
+// ref and the offending status is logged, no frame is published for the
+// drifted run, and another run's feedback-resume publish is unaffected.
+func TestPublishFeedbackResume_VocabularyDriftSkipsNotPanics(t *testing.T) {
+	var logBuf bytes.Buffer
+	server := NewSocketServer(nil, log.New(&logBuf, "", 0))
+
+	sub := server.RunEventBus().Subscribe(RunEventFilter{})
+	defer sub.Close()
+
+	drifted := &model.Run{IssueID: "i-drift", RunID: "r-drift"}
+	// Old behavior: this call panics and the test fails.
+	server.publishFeedbackResume(drifted, model.Status("status-from-the-future"))
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "ERROR i-drift#r-drift") {
+		t.Fatalf("ERROR log line does not name the run ref:\n%s", logged)
+	}
+	if !strings.Contains(logged, "status-from-the-future") {
+		t.Fatalf("log does not name the offending status:\n%s", logged)
+	}
+
+	select {
+	case ev := <-sub.Events():
+		t.Fatalf("expected no event for drifted status, got %+v", ev)
+	case <-time.After(200 * time.Millisecond):
+		// expected: publish skipped
+	}
+
+	// Other runs' updates are unaffected: a healthy run resumed by feedback
+	// still publishes through the full markRunFeedbackSent path.
+	healthy := &model.Run{IssueID: "i", RunID: "r", Status: model.StatusWaiting}
+	st := &mockStore{runs: map[string]*model.Run{"i#r": healthy}, issues: map[string]*model.Issue{}}
+	server.markRunFeedbackSent(st, healthy)
+	select {
+	case ev := <-sub.Events():
+		if ev.IssueId != "i" || ev.RunId != "r" {
+			t.Fatalf("unexpected ids: %+v", ev)
+		}
+		if ev.FromStatus != orchpb.RunStatus_RUN_STATUS_WAITING || ev.ToStatus != orchpb.RunStatus_RUN_STATUS_RUNNING {
+			t.Fatalf("unexpected transition: %+v", ev)
+		}
+		if ev.Source != string(model.EventSourceUser) {
+			t.Fatalf("source = %q, want %q", ev.Source, model.EventSourceUser)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("healthy feedback-resume publish blocked after drift skip")
+	}
+}
+
 func leaseRunSnapshot(lease *WorkerLease) *RunSnapshot {
 	if lease == nil || lease.Payload == nil {
 		return nil


### PR DESCRIPTION
Issue: **beta-daemon-panic-vocab**

## Problem

`internal/daemon/monitor.go` (publishRunEvent) and `internal/daemon/socket.go` (markRunFeedbackSent) called `panic(err)` when `modelStatusToProto` could not map a run status. Daemon recover wrappers re-panic by design (`logAndRepanic`), so ONE unmapped status — possible whenever the status vocabulary drifts ahead of the proto map — killed the entire daemon and stopped monitoring for ALL runs.

```
BEFORE                                          AFTER
──────                                          ─────
drifted status ─▶ modelStatusToProto ─▶ err     drifted status ─▶ modelStatusToProto ─▶ err
                        │                                              │
                    panic(err)                            ERROR log (run ref + status)
                        │                                              │
              logAndRepanic re-panics                     skip this run's publish
                        │                                              │
          ☠ DAEMON DEAD, all runs unmonitored   ✓ daemon alive, other runs unaffected
```

## Changes (per the issue's closed choice space)

1. **Conversion layer returns (value, error)** — already true on main (`proto_convert.go:11`); the panics lived at the call sites. No conversion-layer change needed.
2. **4 call sites → skip+log**: `monitor.go` publishRunEvent (from/to arms) and `socket.go` (from/to arms) now log `ERROR <issue>#<run>: skipping ...: unknown model run status: "<status>"` and return, skipping only that run's publish for that tick. No status event written, no synthetic status invented.
   - The socket-plane publish tail was extracted to `SocketServer.publishFeedbackResume` (same file, same logic, no behavior change). Reason: the `feedbackResumesRun` guard filters unmapped statuses before conversion, so without the seam no unit test could reach the drift arm — and requirement 6 demands tests that fail against the old panic behavior.
3. **logAndRepanic and recover wrappers untouched** — unknown panics still crash the daemon (fail-fast preserved).
4. **step.go / commitRunStatus untouched; no new status writers; no nosemgrep annotations** (`git diff` shows only the 5 files below; semgrep `run-status-write-surface` passes).
5. **Spec revision in same PR**: `docs/design/run-state-machine.md` §8 records the rule *"vocabulary drift at serialization boundaries degrades to skip+log — never panics, never invents a status"* and points at the conversion layer.
6. **Tests** (both planes): `TestPublishRunEvent_VocabularyDriftSkipsNotPanics` (monitor) and `TestPublishFeedbackResume_VocabularyDriftSkipsNotPanics` (socket) feed `model.Status("status-from-the-future")` through each plane and assert: no panic, ERROR logged naming run ref + offending status, no frame published for the drifted run, and a subsequent healthy run's publish goes through.

## Verification that tests fail against the old panic behavior

Temporarily restored `panic(err)` at all 4 sites and ran the two new tests:

```
=== RUN   TestPublishRunEvent_VocabularyDriftSkipsNotPanics
--- FAIL: TestPublishRunEvent_VocabularyDriftSkipsNotPanics (0.00s)
panic: unknown model run status: "status-from-the-future" [recovered, repanicked]
FAIL	github.com/proboscis/orch/internal/daemon	3.884s
```

The panic aborts the whole test binary — exactly the daemon-killing behavior being removed. Fix restored afterwards; both tests pass.

## Done conditions

| Check | Result |
|---|---|
| `go build ./...` | ✅ exit 0 |
| unit `go test ./...` | ✅ all unit packages pass (`internal/daemon` 28.6s ok, 20 packages ok) |
| `make lint` | ✅ "Lint passed!", 106 rules / 146 files, 0 findings; all semgrep rule tests pass |

Note: `test/integration` is flaky **on this shared worker host regardless of this change** — TestMain spawns `orch daemon run` on the default socket while several concurrent orch agent sessions run the same suite (verified: identical failures on a clean checkout, and a clean-vs-fixed binary comparison shows byte-identical daemon startup behavior, including the environmental `0.0.0.0:7777 address already in use` warning). No integration test exercises the changed publish tails; the new unit tests cover both planes.

## Files

- `internal/daemon/monitor.go` — publishRunEvent: 2 panics → skip+log
- `internal/daemon/socket.go` — markRunFeedbackSent tail → publishFeedbackResume: 2 panics → skip+log
- `internal/daemon/monitor_publish_test.go` — monitor-plane drift test
- `internal/daemon/socket_test.go` — socket-plane drift test
- `docs/design/run-state-machine.md` — §8 vocabulary-drift rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)