### PR TITLE
Fix control-agent integration tests: pin test suite to one tmux server

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -215,8 +215,12 @@ func runOpenCodeAgent(orchDir, projectRoot string, opts *agentOptions, controlCf
 			CreatedAt: time.Now(),
 			SessionID: newSessionID,
 		}
+		// Without the state file, later `orch agent` invocations cannot
+		// resume this session, so a failed save is a real error, not a
+		// warning (fail-fast charter).
 		if err := saveControlAgentState(orchDir, newState); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: failed to save state: %v\n", err)
+			return fmt.Errorf("failed to save control agent state to %s: %w",
+				filepath.Join(orchDir, controlAgentFileName), err)
 		}
 		fmt.Fprintf(os.Stderr, "Creating opencode session: %s\n", newSessionID)
 	}
@@ -393,8 +397,12 @@ func createMultiplexerSession(orchDir, projectRoot string, agentType agent.Agent
 		Multiplexer:        string(mux.Type()),
 	}
 
+	// Without the state file, later `orch agent` / `orch agent --kill`
+	// invocations cannot manage the session, so a failed save is a real
+	// error, not a warning (fail-fast charter).
 	if err := saveControlAgentState(orchDir, state); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: failed to save state: %v\n", err)
+		return fmt.Errorf("session %q was created on %s, but saving control agent state to %s failed: %w",
+			controlAgentSessionName, mux.Type(), filepath.Join(orchDir, controlAgentFileName), err)
 	}
 
 	if promptPath != "" {

--- a/test/integration/agent_test.go
+++ b/test/integration/agent_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -15,13 +16,12 @@ const controlAgentSessionName = "orch-control-agent"
 
 // hasSession checks if a multiplexer session exists
 func hasSession(name string) bool {
-	cmd := exec.Command("tmux", "has-session", "-t", name)
-	return cmd.Run() == nil
+	return tmuxCmd("has-session", "-t", name).Run() == nil
 }
 
 // killSession kills a multiplexer session if it exists
 func killSession(name string) {
-	exec.Command("tmux", "kill-session", "-t", name).Run()
+	tmuxCmd("kill-session", "-t", name).Run()
 }
 
 // setupAgentTest creates necessary directories and returns cleanup function
@@ -49,7 +49,23 @@ func setupAgentTest(t *testing.T) (orchDir string, cleanup func()) {
 	return orchDir, cleanup
 }
 
-// runAgentCommand runs orch agent and waits for session creation
+// requireAgentBinary skips the test when the given agent CLI is not in PATH,
+// so the test never passes or fails accidentally on hosts without it.
+// (TestMain installs fake claude/codex shims, so within this suite the
+// binaries are normally present.)
+func requireAgentBinary(t *testing.T, name string) {
+	t.Helper()
+	if !hasBinary(name) {
+		t.Skipf("%s binary not available in PATH", name)
+	}
+}
+
+// runAgentCommand runs `orch agent` with the given args and returns an error
+// if the command failed before reaching its final interactive attach step.
+// The test harness has no TTY, so even a fully successful launch exits
+// non-zero when tmux attach-session reports "not a terminal"; that expected
+// attach failure is not an error, but everything before it (session
+// creation, state save) is.
 func runAgentCommand(t *testing.T, args ...string) error {
 	t.Helper()
 	ensureRepoMapping(t, testRepo, testVault)
@@ -60,15 +76,19 @@ func runAgentCommand(t *testing.T, args ...string) error {
 
 	cmd := exec.Command(orchBinary, fullArgs...)
 	cmd.Dir = testRepo
-	env := make([]string, 0, len(os.Environ())+2)
+	env := make([]string, 0, len(os.Environ())+1)
 	for _, kv := range os.Environ() {
 		if strings.HasPrefix(kv, "ORCH_REMOTE=") || strings.HasPrefix(kv, "ORCH_PROJECT=") {
 			continue
 		}
 		env = append(env, kv)
 	}
-	env = append(env, "ORCH_PROJECT=", "TMUX=")
+	env = append(env, "ORCH_PROJECT=")
 	cmd.Env = env
+
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
 
 	done := make(chan error, 1)
 	go func() {
@@ -77,7 +97,16 @@ func runAgentCommand(t *testing.T, args ...string) error {
 
 	select {
 	case err := <-done:
-		return err
+		if err == nil {
+			return nil
+		}
+		if strings.Contains(output.String(), "Attaching to") {
+			// The command reached the attach step, so session creation
+			// and state save succeeded; only the interactive attach
+			// failed, which is unavoidable without a TTY.
+			return nil
+		}
+		return fmt.Errorf("orch agent %v failed: %w\noutput:\n%s", args, err, output.String())
 	case <-time.After(5 * time.Second):
 		cmd.Process.Kill()
 		return nil
@@ -115,13 +144,16 @@ func TestAgentClaudeCreatesMultiplexerSession(t *testing.T) {
 	if !hasTmux() {
 		t.Skip("tmux not available")
 	}
+	requireAgentBinary(t, "claude")
 
 	orchDir, cleanup := setupAgentTest(t)
 	defer cleanup()
 
 	writeAgentConfig(t, orchDir, "claude", "tmux")
 
-	_ = runAgentCommand(t, "--backend", "claude")
+	if err := runAgentCommand(t, "--backend", "claude"); err != nil {
+		t.Fatal(err)
+	}
 
 	time.Sleep(500 * time.Millisecond)
 
@@ -217,14 +249,14 @@ func TestAgentAttachesToExistingMultiplexerSession(t *testing.T) {
 	if !hasTmux() {
 		t.Skip("tmux not available")
 	}
+	requireAgentBinary(t, "claude")
 
 	orchDir, cleanup := setupAgentTest(t)
 	defer cleanup()
 
 	writeAgentConfig(t, orchDir, "claude", "tmux")
 
-	cmd := exec.Command("tmux", "new-session", "-d", "-s", controlAgentSessionName)
-	if err := cmd.Run(); err != nil {
+	if err := tmuxCmd("new-session", "-d", "-s", controlAgentSessionName).Run(); err != nil {
 		t.Fatalf("failed to create initial session: %v", err)
 	}
 
@@ -239,7 +271,9 @@ func TestAgentAttachesToExistingMultiplexerSession(t *testing.T) {
 		t.Fatalf("failed to write state: %v", err)
 	}
 
-	_ = runAgentCommand(t, "--backend", "claude")
+	if err := runAgentCommand(t, "--backend", "claude"); err != nil {
+		t.Fatal(err)
+	}
 
 	if !hasSession(controlAgentSessionName) {
 		t.Error("expected session to still exist")
@@ -256,13 +290,14 @@ func TestAgentNewForcesNewMultiplexerSession(t *testing.T) {
 	if !hasTmux() {
 		t.Skip("tmux not available")
 	}
+	requireAgentBinary(t, "claude")
 
 	orchDir, cleanup := setupAgentTest(t)
 	defer cleanup()
 
 	writeAgentConfig(t, orchDir, "claude", "tmux")
 
-	exec.Command("tmux", "new-session", "-d", "-s", controlAgentSessionName).Run()
+	tmuxCmd("new-session", "-d", "-s", controlAgentSessionName).Run()
 
 	stateFile := filepath.Join(orchDir, "control-agent.json")
 	oldState := `{
@@ -273,7 +308,9 @@ func TestAgentNewForcesNewMultiplexerSession(t *testing.T) {
 	}`
 	os.WriteFile(stateFile, []byte(oldState), 0644)
 
-	_ = runAgentCommand(t, "--backend", "claude", "--new")
+	if err := runAgentCommand(t, "--backend", "claude", "--new"); err != nil {
+		t.Fatal(err)
+	}
 
 	time.Sleep(500 * time.Millisecond)
 
@@ -303,7 +340,7 @@ func TestAgentKillTerminatesMultiplexerSession(t *testing.T) {
 
 	writeAgentConfig(t, orchDir, "claude", "tmux")
 
-	exec.Command("tmux", "new-session", "-d", "-s", controlAgentSessionName).Run()
+	tmuxCmd("new-session", "-d", "-s", controlAgentSessionName).Run()
 
 	stateFile := filepath.Join(orchDir, "control-agent.json")
 	state := `{
@@ -333,13 +370,16 @@ func TestAgentStatePersistence(t *testing.T) {
 	if !hasTmux() {
 		t.Skip("tmux not available")
 	}
+	requireAgentBinary(t, "claude")
 
 	orchDir, cleanup := setupAgentTest(t)
 	defer cleanup()
 
 	writeAgentConfig(t, orchDir, "claude", "tmux")
 
-	_ = runAgentCommand(t, "--backend", "claude")
+	if err := runAgentCommand(t, "--backend", "claude"); err != nil {
+		t.Fatal(err)
+	}
 
 	time.Sleep(500 * time.Millisecond)
 

--- a/test/integration/github_test.go
+++ b/test/integration/github_test.go
@@ -553,6 +553,6 @@ github:
 	}
 
 	if runResult.SessionName != "" {
-		exec.Command("tmux", "kill-session", "-t", runResult.SessionName).Run()
+		tmuxCmd("kill-session", "-t", runResult.SessionName).Run()
 	}
 }

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -59,6 +59,15 @@ func TestMain(m *testing.M) {
 	os.Setenv("XDG_CONFIG_HOME", configDir)
 	os.Unsetenv("ORCH_REMOTE")
 	os.Unsetenv("ORCH_PROJECT")
+	// The suite creates and inspects tmux sessions on the default tmux
+	// server. When `go test` itself runs inside a tmux client (e.g. an
+	// agent pane on a private socket), an inherited $TMUX would make every
+	// child process target that outer server, while orch-created sessions
+	// land on the default server — assertions and cleanup would silently
+	// look at the wrong server. Unset it once here so the whole suite
+	// (test process, in-process worker, daemon and CLI subprocesses)
+	// behaves identically to a plain shell or CI.
+	os.Unsetenv("TMUX")
 	installFakeAgentBinaries(tmpDir)
 
 	addr, err := reserveLoopbackTCPAddr()
@@ -1311,10 +1320,27 @@ func TestOpenPrintPath(t *testing.T) {
 	}
 }
 
+// tmuxCmd builds a tmux command that never inherits $TMUX, so test-side tmux
+// invocations always target the same (default) tmux server that orch-launched
+// sessions live on, even when the test process runs inside a tmux session.
+// TestMain also unsets TMUX process-wide; this helper keeps every direct tmux
+// invocation correct by construction.
+func tmuxCmd(args ...string) *exec.Cmd {
+	cmd := exec.Command("tmux", args...)
+	env := make([]string, 0, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "TMUX=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	cmd.Env = env
+	return cmd
+}
+
 // Skip tmux tests if tmux is not available
 func hasTmux() bool {
-	cmd := exec.Command("tmux", "-V")
-	return cmd.Run() == nil
+	return tmuxCmd("-V").Run() == nil
 }
 
 func hasBinary(name string) bool {
@@ -1323,7 +1349,7 @@ func hasBinary(name string) bool {
 }
 
 func tmuxGlobalOption(name string) (string, error) {
-	out, err := exec.Command("tmux", "show-option", "-g", "-v", name).CombinedOutput()
+	out, err := tmuxCmd("show-option", "-g", "-v", name).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("show-option %s failed: %w (%s)", name, err, strings.TrimSpace(string(out)))
 	}
@@ -1331,7 +1357,7 @@ func tmuxGlobalOption(name string) (string, error) {
 }
 
 func setTmuxGlobalOption(name, value string) error {
-	out, err := exec.Command("tmux", "set-option", "-g", name, value).CombinedOutput()
+	out, err := tmuxCmd("set-option", "-g", name, value).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("set-option %s failed: %w (%s)", name, err, strings.TrimSpace(string(out)))
 	}
@@ -1466,7 +1492,7 @@ func TestRunWithTmux(t *testing.T) {
 
 	// Clean up: kill the tmux session
 	if result.SessionName != "" {
-		exec.Command("tmux", "kill-session", "-t", result.SessionName).Run()
+		tmuxCmd("kill-session", "-t", result.SessionName).Run()
 	}
 
 	// Clean up: remove worktree
@@ -1507,7 +1533,7 @@ sleep 2
 		t.Fatalf("write fake agent: %v", err)
 	}
 
-	_ = exec.Command("tmux", "start-server").Run()
+	_ = tmuxCmd("start-server").Run()
 	defaultShell, err := tmuxGlobalOption("default-shell")
 	if err != nil {
 		t.Skipf("unable to read tmux default-shell: %v", err)
@@ -1568,7 +1594,7 @@ sleep 2
 	if !found {
 		pane := ""
 		if result.SessionName != "" {
-			if out, err := exec.Command("tmux", "capture-pane", "-t", result.SessionName, "-p", "-S", "-50").CombinedOutput(); err == nil {
+			if out, err := tmuxCmd("capture-pane", "-t", result.SessionName, "-p", "-S", "-50").CombinedOutput(); err == nil {
 				pane = string(out)
 			}
 		}


### PR DESCRIPTION
# Root-cause and fix: control-agent integration tests fail when `go test` runs inside tmux

Issue: `beta-agent-test-rootcause`

## Root cause (named mechanism)

**tmux server mismatch.** tmux clients select their server socket from `$TMUX`. The
integration suite mixed two conventions:

```
                         go test (inside a tmux client, $TMUX=<outer socket>)
                                     |
        +----------------------------+-----------------------------+
        | inherits $TMUX                                           | TMUX cleared (agent_test.go:70)
        v                                                          v
  test helpers                                            orch agent subprocess
  hasSession / killSession /                              mux.NewSession
  bare `tmux new-session -d`                                       |
        |                                                          v
        v                                                  DEFAULT tmux server
  OUTER tmux server  <··· looks here ···X··· session actually here ···>
```

Consequences, all observed live while reproducing:

1. `TestAgentClaudeCreatesMultiplexerSession`: orch creates `orch-control-agent` on the
   **default** server; the assertion `hasSession` asks the **outer** server → "expected
   tmux session to be created" (false failure — the session exists and is alive).
2. `killSession` in `setupAgentTest`/cleanup also targets the outer server, so
   `orch-control-agent` **leaks** on the default server between tests (the fake `claude`
   shim sleeps 30s). A later `orch agent` run then takes the *attach-to-existing* path in
   `runMultiplexerAgent`, which **skips the state save by design** → `control-agent.json`
   missing → `TestAgentStatePersistence` fails. Captured pre-fix:
   ```
   orch agent exited: err=exit status 10 output:
   Attaching to existing control agent session (tmux)   <- leaked session, no state write
   ...
   failed to read state: open .../repo/.orch/control-agent.json: no such file or directory
   ```
3. The issue's original suspects are exonerated: the orch-constructed launch (env
   injection / prompt quoting / cwd) is correct — pre-fix instrumentation shows the
   session is created successfully and stays alive; it was only ever *looked for on the
   wrong server*. The `exit status 10` from `orch agent` is the final interactive
   `tmux attach-session` failing with `open terminal failed: not a terminal`, which is
   unavoidable in a TTY-less test harness and unrelated to the defect.

Additional pre-existing inconsistency fixed by the same change: `runOrch` (used by
`TestAgentKillTerminatesMultiplexerSession`, `TestRunWithTmux`, …) did **not** clear
`TMUX`, and run sessions are created by the daemon/in-process worker which inherit the
test process env — so per-helper sanitization alone would have flipped those tests into
the same creation-side/assertion-side mismatch. The invariant has to live at the process
level, not be sprinkled per call site.

## Fix (at the source)

- **`TestMain` unsets `TMUX` once** (`test/integration/integration_test.go`). The test
  process, the in-process worker goroutine, the daemon subprocess, and every orch CLI
  subprocess now all operate on the default tmux server — identical to a plain shell and
  to CI, regardless of where `go test` was launched.
- **Shared `tmuxCmd` helper** replaces every scattered `exec.Command("tmux", ...)` in
  `test/integration` (agent_test.go, integration_test.go, github_test.go). It strips
  `$TMUX` by construction, so future test code cannot reintroduce the mismatch.
- **`runAgentCommand` errors are no longer swallowed** (was `_ =` at agent_test.go:124
  and three sibling call sites). The helper captures combined output and fails the test
  for any error *before* the attach step; only the final interactive attach failure
  (impossible without a TTY, detected via orch's own "Attaching to" progress line) is
  accepted, and a `nil`-error exit is accepted as-is.
- **`saveControlAgentState` failure is now a real error, not a warning**
  (`internal/cli/agent.go`, both the multiplexer and opencode paths). Fail-fast charter:
  without the state file, later `orch agent` / `orch agent --kill` invocations cannot
  manage the session, so success-with-missing-state is not success. The error names the
  session, the multiplexer, and the state path. (Investigated per the issue: in the test
  environment project identity resolves fine — the missing state file was caused by the
  attach-path skip described above, not by identity resolution. No change to the
  identity requirement was needed; if it ever fails it is now loud instead of a
  swallowed warning.)
- **Explicit skip when the agent binary is absent**: claude-launching tests call
  `requireAgentBinary(t, "claude")` → `t.Skip` when `claude` is not in PATH.

No sleep-tuning, no test-weakening, no restructuring of the control-agent feature. No
daemon core surfaces (step.go / status write surface) were touched.

## What CI actually did before/after

- **Before**: CI (ubuntu-latest) installs tmux (`.github/workflows/quality.yaml`), and
  `TestMain` installs a **fake `claude` shim** into PATH (`installFakeAgentBinaries`,
  integration_test.go) — so contrary to the issue's initial hypothesis, these tests were
  **not** skipped in CI and did not need a real claude binary. They genuinely ran and
  passed — because CI has no `$TMUX`, so the server mismatch never occurred there. The
  failure was strictly local-inside-tmux.
- **After**: CI behavior is unchanged (tests still run, with tmux + the fake shim), but
  it is now *honest by construction*: the binary dependency is an explicit `t.Skip`
  guard instead of an accident of the fake-shim setup, command failures surface instead
  of being discarded, and the inside-tmux and plain-shell environments are equivalent.

## Acceptance criteria evidence

1. **Root cause named and captured**: see mechanism + captured pre-fix output above;
   reproduced deterministically by pointing `$TMUX` at a private socket
   (`tmux -L reprosock`), mirroring the agent-deck environment:
   ```
   $ TMUX=/private/tmp/tmux-<uid>/reprosock,99999,0 go test ./test/integration \
       -run 'TestAgentClaudeCreatesMultiplexerSession|TestAgentStatePersistence' -count=1
   --- FAIL: TestAgentClaudeCreatesMultiplexerSession   (pre-fix)
   ```
2. **Targeted tests pass in all three environments** (post-fix, same machine):
   - plain shell (`env -u TMUX`): `ok ... 61.5s` — both PASS
   - inside tmux, default socket (`TMUX=/private/tmp/tmux-<uid>/default,...`): both PASS
   - inside tmux, private socket (`TMUX=.../reprosock,...`, the pre-fix failing env): both PASS
3. **Full suite no worse than main**: `go test ./test/integration -count=1` run from
   *inside* tmux on this branch: all 7 agent tests pass, 8 GitHub-backend tests skip
   (no token), every other test passes, and the single failure is
   `TestRunWithBuiltInAgents` — the local real `opencode` server returns
   `create session returned status 500 (UnknownError)`. The identical test fails with
   the identical 500 on a clean `origin/main` (b3ff2d82) worktree on the same machine,
   so it is a pre-existing local opencode-runtime environment issue, unrelated to this
   change (`orch run` + HTTP session creation; no tmux, no control-agent state
   involved).
4. **`go build ./...`**, **`go test ./internal/... ./cmd/...`**, and **`make lint`**
   (semgrep architecture rules + fixtures) all pass.

Verification-infra note (out of scope, observed while validating): `TestMain` swaps
`HOME` to a fresh tempdir before its inner `go build`, which empties `GOMODCACHE` and
forces a full module re-download from proxy.golang.org on every suite run; under load
this intermittently fails with `unexpected EOF` ("panic: failed to build orch"). This
exists on main as well; exporting `GOMODCACHE`/`GOCACHE` explicitly works around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
