### PR TITLE
Scrub multiplexer env for tmux worker control

### DIFF
--- a/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
+++ b/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
@@ -192,6 +192,9 @@ Interpretation:
 - **Workers do not reconnect forever.** A master restart or a network blip can leave the local
   worker `exited` (see `Last Error` in `orch worker status`). Verify the worker at the start of
   every orch session and run `orch worker start` again when needed.
+- **Pre-fix workers can inherit a foreign tmux server.** If operating an old binary, start workers
+  from a clean env (`env -u TMUX -u TMUX_PANE orch worker start`) so run sessions do not land on
+  an unrelated app's tmux socket.
 - **File-backend issue files live on the master's checkout** (e.g.
   `~/repos/<repo>/VAULT/Issues/ISSUE-X.md` on the master host). From another host,
   `orch open <ISSUE> --print-path` reports `not found` — read the issue via `orch issue list`

--- a/internal/cli/master_worker.go
+++ b/internal/cli/master_worker.go
@@ -57,6 +57,8 @@ func newWorkerRunCmd() *cobra.Command {
 		Use:   "run",
 		Short: "Run long-lived orch-worker host loop",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			worker.ScrubInheritedMultiplexerEnv()
+
 			client, err := requireDaemonForWorker()
 			if err != nil {
 				return err

--- a/internal/cli/master_worker_test.go
+++ b/internal/cli/master_worker_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -63,6 +64,11 @@ func TestWorkerCommandRegistersRunSubcommand(t *testing.T) {
 }
 
 func TestWorkerRunCommandInvokesExternalLoop(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/foreign,123,0")
+	t.Setenv("TMUX_PANE", "%999")
+	t.Setenv("ZELLIJ", "1")
+	t.Setenv("ZELLIJ_SESSION_NAME", "foreign")
+
 	origRequire := requireDaemonForWorker
 	origRun := runExternalWorkerLoop
 	t.Cleanup(func() {
@@ -71,6 +77,11 @@ func TestWorkerRunCommandInvokesExternalLoop(t *testing.T) {
 	})
 
 	requireDaemonForWorker = func() (worker.Client, error) {
+		for _, key := range []string{"TMUX", "TMUX_PANE", "ZELLIJ", "ZELLIJ_SESSION_NAME"} {
+			if _, ok := os.LookupEnv(key); ok {
+				t.Fatalf("worker run reached daemon setup with %s still set", key)
+			}
+		}
 		return &mockWorkerClient{}, nil
 	}
 

--- a/internal/multiplexer/env.go
+++ b/internal/multiplexer/env.go
@@ -7,13 +7,17 @@ import (
 	"github.com/proboscis/orch/internal/executor"
 )
 
+var tmuxControlEnvVars = []string{"TMUX", "TMUX_PANE"}
+var zellijControlEnvVars = []string{"ZELLIJ", "ZELLIJ_SESSION_NAME"}
+var multiplexerControlEnvVars = append(append([]string{}, tmuxControlEnvVars...), zellijControlEnvVars...)
+
 func sessionEnv(exec executor.Executor, extra []string) []string {
 	filtered := sessionExtraEnv(exec, extra)
 	if _, ok := exec.(*executor.SSHExecutor); ok {
 		return filtered
 	}
 
-	env := append([]string{}, os.Environ()...)
+	env := scrubEnvEntries(os.Environ(), multiplexerControlEnvVars)
 	return append(env, filtered...)
 }
 
@@ -34,4 +38,59 @@ func sessionExtraEnv(exec executor.Executor, extra []string) []string {
 		}
 	}
 	return filtered
+}
+
+func tmuxControlOptions(exec executor.Executor, opts executor.RunOptions) executor.RunOptions {
+	opts.Env = controlCommandEnv(exec, opts.Env, tmuxControlEnvVars)
+	return opts
+}
+
+func zellijControlOptions(exec executor.Executor, opts executor.RunOptions) executor.RunOptions {
+	opts.Env = controlCommandEnv(exec, opts.Env, zellijControlEnvVars)
+	return opts
+}
+
+func controlCommandEnv(exec executor.Executor, env []string, unset []string) []string {
+	if _, ok := exec.(*executor.SSHExecutor); ok {
+		return sshEnvWithUnsets(env, unset)
+	}
+	if len(env) == 0 {
+		env = os.Environ()
+	}
+	return scrubEnvEntries(env, unset)
+}
+
+func sshEnvWithUnsets(env []string, unset []string) []string {
+	filtered := make([]string, 0, len(unset)*2+len(env))
+	for _, key := range unset {
+		filtered = append(filtered, "-u", key)
+	}
+	for _, entry := range env {
+		entry = strings.TrimSpace(entry)
+		if entry == "" || envEntryHasAnyKey(entry, unset) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func scrubEnvEntries(env []string, keys []string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.TrimSpace(entry) == "" || envEntryHasAnyKey(entry, keys) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func envEntryHasAnyKey(entry string, keys []string) bool {
+	for _, key := range keys {
+		if strings.HasPrefix(entry, key+"=") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/multiplexer/multiplexer_test.go
+++ b/internal/multiplexer/multiplexer_test.go
@@ -164,6 +164,8 @@ func TestErrUnsupported(t *testing.T) {
 
 func TestSessionEnvForLocalExecutorIncludesProcessEnv(t *testing.T) {
 	t.Setenv("ORCH_TEST_ENV", "local-value")
+	t.Setenv("TMUX", "/tmp/foreign,123,0")
+	t.Setenv("ZELLIJ", "1")
 
 	env := sessionEnv(executor.NewLocalExecutor(), []string{"FOO=bar"})
 	joined := strings.Join(env, "\n")
@@ -172,6 +174,9 @@ func TestSessionEnvForLocalExecutorIncludesProcessEnv(t *testing.T) {
 	}
 	if !strings.Contains(joined, "FOO=bar") {
 		t.Fatalf("expected local env to include extra env, got %v", env)
+	}
+	if strings.Contains(joined, "TMUX=/tmp/foreign") || strings.Contains(joined, "ZELLIJ=1") {
+		t.Fatalf("expected local session env to scrub multiplexer env, got %v", env)
 	}
 }
 
@@ -191,5 +196,18 @@ func TestSessionEnvForSSHExecutorDoesNotLeakProcessEnv(t *testing.T) {
 	}
 	if _, ok := os.LookupEnv("ORCH_TEST_ENV"); !ok {
 		t.Fatal("expected test env to stay set in process")
+	}
+}
+
+func TestControlCommandEnvForSSHUsesRemoteEnvUnsets(t *testing.T) {
+	env := controlCommandEnv(executor.NewSSHExecutor("mac-e2e"), []string{"FOO=bar", "TMUX=bad"}, tmuxControlEnvVars)
+	want := []string{"-u", "TMUX", "-u", "TMUX_PANE", "FOO=bar"}
+	if len(env) != len(want) {
+		t.Fatalf("env len = %d, want %d: %v", len(env), len(want), env)
+	}
+	for i := range want {
+		if env[i] != want[i] {
+			t.Fatalf("env = %v, want %v", env, want)
+		}
 	}
 }

--- a/internal/multiplexer/tmux.go
+++ b/internal/multiplexer/tmux.go
@@ -50,18 +50,31 @@ func NewTmuxMultiplexerWithExecutor(exec executor.Executor) *TmuxMultiplexer {
 }
 
 func (t *TmuxMultiplexer) run(args ...string) error {
-	_, _, err := t.executor.RunCommand(context.Background(), "tmux", args, executor.RunOptions{})
+	_, _, err := t.executor.RunCommand(context.Background(), "tmux", args, tmuxControlOptions(t.executor, executor.RunOptions{}))
 	return err
 }
 
 func (t *TmuxMultiplexer) output(args ...string) ([]byte, error) {
-	output, _, err := t.executor.RunCommand(context.Background(), "tmux", args, executor.RunOptions{})
+	output, _, err := t.executor.RunCommand(context.Background(), "tmux", args, tmuxControlOptions(t.executor, executor.RunOptions{}))
 	return output, err
 }
 
 func (t *TmuxMultiplexer) runWithOptions(args []string, opts executor.RunOptions) error {
+	opts = tmuxControlOptions(t.executor, opts)
 	_, _, err := t.executor.RunCommand(context.Background(), "tmux", args, opts)
 	return err
+}
+
+// Caller-session operations are intentionally limited to attach UX: these
+// commands must see TMUX so tmux can identify the user's current client.
+func (t *TmuxMultiplexer) runWithCallerSessionEnv(args []string, opts executor.RunOptions) error {
+	_, _, err := t.executor.RunCommand(context.Background(), "tmux", args, opts)
+	return err
+}
+
+func (t *TmuxMultiplexer) outputWithCallerSessionEnv(args ...string) ([]byte, error) {
+	output, _, err := t.executor.RunCommand(context.Background(), "tmux", args, executor.RunOptions{})
+	return output, err
 }
 
 // Type returns the multiplexer type.
@@ -74,7 +87,8 @@ func (t *TmuxMultiplexer) IsAvailable() bool {
 	return t.run("-V") == nil
 }
 
-// IsInsideSession returns true if we're currently inside a tmux session.
+// IsInsideSession is an intentional caller-session exception for attach UX.
+// It reads TMUX to decide whether orch should switch the current client.
 func (t *TmuxMultiplexer) IsInsideSession() bool {
 	return os.Getenv("TMUX") != ""
 }
@@ -390,12 +404,12 @@ func (t *TmuxMultiplexer) WaitForReady(session, pattern string, timeout time.Dur
 
 // SwitchClient switches the active tmux client to a session.
 func (t *TmuxMultiplexer) SwitchClient(session string) error {
-	return t.runWithOptions([]string{"switch-client", "-t", session}, executor.RunOptions{Stderr: os.Stderr})
+	return t.runWithCallerSessionEnv([]string{"switch-client", "-t", session}, executor.RunOptions{Stderr: os.Stderr})
 }
 
-// CurrentSession returns the name of the current tmux session.
+// CurrentSession is an intentional caller-session exception for monitor/attach UX.
 func (t *TmuxMultiplexer) CurrentSession() (string, error) {
-	output, err := t.output("display-message", "-p", "#{session_name}")
+	output, err := t.outputWithCallerSessionEnv("display-message", "-p", "#{session_name}")
 	if err != nil {
 		return "", err
 	}

--- a/internal/multiplexer/tmux_test.go
+++ b/internal/multiplexer/tmux_test.go
@@ -1,12 +1,16 @@
 package multiplexer
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
+	"time"
 )
 
 type fakeCall struct {
@@ -33,13 +37,16 @@ func (f *fakeExecutor) Command(name string, args ...string) *exec.Cmd {
 	}
 	f.index++
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", name)
-	cmd.Args = append(cmd.Args, args...)
-	cmd.Env = append(os.Environ(),
-		"GO_WANT_HELPER_PROCESS=1",
-		fmt.Sprintf("FAKE_CMD_OUTPUT=%s", call.output),
-		fmt.Sprintf("FAKE_CMD_EXIT_CODE=%d", call.exitCode),
+	cmd := exec.Command(
+		os.Args[0],
+		"-test.run=TestHelperProcess",
+		"--",
+		"__orch_multiplexer_helper__",
+		base64.StdEncoding.EncodeToString([]byte(call.output)),
+		fmt.Sprintf("%d", call.exitCode),
+		name,
 	)
+	cmd.Args = append(cmd.Args, args...)
 
 	rec := recordedCall{name: name, args: append([]string(nil), args...), cmd: cmd}
 	f.recorded = append(f.recorded, rec)
@@ -47,22 +54,34 @@ func (f *fakeExecutor) Command(name string, args ...string) *exec.Cmd {
 }
 
 func TestHelperProcess(t *testing.T) {
-	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+	output, code, ok := helperProcessPayload()
+	if !ok {
 		return
 	}
 
-	if output := os.Getenv("FAKE_CMD_OUTPUT"); output != "" {
+	if output != "" {
 		_, _ = fmt.Fprint(os.Stdout, output)
 	}
 
-	code := 0
-	if raw := os.Getenv("FAKE_CMD_EXIT_CODE"); raw != "" {
-		if v, err := strconv.Atoi(raw); err == nil {
-			code = v
-		}
-	}
-
 	os.Exit(code)
+}
+
+func helperProcessPayload() (string, int, bool) {
+	for i, arg := range os.Args {
+		if arg != "--" || i+4 >= len(os.Args) || os.Args[i+1] != "__orch_multiplexer_helper__" {
+			continue
+		}
+		outputBytes, err := base64.StdEncoding.DecodeString(os.Args[i+2])
+		if err != nil {
+			return "", 2, true
+		}
+		code, err := strconv.Atoi(os.Args[i+3])
+		if err != nil {
+			return "", 2, true
+		}
+		return string(outputBytes), code, true
+	}
+	return "", 0, false
 }
 
 func TestTmuxMultiplexer_Type(t *testing.T) {
@@ -150,6 +169,73 @@ func TestTmuxMultiplexer_HasSession_Missing(t *testing.T) {
 	tm := NewTmuxMultiplexer()
 	if tm.HasSession("demo") {
 		t.Fatal("expected session to be missing")
+	}
+}
+
+func TestTmuxMultiplexer_ControlCommandsScrubInheritedTmuxEnv(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/foreign-tmux,123,0")
+	t.Setenv("TMUX_PANE", "%999")
+
+	exec := &fakeExecutor{calls: []fakeCall{{exitCode: 0}}}
+	orig := execCommand
+	execCommand = exec.Command
+	t.Cleanup(func() { execCommand = orig })
+
+	tm := NewTmuxMultiplexer()
+	if !tm.HasSession("demo") {
+		t.Fatal("expected session to exist")
+	}
+
+	env := exec.recorded[0].cmd.Env
+	if envHasKey(env, "TMUX") || envHasKey(env, "TMUX_PANE") {
+		t.Fatalf("tmux control command inherited tmux env: %v", env)
+	}
+}
+
+func TestTmuxMultiplexer_IgnoresInheritedTmuxEnvForSessionLifecycle(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	session := fmt.Sprintf("orch-test-%d-%d", os.Getpid(), time.Now().UnixNano())
+	foreignSession := session + "-foreign"
+	foreignSocket := filepath.Join(t.TempDir(), "foreign")
+
+	if out, err := cleanTmuxCommand("-S", foreignSocket, "new-session", "-d", "-s", foreignSession, "sleep 60").CombinedOutput(); err != nil {
+		t.Skipf("tmux foreign server unavailable: %v (%s)", err, out)
+	}
+	t.Cleanup(func() {
+		_ = cleanTmuxCommand("-S", foreignSocket, "kill-server").Run()
+	})
+	t.Cleanup(func() {
+		_ = cleanTmuxCommand("kill-session", "-t", session).Run()
+	})
+
+	t.Setenv("TMUX", foreignSocket+",123,0")
+	t.Setenv("TMUX_PANE", "%999")
+
+	tm := NewTmuxMultiplexer()
+	if err := tm.NewSession(&SessionConfig{SessionName: session, Command: "sleep 60"}); err != nil {
+		t.Fatalf("NewSession() with inherited TMUX error = %v", err)
+	}
+	if !tm.HasSession(session) {
+		t.Fatal("HasSession() did not find the created session")
+	}
+	if !cleanTmuxHasSession(session) {
+		t.Fatal("TMUX-clean observer did not find the created session on the default tmux server")
+	}
+	if cleanTmuxHasSessionOnSocket(foreignSocket, session) {
+		t.Fatal("session was created on the inherited foreign tmux server")
+	}
+
+	if err := tm.KillSession(session); err != nil {
+		t.Fatalf("KillSession() with inherited TMUX error = %v", err)
+	}
+	if cleanTmuxHasSession(session) {
+		t.Fatal("TMUX-clean observer still sees session after KillSession")
+	}
+	if tm.HasSession(session) {
+		t.Fatal("HasSession() still sees session after KillSession")
 	}
 }
 
@@ -810,9 +896,32 @@ func equalArgs(got, want []string) bool {
 	return true
 }
 
+func cleanTmuxCommand(args ...string) *exec.Cmd {
+	cmd := exec.Command("tmux", args...)
+	cmd.Env = scrubEnvEntries(os.Environ(), tmuxControlEnvVars)
+	return cmd
+}
+
+func cleanTmuxHasSession(session string) bool {
+	return cleanTmuxCommand("has-session", "-t", session).Run() == nil
+}
+
+func cleanTmuxHasSessionOnSocket(socket, session string) bool {
+	return cleanTmuxCommand("-S", socket, "has-session", "-t", session).Run() == nil
+}
+
 func envHas(env []string, want string) bool {
 	for _, entry := range env {
 		if entry == want {
+			return true
+		}
+	}
+	return false
+}
+
+func envHasKey(env []string, key string) bool {
+	for _, entry := range env {
+		if strings.HasPrefix(entry, key+"=") {
 			return true
 		}
 	}

--- a/internal/multiplexer/zellij.go
+++ b/internal/multiplexer/zellij.go
@@ -69,14 +69,14 @@ func NewZellijMultiplexerWithExecutor(exec executor.Executor) *ZellijMultiplexer
 func (z *ZellijMultiplexer) run(args ...string) error {
 	ctx, cancel := zellijCommandContext()
 	defer cancel()
-	_, _, err := z.executor.RunCommand(ctx, "zellij", args, executor.RunOptions{})
+	_, _, err := z.executor.RunCommand(ctx, "zellij", args, zellijControlOptions(z.executor, executor.RunOptions{}))
 	return err
 }
 
 func (z *ZellijMultiplexer) output(args ...string) ([]byte, error) {
 	ctx, cancel := zellijCommandContext()
 	defer cancel()
-	output, _, err := z.executor.RunCommand(ctx, "zellij", args, executor.RunOptions{})
+	output, _, err := z.executor.RunCommand(ctx, "zellij", args, zellijControlOptions(z.executor, executor.RunOptions{}))
 	return output, err
 }
 
@@ -89,6 +89,7 @@ func (z *ZellijMultiplexer) runWithOptions(args []string, opts executor.RunOptio
 // runWithOptionsContext is the unbounded variant for interactive commands
 // (attach) that legitimately run as long as the user stays attached.
 func (z *ZellijMultiplexer) runWithOptionsContext(ctx context.Context, args []string, opts executor.RunOptions) error {
+	opts = zellijControlOptions(z.executor, opts)
 	_, _, err := z.executor.RunCommand(ctx, "zellij", args, opts)
 	return err
 }
@@ -101,6 +102,8 @@ func (z *ZellijMultiplexer) IsAvailable() bool {
 	return z.run("--version") == nil
 }
 
+// IsInsideSession is an intentional caller-session exception for attach UX.
+// Zellij exposes the current session through environment variables.
 func (z *ZellijMultiplexer) IsInsideSession() bool {
 	return os.Getenv("ZELLIJ") != ""
 }
@@ -418,6 +421,7 @@ func (z *ZellijMultiplexer) SwitchClient(session string) error {
 }
 
 func (z *ZellijMultiplexer) CurrentSession() (string, error) {
+	// CurrentSession is the paired caller-session exception for SwitchClient.
 	if name := os.Getenv("ZELLIJ_SESSION_NAME"); name != "" {
 		return name, nil
 	}

--- a/internal/multiplexer/zellij_test.go
+++ b/internal/multiplexer/zellij_test.go
@@ -141,6 +141,26 @@ func TestZellijMultiplexer_KillSession(t *testing.T) {
 	}
 }
 
+func TestZellijMultiplexer_ControlCommandsScrubInheritedZellijEnv(t *testing.T) {
+	t.Setenv("ZELLIJ", "1")
+	t.Setenv("ZELLIJ_SESSION_NAME", "foreign-session")
+
+	exec := &fakeExecutor{calls: []fakeCall{{exitCode: 0}}}
+	orig := execCommand
+	execCommand = exec.Command
+	t.Cleanup(func() { execCommand = orig })
+
+	zm := NewZellijMultiplexer()
+	if err := zm.KillSession("sess"); err != nil {
+		t.Fatalf("KillSession error: %v", err)
+	}
+
+	env := exec.recorded[0].cmd.Env
+	if envHasKey(env, "ZELLIJ") || envHasKey(env, "ZELLIJ_SESSION_NAME") {
+		t.Fatalf("zellij control command inherited zellij env: %v", env)
+	}
+}
+
 func TestZellijMultiplexer_NewWindow(t *testing.T) {
 	exec := &fakeExecutor{calls: []fakeCall{{exitCode: 0}}}
 	orig := execCommand

--- a/internal/worker/env.go
+++ b/internal/worker/env.go
@@ -1,0 +1,36 @@
+package worker
+
+import (
+	"os"
+	"strings"
+)
+
+var workerMultiplexerEnvKeys = []string{"TMUX", "TMUX_PANE", "ZELLIJ", "ZELLIJ_SESSION_NAME"}
+
+// ScrubInheritedMultiplexerEnv detaches worker startup from any shell UI
+// multiplexer the operator happened to run the command inside.
+func ScrubInheritedMultiplexerEnv() {
+	for _, key := range workerMultiplexerEnvKeys {
+		_ = os.Unsetenv(key)
+	}
+}
+
+func scrubWorkerMultiplexerEnvEntries(env []string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.TrimSpace(entry) == "" || workerEnvEntryHasAnyKey(entry, workerMultiplexerEnvKeys) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func workerEnvEntryHasAnyKey(entry string, keys []string) bool {
+	for _, key := range keys {
+		if strings.HasPrefix(entry, key+"=") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/worker/managed.go
+++ b/internal/worker/managed.go
@@ -400,12 +400,12 @@ func mergeManagedEnv(base, extra []string, profile managedProfile) []string {
 		managedWorkerLogPathEnv + "=",
 	}
 	for _, kv := range base {
-		if hasAnyPrefix(kv, omitPrefixes) {
+		if hasAnyPrefix(kv, omitPrefixes) || workerEnvEntryHasAnyKey(kv, workerMultiplexerEnvKeys) {
 			continue
 		}
 		filtered = append(filtered, kv)
 	}
-	filtered = append(filtered, extra...)
+	filtered = append(filtered, scrubWorkerMultiplexerEnvEntries(extra)...)
 	filtered = append(filtered,
 		managedWorkerStateEnv+"="+profile.StatePath,
 		managedWorkerPIDEnv+"="+profile.PIDPath,

--- a/internal/worker/managed_test.go
+++ b/internal/worker/managed_test.go
@@ -183,6 +183,45 @@ func TestStatusManagedReportsUnmanagedRegistration(t *testing.T) {
 	}
 }
 
+func TestMergeManagedEnvScrubsMultiplexerVars(t *testing.T) {
+	profile := managedProfile{
+		StatePath:  "/tmp/state.json",
+		PIDPath:    "/tmp/worker.pid",
+		RemoteAddr: "zeus:7777",
+		LogPath:    "/tmp/worker.log",
+	}
+	env := mergeManagedEnv(
+		[]string{
+			"PATH=/bin",
+			"TMUX=/private/tmp/tmux-501/agent-deck,123,0",
+			"ZELLIJ=1",
+			managedWorkerStateEnv + "=/old/state.json",
+		},
+		[]string{
+			"FOO=bar",
+			"TMUX_PANE=%1",
+			"ZELLIJ_SESSION_NAME=foreign",
+		},
+		profile,
+	)
+
+	joined := strings.Join(env, "\n")
+	for _, key := range workerMultiplexerEnvKeys {
+		if strings.Contains(joined, key+"=") {
+			t.Fatalf("managed worker env leaked %s: %v", key, env)
+		}
+	}
+	if !strings.Contains(joined, "PATH=/bin") || !strings.Contains(joined, "FOO=bar") {
+		t.Fatalf("managed worker env dropped non-multiplexer entries: %v", env)
+	}
+	if strings.Contains(joined, managedWorkerStateEnv+"=/old/state.json") {
+		t.Fatalf("managed worker env kept stale runtime state entry: %v", env)
+	}
+	if !strings.Contains(joined, managedWorkerStateEnv+"="+profile.StatePath) {
+		t.Fatalf("managed worker env missing runtime state path: %v", env)
+	}
+}
+
 func setManagedWorkerTestEnv(t *testing.T) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- Scrub inherited `TMUX` / `TMUX_PANE` from all tmux control subprocesses, with caller-session exceptions limited to attach/monitor UX (`IsInsideSession`, `SwitchClient`, `CurrentSession`).
- Scrub inherited `ZELLIJ` / `ZELLIJ_SESSION_NAME` from zellij control subprocesses while keeping current-session detection as the explicit attach UX exception.
- Scrub multiplexer env vars from managed worker launch env and direct `orch worker run` startup.
- Add a real tmux regression test that sets `TMUX` to a foreign socket and verifies `NewSession` / `HasSession` / `KillSession` agree with a `TMUX`-clean observer on the default server.
- Document the pre-fix worker workaround in `orch-toolset`.

Issue: beta-tmux-socket-hygiene

## Acceptance Criteria Evidence

- tmux wrapper ignores inherited `TMUX` / `TMUX_PANE`:
  - `go test ./internal/multiplexer` passes, including `TestTmuxMultiplexer_IgnoresInheritedTmuxEnvForSessionLifecycle` and `TestTmuxMultiplexer_ControlCommandsScrubInheritedTmuxEnv`.
- zellij env reviewed/fixed equivalently:
  - `go test ./internal/multiplexer` passes, including `TestZellijMultiplexer_ControlCommandsScrubInheritedZellijEnv`.
- worker startup scrubs multiplexer env:
  - `go test ./internal/worker` passes, including `TestMergeManagedEnvScrubsMultiplexerVars`.
  - `go test ./internal/cli -run 'TestWorkerRunCommandInvokesExternalLoop|TestWorkerCommandRegistersRunSubcommand|TestRootRegistersMasterAndWorkerCommands'` passes and asserts `worker run` reaches daemon setup with multiplexer vars already unset.
- Full verification:
  - `go build ./...` passed.
  - `go test ./...` passed, including `github.com/proboscis/orch/test/integration` in 108.482s.
  - `make lint` passed with 0 architecture findings on `./internal/` and TUI lint passing.

## Notes

No session naming or run-status machinery changed. No `nosemgrep` annotations added.
