### PR TITLE
Add version introspection and daemon handshake

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,11 +30,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
       - name: Build binary
         run: |
+          LDFLAGS="-X github.com/proboscis/orch/internal/version.Version=${GITHUB_REF_NAME} -X github.com/proboscis/orch/internal/version.Commit=${GITHUB_SHA} -X github.com/proboscis/orch/internal/version.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
-          go build -o orch-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/orch
+          go build -ldflags "$LDFLAGS" -o orch-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/orch
       - uses: actions/upload-artifact@v4
         with:
           name: orch-${{ matrix.goos }}-${{ matrix.goarch }}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@
 BINARY_NAME := orch
 INSTALL_DIR := $(HOME)/.local/bin
 UNAME_S := $(shell uname -s)
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS := -X github.com/proboscis/orch/internal/version.Version=$(VERSION) -X github.com/proboscis/orch/internal/version.Commit=$(COMMIT) -X github.com/proboscis/orch/internal/version.BuildDate=$(BUILD_DATE)
 TEST_PKGS ?= ./...
 TEST_TIMEOUT ?= 20m
 TEST_GOGC ?= 50
@@ -17,7 +21,7 @@ all: install
 
 # Build Go binary
 build:
-	go build -o $(BINARY_NAME) ./cmd/orch
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) ./cmd/orch
 
 # Install Go CLI + daemon
 install-cli: build

--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,7 @@ INSTALL_ALL_AGENTS=false
 # Skip flags
 SKIP_TUI=false
 SKIP_COMPLETIONS=false
+NO_DAEMON_RESTART=false
 
 # Detected values
 OS=""
@@ -68,6 +69,25 @@ ask_yes_no() {
 }
 
 command_exists() { command -v "$1" &>/dev/null; }
+
+installed_orch_version() {
+    local version_out
+    version_out=$("${INSTALL_DIR}/orch" --version 2>/dev/null | head -n1 | awk '{print $NF}' || true)
+    [ -n "$version_out" ] && echo "$version_out" || echo "unknown"
+}
+
+orch_daemon_running() {
+    if command_exists pgrep && pgrep -f "[o]rch daemon run" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if [ -x "${INSTALL_DIR}/orch" ]; then
+        "${INSTALL_DIR}/orch" daemon status 2>/dev/null | grep -q "Status: running"
+        return $?
+    fi
+
+    return 1
+}
 
 #------------------------------------------------------------------------------
 # Detection functions
@@ -232,6 +252,25 @@ install_orch_binary() {
     
     success "Installed orch to ${INSTALL_DIR}/orch"
     rm -rf "$tmp_dir"
+}
+
+restart_daemon_after_upgrade() {
+    if [ "$NO_DAEMON_RESTART" = true ]; then
+        warn "Skipping daemon restart (--no-daemon-restart)"
+        return 0
+    fi
+
+    if ! orch_daemon_running; then
+        success "No running orch daemon found; restart not needed"
+        return 0
+    fi
+
+    info "Restarting running orch daemon..."
+    if "${INSTALL_DIR}/orch" daemon-restart; then
+        success "Restarted orch daemon"
+    else
+        warn "Could not restart orch daemon automatically; run: ${INSTALL_DIR}/orch daemon-restart"
+    fi
 }
 
 install_uv() {
@@ -466,6 +505,7 @@ show_plan() {
     echo "    - orch CLI ${version} -> ${INSTALL_DIR}/orch"
     [ "$SKIP_TUI" = false ] && echo "    - orch-monitor TUI (via uv)"
     [ -n "$SHELL_NAME" ] && [ "$SKIP_COMPLETIONS" = false ] && echo "    - shell completions for ${SHELL_NAME}"
+    [ "$NO_DAEMON_RESTART" = false ] && echo "    - restart running orch daemon after upgrade"
     echo ""
 }
 
@@ -488,6 +528,7 @@ Options:
     --uninstall         Uninstall orch
     --skip-tui          Skip orch-monitor TUI
     --skip-completions  Skip shell completions
+    --no-daemon-restart Do not restart a running orch daemon after upgrade
     --install-dir DIR   Install directory (default: ~/.local/bin)
     -h, --help          Show this help
 
@@ -521,6 +562,7 @@ parse_args() {
             --all) INSTALL_ALL_AGENTS=true; shift ;;
             --skip-tui) SKIP_TUI=true; shift ;;
             --skip-completions) SKIP_COMPLETIONS=true; shift ;;
