### PR TITLE
Fail clearly on unloadable runs

### DIFF
--- a/internal/monitor/dashboard_filter.go
+++ b/internal/monitor/dashboard_filter.go
@@ -163,7 +163,8 @@ func (d *Dashboard) activateFilterRow() (tea.Model, tea.Cmd) {
 		}
 		status, err := model.NormalizeStatus(row.value)
 		if err != nil {
-			panic(err)
+			d.message = fmt.Sprintf("invalid status filter %q: %v", row.value, err)
+			return d, nil
 		}
 		if d.filter.Statuses == nil {
 			d.filter.Statuses = make(map[model.Status]bool)

--- a/internal/monitor/issues_dashboard.go
+++ b/internal/monitor/issues_dashboard.go
@@ -887,7 +887,11 @@ func (d *IssueDashboard) applyFilter() {
 
 	filtered := make([]IssueRow, 0, len(d.issues))
 	for _, issue := range d.issues {
-		status := mustParseIssueStatusForRow(issue.ID, issue.Status)
+		status, ok := parseIssueStatusForRow(issue.ID, issue.Status)
+		if !ok {
+			filtered = append(filtered, issue)
+			continue
+		}
 		if status == model.IssueStatusResolved && !d.filter.showResolved {
 			continue
 		}

--- a/internal/monitor/sort.go
+++ b/internal/monitor/sort.go
@@ -2,8 +2,10 @@ package monitor
 
 import (
 	"fmt"
+	"log"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/proboscis/orch/internal/model"
@@ -164,6 +166,10 @@ var issueStatusOrder = map[model.IssueStatus]int{
 	model.IssueStatusClosed:   2,
 }
 
+const issueStatusInvalidRank = 1 << 30
+
+var invalidIssueStatusWarnings sync.Map
+
 func runStatusRank(status model.Status) int {
 	if rank, ok := runStatusOrder[status]; ok {
 		return rank
@@ -178,12 +184,29 @@ func issueStatusRank(status model.IssueStatus) int {
 	return len(issueStatusOrder) + 1
 }
 
-func mustParseIssueStatusForRow(rowID, status string) model.IssueStatus {
+func parseIssueStatusForRow(rowID, status string) (model.IssueStatus, bool) {
 	parsed, err := model.ParseIssueStatus(status)
 	if err != nil {
-		panic(fmt.Sprintf("invalid issue status for row %s: %v", rowID, err))
+		warnInvalidIssueStatusForRow(rowID, status, err)
+		return "", false
 	}
-	return parsed
+	return parsed, true
+}
+
+func issueStatusRankForRow(rowID, status string) int {
+	parsed, ok := parseIssueStatusForRow(rowID, status)
+	if !ok {
+		return issueStatusInvalidRank
+	}
+	return issueStatusRank(parsed)
+}
+
+func warnInvalidIssueStatusForRow(rowID, status string, err error) {
+	key := rowID + "\x00" + status
+	if _, loaded := invalidIssueStatusWarnings.LoadOrStore(key, struct{}{}); loaded {
+		return
+	}
+	log.Printf("orch monitor: warning: invalid issue status for row %s: %v (displaying raw status %q)", rowID, err, status)
 }
 
 func runRowRunID(row RunRow) string {
@@ -348,9 +371,14 @@ func sortIssueRowsWithDirection(rows []IssueRow, key SortKey, dir SortDirection)
 
 		switch key {
 		case SortByStatus:
-			aStatus := mustParseIssueStatusForRow(a.ID, a.Status)
-			bStatus := mustParseIssueStatusForRow(b.ID, b.Status)
-			if ar, br := issueStatusRank(aStatus), issueStatusRank(bStatus); ar != br {
+			ar, br := issueStatusRankForRow(a.ID, a.Status), issueStatusRankForRow(b.ID, b.Status)
+			if ar != br {
+				if ar == issueStatusInvalidRank {
+					return false
+				}
+				if br == issueStatusInvalidRank {
+					return true
+				}
 				return (ar < br) == (dir == SortAsc)
 			}
 			if a.LatestUpdated.IsZero() != b.LatestUpdated.IsZero() {

--- a/internal/monitor/sort_test.go
+++ b/internal/monitor/sort_test.go
@@ -1,6 +1,9 @@
 package monitor
 
 import (
+	"bytes"
+	"log"
+	"strings"
 	"testing"
 	"time"
 
@@ -262,6 +265,55 @@ func TestSortIssueRows(t *testing.T) {
 	}
 	if rows[0].Index != 1 || rows[3].Index != 4 {
 		t.Fatalf("SortByUpdated index mismatch: got %d..%d", rows[0].Index, rows[3].Index)
+	}
+}
+
+func TestSortIssueRowsUnknownStatusSortsLastAndDisplaysRaw(t *testing.T) {
+	base := time.Date(2024, 1, 2, 9, 0, 0, 0, time.UTC)
+	var logOutput bytes.Buffer
+	originalLogWriter := log.Writer()
+	originalLogFlags := log.Flags()
+	log.SetOutput(&logOutput)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(originalLogWriter)
+		log.SetFlags(originalLogFlags)
+	}()
+
+	rows := []IssueRow{
+		{ID: "orch-unknown", Status: "triaged", LatestUpdated: base.Add(4 * time.Hour)},
+		{ID: "orch-closed", Status: string(model.IssueStatusClosed), LatestUpdated: base.Add(3 * time.Hour)},
+		{ID: "orch-open", Status: string(model.IssueStatusOpen), LatestUpdated: base},
+	}
+
+	sortIssueRows(rows, SortByStatus)
+	if rows[0].ID != "orch-open" || rows[1].ID != "orch-closed" || rows[2].ID != "orch-unknown" {
+		t.Fatalf("SortByStatus order mismatch: got %s, %s, %s", rows[0].ID, rows[1].ID, rows[2].ID)
+	}
+	if rows[2].Status != "triaged" {
+		t.Fatalf("unknown issue status was rewritten: got %q", rows[2].Status)
+	}
+
+	d := &IssueDashboard{styles: DefaultStyles()}
+	rendered := d.renderRow(3, 12, 12, 10, 6, 20,
+		"3", rows[2].ID, rows[2].Status, "-", "0", "unknown status",
+		false, &rows[2])
+	if !strings.Contains(rendered, "triaged") {
+		t.Fatalf("rendered row does not contain raw status %q: %q", rows[2].Status, rendered)
+	}
+
+	rows = []IssueRow{
+		{ID: "orch-unknown", Status: "triaged", LatestUpdated: base.Add(4 * time.Hour)},
+		{ID: "orch-closed", Status: string(model.IssueStatusClosed), LatestUpdated: base.Add(3 * time.Hour)},
+		{ID: "orch-open", Status: string(model.IssueStatusOpen), LatestUpdated: base},
+	}
+	sortIssueRowsWithDirection(rows, SortByStatus, SortDesc)
+	if rows[2].ID != "orch-unknown" {
+		t.Fatalf("SortByStatus descending should keep unknown status last, got last row %s", rows[2].ID)
+	}
+
+	if got := strings.Count(logOutput.String(), "invalid issue status for row orch-unknown"); got != 1 {
+		t.Fatalf("invalid issue status warning count = %d, want 1; log output: %q", got, logOutput.String())
 	}
 }
 

--- a/internal/store/file/file.go
+++ b/internal/store/file/file.go
@@ -85,6 +85,13 @@ func (s *FileStore) warnOnce(path, format string, args ...any) {
 	s.warnFunc(format, args...)
 }
 
+func (s *FileStore) warn(format string, args ...any) {
+	if s.warnFunc == nil {
+		return
+	}
+	s.warnFunc(format, args...)
+}
+
 // frontmatterKeys are known keys that strongly indicate real frontmatter
 var frontmatterKeys = map[string]bool{
 	"type": true, "id": true, "title": true, "status": true,

--- a/internal/store/file/file_test.go
+++ b/internal/store/file/file_test.go
@@ -588,6 +588,65 @@ func TestListRunsCarriesProfileThroughIndex(t *testing.T) {
 	}
 }
 
+func TestListRunsWarnsAndSkipsUnloadableRun(t *testing.T) {
+	vault, cleanup := setupTestVault(t)
+	defer cleanup()
+
+	createTestIssue(t, vault, "test123", "---\ntype: issue\ntitle: Test\n---\n# Test")
+
+	s, _ := New(vault)
+	goodRun, err := s.CreateRun("test123", "20231220-100000", nil)
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+
+	badRunID := model.RunID("20231220-110000")
+	badRunPath := filepath.Join(vault, "runs", "test123", string(badRunID)+".md")
+	badRunContent := `---
+issue: test123
+run: 20231220-110000
+created: 2023-12-20T11:00:00Z
+---
+
+# Events
+
+- 2023-12-20T11:00:00Z | status | vaporized
+`
+	if err := os.WriteFile(badRunPath, []byte(badRunContent), 0644); err != nil {
+		t.Fatalf("write bad run file: %v", err)
+	}
+
+	var warnings []string
+	s.SetWarnFunc(func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	})
+
+	runs, err := s.ListRuns(nil)
+	if err != nil {
+		t.Fatalf("ListRuns() error = %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("ListRuns() returned %d runs, want only the loadable run", len(runs))
+	}
+	if runs[0].RunID != goodRun.RunID {
+		t.Fatalf("ListRuns() returned run %s, want %s", runs[0].RunID, goodRun.RunID)
+	}
+
+	joinedWarnings := strings.Join(warnings, "")
+	if !strings.Contains(joinedWarnings, badRunPath) {
+		t.Fatalf("warning did not name bad run path %q: %q", badRunPath, joinedWarnings)
+	}
+	if !strings.Contains(joinedWarnings, "test123#20231220-110000") {
+		t.Fatalf("warning did not name bad run id: %q", joinedWarnings)
+	}
+	if !strings.Contains(joinedWarnings, "unknown run status") {
+		t.Fatalf("warning did not include load error: %q", joinedWarnings)
+	}
+	if !strings.Contains(joinedWarnings, "1 run files failed to load - see daemon log") {
+		t.Fatalf("aggregate load warning missing: %q", joinedWarnings)
+	}
+}
+
 func TestListRunsWithStatusFilter(t *testing.T) {
 	vault, cleanup := setupTestVault(t)
 	defer cleanup()

--- a/internal/store/file/run_index.go
+++ b/internal/store/file/run_index.go
@@ -217,6 +217,7 @@ func (s *FileStore) listRunsIndexed(filter *store.ListRunsFilter) ([]*model.Run,
 	validEntries := make(map[string]*runIndexEntry)
 	indexDirty := false
 	seenKeys := make(map[string]bool)
+	failedLoadCount := 0
 
 	for _, issueID := range issueDirs {
 		typedIssueID := model.IssueID(issueID)
@@ -261,6 +262,12 @@ func (s *FileStore) listRunsIndexed(filter *store.ListRunsFilter) ([]*model.Run,
 
 			run, err := s.loadRun(typedIssueID, runID, runPath)
 			if err != nil {
+				failedLoadCount++
+				s.warnOnce(runPath, "orch: warning: failed to load run file %s for run %s#%s: %v\n", runPath, issueID, runID, err)
+				if _, exists := idx.Entries[key]; exists {
+					delete(idx.Entries, key)
+					indexDirty = true
+				}
 				continue
 			}
 
@@ -330,6 +337,10 @@ func (s *FileStore) listRunsIndexed(filter *store.ListRunsFilter) ([]*model.Run,
 
 	if indexDirty {
 		s.saveRunIndex(idx)
+	}
+
+	if failedLoadCount > 0 {
+		s.warn("orch: warning: %d run files failed to load - see daemon log\n", failedLoadCount)
 	}
 
 	runs := make([]*model.Run, 0, len(validEntries))


### PR DESCRIPTION
## Summary

- Warn when `ListRuns` cannot load a run file, including file path, run id, and concrete load error.
- Emit a per-listing aggregate warning when one or more run files failed to load.
- Replace monitor issue-status panics with a display-only fallback: unknown issue statuses log once, sort in a sentinel bucket last, and render the raw status string.
- Remove the filter-panel panic for invalid run status rows and surface an explicit dashboard message instead.

## Issue

Refs: beta-fail-clearly-load

## Verification

- `go test ./internal/store/file ./internal/monitor` passed.
- `go build ./...` passed.
- `go test $(go list ./... | grep -v '/test/integration')` passed.
- `make lint` passed.
- Added regression tests fail against current `origin/main` when applying only the tests:
  - `TestListRunsWarnsAndSkipsUnloadableRun` fails because no warning is emitted for the unloadable run file.
  - `TestSortIssueRowsUnknownStatusSortsLastAndDisplaysRaw` fails because `mustParseIssueStatusForRow` panics on `triaged`.

## Integration note

`go test ./...` was run after rebasing onto latest `origin/main`; all internal packages passed, but `test/integration` failed in `TestMain` before package tests ran:

```text
panic: daemon did not start in time
FAIL github.com/proboscis/orch/test/integration 46.166s
```

Earlier, `TestRunWithBuiltInAgents` also failed inside the full integration suite with opencode session creation returning HTTP 500, while `TMUX= go test ./test/integration -run TestRunWithBuiltInAgents -count=1` passed. Per dispatcher notice, I did not debug or modify integration tests.
