### PR TITLE
Fix opencode install and artifact append logging

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -328,10 +328,10 @@ install_agent() {
     fi
     
     info "Installing ${name}..."
-    if npm install -g "$package" 2>/dev/null; then
+    if npm install -g "$package"; then
         success "Installed ${name}"
     else
-        warn "Failed to install ${name}"
+        warn "Failed to install ${name} from npm package ${package}"
     fi
 }
 
@@ -346,8 +346,8 @@ install_agents_interactive() {
     echo "  These tools let orch run AI agents in your terminal."
     echo ""
     
-    if ask_yes_no "Install opencode (Anthropic)?"; then
-        install_agent "opencode" "@anthropics/opencode"
+    if ask_yes_no "Install OpenCode?"; then
+        install_agent "opencode" "opencode-ai"
     fi
     
     if ask_yes_no "Install claude (Anthropic Claude Code)?"; then
@@ -371,7 +371,7 @@ install_agents_auto() {
         INSTALL_GEMINI=true
     fi
     
-    [ "$INSTALL_OPENCODE" = true ] && install_agent "opencode" "@anthropics/opencode"
+    [ "$INSTALL_OPENCODE" = true ] && install_agent "opencode" "opencode-ai"
     [ "$INSTALL_CLAUDE" = true ] && install_agent "claude" "@anthropic-ai/claude-code"
     [ "$INSTALL_CODEX" = true ] && install_agent "codex" "@openai/codex"
     [ "$INSTALL_GEMINI" = true ] && install_agent "gemini" "@google/gemini-cli"

--- a/internal/daemon/artifact_events.go
+++ b/internal/daemon/artifact_events.go
@@ -1,0 +1,23 @@
+package daemon
+
+import (
+	"github.com/proboscis/orch/internal/model"
+	"github.com/proboscis/orch/internal/store"
+)
+
+func (s *SocketServer) appendArtifactEventBestEffort(st store.Store, ref *model.RunRef, kind string, attrs map[string]string) {
+	if err := st.AppendEvent(ref, model.NewArtifactEvent(kind, attrs)); err != nil {
+		s.logArtifactAppendError(ref, kind, err)
+	}
+}
+
+func (s *SocketServer) logArtifactAppendError(ref *model.RunRef, kind string, err error) {
+	if err == nil || s == nil || s.logger == nil {
+		return
+	}
+	runRef := "<nil>"
+	if ref != nil {
+		runRef = ref.String()
+	}
+	s.logger.Printf("%s: failed to record %s artifact: %v", runRef, kind, err)
+}

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -1520,10 +1520,10 @@ func (s *SocketServer) syncStartRunResultToMasterStore(st store.Store, req *orch
 	}
 
 	if result.WorktreePath != "" {
-		_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("worktree", map[string]string{"path": result.WorktreePath}))
+		s.appendArtifactEventBestEffort(st, run.Ref(), "worktree", map[string]string{"path": result.WorktreePath})
 	}
 	if result.Branch != "" {
-		_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("branch", map[string]string{"name": result.Branch}))
+		s.appendArtifactEventBestEffort(st, run.Ref(), "branch", map[string]string{"name": result.Branch})
 	}
 	if result.SessionName != "" {
 		attrs := map[string]string{"name": result.SessionName}
@@ -1536,17 +1536,17 @@ func (s *SocketServer) syncStartRunResultToMasterStore(st store.Store, req *orch
 		if strings.TrimSpace(result.WorkerID) != "" {
 			attrs["worker_id"] = strings.TrimSpace(result.WorkerID)
 		}
-		_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("session", attrs))
+		s.appendArtifactEventBestEffort(st, run.Ref(), "session", attrs)
 	}
 	if result.ServerPort > 0 {
-		_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("server", map[string]string{
+		s.appendArtifactEventBestEffort(st, run.Ref(), "server", map[string]string{
 			"port": fmt.Sprintf("%d", result.ServerPort),
-		}))
+		})
 	}
 	if strings.TrimSpace(result.OpenCodeSessionID) != "" {
-		_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("opencode_session", map[string]string{
+		s.appendArtifactEventBestEffort(st, run.Ref(), "opencode_session", map[string]string{
 			"id": strings.TrimSpace(result.OpenCodeSessionID),
-		}))
+		})
 	}
 	if targetName != "" {
 		targetAttrs := map[string]string{"name": targetName}
@@ -1557,7 +1557,7 @@ func (s *SocketServer) syncStartRunResultToMasterStore(st store.Store, req *orch
 				targetAttrs["worker_id"] = target.WorkerID
 			}
 		}