+            --no-daemon-restart) NO_DAEMON_RESTART=true; shift ;;
             --install-dir) INSTALL_DIR="$2"; shift 2 ;;
             -h|--help) show_help; exit 0 ;;
             *) die "Unknown option: $1" ;;
@@ -541,7 +583,7 @@ main() {
     # Check existing installation
     if [ -f "${INSTALL_DIR}/orch" ]; then
         local cur_ver
-        cur_ver=$("${INSTALL_DIR}/orch" --version 2>/dev/null | awk '{print $NF}' || echo "unknown")
+        cur_ver=$(installed_orch_version)
         warn "orch already installed (${cur_ver})"
         confirm "Reinstall/upgrade?" || { echo "Aborted."; exit 0; }
     fi
@@ -556,6 +598,7 @@ main() {
     
     echo ""
     install_orch_binary "$version"
+    restart_daemon_after_upgrade
     install_orch_monitor
     
     # Agent installation

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -9,11 +9,25 @@ import (
 	"time"
 
 	"github.com/proboscis/orch/internal/daemon"
+	buildversion "github.com/proboscis/orch/internal/version"
 	"github.com/spf13/cobra"
 )
 
 var daemonDebugMode bool
 var daemonListenAddr string
+
+type daemonVersionPinger interface {
+	PingStatus() (*daemon.PingResponse, error)
+}
+
+func pingDaemonWithVersionCheck(client daemonVersionPinger) error {
+	resp, err := client.PingStatus()
+	if err != nil {
+		return err
+	}
+	warnIfDaemonVersionMismatch(resp.Version)
+	return nil
+}
 
 func newDaemonCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -86,7 +100,7 @@ func requireDaemonAdminClient() (*daemon.ProtoClient, error) {
 	remoteAddr := getRemoteAddr()
 	if remoteAddr != "" {
 		client := daemon.NewProtoClientWithAddress("", remoteAddr)
-		if err := client.Ping(); err != nil {
+		if err := pingDaemonWithVersionCheck(client); err != nil {
 			_ = client.Close()
 			return nil, fmt.Errorf("remote daemon %s is not reachable: %w", remoteAddr, err)
 		}
@@ -95,6 +109,10 @@ func requireDaemonAdminClient() (*daemon.ProtoClient, error) {
 
 	client := daemon.NewProtoClientWithAddress("", "")
 	if client.IsAvailable() {
+		if err := pingDaemonWithVersionCheck(client); err != nil {
+			_ = client.Close()
+			return nil, fmt.Errorf("daemon is not reachable: %w", err)
+		}
 		return client, nil
 	}
 
@@ -106,6 +124,10 @@ func requireDaemonAdminClient() (*daemon.ProtoClient, error) {
 	for i := 0; i < 10; i++ {
 		time.Sleep(100 * time.Millisecond)
 		if client.IsAvailable() {
+			if err := pingDaemonWithVersionCheck(client); err != nil {
+				_ = client.Close()
+				return nil, fmt.Errorf("daemon started but is not reachable: %w", err)
+			}
 			return client, nil
 		}
 	}
@@ -312,15 +334,27 @@ func runDaemonStatus() error {
 		client := daemon.NewProtoClientWithAddress("", remoteAddr)
 		defer client.Close()
 
-		if err := client.Ping(); err != nil {
+		if err := pingDaemonWithVersionCheck(client); err != nil {
 			return fmt.Errorf("remote daemon %s is not reachable: %w", remoteAddr, err)
 		}
 
-		fmt.Printf("Status: running (remote=%s)\n", remoteAddr)
+		status, err := client.GetDaemonStatus()
+		if err != nil {
+			return fmt.Errorf("failed to get remote daemon status from %s: %w", remoteAddr, err)
+		}
+
+		warnIfDaemonVersionMismatch(status.Version)
+		fmt.Printf("CLI Version: %s\n", buildversion.Version)
+		fmt.Printf("Daemon Version: %s\n", status.Version)
+		fmt.Printf("Status: running (remote=%s, pid=%d)\n", remoteAddr, status.PID)
+		fmt.Printf("Log: %s\n", status.LogPath)
 		return nil
 	}
 
+	fmt.Printf("CLI Version: %s\n", buildversion.Version)
+
 	if !daemon.IsRunning("") {
+		fmt.Println("Daemon Version: not running")
 		fmt.Println("Status: not running")
 		return nil
 	}
@@ -330,8 +364,18 @@ func runDaemonStatus() error {
 
 	if daemon.IsDaemonSocketAvailable("") {
 		fmt.Println("Socket: available")
+		client := daemon.NewProtoClientWithAddress("", "")
+		defer client.Close()
+		status, err := client.GetDaemonStatus()
+		if err != nil {
+			fmt.Printf("Daemon Version: unavailable (%v)\n", err)
+		} else {
+			warnIfDaemonVersionMismatch(status.Version)
+			fmt.Printf("Daemon Version: %s\n", status.Version)
+		}
 	} else {
 		fmt.Println("Socket: unavailable")
+		fmt.Println("Daemon Version: unavailable (socket unavailable)")
 	}
 
 	if meta, err := daemon.ReadMetadata(""); err == nil {
@@ -437,7 +481,7 @@ func requireDaemon() (*daemon.ProtoClient, error) {
 
 	if remoteAddr != "" {
 		client := daemon.NewProtoClientWithAddress(projectRoot, remoteAddr)
-		if err := client.Ping(); err != nil {
+		if err := pingDaemonWithVersionCheck(client); err != nil {
 			_ = client.Close()
 			return nil, fmt.Errorf("remote daemon %s is not reachable: %w", remoteAddr, err)
 		}
@@ -446,6 +490,10 @@ func requireDaemon() (*daemon.ProtoClient, error) {
 
 	client := daemon.NewProtoClientLocal(projectRoot)
 	if client.IsAvailable() {
+		if err := pingDaemonWithVersionCheck(client); err != nil {
+			_ = client.Close()
+			return nil, fmt.Errorf("daemon is not reachable: %w", err)
+		}
 		return client, nil
 	}
 
@@ -457,6 +505,10 @@ func requireDaemon() (*daemon.ProtoClient, error) {
 	for i := 0; i < 10; i++ {
 		time.Sleep(100 * time.Millisecond)
 		if client.IsAvailable() {
+			if err := pingDaemonWithVersionCheck(client); err != nil {
+				_ = client.Close()
+				return nil, fmt.Errorf("daemon started but is not reachable: %w", err)
+			}
 			return client, nil
 		}
 	}

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -62,6 +62,10 @@ func runModels(opts *modelsOptions) error {
 	defer cancel()
 
 	api := orchapi.NewDaemonClientWithAddress("", getRemoteAddr())
+	if err := pingAPIWithVersionCheck(ctx, api); err != nil {
+		return fmt.Errorf("failed to reach daemon: %w", err)
+	}
+
 	result, err := api.QueryOpenCodeServer(ctx, opts.Port)
 	if err != nil {
 		return fmt.Errorf("failed to query opencode server: %w", err)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/proboscis/orch/internal/config"
 	"github.com/proboscis/orch/internal/model"
 	"github.com/proboscis/orch/internal/orchapi"
+	buildversion "github.com/proboscis/orch/internal/version"
 	"github.com/proboscis/orch/internal/xdg"
 	"github.com/spf13/cobra"
 )
@@ -73,12 +74,18 @@ var noDaemonCommands = map[string]bool{
 	"tutorial":             true,
 	"agent":                true,
 	"validate-issue-files": true,
+	"version":              true,
+}
+
+var noConfigValidationCommands = map[string]bool{
+	"version": true,
 }
 
 // rootCmd represents the base command
 var rootCmd = &cobra.Command{
-	Use:   "orch",
-	Short: "Orchestrator for multiple LLM CLIs",
+	Use:     "orch",
+	Short:   "Orchestrator for multiple LLM CLIs",
+	Version: buildversion.Version,
 	Long: `orch is an orchestrator for managing multiple LLM CLIs (claude/codex/gemini)
 using a unified vocabulary of issue/run/event.
 
@@ -89,8 +96,10 @@ It operates non-interactively by default, using events to track state
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		remoteFlagWasSet = cmd.Flags().Changed("remote") || cmd.PersistentFlags().Changed("remote")
 
-		if err := validateConfigForCommand(); err != nil {
-			return err
+		if shouldValidateConfigForCommand(cmd) {
+			if err := validateConfigForCommand(); err != nil {
+				return err
+			}
 		}
 
 		// Auto-start daemon for most commands.
@@ -114,6 +123,15 @@ func shouldAutoStartDaemonForCommand(cmd *cobra.Command, remoteAddr string) bool
 		}
 	}
 
+	return true
+}
+
+func shouldValidateConfigForCommand(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if noConfigValidationCommands[c.Name()] {
+			return false
+		}
+	}
 	return true
 }
 
@@ -157,6 +175,7 @@ func init() {
 		withCommandGroup(newDaemonRestartCmd(), commandGroupSetupOps),
 		withCommandGroup(newRepairCmd(), commandGroupSetupOps),
 		withCommandGroup(newTutorialCmd(), commandGroupSetupOps),
+		withCommandGroup(newVersionCmd(), commandGroupSetupOps),
 		withCommandGroup(newCleanCmd(), commandGroupSetupOps),
 		withCommandGroup(newDeleteCmd(), commandGroupSetupOps),
 		withCommandGroup(newNotifyCmd(), commandGroupSetupOps),
@@ -418,6 +437,9 @@ func defaultGetAPIWithOptions(requireProjectRoot bool) (orchapi.OrchAPI, error) 
 	client := orchapi.NewDaemonClientWithAddress(clientProjectScope, remoteAddr)
 	if remoteAddr == "" && !client.IsAvailable() {
 		ensureDaemon()
+	}
+	if err := pingAPIWithVersionCheck(context.Background(), client); err != nil && remoteAddr != "" {
+		return nil, fmt.Errorf("remote daemon %s is not reachable: %w", remoteAddr, err)
 	}
 
 	return client, nil

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/proboscis/orch/internal/orchapi"
+	buildversion "github.com/proboscis/orch/internal/version"
+	"github.com/spf13/cobra"
+)
+
+type apiVersionPinger interface {
+	PingStatus(context.Context) (*orchapi.PingStatus, error)
+}
+
+var daemonVersionMismatchWarned bool
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print orch version information",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			printVersion()
+			return nil
+		},
+	}
+}
+
+func printVersion() {
+	fmt.Printf("version %s\n", buildversion.Version)
+	fmt.Printf("commit %s\n", buildversion.Commit)
+	fmt.Printf("build_date %s\n", buildversion.BuildDate)
+	fmt.Printf("goos/goarch %s/%s\n", runtime.GOOS, runtime.GOARCH)
+}
+
+func pingAPIWithVersionCheck(ctx context.Context, client apiVersionPinger) error {
+	resp, err := client.PingStatus(ctx)
+	if err != nil {
+		return err
+	}
+	warnIfDaemonVersionMismatch(resp.Version)
+	return nil
+}
+
+func warnIfDaemonVersionMismatch(daemonVersion string) {
+	if daemonVersionMismatchWarned {
+		return
+	}
+
+	cliVersion := strings.TrimSpace(buildversion.Version)
+	daemonVersion = strings.TrimSpace(daemonVersion)
+	if cliVersion == daemonVersion {
+		return
+	}
+
+	if cliVersion == "" {
+		cliVersion = "unknown"
+	}
+	if daemonVersion == "" {
+		daemonVersion = "unknown"
+	}
+
+	fmt.Fprintf(os.Stderr, "warning: orch CLI %s / daemon %s version mismatch - run 'orch daemon-restart'\n", cliVersion, daemonVersion)
+	daemonVersionMismatchWarned = true
+}

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/proboscis/orch/internal/daemon"
+	buildversion "github.com/proboscis/orch/internal/version"
+)
+
+type fakeVersionPinger struct {
+	version string
+	err     error
+	calls   int
+}
+
+func (f *fakeVersionPinger) PingStatus() (*daemon.PingResponse, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &daemon.PingResponse{OK: true, Version: f.version}, nil
+}
+
+func withBuildVersion(t *testing.T, version, commit, buildDate string) {
+	t.Helper()
+	origVersion := buildversion.Version
+	origCommit := buildversion.Commit
+	origBuildDate := buildversion.BuildDate
+	t.Cleanup(func() {
+		buildversion.Version = origVersion
+		buildversion.Commit = origCommit
+		buildversion.BuildDate = origBuildDate
+	})
+
+	buildversion.Version = version
+	buildversion.Commit = commit
+	buildversion.BuildDate = buildDate
+}
+
+func resetDaemonVersionMismatchWarning(t *testing.T) {
+	t.Helper()
+	orig := daemonVersionMismatchWarned
+	daemonVersionMismatchWarned = false
+	t.Cleanup(func() {
+		daemonVersionMismatchWarned = orig
+	})
+}
+
+func TestPrintVersionIncludesBuildMetadata(t *testing.T) {
+	withBuildVersion(t, "test-version", "abc123", "2026-07-07T00:00:00Z")
+
+	out := captureStdout(t, func() {
+		printVersion()
+	})
+
+	for _, want := range []string{
+		"version test-version",
+		"commit abc123",
+		"build_date 2026-07-07T00:00:00Z",
+		"goos/goarch " + runtime.GOOS + "/" + runtime.GOARCH,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("version output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestPingDaemonWithVersionCheckWarnsOnceOnMismatch(t *testing.T) {
+	withBuildVersion(t, "cli-version", "abc123", "2026-07-07T00:00:00Z")
+	resetDaemonVersionMismatchWarning(t)
+	pinger := &fakeVersionPinger{version: "daemon-version"}
+
+	errOut := captureStderr(t, func() {
+		if err := pingDaemonWithVersionCheck(pinger); err != nil {
+			t.Fatalf("first ping error = %v", err)
+		}
+		if err := pingDaemonWithVersionCheck(pinger); err != nil {
+			t.Fatalf("second ping error = %v", err)
+		}
+	})
+
+	want := "warning: orch CLI cli-version / daemon daemon-version version mismatch - run 'orch daemon-restart'"
+	if count := strings.Count(errOut, want); count != 1 {
+		t.Fatalf("warning count = %d, want 1; stderr:\n%s", count, errOut)
+	}
+	if pinger.calls != 2 {
+		t.Fatalf("ping calls = %d, want 2", pinger.calls)
+	}
+}
+
+func TestPingDaemonWithVersionCheckPropagatesPingError(t *testing.T) {
+	resetDaemonVersionMismatchWarning(t)
+	pinger := &fakeVersionPinger{err: errors.New("boom")}
+
+	errOut := captureStderr(t, func() {
+		err := pingDaemonWithVersionCheck(pinger)
+		if err == nil || !strings.Contains(err.Error(), "boom") {
+			t.Fatalf("error = %v, want boom", err)
+		}
+	})
+
+	if errOut != "" {
+		t.Fatalf("stderr = %q, want empty", errOut)
+	}
+}

--- a/internal/daemon/proto_client.go
+++ b/internal/daemon/proto_client.go
@@ -292,21 +292,38 @@ func (c *ProtoClient) doSendRequest(conn net.Conn, req *orchpb.Request) (*orchpb
 	return &resp, nil
 }
 
-func (c *ProtoClient) Ping() error {
+func (c *ProtoClient) PingStatus() (*PingResponse, error) {
 	req := &orchpb.Request{
 		Request: &orchpb.Request_Ping{Ping: &orchpb.PingRequest{}},
 	}
 
 	resp, err := c.sendRequest(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !resp.Ok {
-		return fmt.Errorf("daemon error: %s", resp.Error)
+		return nil, fmt.Errorf("daemon error: %s", resp.Error)
 	}
 
-	return nil
+	pingResp := resp.GetPing()
+	if pingResp == nil {
+		return nil, fmt.Errorf("unexpected response type")
+	}
+
+	if !pingResp.GetOk() {
+		return nil, fmt.Errorf("daemon ping returned not ok")
+	}
+
+	return &PingResponse{
+		OK:      pingResp.GetOk(),
+		Version: pingResp.GetVersion(),
+	}, nil
+}
+
+func (c *ProtoClient) Ping() error {
+	_, err := c.PingStatus()
+	return err
 }
 
 func (c *ProtoClient) ListRuns(filter *ListRunsFilter) (*ListRunsResponse, error) {

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/proboscis/orch/internal/multiplexer"
 	"github.com/proboscis/orch/internal/pr"
 	"github.com/proboscis/orch/internal/store"
+	buildversion "github.com/proboscis/orch/internal/version"
 	"github.com/proboscis/orch/internal/xdg"
 	"google.golang.org/protobuf/proto"
 )
@@ -838,7 +839,7 @@ func (s *SocketServer) handleProtoPing(_ *orchpb.PingRequest) *orchpb.Response {
 	return &orchpb.Response{
 		Ok: true,
 		Response: &orchpb.Response_Ping{
-			Ping: &orchpb.PingResponse{Ok: true, Version: "1.0.0"},
+			Ping: &orchpb.PingResponse{Ok: true, Version: buildversion.Version},
 		},
 	}
 }
@@ -4088,7 +4089,7 @@ func (s *SocketServer) handleProtoGetDaemonStatus(_ *orchpb.GetDaemonStatusReque
 				Running: true,
 				Pid:     int32(os.Getpid()),
 				LogPath: LogFilePath(""),
-				Version: "1.0.0",
+				Version: buildversion.Version,
 			},
 		},
 	}

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -1025,3 +1025,8 @@ type DaemonStatusResponse struct {
 	LogPath string
 	Version string
 }
+
+type PingResponse struct {
+	OK      bool
+	Version string
+}

--- a/internal/orchapi/daemon_client.go
+++ b/internal/orchapi/daemon_client.go
@@ -44,6 +44,17 @@ func (c *DaemonClient) Ping(ctx context.Context) error {
 	return c.proto.Ping()
 }
 
+func (c *DaemonClient) PingStatus(ctx context.Context) (*PingStatus, error) {
+	resp, err := c.proto.PingStatus()
+	if err != nil {
+		return nil, err
+	}
+	return &PingStatus{
+		OK:      resp.OK,
+		Version: resp.Version,
+	}, nil
+}
+
 func (c *DaemonClient) EnsureDaemonHealthy(ctx context.Context) error {
 	if c.isRemote() {
 		if err := c.proto.Ping(); err != nil {

--- a/internal/orchapi/types.go
+++ b/internal/orchapi/types.go
@@ -603,6 +603,11 @@ type DaemonStatus struct {
 	Version string
 }
 
+type PingStatus struct {
+	OK      bool
+	Version string
+}
+
 type ControlAgentConfig struct {
 	PromptContent string
 	Agent         string

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)


### PR DESCRIPTION
## Summary
- Add internal/version build metadata and wire Cobra --version plus an `orch version` command.
- Report the same build version from daemon Ping and daemon status RPCs, and warn once per invocation when CLI/daemon versions differ.
- Show CLI and daemon versions in `orch daemon status`.
- Inject versions from Makefile/release builds and restart a running daemon by default in install.sh, with `--no-daemon-restart` opt-out.

Refs: beta-version-infra

## Evidence
- `go run ./cmd/orch version`:
```
version dev
commit unknown
build_date unknown
goos/goarch darwin/arm64
```
- `make build && ./orch version`:
```
go build -ldflags "-X github.com/proboscis/orch/internal/version.Version=v1.2.0-124-gbbee2538 -X github.com/proboscis/orch/internal/version.Commit=bbee2538 -X github.com/proboscis/orch/internal/version.BuildDate=2026-07-07T11:53:29Z" -o orch ./cmd/orch
version v1.2.0-124-gbbee2538
commit bbee2538
build_date 2026-07-07T11:53:29Z
goos/goarch darwin/arm64
```
- Isolated daemon started from that binary, then `./orch daemon status`:
```
CLI Version: v1.2.0-124-gbbee2538
Status: running (pid=44759)
Socket: available
Daemon Version: v1.2.0-124-gbbee2538
```
- `go build ./...`: passed.
- `go test ./internal/cli -run 'Test(PrintVersionIncludesBuildMetadata|PingDaemonWithVersionCheck)' -count=1`: passed.
- `TMUX= ORCH_SAFE_CLI_TEST=1 go test \github.com/proboscis/orch/api/orchpb
github.com/proboscis/orch/cmd/orch
github.com/proboscis/orch/internal/agent
github.com/proboscis/orch/internal/backend
github.com/proboscis/orch/internal/cli
github.com/proboscis/orch/internal/config
github.com/proboscis/orch/internal/daemon
github.com/proboscis/orch/internal/executor
github.com/proboscis/orch/internal/git
github.com/proboscis/orch/internal/github
github.com/proboscis/orch/internal/model
github.com/proboscis/orch/internal/monitor
github.com/proboscis/orch/internal/multiplexer
github.com/proboscis/orch/internal/notify
github.com/proboscis/orch/internal/orchapi
github.com/proboscis/orch/internal/pr
github.com/proboscis/orch/internal/query
github.com/proboscis/orch/internal/runevents
github.com/proboscis/orch/internal/store
github.com/proboscis/orch/internal/store/file
github.com/proboscis/orch/internal/testutil
github.com/proboscis/orch/internal/version
github.com/proboscis/orch/internal/worker
github.com/proboscis/orch/internal/xdg`: passed.
- `TMUX= go test ./test/integration -run TestAgentClaude -count=1`: passed.
- `make lint`: passed.
- `bash -n install.sh`: passed.
- `bash install.sh --help`: shows `--no-daemon-restart`.

## Integration note
- Full `TMUX= ORCH_SAFE_CLI_TEST=1 go test -p 1 ./...` did not complete cleanly in this host session: `test/integration` failed in `TestRunWithBuiltInAgents` when the opencode server returned HTTP 500 while sending the prompt.
- A later focused `TMUX= go test ./test/integration -run TestRunWithBuiltInAgents -count=1` hit `daemon did not start in time` while multiple other integration daemons from concurrent worktrees were running. I did not debug or change those integration tests; the user-specified `TestAgentClaude` verification with `TMUX=` passed.
