### PR TITLE
Worker reconnects with backoff instead of exiting on transient master outage

### DIFF
--- a/internal/cli/master_worker.go
+++ b/internal/cli/master_worker.go
@@ -132,6 +132,9 @@ func runWorkerStatus(workerID string) error {
 		if !status.Local.LastHeartbeatAt.IsZero() {
 			fmt.Printf("Last Heartbeat: %s\n", humanizeWorkerTime(status.Local.LastHeartbeatAt))
 		}
+		if !status.Local.ReconnectingSince.IsZero() {
+			fmt.Printf("Reconnecting Since: %s\n", status.Local.ReconnectingSince.Format(time.RFC3339))
+		}
 		if !status.Local.ExitedAt.IsZero() {
 			fmt.Printf("Exited: %s\n", status.Local.ExitedAt.Format(time.RFC3339))
 		}

--- a/internal/daemon/client_errors.go
+++ b/internal/daemon/client_errors.go
@@ -1,0 +1,26 @@
+package daemon
+
+// WorkerRPCRejectedError is returned by worker-plane client RPCs
+// (RegisterWorker, WorkerHeartbeat, LeaseWork, AcknowledgeEffect,
+// UnregisterWorker) when the master received the request and explicitly
+// refused it (resp.ok == false), as opposed to a transport failure that
+// never reached the master. The worker run loop relies on this distinction:
+// transport failures are retried with backoff indefinitely, while a live
+// master refusing registration (auth/policy) is fatal.
+type WorkerRPCRejectedError struct {
+	Message string
+}
+
+func (e *WorkerRPCRejectedError) Error() string {
+	return "daemon error: " + e.Message
+}
+
+// ClientConfigError marks a client-side configuration problem (e.g. an
+// unparseable daemon address) that no amount of reconnecting can fix.
+type ClientConfigError struct {
+	Message string
+}
+
+func (e *ClientConfigError) Error() string {
+	return e.Message
+}

--- a/internal/daemon/proto_client.go
+++ b/internal/daemon/proto_client.go
@@ -224,7 +224,7 @@ func (c *ProtoClient) dialTarget() (string, string, error) {
 	if strings.HasPrefix(addr, "tcp://") {
 		hostPort := strings.TrimPrefix(addr, "tcp://")
 		if hostPort == "" {
-			return "", "", fmt.Errorf("invalid daemon address: %q", c.daemonAddr)
+			return "", "", &ClientConfigError{Message: fmt.Sprintf("invalid daemon address: %q", c.daemonAddr)}
 		}
 		return "tcp", hostPort, nil
 	}
@@ -232,13 +232,13 @@ func (c *ProtoClient) dialTarget() (string, string, error) {
 	if strings.HasPrefix(addr, "unix://") {
 		socketPath := strings.TrimPrefix(addr, "unix://")
 		if socketPath == "" {
-			return "", "", fmt.Errorf("invalid daemon address: %q", c.daemonAddr)
+			return "", "", &ClientConfigError{Message: fmt.Sprintf("invalid daemon address: %q", c.daemonAddr)}
 		}
 		return "unix", socketPath, nil
 	}
 
 	if strings.Contains(addr, "://") {
-		return "", "", fmt.Errorf("unsupported daemon address scheme: %q", c.daemonAddr)
+		return "", "", &ClientConfigError{Message: fmt.Sprintf("unsupported daemon address scheme: %q", c.daemonAddr)}
 	}
 
 	return "tcp", addr, nil
@@ -1062,7 +1062,7 @@ func (c *ProtoClient) RegisterWorkerWithCapabilities(workerID, workerType, host,
 	}
 
 	if !resp.Ok {
-		return nil, fmt.Errorf("daemon error: %s", resp.Error)
+		return nil, &WorkerRPCRejectedError{Message: resp.Error}
 	}
 
 	regResp := resp.GetRegisterWorker()
@@ -1089,7 +1089,7 @@ func (c *ProtoClient) UnregisterWorker(workerID string) error {
 		return err
 	}
 	if !resp.Ok {
-		return fmt.Errorf("daemon error: %s", resp.Error)
+		return &WorkerRPCRejectedError{Message: resp.Error}
 	}
 	return nil
 }
@@ -1106,7 +1106,7 @@ func (c *ProtoClient) WorkerHeartbeat(workerID string) error {
 		return err
 	}
 	if !resp.Ok {
-		return fmt.Errorf("daemon error: %s", resp.Error)
+		return &WorkerRPCRejectedError{Message: resp.Error}
 	}
 	return nil
 }
@@ -1158,7 +1158,7 @@ func (c *ProtoClient) LeaseWork(workerID string) (*LeaseWorkResponse, error) {
 		return nil, err
 	}
 	if !resp.Ok {
-		return nil, fmt.Errorf("daemon error: %s", resp.Error)
+		return nil, &WorkerRPCRejectedError{Message: resp.Error}
 	}
 
 	leaseResp := resp.GetLeaseWork()
@@ -1210,7 +1210,7 @@ func (c *ProtoClient) AcknowledgeEffect(workerID, leaseID string, success bool, 
 		return err
 	}
 	if !resp.Ok {
-		return fmt.Errorf("daemon error: %s", resp.Error)
+		return &WorkerRPCRejectedError{Message: resp.Error}
 	}
 	return nil
 }