-		_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("target", targetAttrs))
+		s.appendArtifactEventBestEffort(st, run.Ref(), "target", targetAttrs)
 	}
 
 	status, err := model.NormalizeStatus(result.Status)
@@ -1617,10 +1617,10 @@ func (s *SocketServer) syncContinueRunResultToMasterStore(st store.Store, req *o
 	}
 
 	if result.WorktreePath != "" {
-		_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("worktree", map[string]string{"path": result.WorktreePath}))
+		s.appendArtifactEventBestEffort(st, run.Ref(), "worktree", map[string]string{"path": result.WorktreePath})
 	}
 	if result.Branch != "" {
-		_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("branch", map[string]string{"name": result.Branch}))
+		s.appendArtifactEventBestEffort(st, run.Ref(), "branch", map[string]string{"name": result.Branch})
 	}
 	if result.SessionName != "" {
 		attrs := map[string]string{"name": result.SessionName}
@@ -1633,17 +1633,17 @@ func (s *SocketServer) syncContinueRunResultToMasterStore(st store.Store, req *o
 		if strings.TrimSpace(result.WorkerID) != "" {
 			attrs["worker_id"] = strings.TrimSpace(result.WorkerID)
 		}
-		_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("session", attrs))
+		s.appendArtifactEventBestEffort(st, run.Ref(), "session", attrs)
 	}
 	if result.ServerPort > 0 {
-		_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("server", map[string]string{
+		s.appendArtifactEventBestEffort(st, run.Ref(), "server", map[string]string{
 			"port": fmt.Sprintf("%d", result.ServerPort),
-		}))
+		})
 	}
 	if strings.TrimSpace(result.OpenCodeSessionID) != "" {
-		_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("opencode_session", map[string]string{
+		s.appendArtifactEventBestEffort(st, run.Ref(), "opencode_session", map[string]string{
 			"id": strings.TrimSpace(result.OpenCodeSessionID),
-		}))
+		})
 	}
 	if targetName = strings.TrimSpace(targetName); targetName != "" {
 		targetAttrs := map[string]string{"name": targetName}
@@ -1654,7 +1654,7 @@ func (s *SocketServer) syncContinueRunResultToMasterStore(st store.Store, req *o
 				targetAttrs["worker_id"] = target.WorkerID
 			}
 		}
-		_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("target", targetAttrs))
+		s.appendArtifactEventBestEffort(st, run.Ref(), "target", targetAttrs)
 	}
 
 	status, err := model.NormalizeStatus(result.Status)

--- a/internal/daemon/proto_handler_test.go
+++ b/internal/daemon/proto_handler_test.go
@@ -1095,6 +1095,58 @@ func TestSyncStartRunResultToMasterStorePreservesOpenCodeArtifacts(t *testing.T)
 	}
 }
 
