### PR TITLE
Fix CI red on main: tmux exact-match targets + hermetic remote-identity tests

### DIFF
--- a/internal/cli/root_remote_test.go
+++ b/internal/cli/root_remote_test.go
@@ -198,7 +198,12 @@ func TestDefaultGetAPIWithOptionsRemoteAllowsGitDerivedProjectIdentity(t *testin
 	origRemote := globalOpts.Remote
 	origFlag := remoteFlagWasSet
 	globalOpts.Project = ""
-	globalOpts.Remote = "zeus:7777"
+	// Unreachable-but-resolvable address: identity resolution happens before
+	// the dial, so passing it means the error (if any) is a reachability
+	// error, never "project identity required". A live daemon must not be a
+	// test dependency (the previous "zeus:7777" only worked on the author's
+	// machine).
+	globalOpts.Remote = "127.0.0.1:1"
 	remoteFlagWasSet = true
 	t.Cleanup(func() {
 		globalOpts.Project = origProject
@@ -206,12 +211,9 @@ func TestDefaultGetAPIWithOptionsRemoteAllowsGitDerivedProjectIdentity(t *testin
 		remoteFlagWasSet = origFlag
 	})
 
-	api, err := defaultGetAPIWithOptions(true)
-	if err != nil {
+	_, err := defaultGetAPIWithOptions(true)
+	if err != nil && strings.Contains(err.Error(), "project identity required") {
 		t.Fatalf("expected git-derived project identity to pass in remote mode, got: %v", err)
-	}
-	if api == nil {
-		t.Fatal("expected non-nil API client")
 	}
 }
 
@@ -222,7 +224,7 @@ func TestDefaultGetAPIWithOptionsRemoteAllowsExplicitProjectFlag(t *testing.T) {
 	origRemote := globalOpts.Remote
 	origFlag := remoteFlagWasSet
 	globalOpts.Project = "example-" + filepath.Base(repo)
-	globalOpts.Remote = "zeus:7777"
+	globalOpts.Remote = "127.0.0.1:1"
 	remoteFlagWasSet = true
 	t.Cleanup(func() {
 		globalOpts.Project = origProject
@@ -230,12 +232,9 @@ func TestDefaultGetAPIWithOptionsRemoteAllowsExplicitProjectFlag(t *testing.T) {
 		remoteFlagWasSet = origFlag
 	})
 
-	api, err := defaultGetAPIWithOptions(true)
-	if err != nil {
+	_, err := defaultGetAPIWithOptions(true)
+	if err != nil && strings.Contains(err.Error(), "project identity required") {
 		t.Fatalf("expected explicit project to pass in remote mode, got: %v", err)
-	}
-	if api == nil {
-		t.Fatal("expected non-nil API client")
 	}
 }
 

--- a/internal/multiplexer/tmux.go
+++ b/internal/multiplexer/tmux.go
@@ -93,9 +93,18 @@ func (t *TmuxMultiplexer) IsInsideSession() bool {
 	return os.Getenv("TMUX") != ""
 }
 
-// HasSession checks if a tmux session exists.
+// HasSession checks if a tmux session exists. The target is exact-matched
+// ("=" prefix): tmux's default prefix matching would report a session named
+// "<name>-suffix" as a hit for "<name>", which turns existence checks and
+// the daemon's aliveness verdicts into false positives.
 func (t *TmuxMultiplexer) HasSession(name string) bool {
-	return t.run("has-session", "-t", name) == nil
+	return t.run("has-session", "-t", exactSessionTarget(name)) == nil
+}
+
+// exactSessionTarget disables tmux prefix/fnmatch target resolution so a
+// bare session name only ever matches itself.
+func exactSessionTarget(name string) string {
+	return "=" + name
 }
 
 // NewSession creates a new tmux session.
@@ -146,7 +155,7 @@ func (t *TmuxMultiplexer) AttachSession(session string) error {
 
 // KillSession kills a tmux session.
 func (t *TmuxMultiplexer) KillSession(session string) error {
-	return t.runWithOptions([]string{"kill-session", "-t", session}, executor.RunOptions{Stderr: os.Stderr})
+	return t.runWithOptions([]string{"kill-session", "-t", exactSessionTarget(session)}, executor.RunOptions{Stderr: os.Stderr})
 }
 
 // ListSessions returns all tmux session names.

--- a/internal/multiplexer/tmux_test.go
+++ b/internal/multiplexer/tmux_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -155,8 +154,8 @@ func TestTmuxMultiplexer_HasSession(t *testing.T) {
 	if call.name != "tmux" {
 		t.Fatalf("command = %q, want %q", call.name, "tmux")
 	}
-	if !equalArgs(call.args, []string{"has-session", "-t", "demo"}) {
-		t.Fatalf("args = %v, want %v", call.args, []string{"has-session", "-t", "demo"})
+	if !equalArgs(call.args, []string{"has-session", "-t", "=demo"}) {
+		t.Fatalf("args = %v, want %v", call.args, []string{"has-session", "-t", "=demo"})
 	}
 }
 
@@ -199,7 +198,11 @@ func TestTmuxMultiplexer_IgnoresInheritedTmuxEnvForSessionLifecycle(t *testing.T
 
 	session := fmt.Sprintf("orch-test-%d-%d", os.Getpid(), time.Now().UnixNano())
 	foreignSession := session + "-foreign"
-	foreignSocket := filepath.Join(t.TempDir(), "foreign")
+	// Unix socket paths are capped (~104 bytes on macOS); t.TempDir() under
+	// /var/folders exceeds it and silently degraded this test to a skip on
+	// dev machines. Use a short /tmp path with explicit cleanup instead.
+	foreignSocket := fmt.Sprintf("/tmp/orch-mux-t-%d", os.Getpid())
+	t.Cleanup(func() { _ = os.Remove(foreignSocket) })
 
 	if out, err := cleanTmuxCommand("-S", foreignSocket, "new-session", "-d", "-s", foreignSession, "sleep 60").CombinedOutput(); err != nil {
 		t.Skipf("tmux foreign server unavailable: %v (%s)", err, out)
@@ -208,7 +211,7 @@ func TestTmuxMultiplexer_IgnoresInheritedTmuxEnvForSessionLifecycle(t *testing.T
 		_ = cleanTmuxCommand("-S", foreignSocket, "kill-server").Run()
 	})
 	t.Cleanup(func() {
-		_ = cleanTmuxCommand("kill-session", "-t", session).Run()
+		_ = cleanTmuxCommand("kill-session", "-t", "="+session).Run()
 	})
 
 	t.Setenv("TMUX", foreignSocket+",123,0")
@@ -322,7 +325,7 @@ func TestTmuxMultiplexer_KillSession(t *testing.T) {
 	}
 
 	call := exec.recorded[0]
-	if !equalArgs(call.args, []string{"kill-session", "-t", "sess"}) {
+	if !equalArgs(call.args, []string{"kill-session", "-t", "=sess"}) {
 		t.Fatalf("kill-session args = %v", call.args)
 	}
 }
@@ -903,11 +906,15 @@ func cleanTmuxCommand(args ...string) *exec.Cmd {
 }
 
 func cleanTmuxHasSession(session string) bool {
-	return cleanTmuxCommand("has-session", "-t", session).Run() == nil
+	// "=" disables tmux prefix matching: without it, the foreign server's
+	// "<session>-foreign" session false-positives an existence check for
+	// "<session>" (this exact bug made the lifecycle test report the scrub
+	// as broken on CI).
+	return cleanTmuxCommand("has-session", "-t", "="+session).Run() == nil
 }
 
 func cleanTmuxHasSessionOnSocket(socket, session string) bool {
-	return cleanTmuxCommand("-S", socket, "has-session", "-t", session).Run() == nil
+	return cleanTmuxCommand("-S", socket, "has-session", "-t", "="+session).Run() == nil
 }
 
 func envHas(env []string, want string) bool {


### PR DESCRIPTION
Main went red after #483/#484 merged. Neither failure was a product regression — both were test defects, but one exposed a real product hazard worth hardening.

## 1. tmux prefix-matching false positive (failed #483's lifecycle test on CI)

`tmux has-session -t <name>` resolves targets by PREFIX: the test's foreign server holds `<name>-foreign`, which matches `<name>`, so the assertion "session was created on the inherited foreign tmux server" fired even though the env scrub works correctly. Verified live: `has-session -t abc123` exits 0 against a server holding only `abc123-foreign`; `-t =abc123` exits 1.

On dev macOS the test never ran at all — `t.TempDir()` under /var/folders exceeds the ~104-byte unix socket path cap, so the foreign server failed to boot and the test silently skipped. That is why local verification reported green.

Fixes:
- **Product hardening (owning layer)**: `HasSession`/`KillSession` now use exact-match targets (`=` prefix), so session existence checks — including the daemon's aliveness verdicts — can never prefix-false-positive against a similarly named session.
- Test helpers exact-match too; foreign socket moved to a short `/tmp` path so the lifecycle test actually runs on macOS (verified: runs and passes, no longer skips).

## 2. Author-environment dependence (failed #484's tests on CI)

`TestDefaultGetAPIWithOptionsRemoteAllows{GitDerivedProjectIdentity,ExplicitProjectFlag}` dialed the author's live master `zeus:7777` and required success — green only where that host resolves and serves. In CI: `lookup zeus ... server misbehaving`. Rewritten hermetically against unreachable-but-resolvable `127.0.0.1:1`: identity resolution precedes the dial, so the tests now assert the error is never `project identity required` (mirroring the sibling test's error-class pattern at root_remote_test.go:189).

## Verification
- `go build ./...`
- Unit sweep green; `TMPDIR=/tmp` runs the previously-skipped lifecycle test for real on macOS: PASS
- `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)