--- a/internal/worker/loop.go
+++ b/internal/worker/loop.go
@@ -1,9 +1,11 @@
 package worker
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"os"
 	"os/signal"
 	"sync"
@@ -31,11 +33,22 @@ type capabilityRegisterClient interface {
 	RegisterWorkerWithCapabilities(workerID, workerType, host, mode string, capabilities []string) (*daemon.RegisterWorkerResponse, error)
 }
 
+const (
+	defaultReconnectMinBackoff = 1 * time.Second
+	defaultReconnectMaxBackoff = 60 * time.Second
+)
+
 type RunConfig struct {
 	WorkerID          string
 	Once              bool
 	PollInterval      time.Duration
 	HeartbeatInterval time.Duration
+
+	// Test seams. The reconnect backoff window defaults to 1s..60s; stopCh
+	// lets tests stop a long-lived loop without process signals.
+	reconnectMinBackoff time.Duration
+	reconnectMaxBackoff time.Duration
+	stopCh              <-chan struct{}
 }
 
 type leaseExecutor interface {
@@ -51,6 +64,55 @@ var newLeaseExecutor = func(workerID, host string) leaseExecutor {
 	return server
 }
 
+// fatalWorkerError marks a session failure that reconnecting can never fix:
+// the master was reached and explicitly refused registration (auth/policy).
+type fatalWorkerError struct {
+	err error
+}
+
+func (e *fatalWorkerError) Error() string { return e.err.Error() }
+func (e *fatalWorkerError) Unwrap() error { return e.err }
+
+// isFatalWorkerError separates fatal, non-retryable session failures (invalid
+// client config, register-time rejection by a live master) from transient
+// master-connection failures, which the run loop retries indefinitely.
+func isFatalWorkerError(err error) bool {
+	var cfgErr *daemon.ClientConfigError
+	if errors.As(err, &cfgErr) {
+		return true
+	}
+	var fatal *fatalWorkerError
+	return errors.As(err, &fatal)
+}
+
+// classifyRegisterError decides whether a failed registration attempt should
+// stop the worker. A rejection from a live master (bad auth token, policy)
+// cannot be fixed by retrying; a transport failure means the master is
+// unreachable and the loop should keep reconnecting.
+func classifyRegisterError(err error) error {
+	var rejected *daemon.WorkerRPCRejectedError
+	if errors.As(err, &rejected) {
+		return &fatalWorkerError{err: err}
+	}
+	return err
+}
+
+// reconnectJitterDelay returns a delay in [backoff/2, backoff) so that
+// workers disconnected by the same outage do not reconnect in lockstep.
+func reconnectJitterDelay(backoff time.Duration) time.Duration {
+	half := backoff / 2
+	if half <= 0 {
+		return backoff
+	}
+	return half + time.Duration(rand.Int63n(int64(half)))
+}
+
+// RunExternalLoop runs the long-lived worker host loop. Master-connection
+// failures are treated as retryable: the loop re-registers with exponential
+// backoff plus jitter, indefinitely. It exits only on an explicit stop
+// (signal), on fatal non-retryable errors (invalid client config, the master
+// rejecting registration), or after one lease in Once mode, which keeps
+// fail-fast semantics as a bounded one-shot probe.
 func RunExternalLoop(client Client, cfg RunConfig) (err error) {
 	if client == nil {
 		return fmt.Errorf("client required")
@@ -63,13 +125,20 @@ func RunExternalLoop(client Client, cfg RunConfig) (err error) {
 		}
 	}()
 
-	pollInterval := cfg.PollInterval
-	if pollInterval <= 0 {
-		pollInterval = 200 * time.Millisecond
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 200 * time.Millisecond
 	}
-	heartbeatInterval := cfg.HeartbeatInterval
-	if heartbeatInterval <= 0 {
-		heartbeatInterval = 5 * time.Second
+	if cfg.HeartbeatInterval <= 0 {
+		cfg.HeartbeatInterval = 5 * time.Second
+	}
+	if cfg.reconnectMinBackoff <= 0 {
+		cfg.reconnectMinBackoff = defaultReconnectMinBackoff
+	}
+	if cfg.reconnectMaxBackoff <= 0 {
+		cfg.reconnectMaxBackoff = defaultReconnectMaxBackoff
+	}
+	if cfg.reconnectMaxBackoff < cfg.reconnectMinBackoff {
+		cfg.reconnectMaxBackoff = cfg.reconnectMinBackoff
 	}
 
 	host, _ := currentWorkerHostname()
@@ -84,33 +153,96 @@ func RunExternalLoop(client Client, cfg RunConfig) (err error) {
 		runtimeState.markStarting(workerID)
 	}
 
+	// The executor outlives reconnect cycles: a master outage must not tear
+	// down worker-local execution state.
+	executor := newLeaseExecutor(workerID, host)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	registered := false
+	defer func() {
+		if registered {
+			_ = client.UnregisterWorker(workerID)
+		}
+	}()
+
+	backoff := cfg.reconnectMinBackoff
+	resuming := false
+	for {
+		sessionStart := time.Now()
+		sessionErr := runWorkerSession(client, cfg, workerID, host, executor, runtimeState, sigCh, resuming, &registered)
+		if sessionErr == nil {
+			return nil
+		}
+		if cfg.Once {
+			return sessionErr
+		}
+		if isFatalWorkerError(sessionErr) {
+			return sessionErr
+		}
+
+		// A session that stayed healthy well past the backoff cap starts a
+		// fresh backoff ramp; consecutive quick failures keep escalating.
+		if time.Since(sessionStart) >= 2*cfg.reconnectMaxBackoff {
+			backoff = cfg.reconnectMinBackoff
+		}
+		delay := reconnectJitterDelay(backoff)
+		if runtimeState != nil {
+			runtimeState.markReconnecting(sessionErr)
+		}
+		log.Printf("orch-worker %s: master connection failed: %v; reconnecting in %s", workerID, sessionErr, delay.Round(time.Millisecond))
+		select {
+		case <-sigCh:
+			return nil
+		case <-cfg.stopCh:
+			return nil
+		case <-time.After(delay):
+		}
+		backoff *= 2
+		if backoff > cfg.reconnectMaxBackoff {
+			backoff = cfg.reconnectMaxBackoff
+		}
+		resuming = true
+	}
+}
+
+// runWorkerSession registers the worker and serves heartbeats and lease polls
+// until the connection to the master fails, a signal arrives, or (in Once
+// mode) one lease completes. It returns nil for clean exits and the causing
+// error otherwise; the caller decides between reconnecting and exiting.
+func runWorkerSession(client Client, cfg RunConfig, workerID, host string, executor leaseExecutor, runtimeState *managedRuntimeStateWriter, sigCh <-chan os.Signal, resuming bool, registered *bool) error {
 	if capClient, ok := client.(capabilityRegisterClient); ok {
 		if _, err := capClient.RegisterWorkerWithCapabilities(workerID, "executor", host, "external", []string{"capture_session", "continue_run", "get_branch_state", "get_diff", "get_diff_stats", "send_message", "start_run", "stop_run"}); err != nil {
-			return err
+			return classifyRegisterError(err)
 		}
 	} else if _, err := client.RegisterWorker(workerID, "executor", host, "external"); err != nil {
-		return err
+		return classifyRegisterError(err)
 	}
+	*registered = true
 	if runtimeState != nil {
 		runtimeState.markRegistered()
 	}
-	defer client.UnregisterWorker(workerID)
-
-	executor := newLeaseExecutor(workerID, host)
+	if resuming {
+		log.Printf("orch-worker %s: reconnected to master and re-registered", workerID)
+	}
 
 	// Heartbeats run on their own goroutine so a long-running effect
 	// execution cannot starve them: a worker that stops heartbeating while
 	// busy looks dead to the master, which then refuses new leases with
 	// "no active workers available" and fails the lease the worker is still
 	// faithfully executing. The proto client serializes concurrent requests
-	// internally.
+	// internally. On failure the goroutine reports but keeps ticking: while
+	// an effect executes the poll loop cannot act on the report, and the
+	// master must see heartbeats resume the moment the network recovers.
 	heartbeatStop := make(chan struct{})
 	heartbeatErrCh := make(chan error, 1)
 	var heartbeatDone sync.WaitGroup
 	heartbeatDone.Add(1)
 	go func() {
 		defer heartbeatDone.Done()
-		ticker := time.NewTicker(heartbeatInterval)
+		ticker := time.NewTicker(cfg.HeartbeatInterval)
 		defer ticker.Stop()
 		for {
 			select {
@@ -122,7 +254,13 @@ func RunExternalLoop(client Client, cfg RunConfig) (err error) {
 					case heartbeatErrCh <- err:
 					default:
 					}
-					return
+					continue
+				}
+				// Recovered without the poll loop noticing: withdraw any
+				// stale failure report so a healthy session is not torn down.
+				select {
+				case <-heartbeatErrCh:
+				default:
 				}
 				if runtimeState != nil {
 					runtimeState.markHeartbeat()
@@ -135,16 +273,14 @@ func RunExternalLoop(client Client, cfg RunConfig) (err error) {
 	defer heartbeatDone.Wait()
 	defer close(heartbeatStop)
 
-	pollTicker := time.NewTicker(pollInterval)
+	pollTicker := time.NewTicker(cfg.PollInterval)
 	defer pollTicker.Stop()
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-	defer signal.Stop(sigCh)
 
 	for {
 		select {
 		case <-sigCh:
+			return nil
+		case <-cfg.stopCh:
 			return nil
 		case err := <-heartbeatErrCh:
 			return err
@@ -167,6 +303,9 @@ func RunExternalLoop(client Client, cfg RunConfig) (err error) {
 			}
 			resultJSON := daemon.EncodeWorkerEffectResult(result)
 			if ackErr := client.AcknowledgeEffect(workerID, leaseResp.Lease.LeaseID, execErr == nil, errMsg, resultJSON); ackErr != nil {
+				// The lease result is not carried across sessions: on ack
+				// loss the master re-dispatches the lease after its TTL and
+				// completion stays idempotent (first verdict wins).
 				return ackErr
 			}
 

--- a/internal/worker/loop_test.go
+++ b/internal/worker/loop_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -9,22 +10,24 @@ import (
 )
 
 type mockClient struct {
-	mu          sync.Mutex
-	heartbeats  int
-	registered  bool
-	acked       bool
-	lease       *daemon.WorkerLease
-	ackResult   string
-	workerID    string
-	workerType  string
-	host        string
-	mode        string
-	regErr      error
-	hbErr       error
-	leaseErr    error
-	ackErr      error
-	unregErr    error
-	unregCalled bool
+	mu           sync.Mutex
+	heartbeats   int
+	registered   bool
+	regSuccesses int
+	regAttempts  []time.Time
+	acked        bool
+	lease        *daemon.WorkerLease
+	ackResult    string
+	workerID     string
+	workerType   string
+	host         string
+	mode         string
+	regErr       error
+	hbErr        error
+	leaseErr     error
+	ackErr       error
+	unregErr     error
+	unregCalled  bool
 }
 
 type mockCapClient struct {
@@ -40,6 +43,7 @@ func (m *mockCapClient) RegisterWorkerWithCapabilities(workerID, workerType, hos
 func (m *mockClient) RegisterWorker(workerID, workerType, host, mode string) (*daemon.RegisterWorkerResponse, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.regAttempts = append(m.regAttempts, time.Now())
 	if m.regErr != nil {
 		return nil, m.regErr
 	}
@@ -48,6 +52,7 @@ func (m *mockClient) RegisterWorker(workerID, workerType, host, mode string) (*d
 	m.host = host
 	m.mode = mode
 	m.registered = true
+	m.regSuccesses++
 	return &daemon.RegisterWorkerResponse{OK: true, WorkerID: workerID}, nil
 }
 
@@ -68,6 +73,40 @@ func (m *mockClient) heartbeatCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.heartbeats
+}
+
+func (m *mockClient) registerAttempts() []time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]time.Time(nil), m.regAttempts...)
+}
+
+func (m *mockClient) registerSuccessCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.regSuccesses
+}
+
+func (m *mockClient) unregisterCalled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.unregCalled
+}
+
+// setConnectivity flips all connection-shaped RPCs between healthy (nil) and
+// failing with the given error, simulating a master outage and recovery.
+func (m *mockClient) setConnectivity(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.regErr = err
+	m.hbErr = err
+	m.leaseErr = err
+}
+
+func (m *mockClient) setHeartbeatErr(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.hbErr = err
 }
 
 func (m *mockClient) LeaseWork(workerID string) (*daemon.LeaseWorkResponse, error) {
@@ -142,6 +181,8 @@ func TestRunExternalLoopOnceNoLeaseReturnsNil(t *testing.T) {
 	}
 }
 
+// Once mode is a bounded one-shot probe and keeps fail-fast semantics: no
+// reconnect loop, the first error is returned as-is.
 func TestRunExternalLoopRegisterFailure(t *testing.T) {
 	client := &mockClient{regErr: assertErr("register failed")}
 	err := RunExternalLoop(client, RunConfig{WorkerID: "w3", Once: true, PollInterval: 10 * time.Millisecond, HeartbeatInterval: time.Second})
@@ -153,18 +194,206 @@ func TestRunExternalLoopRegisterFailure(t *testing.T) {
 	}
 }
 
-func TestRunExternalLoopHeartbeatFailure(t *testing.T) {
+// A live master explicitly rejecting registration (auth/policy) is fatal:
+// retrying cannot help, so the long-lived loop must exit with the error
+// instead of reconnecting forever.
+func TestRunExternalLoopExitsOnRegisterRejection(t *testing.T) {
 	origNew := newLeaseExecutor
 	t.Cleanup(func() { newLeaseExecutor = origNew })
 	newLeaseExecutor = func(string, string) leaseExecutor { return &mockExecutor{} }
 
-	client := &mockClient{hbErr: assertErr("heartbeat failed")}
-	err := RunExternalLoop(client, RunConfig{WorkerID: "w4", PollInterval: 200 * time.Millisecond, HeartbeatInterval: 10 * time.Millisecond})
-	if err == nil || err.Error() != "heartbeat failed" {
-		t.Fatalf("RunExternalLoop() error = %v, want heartbeat failed", err)
+	client := &mockClient{regErr: &daemon.WorkerRPCRejectedError{Message: "unauthorized worker"}}
+	done := make(chan error, 1)
+	go func() {
+		done <- RunExternalLoop(client, RunConfig{
+			WorkerID:            "w-auth",
+			PollInterval:        5 * time.Millisecond,
+			HeartbeatInterval:   5 * time.Millisecond,
+			reconnectMinBackoff: 5 * time.Millisecond,
+			reconnectMaxBackoff: 20 * time.Millisecond,
+		})
+	}()
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "unauthorized worker") {
+			t.Fatalf("RunExternalLoop() error = %v, want unauthorized worker", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not exit on register rejection")
 	}
-	if !client.unregCalled {
-		t.Fatal("expected unregister call on heartbeat failure")
+	if client.unregisterCalled() {
+		t.Fatal("unexpected unregister call when registration was rejected")
+	}
+}
+
+// Invalid client configuration can never be fixed by reconnecting and must
+// exit immediately.
+func TestRunExternalLoopExitsOnClientConfigError(t *testing.T) {
+	origNew := newLeaseExecutor
+	t.Cleanup(func() { newLeaseExecutor = origNew })
+	newLeaseExecutor = func(string, string) leaseExecutor { return &mockExecutor{} }
+
+	client := &mockClient{regErr: &daemon.ClientConfigError{Message: `unsupported daemon address scheme: "grpc://zeus"`}}
+	done := make(chan error, 1)
+	go func() {
+		done <- RunExternalLoop(client, RunConfig{
+			WorkerID:            "w-cfg",
+			PollInterval:        5 * time.Millisecond,
+			HeartbeatInterval:   5 * time.Millisecond,
+			reconnectMinBackoff: 5 * time.Millisecond,
+			reconnectMaxBackoff: 20 * time.Millisecond,
+		})
+	}()
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "unsupported daemon address scheme") {
+			t.Fatalf("RunExternalLoop() error = %v, want config error", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not exit on client config error")
+	}
+}
+
+// The regression test for the 2026-07-07 incident: a transient master outage
+// (every RPC failing with a connection error) must not kill the worker. The
+// loop has to survive N consecutive connection failures, back off between
+// attempts, re-register once the master is reachable again, and resume
+// heartbeats — all without operator action.
+func TestRunExternalLoopSurvivesOutageAndReconnects(t *testing.T) {
+	origNew := newLeaseExecutor
+	t.Cleanup(func() { newLeaseExecutor = origNew })
+	newLeaseExecutor = func(string, string) leaseExecutor { return &mockExecutor{} }
+
+	client := &mockClient{}
+	stopCh := make(chan struct{})
+	minBackoff := 10 * time.Millisecond
+	loopDone := make(chan error, 1)
+	go func() {
+		loopDone <- RunExternalLoop(client, RunConfig{
+			WorkerID:            "w-flaky",
+			PollInterval:        2 * time.Millisecond,
+			HeartbeatInterval:   2 * time.Millisecond,
+			reconnectMinBackoff: minBackoff,
+			reconnectMaxBackoff: 8 * minBackoff,
+			stopCh:              stopCh,
+		})
+	}()
+
+	waitFor := func(cond func() bool, msg string) {
+		t.Helper()
+		deadline := time.Now().Add(10 * time.Second)
+		for !cond() {
+			select {
+			case err := <-loopDone:
+				t.Fatalf("loop exited early (%s): %v", msg, err)
+			default:
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("timeout waiting for %s", msg)
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}
+
+	waitFor(func() bool { return client.registerSuccessCount() >= 1 }, "initial registration")
+	waitFor(func() bool { return client.heartbeatCount() >= 1 }, "initial heartbeat")
+
+	// Master outage: every RPC fails the way a dropped TCP connection does.
+	connErr := assertErr("daemon request failed: failed to read response length: read tcp: i/o timeout (reconnect failed: dial tcp zeus:7777: i/o timeout)")
+	client.setConnectivity(connErr)
+	attemptsAtOutage := len(client.registerAttempts())
+
+	// Survive at least 3 consecutive failed reconnect attempts.
+	waitFor(func() bool { return len(client.registerAttempts()) >= attemptsAtOutage+3 }, "3 failed reconnect attempts")
+
+	// Exponential backoff: each retry sleeps a jittered delay in
+	// [backoff/2, backoff), so the gaps between consecutive attempts have
+	// deterministic lower bounds (min/2, then min after doubling).
+	attempts := client.registerAttempts()
+	gap1 := attempts[attemptsAtOutage+1].Sub(attempts[attemptsAtOutage])
+	gap2 := attempts[attemptsAtOutage+2].Sub(attempts[attemptsAtOutage+1])
+	if gap1 < minBackoff/2 {
+		t.Fatalf("first reconnect gap %v below backoff floor %v", gap1, minBackoff/2)
+	}
+	if gap2 < minBackoff {
+		t.Fatalf("second reconnect gap %v below doubled backoff floor %v", gap2, minBackoff)
+	}
+
+	// Master comes back: the worker must re-register and resume heartbeats
+	// without operator action.
+	client.setConnectivity(nil)
+	waitFor(func() bool { return client.registerSuccessCount() >= 2 }, "re-registration after outage")
+	heartbeatsAtRecovery := client.heartbeatCount()
+	waitFor(func() bool { return client.heartbeatCount() >= heartbeatsAtRecovery+3 }, "heartbeats resumed after reconnect")
+
+	close(stopCh)
+	select {
+	case err := <-loopDone:
+		if err != nil {
+			t.Fatalf("RunExternalLoop() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not stop")
+	}
+	if !client.unregisterCalled() {
+		t.Fatal("expected unregister on clean shutdown")
+	}
+}
+
+// Heartbeat failures alone (e.g. the master restarted and forgot the
+// registration) must also route through the reconnect path: tear down the
+// session, re-register, and resume — never exit.
+func TestRunExternalLoopReregistersAfterHeartbeatFailures(t *testing.T) {
+	origNew := newLeaseExecutor
+	t.Cleanup(func() { newLeaseExecutor = origNew })
+	newLeaseExecutor = func(string, string) leaseExecutor { return &mockExecutor{} }
+
+	client := &mockClient{}
+	stopCh := make(chan struct{})
+	loopDone := make(chan error, 1)
+	go func() {
+		loopDone <- RunExternalLoop(client, RunConfig{
+			WorkerID:            "w-hb",
+			PollInterval:        2 * time.Millisecond,
+			HeartbeatInterval:   2 * time.Millisecond,
+			reconnectMinBackoff: 5 * time.Millisecond,
+			reconnectMaxBackoff: 20 * time.Millisecond,
+			stopCh:              stopCh,
+		})
+	}()
+
+	waitFor := func(cond func() bool, msg string) {
+		t.Helper()
+		deadline := time.Now().Add(10 * time.Second)
+		for !cond() {
+			select {
+			case err := <-loopDone:
+				t.Fatalf("loop exited early (%s): %v", msg, err)
+			default:
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("timeout waiting for %s", msg)
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}
+
+	waitFor(func() bool { return client.registerSuccessCount() >= 1 }, "initial registration")
+	client.setHeartbeatErr(&daemon.WorkerRPCRejectedError{Message: "worker not found: w-hb"})
+	waitFor(func() bool { return client.registerSuccessCount() >= 2 }, "re-registration after heartbeat failure")
+	client.setHeartbeatErr(nil)
+
+	heartbeatsAtRecovery := client.heartbeatCount()
+	waitFor(func() bool { return client.heartbeatCount() >= heartbeatsAtRecovery+3 }, "heartbeats resumed")
+
+	close(stopCh)
+	select {
+	case err := <-loopDone:
+		if err != nil {
+			t.Fatalf("RunExternalLoop() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not stop")
 	}
 }
 
@@ -263,5 +492,56 @@ func TestRunExternalLoopHeartbeatsDuringEffectExecution(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("loop did not finish after effect release")
+	}
+}
+
+// An in-flight effect must survive a heartbeat outage: the loop may not
+// abandon or interrupt the execution, and the heartbeat goroutine must keep
+// attempting (not exit on first failure) so the master sees the worker again
+// the moment the network recovers.
+func TestRunExternalLoopEffectSurvivesHeartbeatOutage(t *testing.T) {
+	origNew := newLeaseExecutor
+	t.Cleanup(func() { newLeaseExecutor = origNew })
+	blocking := &blockingExecutor{started: make(chan struct{}), release: make(chan struct{})}
+	newLeaseExecutor = func(string, string) leaseExecutor { return blocking }
+
+	client := &mockClient{lease: &daemon.WorkerLease{LeaseID: "lease-1", WorkerID: "w1", Effect: "start_run", Payload: &daemon.WorkerEffectPayload{StartRun: &daemon.StartRunOptions{}}}}
+
+	loopDone := make(chan error, 1)
+	go func() {
+		loopDone <- RunExternalLoop(client, RunConfig{WorkerID: "w1", Once: true, PollInterval: 5 * time.Millisecond, HeartbeatInterval: 5 * time.Millisecond})
+	}()
+
+	select {
+	case <-blocking.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("lease execution never started")
+	}
+
+	// Heartbeats start failing mid-effect; attempts must continue anyway.
+	client.setHeartbeatErr(assertErr("write tcp: broken pipe"))
+	failingSince := client.heartbeatCount()
+	deadline := time.Now().Add(5 * time.Second)
+	for client.heartbeatCount() < failingSince+3 {
+		if time.Now().After(deadline) {
+			t.Fatalf("heartbeat attempts stopped during outage: %d -> %d", failingSince, client.heartbeatCount())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Network recovers before the effect completes; the effect then finishes
+	// and is acknowledged as if nothing happened.
+	client.setHeartbeatErr(nil)
+	close(blocking.release)
+	select {
+	case err := <-loopDone:
+		if err != nil {
+			t.Fatalf("RunExternalLoop() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not finish after effect release")
+	}
+	if !client.acked {
+		t.Fatal("expected the in-flight lease to be acknowledged after the heartbeat outage")
 	}
 }

--- a/internal/worker/managed.go
+++ b/internal/worker/managed.go
@@ -24,6 +24,7 @@ const (
 	localProcessStateMissing      = "missing"
 	localProcessStateStarting     = "starting"
 	localProcessStateRunning      = "running"
+	localProcessStateReconnecting = "reconnecting"
 	localProcessStateStopped      = "stopped"
 	localProcessStateExited       = "exited"
 	localProcessStateUnmanaged    = "unmanaged"
@@ -65,25 +66,27 @@ type ManagedState struct {
 	LogPath         string    `json:"log_path,omitempty"`
 	PID             int       `json:"pid,omitempty"`
 	ProcessState    string    `json:"process_state,omitempty"`
-	StartedAt       time.Time `json:"started_at,omitempty"`
-	RegisteredAt    time.Time `json:"registered_at,omitempty"`
-	LastHeartbeatAt time.Time `json:"last_heartbeat_at,omitempty"`
-	ExitedAt        time.Time `json:"exited_at,omitempty"`
-	LastError       string    `json:"last_error,omitempty"`
-	UpdatedAt       time.Time `json:"updated_at,omitempty"`
+	StartedAt         time.Time `json:"started_at,omitempty"`
+	RegisteredAt      time.Time `json:"registered_at,omitempty"`
+	LastHeartbeatAt   time.Time `json:"last_heartbeat_at,omitempty"`
+	ReconnectingSince time.Time `json:"reconnecting_since,omitempty"`
+	ExitedAt          time.Time `json:"exited_at,omitempty"`
+	LastError         string    `json:"last_error,omitempty"`
+	UpdatedAt         time.Time `json:"updated_at,omitempty"`
 }
 
 type ManagedLocalStatus struct {
-	Managed         bool      `json:"managed"`
-	ProcessExists   bool      `json:"process_exists"`
-	State           string    `json:"state"`
-	PID             int       `json:"pid,omitempty"`
-	LogPath         string    `json:"log_path,omitempty"`
-	StartedAt       time.Time `json:"started_at,omitempty"`
-	RegisteredAt    time.Time `json:"registered_at,omitempty"`
-	LastHeartbeatAt time.Time `json:"last_heartbeat_at,omitempty"`
-	ExitedAt        time.Time `json:"exited_at,omitempty"`
-	LastError       string    `json:"last_error,omitempty"`
+	Managed           bool      `json:"managed"`
+	ProcessExists     bool      `json:"process_exists"`
+	State             string    `json:"state"`
+	PID               int       `json:"pid,omitempty"`
+	LogPath           string    `json:"log_path,omitempty"`
+	StartedAt         time.Time `json:"started_at,omitempty"`
+	RegisteredAt      time.Time `json:"registered_at,omitempty"`
+	LastHeartbeatAt   time.Time `json:"last_heartbeat_at,omitempty"`
+	ReconnectingSince time.Time `json:"reconnecting_since,omitempty"`
+	ExitedAt          time.Time `json:"exited_at,omitempty"`
+	LastError         string    `json:"last_error,omitempty"`
 }
 
 type ManagedMasterStatus struct {
@@ -267,6 +270,7 @@ func StatusManaged(opts ManagedOptions) (*ManagedStatus, error) {
 		local.StartedAt = state.StartedAt
 		local.RegisteredAt = state.RegisteredAt
 		local.LastHeartbeatAt = state.LastHeartbeatAt
+		local.ReconnectingSince = state.ReconnectingSince
 		local.ExitedAt = state.ExitedAt
 		local.LastError = state.LastError
 	}
@@ -304,6 +308,12 @@ func StatusManaged(opts ManagedOptions) (*ManagedStatus, error) {
 	}
 	if local.Managed && local.ProcessExists && master.State == masterStateNotRegistered {
 		diagnostic = fmt.Sprintf("local worker process %q is running but has not registered with orch-master profile %q", profile.WorkerID, managedProfileDisplay(profile.RemoteAddr))
+	}
+	if local.Managed && local.ProcessExists && local.State == localProcessStateReconnecting {
+		diagnostic = fmt.Sprintf("worker %q is reconnecting to orch-master profile %q since %s", profile.WorkerID, managedProfileDisplay(profile.RemoteAddr), local.ReconnectingSince.Format(time.RFC3339))
+		if strings.TrimSpace(local.LastError) != "" {
+			diagnostic += "; last error: " + strings.TrimSpace(local.LastError)
+		}
 	}
 	if local.Managed && !local.ProcessExists && strings.TrimSpace(local.LastError) != "" {
 		diagnostic = local.LastError
@@ -695,6 +705,7 @@ func (w *managedRuntimeStateWriter) markStarting(workerID string) {
 		if state.StartedAt.IsZero() {
 			state.StartedAt = managedWorkerNow()
 		}
+		state.ReconnectingSince = time.Time{}
 		state.ExitedAt = time.Time{}
 		state.LastError = ""
 	})
@@ -721,8 +732,33 @@ func (w *managedRuntimeStateWriter) markRegistered() {
 			state.RegisteredAt = now
 		}
 		state.LastHeartbeatAt = now
+		state.ReconnectingSince = time.Time{}
 		state.ExitedAt = time.Time{}
 		state.LastError = ""
+	})
+}
+
+// markReconnecting records that the worker lost its master connection and is
+// retrying with backoff, so `orch worker status` shows "reconnecting since
+// ... last error ..." instead of a dead-looking exited state.
+func (w *managedRuntimeStateWriter) markReconnecting(err error) {
+	if w == nil {
+		return
+	}
+	now := managedWorkerNow()
+	_ = updateManagedState(w.statePath, func(state *ManagedState) {
+		state.WorkerID = w.workerID
+		state.RemoteAddr = w.remoteAddr
+		state.LogPath = w.logPath
+		state.PID = w.pid
+		if state.ProcessState != localProcessStateReconnecting || state.ReconnectingSince.IsZero() {
+			state.ReconnectingSince = now
+		}
+		state.ProcessState = localProcessStateReconnecting
+		state.ExitedAt = time.Time{}
+		if err != nil {
+			state.LastError = err.Error()
+		}
 	})
 }
 
@@ -746,6 +782,7 @@ func (w *managedRuntimeStateWriter) markExited(err error) {
 	now := managedWorkerNow()
 	_ = updateManagedState(w.statePath, func(state *ManagedState) {
 		state.ExitedAt = now
+		state.ReconnectingSince = time.Time{}
 		state.ProcessState = localProcessStateStopped
 		if err != nil {
 			state.ProcessState = localProcessStateExited


### PR DESCRIPTION
## Issue

beta-worker-reconnect — live incident 2026-07-07 19:00 JST: the mac worker hit a transient network timeout to the zeus master and exited, freezing run statuses and requiring a manual `orch worker start` an hour later.

## Root cause and fix

`RunExternalLoop` treated **every** client error (heartbeat, lease poll, ack) as fatal and returned, killing the worker process on the first connection blip.

```
before:  register → [heartbeat goroutine │ poll loop] → any error → process exit
after:   ┌─ supervision loop ──────────────────────────────────────────┐
         │ session = register → heartbeat + poll                       │
         │  ├ clean (signal / --once)            → exit 0              │
         │  ├ fatal (config / register rejected) → exit with error     │
         │  └ connection failure → markReconnecting                    │
         │       → backoff (1s..60s cap, jitter [b/2,b)) → re-register │
         └──────────────────────────────────────────────────────────────┘
```

Fatal vs retryable is decided by **type**, not string matching: new `daemon.WorkerRPCRejectedError` (master reached, request explicitly refused — worker-plane RPCs only, error strings unchanged) and `daemon.ClientConfigError` (unparseable daemon address). A register-time rejection from a live master (unrecoverable auth/policy) is fatal; every transport failure retries forever. `--once` keeps fail-fast semantics as a bounded one-shot probe.

The heartbeat goroutine no longer exits on first error — it keeps attempting (and withdraws its failure report on self-recovery), preserving the PR #461 guarantee that workers heartbeat while executing effects, which `waitForWorkerLeaseCompletion`'s worker-liveness fail-fast relies on.

## Acceptance criteria evidence

**1. Retryable connection failures, exponential backoff + jitter, indefinite** — live verification with a real daemon + managed worker in an isolated XDG sandbox (`orch daemon run --listen`, `orch worker start`, then `kill -9` the daemon). Worker log shows the incident's exact error shape now retried:

```
23:13:14 orch-worker w-e2e: master connection failed: daemon request failed: failed to read response length: EOF (reconnect failed: ... connection refused); reconnecting in 829ms
23:13:15 ... reconnecting in 1.635s
23:13:17 ... reconnecting in 3.028s
23:13:20 ... reconnecting in 5.801s
23:13:26 ... reconnecting in 10.012s
23:13:36 ... reconnecting in 27.146s
23:14:03 ... reconnecting in 48.957s        ← approaching 60s cap
```

**2. Re-register + heartbeats resume without operator action; in-flight effects survive** — after restarting the daemon (worker untouched):

```
23:14:52 orch-worker w-e2e: reconnected to master and re-registered
$ orch --remote 127.0.0.1:17877 worker status --worker-id w-e2e
Local Process: running (pid: 13036)          ← same pid, never restarted
Master Registration: active
Master Heartbeat: 0s ago
```

Master-side `registerWorker` is already idempotent (keeps `RegisteredAt`); no `worker_plane.go` changes. Note: the issue's parenthetical "effects already run in goroutines" is not quite accurate — effects execute synchronously in the poll loop, only heartbeats run on their own goroutine (PR #461). That structure means an in-flight effect can never be interrupted by a reconnect (session teardown only happens between polls); covered by `TestRunExternalLoopEffectSurvivesHeartbeatOutage` and the unchanged `TestRunExternalLoopHeartbeatsDuringEffectExecution`.

**3. `orch worker status` shows reconnect state** — during the outage:

```
Local Process: reconnecting (pid: 13036)
Reconnecting Since: 2026-07-07T23:13:14+09:00
Last Error: failed to connect to daemon (tcp 127.0.0.1:17877): ... connection refused
Diagnostic: worker "w-e2e" is reconnecting to orch-master profile "127.0.0.1:17877" since 2026-07-07T23:13:14+09:00; last error: ...
```

**4. Unit tests** — `internal/worker/loop_test.go`, all passing under `-race -count=2`:
- `TestRunExternalLoopSurvivesOutageAndReconnects` — flaky mock client: survives ≥3 consecutive connection failures, asserts jittered-backoff gap floors between attempts, re-registers, heartbeats resume, clean stop unregisters
- `TestRunExternalLoopReregistersAfterHeartbeatFailures` — heartbeat-only failure ("worker not found" after master restart) routes through re-register
- `TestRunExternalLoopExitsOnRegisterRejection` / `TestRunExternalLoopExitsOnClientConfigError` — fatal paths still exit
- `TestRunExternalLoopEffectSurvivesHeartbeatOutage` — heartbeat attempts continue through an outage mid-effect; effect completes and acks

## Done conditions

- `go build ./...` ✅
- `go test ./...` ✅ except 3 pre-existing environment-dependent failures in `test/integration` (real tmux / opencode server 500) — verified identical on the base commit via `git stash`
- `make lint` ✅ (all semgrep rules incl. `run-status-write-surface`, `worker-lease-mutation`)

## Coupling-core constraints

- `internal/daemon/worker_plane.go` untouched; lease semantics unchanged (lost acks covered by existing TTL re-dispatch + LL3 first-verdict-wins idempotency)
- No new registries/ID types/state mirrors; no `nosemgrep`

🤖 Generated with [Claude Code](https://claude.com/claude-code)