+type artifactFailingStore struct {
+	mockStore
+	appendErr error
+}
+
+func (s *artifactFailingStore) AppendEvent(ref *model.RunRef, event *model.Event) error {
+	if event != nil && event.Type == model.EventTypeArtifact {
+		return s.appendErr
+	}
+	return s.mockStore.AppendEvent(ref, event)
+}
+
+func TestSyncStartRunResultToMasterStoreLogsArtifactAppendFailure(t *testing.T) {
+	st := &artifactFailingStore{
+		mockStore: mockStore{
+			runs: map[string]*model.Run{},
+			issues: map[string]*model.Issue{
+				"issue-artifact-log": {ID: "issue-artifact-log", Status: model.IssueStatusOpen},
+			},
+		},
+		appendErr: errors.New("artifact append failed"),
+	}
+	logger := &timingTestLogger{}
+	server := NewSocketServer(nil, logger)
+
+	err := server.syncStartRunResultToMasterStore(st, &orchpb.StartRunRequest{
+		IssueId: "issue-artifact-log",
+		Agent:   "opencode",
+	}, &StartRunResult{
+		RunID:        "run-artifact-log",
+		WorktreePath: "/tmp/artifact-log",
+		Status:       string(model.StatusRunning),
+	}, "", "")
+	if err != nil {
+		t.Fatalf("syncStartRunResultToMasterStore() error = %v", err)
+	}
+
+	logOutput := logger.String()
+	wantLog := "issue-artifact-log#run-artifact-log: failed to record worktree artifact: artifact append failed"
+	if !strings.Contains(logOutput, wantLog) {
+		t.Fatalf("log output %q does not contain %q", logOutput, wantLog)
+	}
+
+	run, err := st.GetRun(&model.RunRef{IssueID: "issue-artifact-log", RunID: "run-artifact-log"})
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if run.Status != model.StatusRunning {
+		t.Fatalf("run.Status = %q, want %q", run.Status, model.StatusRunning)
+	}
+}
+
 func TestHandleProtoWaitForRunsReturnsImmediatelyForShortID(t *testing.T) {
 	run := &model.Run{
 		IssueID: "issue-1",

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -1993,9 +1993,9 @@ func (s *SocketServer) bootstrapOpenCodeRunSession(
 		return 0, "", s.failOpenCodeRunBootstrap(st, run, fmt.Errorf("server health check failed: %w", err))
 	}
 
-	_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("server", map[string]string{
+	s.appendArtifactEventBestEffort(st, run.Ref(), "server", map[string]string{
 		"port": fmt.Sprintf("%d", port),
-	}))
+	})
 
 	session, err := client.CreateSession(ctx, fmt.Sprintf("%s#%s", issueID, runID), launchCfg.WorkDir)
 	if err != nil && isOpenCodeSQLiteIOError(err) {
@@ -2012,9 +2012,9 @@ func (s *SocketServer) bootstrapOpenCodeRunSession(
 			if waitErr := client.WaitForHealthy(ctx, timeout); waitErr != nil {
 				err = fmt.Errorf("server health check failed after sqlite reset: %w", waitErr)
 			} else {
-				_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("server", map[string]string{
+				s.appendArtifactEventBestEffort(st, run.Ref(), "server", map[string]string{
 					"port": fmt.Sprintf("%d", port),
-				}))
+				})
 				session, err = client.CreateSession(ctx, fmt.Sprintf("%s#%s", issueID, runID), launchCfg.WorkDir)
 			}
 		}
@@ -2023,9 +2023,9 @@ func (s *SocketServer) bootstrapOpenCodeRunSession(
 		return port, "", s.failOpenCodeRunBootstrap(st, run, fmt.Errorf("failed to create opencode session: %w", err))
 	}
 
-	_ = st.AppendEvent(run.Ref(), model.NewArtifactEvent("opencode_session", map[string]string{
+	s.appendArtifactEventBestEffort(st, run.Ref(), "opencode_session", map[string]string{
 		"id": session.ID,
-	}))
+	})
 
 	if strings.TrimSpace(launchCfg.Prompt) == "" {
 		return port, session.ID, nil


### PR DESCRIPTION
## Summary

- Update `install.sh` to install OpenCode from the official npm package, `opencode-ai`, and leave npm stderr visible when installs fail.
- Add best-effort artifact append logging for delegated start/continue projections and OpenCode bootstrap artifacts, without changing launch control flow or writing new status events.
- Add a focused daemon test proving artifact append failures are logged while status progression remains best-effort.

## Evidence

- Official OpenCode docs list `npm install -g opencode-ai`: https://opencode.ai/docs/
- `npm view opencode-ai name version` -> `name = 'opencode-ai'`, `version = '1.17.14'`
- `git ls-tree -r --name-only HEAD -- orch-monitor-tui/orch_vault_rs` -> no output; the orphan path is already absent from this branch
- `grep -n "_ = st.AppendEvent" internal/daemon/proto_handler.go internal/daemon/socket.go || true` -> no output
- `go build ./...` -> pass
- `go list ./... | grep -v '^github.com/proboscis/orch/test/integration$' | xargs go test` -> pass
- `make lint` -> pass

## Known validation failure

- `go test ./...` currently fails in `github.com/proboscis/orch/test/integration` at `TestRunWithBuiltInAgents` because the local OpenCode server returns HTTP 500 while creating an OpenCode session:
  `daemon error: failed to create opencode session: create session returned status 500: {"name":"UnknownError","data":{"message":"Unexpected server error. Check server logs for details.","ref":"err_7016e16f"}}`
- All non-integration Go packages pass after rebasing onto `origin/main`.

## Issue

Refs beta-p2-cleanup