### PR TITLE
fix restart-from continuity defaults

### DIFF
--- a/internal/cli/continue.go
+++ b/internal/cli/continue.go
@@ -77,7 +77,7 @@ Use --branch with an issue ID to restart from an untracked branch.`,
 	cmd.Flags().StringVar(&opts.Agent, "agent", "", "Agent type (claude|codex|gemini|custom)")
 	cmd.Flags().StringVar(&opts.AgentCmd, "agent-cmd", "", "Custom agent command (when --agent=custom)")
 	cmd.Flags().StringVar(&opts.AgentProfile, "profile", "", "Agent profile (e.g., claude --profile)")
-	cmd.Flags().StringVar(&opts.CodexProfile, "codex-profile", "", "Codex execution profile from config (codex.profiles); defaults to the prior run's profile via codex.default_profile")
+	cmd.Flags().StringVar(&opts.CodexProfile, "codex-profile", "", "Codex execution profile from config (codex.profiles); defaults to the prior run's profile, then codex.default_profile")
 	cmd.Flags().BoolVar(&opts.Tmux, "tmux", true, "Run in tmux session")
 	cmd.Flags().StringVar(&opts.SessionName, "session-name", "", "Session name (default: run-<ISSUE>-<RUN>)")
 	cmd.Flags().StringVar(&opts.Multiplexer, "multiplexer", "", "Terminal multiplexer (tmux|zellij)")

--- a/internal/cli/continue_test.go
+++ b/internal/cli/continue_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/proboscis/orch/internal/orchapi"
@@ -15,6 +16,17 @@ func TestRestartFromCommandDoesNotExposePathSelectorFlags(t *testing.T) {
 	}
 	if flag := cmd.Flags().Lookup("worktree-dir"); flag != nil {
 		t.Fatalf("unexpected worktree-dir flag: %#v", flag)
+	}
+}
+
+func TestRestartFromCodexProfileHelpMatchesInheritanceSemantics(t *testing.T) {
+	cmd := newRestartFromCmd()
+	flag := cmd.Flags().Lookup("codex-profile")
+	if flag == nil {
+		t.Fatal("expected --codex-profile flag")
+	}
+	if !strings.Contains(flag.Usage, "defaults to the prior run's profile, then codex.default_profile") {
+		t.Fatalf("codex-profile help = %q, want source-run profile before config default", flag.Usage)
 	}
 }
 

--- a/internal/daemon/agent_profile.go
+++ b/internal/daemon/agent_profile.go
@@ -232,14 +232,21 @@ func applyClaudeProfile(cfg *config.Config, opts *StartRunOptions) error {
 	return nil
 }
 
-// applyCodexProfileContinue resolves the codex profile for a continue/restart-from
-// request and binds the decision onto opts.
-func applyCodexProfileContinue(cfg *config.Config, opts *ContinueRunOptions, fromRunAgent string) error {
+// applyCodexProfileContinue resolves the codex profile for a
+// continue/restart-from request and binds the decision onto opts. When the
+// caller did not explicitly request a codex profile, a codex source run's
+// recorded profile wins over codex.default_profile.
+func applyCodexProfileContinue(cfg *config.Config, opts *ContinueRunOptions, fromRunAgent, fromRunProfile string) error {
 	if cfg == nil || opts == nil {
 		return nil
 	}
 
-	decision, err := resolveCodexProfile(cfg, effectiveContinueAgent(cfg, opts.Agent, fromRunAgent), opts.CodexProfile, opts.Target)
+	profileReq := strings.TrimSpace(opts.CodexProfile)
+	if profileReq == "" && strings.TrimSpace(fromRunAgent) == "codex" {
+		profileReq = strings.TrimSpace(fromRunProfile)
+	}
+
+	decision, err := resolveCodexProfile(cfg, effectiveContinueAgent(cfg, opts.Agent, fromRunAgent), profileReq, opts.Target)
 	if err != nil {
 		return err
 	}
@@ -253,8 +260,10 @@ func applyCodexProfileContinue(cfg *config.Config, opts *ContinueRunOptions, fro
 }
 
 // applyClaudeProfileContinue resolves the claude profile for a
-// continue/restart-from request and binds the decision onto opts.
-func applyClaudeProfileContinue(cfg *config.Config, opts *ContinueRunOptions, fromRunAgent string) error {
+// continue/restart-from request and binds the decision onto opts. When the
+// caller did not explicitly request a claude profile, a claude source run's
+// recorded profile wins over claude.default_profile.
+func applyClaudeProfileContinue(cfg *config.Config, opts *ContinueRunOptions, fromRunAgent, fromRunProfile string) error {
 	if cfg == nil || opts == nil {
 		return nil
 	}
@@ -262,7 +271,12 @@ func applyClaudeProfileContinue(cfg *config.Config, opts *ContinueRunOptions, fr
 		return nil
 	}
 
-	decision, err := resolveClaudeProfile(cfg, "claude", opts.AgentProfile, opts.Target)
+	profileReq := strings.TrimSpace(opts.AgentProfile)
+	if profileReq == "" && strings.TrimSpace(fromRunAgent) == "claude" {
+		profileReq = strings.TrimSpace(fromRunProfile)
+	}
+
+	decision, err := resolveClaudeProfile(cfg, "claude", profileReq, opts.Target)
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/agent_profile_test.go
+++ b/internal/daemon/agent_profile_test.go
@@ -209,7 +209,7 @@ func TestApplyCodexProfileContinue_RestartCompanyEnforcesAndCarriesCodexHome(t *
 	// prior run (codex), and the prior run's target (mac) inherited.
 	opts := &ContinueRunOptions{Target: "mac"}
 
-	if err := applyCodexProfileContinue(cfg, opts, "codex"); err != nil {
+	if err := applyCodexProfileContinue(cfg, opts, "codex", ""); err != nil {
 		t.Fatalf("applyCodexProfileContinue error: %v", err)
 	}
 	if opts.Target != "mac" {
@@ -226,7 +226,7 @@ func TestApplyCodexProfileContinue_RestartDisallowedTargetFailsFast(t *testing.T
 	cfg := newCodexProfileConfig()
 	opts := &ContinueRunOptions{CodexProfile: "company", Target: "zeus"}
 
-	err := applyCodexProfileContinue(cfg, opts, "codex")
+	err := applyCodexProfileContinue(cfg, opts, "codex", "")
 	if err == nil {
 		t.Fatal("expected fail-fast restarting company run onto zeus, got nil")
 	}
@@ -241,7 +241,7 @@ func TestApplyCodexProfileContinue_NonCodexPriorAgentIsNoOp(t *testing.T) {
 	cfg := newCodexProfileConfig()
 	opts := &ContinueRunOptions{}
 
-	if err := applyCodexProfileContinue(cfg, opts, "opencode"); err != nil {
+	if err := applyCodexProfileContinue(cfg, opts, "opencode", ""); err != nil {
 		t.Fatalf("applyCodexProfileContinue error: %v", err)
 	}
 	if opts.Target != "" || opts.CodexHome != "" {
@@ -256,11 +256,54 @@ func TestApplyCodexProfileContinue_DefaultProfileInjectsTarget(t *testing.T) {
 	cfg := newCodexProfileConfig()
 	opts := &ContinueRunOptions{} // no target inherited
 
-	if err := applyCodexProfileContinue(cfg, opts, "codex"); err != nil {
+	if err := applyCodexProfileContinue(cfg, opts, "codex", ""); err != nil {
 		t.Fatalf("applyCodexProfileContinue error: %v", err)
 	}
 	if opts.Target != "mac" {
 		t.Errorf("opts.Target = %q, want mac (default company profile injected on restart)", opts.Target)
+	}
+}
+
+func TestApplyCodexProfileContinue_InheritedProfileOverridesDefault(t *testing.T) {
+	cfg := newCodexProfileConfig()
+	opts := &ContinueRunOptions{}
+
+	if err := applyCodexProfileContinue(cfg, opts, "codex", "personal"); err != nil {
+		t.Fatalf("applyCodexProfileContinue error: %v", err)
+	}
+	if opts.CodexProfile != "personal" {
+		t.Errorf("opts.CodexProfile = %q, want inherited personal profile", opts.CodexProfile)
+	}
+	if opts.Target != "" {
+		t.Errorf("opts.Target = %q, want empty: inherited personal profile has no target", opts.Target)
+	}
+	if opts.CodexHome != "" {
+		t.Errorf("opts.CodexHome = %q, want empty: inherited personal profile uses agent default", opts.CodexHome)
+	}
+}
+
+func TestApplyCodexProfileContinue_ExplicitProfileOverridesInherited(t *testing.T) {
+	cfg := newCodexProfileConfig()
+	opts := &ContinueRunOptions{CodexProfile: "company", Target: "mac"}
+
+	if err := applyCodexProfileContinue(cfg, opts, "codex", "personal"); err != nil {
+		t.Fatalf("applyCodexProfileContinue error: %v", err)
+	}
+	if opts.CodexProfile != "company" {
+		t.Errorf("opts.CodexProfile = %q, want explicit company profile", opts.CodexProfile)
+	}
+}
+
+func TestApplyCodexProfileContinue_UnknownInheritedProfileFailsFast(t *testing.T) {
+	cfg := newCodexProfileConfig()
+	opts := &ContinueRunOptions{}
+
+	err := applyCodexProfileContinue(cfg, opts, "codex", "ghost")
+	if err == nil {
+		t.Fatal("expected fail-fast for unknown inherited codex profile, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown codex profile") || !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("error = %q, want it to name inherited unknown profile ghost", err.Error())
 	}
 }
 
@@ -385,7 +428,7 @@ func TestApplyCodexProfileContinue_WritesBackResolvedProfileName(t *testing.T) {
 	cfg := newCodexProfileConfig()
 	opts := &ContinueRunOptions{Target: "mac"} // agent inferred from prior run
 
-	if err := applyCodexProfileContinue(cfg, opts, "codex"); err != nil {
+	if err := applyCodexProfileContinue(cfg, opts, "codex", ""); err != nil {
 		t.Fatalf("applyCodexProfileContinue error: %v", err)
 	}
 	if opts.CodexProfile != "company" {
@@ -437,7 +480,7 @@ func TestApplyCodexProfileContinue_NonCodexAgentPreservesIncomingTarget(t *testi
 	cfg := newCodexProfileConfig()
 	opts := &ContinueRunOptions{Target: "zeus"}
 
-	if err := applyCodexProfileContinue(cfg, opts, "claude"); err != nil {
+	if err := applyCodexProfileContinue(cfg, opts, "claude", ""); err != nil {
 		t.Fatalf("applyCodexProfileContinue error: %v", err)
 	}
 	if opts.Target != "zeus" {
@@ -574,7 +617,7 @@ func TestApplyClaudeProfileContinue_RestartCarriesConfigDir(t *testing.T) {
 	cfg := newClaudeProfileConfig()
 	opts := &ContinueRunOptions{AgentProfile: "personal", Target: "zeus"}
 
-	if err := applyClaudeProfileContinue(cfg, opts, "claude"); err != nil {
+	if err := applyClaudeProfileContinue(cfg, opts, "claude", ""); err != nil {
 		t.Fatalf("applyClaudeProfileContinue error: %v", err)
 	}
 	if opts.ClaudeConfigDir != "~/.config/claude-nameissoap" {
@@ -582,11 +625,26 @@ func TestApplyClaudeProfileContinue_RestartCarriesConfigDir(t *testing.T) {
 	}
 }
 
+func TestApplyClaudeProfileContinue_InheritedProfileOverridesDefault(t *testing.T) {
+	cfg := newClaudeProfileConfig()
+	opts := &ContinueRunOptions{}
+
+	if err := applyClaudeProfileContinue(cfg, opts, "claude", "personal"); err != nil {
+		t.Fatalf("applyClaudeProfileContinue error: %v", err)
+	}
+	if opts.AgentProfile != "personal" {
+		t.Errorf("opts.AgentProfile = %q, want inherited personal profile", opts.AgentProfile)
+	}
+	if opts.ClaudeConfigDir != "~/.config/claude-nameissoap" {
+		t.Errorf("opts.ClaudeConfigDir = %q, want inherited personal config dir", opts.ClaudeConfigDir)
+	}
+}
+
 func TestApplyClaudeProfileContinue_RestartDisallowedTargetFailsFast(t *testing.T) {
 	cfg := newClaudeProfileConfig()
 	opts := &ContinueRunOptions{AgentProfile: "ca", Target: "zeus"}
 
-	if err := applyClaudeProfileContinue(cfg, opts, "claude"); err == nil {
+	if err := applyClaudeProfileContinue(cfg, opts, "claude", ""); err == nil {
 		t.Fatal("expected fail-fast restarting ca claude run onto zeus, got nil")
 	}
 }

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -1572,9 +1572,9 @@ func (s *SocketServer) syncStartRunResultToMasterStore(st store.Store, req *orch
 }
 
 // syncContinueRunResultToMasterStore projects a delegated continue_run result
-// onto the master store. targetName and profile are the RESOLVED values from the
-// continue options (after applyCodexProfileContinue), not the raw request values.
-func (s *SocketServer) syncContinueRunResultToMasterStore(st store.Store, req *orchpb.ContinueRunRequest, result *ContinueRunResult, targetName, profile string) error {
+// onto the master store. targetName/profile/agent/model are the RESOLVED values
+// from the continue options, not the raw request values.
+func (s *SocketServer) syncContinueRunResultToMasterStore(st store.Store, req *orchpb.ContinueRunRequest, result *ContinueRunResult, targetName, profile, agentName, modelName, modelVariant string) error {
 	if st == nil || result == nil {
 		return nil
 	}
@@ -1585,7 +1585,9 @@ func (s *SocketServer) syncContinueRunResultToMasterStore(st store.Store, req *o
 	run, err := st.GetRun(ref)
 	if err != nil {
 		metadata := map[string]string{}
-		if req.Agent != "" {
+		if agentName := strings.TrimSpace(agentName); agentName != "" {
+			metadata["agent"] = agentName
+		} else if req.Agent != "" {
 			metadata["agent"] = req.Agent
 		}
 		if strings.TrimSpace(result.ContinuedFrom) != "" {
@@ -1600,6 +1602,12 @@ func (s *SocketServer) syncContinueRunResultToMasterStore(st store.Store, req *o
 		}
 		if profile != "" {
 			metadata["profile"] = profile
+		}
+		if modelName := strings.TrimSpace(modelName); modelName != "" {
+			metadata["model"] = modelName
+		}
+		if modelVariant := strings.TrimSpace(modelVariant); modelVariant != "" {
+			metadata["model_variant"] = modelVariant
 		}
 		run, err = st.CreateRun(resultIssueID, resultRunID, metadata)
 		if err != nil {
@@ -1699,11 +1707,12 @@ func (s *SocketServer) handleProtoContinueRun(req *orchpb.ContinueRunRequest) *o
 		SessionName:    req.SessionName,
 		NoSession:      req.NoSession,
 	}
-	// Inherit the prior run's target and agent from the master store so the codex
-	// profile constraint and CODEX_HOME are re-applied identically on
+	// Inherit the prior run's execution identity from the master store so profile,
+	// target, model, and multiplexer constraints are re-applied identically on
 	// restart-from/continue. The worker receives the resolved run snapshot and must
 	// not re-resolve this run against its own host-local store.
 	var fromRunAgent string
+	var fromRunProfile string
 	issueID := model.IssueID(req.IssueId)
 	if strings.TrimSpace(req.Branch) == "" {
 		run, err := resolveRunForMutation(st, req.IssueId, req.RunId, req.ShortId)
@@ -1717,6 +1726,16 @@ func (s *SocketServer) handleProtoContinueRun(req *orchpb.ContinueRunRequest) *o
 		opts.TargetWorkerID = strings.TrimSpace(run.TargetWorkerID)
 		opts.RunSnapshot = newRunSnapshot(run)
 		fromRunAgent = strings.TrimSpace(run.Agent)
+		fromRunProfile = strings.TrimSpace(run.Profile)
+		if strings.TrimSpace(opts.Multiplexer) == "" {
+			opts.Multiplexer = strings.TrimSpace(run.Multiplexer)
+		}
+		if strings.TrimSpace(opts.Model) == "" {
+			opts.Model = strings.TrimSpace(run.Model)
+		}
+		if strings.TrimSpace(opts.ModelVariant) == "" {
+			opts.ModelVariant = strings.TrimSpace(run.ModelVariant)
+		}
 		if run.IssueID != "" {
 			issueID = run.IssueID
 		}
@@ -1729,12 +1748,17 @@ func (s *SocketServer) handleProtoContinueRun(req *orchpb.ContinueRunRequest) *o
 	if profileCfgErr != nil {
 		return errorResponse(fmt.Sprintf("failed to load config: %v", profileCfgErr))
 	}
-	if err := applyCodexProfileContinue(profileCfg, opts, fromRunAgent); err != nil {
+	if strings.TrimSpace(opts.Multiplexer) == "" {
+		opts.Multiplexer = strings.TrimSpace(profileCfg.GetAgentMultiplexer())
+	}
+	if err := applyCodexProfileContinue(profileCfg, opts, fromRunAgent, fromRunProfile); err != nil {
 		return errorResponse(err.Error())
 	}
-	if err := applyClaudeProfileContinue(profileCfg, opts, fromRunAgent); err != nil {
+	if err := applyClaudeProfileContinue(profileCfg, opts, fromRunAgent, fromRunProfile); err != nil {
 		return errorResponse(err.Error())
 	}
+	resolvedAgent := effectiveContinueAgent(profileCfg, opts.Agent, fromRunAgent)
+	opts.Model, opts.ModelVariant = profileCfg.ResolveModelAndVariant(resolvedAgent, "", opts.Model, opts.ModelVariant)
 
 	if strings.TrimSpace(opts.TargetWorkerID) == "" && strings.TrimSpace(opts.TargetHost) != "" {
 		opts.TargetWorkerID = HostWorkerID(opts.TargetHost)
@@ -1775,7 +1799,7 @@ func (s *SocketServer) handleProtoContinueRun(req *orchpb.ContinueRunRequest) *o
 	if result == nil {
 		return errorResponse("worker lease completed without continue_run result")
 	}
-	if err := s.syncContinueRunResultToMasterStore(st, req, result, opts.Target, effectiveAgentProfile(opts.CodexProfile, opts.AgentProfile)); err != nil {
+	if err := s.syncContinueRunResultToMasterStore(st, req, result, opts.Target, effectiveAgentProfile(opts.CodexProfile, opts.AgentProfile), resolvedAgent, opts.Model, opts.ModelVariant); err != nil {
 		return errorResponse(fmt.Sprintf("failed to sync continue_run result to master store: %v", err))
 	}
 

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -4062,6 +4062,9 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 	var worktreePath string
 	var continuedFrom string
 	var fromRunAgent string
+	var fromRunModel string
+	var fromRunModelVariant string
+	var fromRunMultiplexer string
 
 	if opts.Branch != "" {
 		if opts.IssueID == "" {
@@ -4202,6 +4205,18 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		branch = fromRun.Branch
 		worktreePath = fromRun.WorktreePath
 		fromRunAgent = fromRun.Agent
+		fromRunModel = strings.TrimSpace(fromRun.Model)
+		fromRunModelVariant = strings.TrimSpace(fromRun.ModelVariant)
+		fromRunMultiplexer = strings.TrimSpace(fromRun.Multiplexer)
+		if strings.TrimSpace(opts.Target) == "" {
+			opts.Target = strings.TrimSpace(fromRun.Target)
+		}
+		if strings.TrimSpace(opts.TargetHost) == "" {
+			opts.TargetHost = strings.TrimSpace(fromRun.TargetHost)
+		}
+		if strings.TrimSpace(opts.TargetWorkerID) == "" {
+			opts.TargetWorkerID = strings.TrimSpace(fromRun.TargetWorkerID)
+		}
 		continuedFrom = fmt.Sprintf("%s#%s", fromRun.IssueID, fromRun.RunID)
 	}
 
@@ -4245,6 +4260,18 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		return nil, fmt.Errorf("agent not available: %s", agentName)
 	}
 
+	reqModel := strings.TrimSpace(opts.Model)
+	if reqModel == "" {
+		reqModel = fromRunModel
+	}
+	reqModelVariant := strings.TrimSpace(opts.ModelVariant)
+	if reqModelVariant == "" {
+		reqModelVariant = fromRunModelVariant
+	}
+	runModel, runVariant := cfg.ResolveModelAndVariant(agentName, "", reqModel, reqModelVariant)
+	opts.Model = runModel
+	opts.ModelVariant = runVariant
+
 	runID := model.GenerateRunID()
 	sessionName := opts.SessionName
 	if sessionName == "" {
@@ -4260,6 +4287,12 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 	}
 	if profile := effectiveAgentProfile(opts.CodexProfile, opts.AgentProfile); profile != "" {
 		metadata["profile"] = profile
+	}
+	if runModel != "" {
+		metadata["model"] = runModel
+	}
+	if runVariant != "" {
+		metadata["model_variant"] = runVariant
 	}
 	// When the issue came from the master snapshot (worker-delegation path), the
 	// master has already verified it; the worker must not re-verify against a
@@ -4294,7 +4327,6 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 
 	continuePrompt := fmt.Sprintf("ultrathink Please read 'ORCH_PROMPT.md' in the current directory and follow the instructions found there.\nThis run continues from %s. Use the existing worktree and branch and resume from the current state.", continuedFrom)
 
-	runModel, runVariant := cfg.ResolveModelAndVariant(agentName, "", "", "")
 	serverPort := 0
 	opencodeSessionID := ""
 
@@ -4345,7 +4377,20 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		}, nil
 	}
 
-	muxType, _ := multiplexer.ParseType(opts.Multiplexer)
+	effectiveMux := strings.TrimSpace(opts.Multiplexer)
+	if effectiveMux == "" {
+		effectiveMux = fromRunMultiplexer
+	}
+	if effectiveMux == "" {
+		effectiveMux = strings.TrimSpace(cfg.GetAgentMultiplexer())
+	}
+	opts.Multiplexer = effectiveMux
+
+	muxType, parseMuxErr := multiplexer.ParseType(effectiveMux)
+	if parseMuxErr != nil {
+		s.reportLaunchProgress(st, run, launchFailed("multiplexer", parseMuxErr))
+		return nil, fmt.Errorf("invalid multiplexer %q: %w", effectiveMux, parseMuxErr)
+	}
 
 	var mux multiplexer.Multiplexer
 	if muxType == multiplexer.TypeAuto {

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -131,6 +131,7 @@ func (m *mockStore) createRunDoc(issueID model.IssueID, runID model.RunID, metad
 		IssueID:       issueID,
 		RunID:         runID,
 		Agent:         metadata["agent"],
+		Profile:       metadata["profile"],
 		Model:         metadata["model"],
 		ModelVariant:  metadata["model_variant"],
 		Target:        metadata["target"],
@@ -773,6 +774,222 @@ func TestProtoContinueRunUsesExternalWorkerResultJSON(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("expected continue_run lease assigned to external worker")
+	}
+}
+
+func TestProtoContinueRunInheritsSourceExecutionDefaults(t *testing.T) {
+	cleanup := setupXDGTestEnv(t)
+	defer cleanup()
+
+	projectRoot := t.TempDir()
+	issuesRoot := filepath.Join(projectRoot, "issues-store")
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".orch"), 0o755); err != nil {
+		t.Fatalf("mkdir .orch: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(issuesRoot, "issues"), 0o755); err != nil {
+		t.Fatalf("mkdir issues: %v", err)
+	}
+	configBody := fmt.Sprintf(`agent: codex
+model: cfg-model
+model_variant: cfg-variant
+monitor_multiplexer: tmux
+agent_multiplexer: zellij
+issues:
+  path: %s
+codex:
+  default_profile: company
+  profiles:
+    company:
+      target: mac
+      codex_home: ~/.codex-company
+    personal:
+      target: mac
+      codex_home: ~/.codex-personal
+targets:
+  - name: mac
+    host: mac-host
+`, issuesRoot)
+	if err := os.WriteFile(filepath.Join(projectRoot, ".orch", "config.yaml"), []byte(configBody), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	tests := []struct {
+		name            string
+		run             *model.Run
+		req             *orchpb.ContinueRunRequest
+		wantProfile     string
+		wantCodexHome   string
+		wantMultiplexer string
+		wantModel       string
+		wantVariant     string
+	}{
+		{
+			name: "source run wins over config defaults",
+			run: &model.Run{
+				IssueID:        "issue-cont",
+				RunID:          "run-prev-inherit",
+				Status:         model.StatusFailed,
+				Agent:          "codex",
+				Profile:        "personal",
+				Model:          "source-model",
+				ModelVariant:   "source-variant",
+				Branch:         "cont-branch",
+				WorktreePath:   "/tmp/cont-prev",
+				Target:         "mac",
+				TargetHost:     "mac-host",
+				TargetWorkerID: HostWorkerID("mac-host"),
+				Multiplexer:    "tmux",
+			},
+			req: &orchpb.ContinueRunRequest{
+				IssueId: "issue-cont",
+				RunId:   "run-prev-inherit",
+			},
+			wantProfile:     "personal",
+			wantCodexHome:   "~/.codex-personal",
+			wantMultiplexer: "tmux",
+			wantModel:       "source-model",
+			wantVariant:     "source-variant",
+		},
+		{
+			name: "explicit flags override source run",
+			run: &model.Run{
+				IssueID:        "issue-cont",
+				RunID:          "run-prev-override",
+				Status:         model.StatusFailed,
+				Agent:          "codex",
+				Profile:        "personal",
+				Model:          "source-model",
+				ModelVariant:   "source-variant",
+				Branch:         "cont-branch",
+				WorktreePath:   "/tmp/cont-prev",
+				Target:         "mac",
+				TargetHost:     "mac-host",
+				TargetWorkerID: HostWorkerID("mac-host"),
+				Multiplexer:    "tmux",
+			},
+			req: &orchpb.ContinueRunRequest{
+				IssueId:      "issue-cont",
+				RunId:        "run-prev-override",
+				CodexProfile: "company",
+				Multiplexer:  "zellij",
+			},
+			wantProfile:     "company",
+			wantCodexHome:   "~/.codex-company",
+			wantMultiplexer: "zellij",
+			wantModel:       "source-model",
+			wantVariant:     "source-variant",
+		},
+		{
+			name: "missing source records fall back to config defaults",
+			run: &model.Run{
+				IssueID:      "issue-cont",
+				RunID:        "run-prev-default",
+				Status:       model.StatusFailed,
+				Agent:        "codex",
+				Branch:       "cont-branch",
+				WorktreePath: "/tmp/cont-prev",
+			},
+			req: &orchpb.ContinueRunRequest{
+				IssueId: "issue-cont",
+				RunId:   "run-prev-default",
+			},
+			wantProfile:     "company",
+			wantCodexHome:   "~/.codex-company",
+			wantMultiplexer: "zellij",
+			wantModel:       "cfg-model",
+			wantVariant:     "cfg-variant",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := &mockStore{
+				runs: map[string]*model.Run{
+					tt.run.Ref().String(): tt.run,
+				},
+				issues: map[string]*model.Issue{
+					"issue-cont": {ID: "issue-cont", Title: "Cont", Status: model.IssueStatusOpen},
+				},
+			}
+			server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+			registerRepoContextForTest(t, server, testProjectID, projectRoot, st)
+			if err := server.Start(); err != nil {
+				t.Fatalf("failed to start server: %v", err)
+			}
+			defer server.Stop()
+
+			client := NewProtoClientWithAddress("", "")
+			defer client.Close()
+
+			workerID := HostWorkerID("mac-host")
+			if _, err := client.RegisterWorker(workerID, "executor", "mac-host", "external"); err != nil {
+				t.Fatalf("register external worker failed: %v", err)
+			}
+			defer client.UnregisterWorker(workerID)
+
+			resultRunID := "run-cont-" + strings.TrimPrefix(string(tt.run.RunID), "run-prev-")
+			resultJSON := fmt.Sprintf(`{"continue_run_result":{"RunID":%q,"Branch":"cont-branch","WorktreePath":"/tmp/cont","SessionName":"sess-cont","Status":"running","ContinuedFrom":%q,"IssueID":"issue-cont","Multiplexer":%q}}`, resultRunID, tt.run.Ref().String(), tt.wantMultiplexer)
+			cmd := exec.Command(os.Args[0], "-test.run=TestExternalWorkerHelperProcess")
+			var outBuf bytes.Buffer
+			cmd.Stdout = &outBuf
+			cmd.Stderr = &outBuf
+			cmd.Env = append(os.Environ(),
+				"ORCH_WORKER_HELPER=1",
+				"ORCH_WORKER_ID="+workerID,
+				"ORCH_WORKER_HELPER_MODE=success",
+				"ORCH_WORKER_EXPECT_EFFECT=continue_run",
+				"ORCH_WORKER_HELPER_RESULT_JSON="+resultJSON,
+			)
+			if err := cmd.Start(); err != nil {
+				t.Fatalf("failed to start helper process: %v", err)
+			}
+
+			tt.req.Context = &orchpb.RequestContext{ProjectId: testProjectID}
+			resp := sendProtoRequest(t, &orchpb.Request{
+				Request: &orchpb.Request_ContinueRun{ContinueRun: tt.req},
+			})
+
+			if err := cmd.Wait(); err != nil {
+				t.Fatalf("helper process failed: %v, output: %s", err, outBuf.String())
+			}
+			if !resp.Ok || resp.GetContinueRun() == nil {
+				t.Fatalf("expected successful continue_run response, got ok=%v error=%q", resp.Ok, resp.Error)
+			}
+
+			var payload *ContinueRunOptions
+			for _, lease := range server.listWorkerLeases(true) {
+				if lease.Effect == "continue_run" && lease.IssueID == "issue-cont" && lease.Payload != nil {
+					payload = lease.Payload.ContinueRun
+					break
+				}
+			}
+			if payload == nil {
+				t.Fatal("expected continue_run payload")
+			}
+			if payload.CodexProfile != tt.wantProfile {
+				t.Fatalf("payload.CodexProfile = %q, want %q", payload.CodexProfile, tt.wantProfile)
+			}
+			if payload.CodexHome != tt.wantCodexHome {
+				t.Fatalf("payload.CodexHome = %q, want %q", payload.CodexHome, tt.wantCodexHome)
+			}
+			if payload.Multiplexer != tt.wantMultiplexer {
+				t.Fatalf("payload.Multiplexer = %q, want %q", payload.Multiplexer, tt.wantMultiplexer)
+			}
+			if payload.Model != tt.wantModel || payload.ModelVariant != tt.wantVariant {
+				t.Fatalf("payload model = (%q, %q), want (%q, %q)", payload.Model, payload.ModelVariant, tt.wantModel, tt.wantVariant)
+			}
+			if payload.Target != "mac" || payload.TargetHost != "mac-host" || payload.TargetWorkerID != HostWorkerID("mac-host") {
+				t.Fatalf("payload target = (%q, %q, %q), want mac/mac-host/%s", payload.Target, payload.TargetHost, payload.TargetWorkerID, HostWorkerID("mac-host"))
+			}
+
+			projected, err := st.GetRun(&model.RunRef{IssueID: "issue-cont", RunID: model.RunID(resultRunID)})
+			if err != nil {
+				t.Fatalf("expected projected master run: %v", err)
+			}
+			if projected.Agent != "codex" || projected.Profile != tt.wantProfile || projected.Model != tt.wantModel || projected.ModelVariant != tt.wantVariant {
+				t.Fatalf("projected run execution identity = agent=%q profile=%q model=%q variant=%q", projected.Agent, projected.Profile, projected.Model, projected.ModelVariant)
+			}
+		})
 	}
 }
 
@@ -5835,6 +6052,67 @@ func TestMasterFailsFastOnMissingIssueBeforeDelegation(t *testing.T) {
 			t.Fatalf("expected explicit master-store miss for deadbe, got: %q", resp.Error)
 		}
 	})
+}
+
+func TestProtoContinueRunFailsFastOnUnknownInheritedProfileBeforeDelegation(t *testing.T) {
+	cleanup := setupXDGTestEnv(t)
+	defer cleanup()
+
+	projectRoot := t.TempDir()
+	issuesRoot := filepath.Join(projectRoot, "issues-store")
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".orch"), 0o755); err != nil {
+		t.Fatalf("mkdir .orch: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(issuesRoot, "issues"), 0o755); err != nil {
+		t.Fatalf("mkdir issues: %v", err)
+	}
+	configBody := fmt.Sprintf(`agent: codex
+issues:
+  path: %s
+codex:
+  default_profile: company
+  profiles:
+    company:
+      codex_home: ~/.codex-company
+`, issuesRoot)
+	if err := os.WriteFile(filepath.Join(projectRoot, ".orch", "config.yaml"), []byte(configBody), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	run := &model.Run{
+		IssueID:      "issue-cont",
+		RunID:        "run-prev",
+		Status:       model.StatusFailed,
+		Agent:        "codex",
+		Profile:      "ghost",
+		Branch:       "cont-branch",
+		WorktreePath: "/tmp/cont-prev",
+	}
+	st := &mockStore{
+		runs: map[string]*model.Run{
+			run.Ref().String(): run,
+		},
+		issues: map[string]*model.Issue{
+			"issue-cont": {ID: "issue-cont", Title: "Cont", Status: model.IssueStatusOpen},
+		},
+	}
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+	registerRepoContextForTest(t, server, testProjectID, projectRoot, st)
+
+	resp := server.handleProtoContinueRun(&orchpb.ContinueRunRequest{
+		IssueId: "issue-cont",
+		RunId:   "run-prev",
+		Context: &orchpb.RequestContext{ProjectId: testProjectID},
+	})
+	if resp.Ok {
+		t.Fatalf("expected unknown inherited profile failure, got ok response: %+v", resp)
+	}
+	if !strings.Contains(resp.Error, `unknown codex profile "ghost"`) {
+		t.Fatalf("expected unknown inherited profile error, got %q", resp.Error)
+	}
+	if leases := server.listWorkerLeases(true); len(leases) != 0 {
+		t.Fatalf("expected fail-fast before worker delegation, got %d leases", len(leases))
+	}
 }
 
 func TestRunMutationUsesMasterSnapshotAndHostAffinity(t *testing.T) {

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -687,6 +687,8 @@ type ContinueRunOptions struct {
 	AgentCmd       string
 	AgentProfile   string
 	CodexProfile   string
+	Model          string
+	ModelVariant   string
 	WorktreeDir    string
 	NoPR           bool
 	PromptTemplate string


### PR DESCRIPTION
## Summary

Fixes `orch restart-from` continuity so a restarted run keeps the source run's execution identity instead of silently falling back to config defaults.

- Inherit the source run's profile, model, multiplexer, and target metadata through the existing continue option plumbing and worker payload.
- Keep explicit restart flags authoritative, including `--codex-profile` and `--multiplexer`.
- Fall back to config defaults only when the source run has no recorded value.
- Fail before worker dispatch when an inherited profile is unknown in the master config.
- Update `--codex-profile` help text to describe the actual precedence.

Issue: `beta-restart-from-continuity`

## Verification

Acceptance coverage:

- Source run profile/multiplexer/model/target inheritance: `TestProtoContinueRunInheritsSourceExecutionDefaults/source run wins over config defaults` verifies worker payload has `personal`, `tmux`, source model/variant, and source target.
- Explicit override: `TestProtoContinueRunInheritsSourceExecutionDefaults/explicit flags override source run` verifies request profile/multiplexer override source run values.
- Missing source records: `TestProtoContinueRunInheritsSourceExecutionDefaults/missing source records fall back to config defaults` verifies config default profile/multiplexer/model/variant are used.
- Unknown inherited profile fail-fast: `TestProtoContinueRunFailsFastOnUnknownInheritedProfileBeforeDelegation` verifies no worker lease is created when source profile is not configured.
- Help text: `TestRestartFromCodexProfileHelpMatchesInheritanceSemantics` verifies the `--codex-profile` precedence text.
- Main's tmux lifecycle invariant remains intact: `TestTmuxMultiplexer_IgnoresInheritedTmuxEnvForSessionLifecycle` passes with `TMPDIR=/tmp`.

Commands run after rebasing onto `origin/main` (`dec3e778`):

```bash
TMPDIR=/tmp go test ./internal/multiplexer -run TestTmuxMultiplexer_IgnoresInheritedTmuxEnvForSessionLifecycle -count=1 -v
go test ./internal/daemon -run 'TestApply(Codex|Claude)ProfileContinue|TestProtoContinueRun(InheritsSourceExecutionDefaults|FailsFastOnUnknownInheritedProfileBeforeDelegation)' -count=1
go test ./internal/cli -run 'TestRestartFrom(CodexProfileHelp|CommandDoesNotExposePathSelectorFlags)|TestApplyContinueConfigDefaults|TestDefaultGetAPIWithOptionsRemoteAllows(GitDerivedProjectIdentity|ExplicitProjectFlag)' -count=1
go build ./...
go test $(go list ./... | rg -v '/test/integration$')
make lint
git diff --check
```
