### PR TITLE
feat(daemon): implement §9 gate detection + §10 observer attestation

### DIFF
--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -72,6 +72,7 @@ Facts the daemon can notice about a run, with their sources:
 | O4b | — derived: prompt showing (mux agents) | `IsWaitingForInput` string heuristics | pure |
 | O4c | — derived: agent verdict (exited/completed/api-limited/failed) | mux string heuristics; opencode session-status HTTP API (busy/idle/retry/gone) | pure / HTTP |
 | O4d | — derived: PR URL in output | regex | pure |
+| O4e | — derived: interactive gate showing (kind) | `DetectGate` declarative table (`internal/agent/gates.go`), busy veto shared with O4b (§9) | pure |
 | O5 | git evidence (PR info, ahead count, uncommitted changes) | gh cache + git, gathered only after a dead verdict is near | subprocess |
 | O6 | user feedback delivered (`orch send` without `--no-enter`) | send paths | — |
 | O7 | user stop | stop path | — |
@@ -114,7 +115,9 @@ O3 session gone, count ≥ 3   → O5 git evidence を収集して判定:
 
 O2 session alive                                                   カウンタreset, WasAlive=true
 O4 captured + PR URL in output   未記録                            → pr_open (+pr artifact)
-O4 captured + agent verdict:     (mux: 優先順位順)
+O4 captured + agent verdict:     (mux: 優先順位順 — L10b)
+   gate reading streak ≥ 2 (O4e)                                   → waiting (reason gate_<kind>)
+   gate reading streak < 2                                         遷移なし (未確定gateは下位読みを全てマスク)
    exited                                                          → unknown
    completed                                                       → done
    api-limited                                                     → rate_limited
@@ -124,8 +127,9 @@ O4 captured + agent verdict:     (mux: 優先順位順)
    (opencode: busy→running, idle→waiting, retry→rate_limited,
     gone→unknown; booting/queued→running)
    status append 成功後に updateStatus が fireStatusChange (Slack等)
+   同status・reason違いの確定読み変化は再append (D-G1, §9.3)
 
-O6 feedback delivered        status ∈ {waiting,pr_open,            → running (+PromptStreak reset)
+O6 feedback delivered        status ∈ {waiting,pr_open,            → running (+reading streak reset)
                              rate_limited,unknown}
 O7 user stop                 非terminal                            → canceled (source=user)
 O8 launch progress           stageRunCreated                       → queued
@@ -143,8 +147,8 @@ O8 launch progress           stageRunCreated                       → queued
 |---|-----------|--------|
 | I1 | `DeadCheckCount == 0` ⇔ last observation was alive; `>= 3` consecutive dead checks ⇒ verdict allowed | holds, but scattered across two paths |
 | I2 | `WasAlive` is monotone (never unset) | holds across restarts since D-C1 (§7, 2026-06-12): `WasAlive`/`PRRecorded` are re-derived from the event log at registration; the ephemeral counters reset by design and re-converge (L7) |
-| I3 | `PromptStreak >= 2` required before `waiting` (debounce); reset on feedback | holds (W6 + `noteRunFeedback`) |
-| I4 | duplicate status events must not accumulate | enforced only in W1 (same-status no-op); W2–W9 rely on transition legality alone |
+| I3 | `ReadingStreak >= 2` on the same `ReadingKind` required before `waiting` (kind-tagged debounce since §9: kinds `prompt`, `gate:<kind>`); reset on feedback | holds (W6 + `noteRunFeedback`) |
+| I4 | duplicate status events must not accumulate | enforced only in W1 (same-(status, reason) pair no-op since D-G1, §9.3); W2–W9 rely on transition legality alone |
 | I5 | `PRRecorded` dedupes `pr` artifacts | holds across restarts since D-C1 (§7, 2026-06-12): derived from existing `pr` artifacts at registration |
 | I6 | every non-terminal run is eventually observed | holds since `monitorAll` lists `queued` as well as the other non-terminal states, so a run orphaned before `booting` still reaches the monitor plane |
 | I7 | a gone session must eventually produce a verdict | holds since L3' (§7 D-C3, 2026-06-12): both planes conclude `unknown` after the never-alive grace |
@@ -184,11 +188,11 @@ append (W10).
         └── capture pacing, backoff, lease scheduling stay in the shell (mechanism)
 ```
 
-- `runView` — read-only run fields the policy needs (status, agent, branch,
-  PR URL, StartedAt).
+- `runView` — read-only run fields the policy needs (status, status reason,
+  agent, branch, PR URL, StartedAt).
 - `runCore` — the semantic counters (`WasAlive`, `DeadCheckCount`,
-  `PromptStreak`, `OutputHash`, `LastOutput*`, `PRRecorded`), embedded in
-  `RunState` so existing field accesses keep working. Capture backoff and
+  `ReadingKind`/`ReadingStreak`, `OutputHash`, `LastOutput*`, `PRRecorded`),
+  embedded in `RunState` so existing field accesses keep working. Capture backoff and
   lease pacing fields remain shell-owned: *when* to observe is mechanism,
   *what an observation means* is policy.
 - Expensive git/PR evidence is requested by `step` via an effect
@@ -200,8 +204,8 @@ append (W10).
   an equivalent in-memory rollback; a failed status append could leak
   hash/streak updates — the commit rule makes retry uniform.)
 - `updateStatus` remains the single executor for status effects, keeping the
-  store-level guard, same-status no-op, auto-resolve, and event publication
-  as defense in depth beneath the matrix.
+  store-level guard, same-(status, reason) no-op (D-G1), auto-resolve, and
+  event publication as defense in depth beneath the matrix.
 
 ### Laws (encoded as property tests in `step_test.go`)
 
@@ -222,9 +226,12 @@ distinction the law tests themselves forced:
 | L3' grace | a never-alive run within `neverAliveVerdictGrace` never receives an `unknown`/`failed` verdict, on any observation sequence; after the grace, any plane concludes `unknown` on the standing evidence (revised from v1's pinned asymmetry by §7 D-C3) |
 | L4 terminality | from a terminal status, `step` emits no effect and no core change for any observation |
 | L5 verdict requires evidence | `obsSessionGone` never emits a status directly; it requests git evidence exactly when the dead-check threshold is reached |
-| L6 debounce | `waiting` via prompt requires ≥ `waitingPromptStreakThreshold` consecutive prompt observations; any busy capture resets the streak |
-| L8 listener commit point | every committed W1 status transition fires exactly one status-change listener event after `AppendEvent` succeeds; duplicate-status no-ops and failed appends fire none |
+| L6 debounce | `waiting` via prompt requires ≥ `waitingPromptStreakThreshold` consecutive prompt observations; any busy capture resets the streak. Since §9 this is the `reading = prompt` special case of L10a |
+| L8 listener commit point | every committed W1 status transition fires exactly one status-change listener event after `AppendEvent` succeeds; duplicate-(status, reason) no-ops and failed appends fire none |
 | L9 launch failure reason | a launch-failure verdict (O8) always carries the machine-readable reason `launch_<step>`, preceded by an error artifact recording the bootstrap error; launch milestones on a terminal or already-reached status emit nothing |
+| L10a gate debounce (generalizes L6) | a `waiting` verdict with reason `gate_<kind>` requires ≥ `waitingPromptStreakThreshold` consecutive captures whose input-request reading is the same `gate:<kind>`; any busy capture or different reading resets the streak |
+| L10b reading precedence | busy veto > gate > {exited, completed, api-limited, failed} > prompt > output-changed; an unconfirmed gate reading masks every lower reading; each gate row's fixture locks its intended winner end-to-end |
+| L10c reason fidelity | the `waiting` reason always reflects the latest *confirmed* reading; a confirmed reading change re-appends under D-G1 and fires exactly one listener event (L8) |
 
 ### Status reasons (verdict payload)
 
@@ -239,6 +246,7 @@ travels as a machine-readable `reason` attribute on the status event
 | `session_lost` | opencode session not found after dead checks | backend lost observability; backend-specific triage |
 | `agent_exited` | capture verdict: process exited, shell prompt showing | check transcript/worktree; retry plausible |
 | `launch_<step>` | O8 bootstrap failure (`failed` verdict); `<step>` ∈ worktree, prompt, agent_command, multiplexer, opencode_server, session, opencode_bootstrap, bootstrap | the named bootstrap step broke; the paired error artifact carries the detail |
+| `gate_<kind>` (`gate_login`, `gate_trust`, …) | O4e gate reading confirmed by L10a (`waiting` verdict) | `orch attach` and complete the gate interactively; `orch send` will NOT clear it — the run re-asserts `waiting(gate_<kind>)` while the gate persists |
 
 `orch ps` renders the reason inline (`unknown(never_alive)`); the event log
 carries it as `reason=…`; `StatusChangeEvent.Reason` exposes it to listeners.
@@ -406,10 +414,12 @@ remains banned by the `fail-fast-no-discard-status-parse-error` semgrep rule.
 
 ## 9. Interactive gates — parked-at-gate detection (designed 2026-07-07)
 
-Status: **design — accepted pending human review; no implementation yet.**
-All matrix rows, reason-table rows, and core fields in this section are
-deltas to fold into §2/§3/§4/§5 when the implementation issue lands; the
-tables above still describe the code on main.
+Status: **implemented 2026-07-08.** The deltas of this section are folded
+into §2 (O4e), §3 (gate rows, D-G1 re-append), §4 (I3/I4), and §5 (L10a–c,
+`gate_<kind>` reason row); this section remains as the design record. Gate
+rules live in `internal/agent/gates.go` with real-pane fixtures under
+`internal/agent/testdata/gates/`; laws L10a–c are property tests in
+`internal/daemon/step_gate_test.go`.
 
 Trigger — live incident 2026-07-07: two codex runs sat ~2 hours at the
 codex login screen ("Sign in with ChatGPT") while `orch ps` reported
@@ -573,15 +583,16 @@ Counterexamples (must become fixtures/property tests at implementation):
    streak reset → `running` on the next changed capture. No stale
    `waiting(gate_*)` persists.
 
-### 9.6 Follow-up (do not implement in this issue)
+### 9.6 Follow-up (implemented 2026-07-08)
 
-One implementation issue, **frontier + human** (touches `step.go`,
-`stepCaptured` precedence, `commitRunStatus` no-op predicate, and the
-`AgentManager` interface — all core surfaces): `agentSignal.Gate`,
-`DetectGate` + gate table + fixtures + meta-test, kind-tagged streak in
-`runCore`, D-G1 pair no-op, L10 property tests in `step_test.go`, §2/§3/
-§4/§5 fold-in. Real gate screens must be captured for fixtures *before*
-the pattern rows are written.
+Implemented as designed, frontier + human in-session: `agentSignal.Gate`,
+`DetectGate` + gate table + fixtures + meta-test (`internal/agent/gates.go`,
+`gates_test.go`), kind-tagged streak in `runCore`
+(`ReadingKind`/`ReadingStreak`), D-G1 pair no-op in `commitRunStatus` and
+`runView.StatusReason` in the pure core, L10 property tests
+(`step_gate_test.go`), §2/§3/§4/§5 fold-in. All three fixture screens
+(codex login, codex trust, claude trust) were captured from real tmux panes
+before the pattern rows were written, as required.
 
 ## 10. Observation-channel health — death verdicts require attestation (designed 2026-07-07)
 

--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -65,8 +65,8 @@ Facts the daemon can notice about a run, with their sources:
 | Obs | Fact | Source | Cost |
 |-----|------|--------|------|
 | O1 | PR outcome (`open/merged/closed/unknown`) + URL | gh cache via `PRUrl` or branch lookup | cached |
-| O2 | session alive | local mux `IsAlive` / successful lease capture | cheap / lease RTT |
-| O3 | session gone (one dead check) | local `IsAlive=false` / lease `session_not_found` | same |
+| O2 | session alive + ObserverID of the observing channel instance (§10.2) | local mux `IsAlive` / successful lease capture (`CaptureSessionResult.ObserverID`) | cheap / lease RTT |
+| O3 | session gone (one dead check) + ObserverID + GoneClass ∈ {session_absent, server_absent, unclassified}, classified observation-side (§10.2, L11d) | local `IsAlive=false` / structured lease gone verdict (`CaptureSessionResult.Gone`); legacy error strings → unattested unclassified | same |
 | O4 | captured output | local `CapturePane` / `capture_session` lease | cheap / lease RTT (paced 15s) |
 | O4a | — derived: output changed | content hash vs `OutputHash` (excludes status-bar lines) | pure |
 | O4b | — derived: prompt showing (mux agents) | `IsWaitingForInput` string heuristics | pure |
@@ -102,16 +102,18 @@ O3 session gone, count ≥ 3   → O5 git evidence を収集して判定:
    O5: PRUrl set, lookup ok                                        → done/canceled/pr_open
    O5: PRUrl set, lookup fail                                      → pr_open (PR存在は既知)
    O5: commits ahead > 0 or uncommitted                            → waiting
-   O5: no signal, agent=opencode, was-alive                        → done   (opencodeは完了でexitする)
-   O5: no signal, agent=opencode, never-alive, grace超過           → failed
+   O5: no signal, agent=opencode, was-alive, attested              → unknown (session_lost)
+   O5: no signal, agent=opencode, was-alive, unattested            → unknown (observer_unverified, L11c)
+   O5: no signal, agent=opencode, never-alive, grace超過           → failed (evidence ladder: 完了時exitする
+                                                                     agentの無成果+never-alive)
    O5: no signal, agent=opencode, never-alive, grace内             遷移なし
    O5: no signal, agent≠opencode:
-       local,  was-alive                                           → failed
-       local,  never-alive, grace内                                 遷移なし
-       local,  never-alive, grace超過                               → unknown (L3', §7 D-C3)
-       remote, was-alive                                           → failed
-       remote, never-alive, grace内                                 遷移なし
-       remote, never-alive, grace超過                               → unknown
+       was-alive, attested (local/remote共通)                       → failed
+       was-alive, unattested (L11b/c: 死亡宣告chが最後にalive目撃    → unknown (observer_unverified)
+                  したchでない、または観測者不明)
+       never-alive, grace内 (local/remote共通)                      遷移なし
+       never-alive, grace超過                                       → unknown (never_alive; L3', §7 D-C3)
+   attested ⇔ DeadCheckObserver ≠ "" ∧ DeadCheckObserver == AliveObserver
 
 O2 session alive                                                   カウンタreset, WasAlive=true
 O4 captured + PR URL in output   未記録                            → pr_open (+pr artifact)
@@ -153,6 +155,7 @@ O8 launch progress           stageRunCreated                       → queued
 | I6 | every non-terminal run is eventually observed | holds since `monitorAll` lists `queued` as well as the other non-terminal states, so a run orphaned before `booting` still reaches the monitor plane |
 | I7 | a gone session must eventually produce a verdict | holds since L3' (§7 D-C3, 2026-06-12): both planes conclude `unknown` after the never-alive grace |
 | I8 | status-change listeners observe every committed W1 transition | holds since D-C4 (§7, 2026-06-12): `updateStatus` fires once after a successful status append; same-status no-ops and append failures fire nothing |
+| I9 | no `failed` is ever written on the sole testimony of a channel that never observed this run alive | holds since §10 (2026-07-08): the no-evidence fallback verdicts require attestation (L11b); property-swept in `step_observer_test.go` |
 
 I2, I5 (via D-C1), I7 (via D-C3), I6 (`inv-monitor-queued-orphans`) and
 I8 (D-C4, `inv-fire-status-change-all`) were resolved on 2026-06-12. I4's
@@ -232,6 +235,10 @@ distinction the law tests themselves forced:
 | L10a gate debounce (generalizes L6) | a `waiting` verdict with reason `gate_<kind>` requires ≥ `waitingPromptStreakThreshold` consecutive captures whose input-request reading is the same `gate:<kind>`; any busy capture or different reading resets the streak |
 | L10b reading precedence | busy veto > gate > {exited, completed, api-limited, failed} > prompt > output-changed; an unconfirmed gate reading masks every lower reading; each gate row's fixture locks its intended winner end-to-end |
 | L10c reason fidelity | the `waiting` reason always reflects the latest *confirmed* reading; a confirmed reading change re-appends under D-G1 and fires exactly one listener event (L8) |
+| L11a streak continuity | `DeadCheckCount` accumulates only while the observation's ObserverID equals `DeadCheckObserver`; a gone observation from a different observer restarts the streak at 1 (and re-owns it) |
+| L11b attestation | the no-evidence fallback death verdicts (`failed`; opencode's `unknown(session_lost)`) require `DeadCheckObserver == AliveObserver ≠ ""` — the channel pronouncing death must be the channel that last saw this run alive. Evidence-ladder verdicts are channel-independent and unaffected |
+| L11c unverified fallback | the same standing evidence from an unattested channel concludes at most `unknown(observer_unverified)`; never `failed`. Recovery is automatic: any successful capture re-attests the channel |
+| L11d classification locality | gone-class and observer identity are decided at the observing side and travel as structured lease payload; master-side natural-language matching is a frozen legacy shim (`legacyRemoteSessionGone`) that can only feed unattested observations and shrinks to deletion |
 
 ### Status reasons (verdict payload)
 
@@ -247,6 +254,7 @@ travels as a machine-readable `reason` attribute on the status event
 | `agent_exited` | capture verdict: process exited, shell prompt showing | check transcript/worktree; retry plausible |
 | `launch_<step>` | O8 bootstrap failure (`failed` verdict); `<step>` ∈ worktree, prompt, agent_command, multiplexer, opencode_server, session, opencode_bootstrap, bootstrap | the named bootstrap step broke; the paired error artifact carries the detail |
 | `gate_<kind>` (`gate_login`, `gate_trust`, …) | O4e gate reading confirmed by L10a (`waiting` verdict) | `orch attach` and complete the gate interactively; `orch send` will NOT clear it — the run re-asserts `waiting(gate_<kind>)` while the gate persists |
+| `observer_unverified` | L11c: dead-check threshold reached through an unattested channel | the observer cannot see the session — check the worker/daemon mux environment (TMUX socket, #483 class) and worker process; the run self-recovers on the next successful capture |
 
 `orch ps` renders the reason inline (`unknown(never_alive)`); the event log
 carries it as `reason=…`; `StatusChangeEvent.Reason` exposes it to listeners.
@@ -301,7 +309,10 @@ implementation exists (daemon), and the TUI client calls it.
 - **Ephemeral by law (bounded re-convergence)** — deliberately reset on
   restart; L1b guarantees they re-converge within bounded ticks, and the
   reset direction is safe (verdicts/debounce are *delayed*, never wrong):
-  `DeadCheckCount`, `PromptStreak`, `OutputHash`, `LastOutput*`.
+  `DeadCheckCount`, `ReadingKind`/`ReadingStreak` (§9), `OutputHash`,
+  `LastOutput*`, `AliveObserver`/`DeadCheckObserver` (§10 — their reset
+  direction is governed by L7': a restart may soften or delay a would-be
+  `failed` into `unknown(observer_unverified)`, never strengthen).
 
 Rejected alternatives: (a) full observation replay (observations are not
 events; would require recording per-tick captures), (b) persisting counter
@@ -312,6 +323,7 @@ forbids).
 | Law | Statement |
 |-----|-----------|
 | L7 restart transparency | for any observation sequence and any restart point, the sequence of *transition targets* is identical with and without the restart; only their timing may differ, by at most `max(deadCheckThreshold, waitingPromptStreakThreshold)` ticks |
+| L7' verdict-strength monotonicity (amends L7, §10) | a restart of the master or of an observer may *soften or delay* a would-be `failed` into `unknown(observer_unverified)` (until the channel re-attests); it must never strengthen, terminalize, or invent a verdict. L7's target-equality clause is relaxed exactly this far and no further |
 
 ### D-C3 — never-alive verdict asymmetry resolved (implemented 2026-06-12)
 
@@ -596,8 +608,13 @@ before the pattern rows were written, as required.
 
 ## 10. Observation-channel health — death verdicts require attestation (designed 2026-07-07)
 
-Status: **design — accepted pending human review; no implementation yet.**
-Deltas to fold into §2/§3/§4/§5 at implementation time.
+Status: **implemented 2026-07-08.** The deltas of this section are folded
+into §2 (O2/O3 observer fields), §3 (attestation arms of the O5 fallback),
+§4 (I9), §5 (L11a–d, `observer_unverified` reason row), and §7 (D-C1
+ephemeral list, L7'); this section remains as the design record. Observer
+identity is generated per process (`SocketServer.instanceNonce`,
+`Daemon.instanceNonce`), carried in `CaptureSessionResult`; laws are
+property tests in `internal/daemon/step_observer_test.go`.
 
 Trigger — live incident 2026-07-07 22:53: two ALIVE runs (agents actively
 working, sessions intact on the default tmux server) were marked `failed`
@@ -735,16 +752,19 @@ Invariant delta for the §4 table:
    `unclassified`, no ObserverID → unattested → at most `unknown`. Safe
    degradation; upgrade restores `failed` capability.
 
-### 10.6 Follow-ups (do not implement in this issue)
+### 10.6 Follow-ups
 
-- Implementation issue, **frontier + human** (touches `step.go`,
-  `monitor.go`, `worker_plane.go`, proto lease payloads — core surfaces):
-  worker instance nonce + observer context in lease results, local-plane
-  observer identity, `runCore` fields, L11 arms in `stepSessionGone`/
-  `stepGitEvidence`, retirement of `isRemoteSessionGone`, L11/L7'/I9
-  property tests, §2/§3/§4/§5 fold-in.
-- Separate issue (delegable once specced): worker-side git corroboration
-  for worker-hosted dead verdicts via existing `get_diff_stats`/
+- ~~Implementation issue~~ **implemented 2026-07-08**, frontier + human
+  in-session: worker instance nonce + observer context in lease results
+  (`CaptureSessionResult.ObserverID`/`Gone` — JSON lease payload, no proto
+  change needed), local-plane observer identity, `runCore` fields, L11 arms
+  in `stepSessionGone`/`stepGitEvidence`, `isRemoteSessionGone` demoted to
+  the frozen `legacyRemoteSessionGone` shim (unattested-only, deletable
+  once no pre-attestation workers remain), L11/L7'/I9 property tests,
+  §2/§3/§4/§5 fold-in.
+- Separate issue (delegable once specced, still open —
+  `worker-side-git-corroboration`): worker-side git corroboration for
+  worker-hosted dead verdicts via existing `get_diff_stats`/
   `get_branch_state` capabilities (closes the corroboration blindness
   noted in 10.0; benefits the attested path too).
 - Cross-reference: this partially delivers the O12 (worker presence)

--- a/internal/agent/gates.go
+++ b/internal/agent/gates.go
@@ -1,0 +1,106 @@
+package agent
+
+// Interactive-gate detection (run-state-machine.md §9, observation O4e).
+//
+// A gate is a pre-agent full-screen dialog (login, workspace trust, …) that
+// blocks the agent until a human interacts: the pane is stable, matches no
+// busy marker and no composer-prompt pattern, so without these rules the run
+// is indistinguishable from productive work (the 2026-07-07 2h login-screen
+// stall). Detection is gather-side observation vocabulary only — the status
+// transition (waiting, reason gate_<kind>) is decided in the daemon's stepRun
+// after the L10a streak confirms the reading.
+//
+// Contribution contract, enforced mechanically by TestGateRuleTable:
+//   - every rule needs >= 2 conjunctive lowercase substrings (no
+//     single-string rules — the false-positive budget of §9.5);
+//   - every rule needs >= 1 positive fixture in testdata/gates/, a REAL
+//     captured pane named <agent>_<kind>*.txt — never write a rule from
+//     memory of what a screen "probably says";
+//   - the daemon-side fixture test (TestGateFixturePrecedence in
+//     internal/daemon) locks each fixture's intended winner across the full
+//     reading precedence, not just the substring match.
+//
+// opencode contributes no rows: it is observed via its server API, and its
+// login problems surface as O8 bootstrap failures (launch_opencode_*).
+
+import "strings"
+
+// GateKind values are the machine-readable gate vocabulary; the daemon turns
+// them into status reasons as "gate_" + kind.
+const (
+	GateLogin = "login"
+	GateTrust = "trust"
+)
+
+// gateRule declares one gate screen: the gate is detected when ALL substrings
+// co-occur (lowercased) within the last gateWindowLines lines of the pane and
+// no busy marker is visible.
+type gateRule struct {
+	Kind string
+	All  []string
+}
+
+// gateWindowLines matches the IsWaitingForInput window so gate and prompt
+// readings look at the same evidence.
+const gateWindowLines = 40
+
+// gateRules is the compiled-in declarative gate table, keyed by agent name
+// (model.Run.Agent). Append rules here together with their fixture; the
+// meta-test audits every row.
+var gateRules = map[string][]gateRule{
+	string(AgentCodex): {
+		// testdata/gates/codex_login.txt — codex with no auth.json parks at
+		// the ChatGPT sign-in menu.
+		{Kind: GateLogin, All: []string{"sign in with chatgpt", "press enter to continue"}},
+		// testdata/gates/codex_trust.txt — codex in an untrusted directory.
+		{Kind: GateTrust, All: []string{"do you trust the contents of this directory", "press enter to continue"}},
+	},
+	string(AgentClaude): {
+		// testdata/gates/claude_trust.txt — claude code folder-trust dialog.
+		{Kind: GateTrust, All: []string{"is this a project you created or one you trust", "yes, i trust this folder"}},
+	},
+}
+
+// busyMarkers veto both prompt and gate readings: a pane actively working is
+// never waiting for input, even if its transcript quotes gate text.
+var busyMarkers = []string{
+	"esc to interrupt",
+	"working (",
+	"background terminal running",
+}
+
+func hasBusyMarker(lowerLines string) bool {
+	for _, pattern := range busyMarkers {
+		if strings.Contains(lowerLines, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// DetectGate reports the gate kind visible on a captured pane ("" = none)
+// for the given agent backend. The busy-marker veto of IsWaitingForInput
+// applies identically.
+func DetectGate(agentName, output string) string {
+	rules := gateRules[agentName]
+	if len(rules) == 0 {
+		return ""
+	}
+	lines := strings.ToLower(getLastLines(output, gateWindowLines))
+	if hasBusyMarker(lines) {
+		return ""
+	}
+	for _, rule := range rules {
+		matched := true
+		for _, sub := range rule.All {
+			if !strings.Contains(lines, sub) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return rule.Kind
+		}
+	}
+	return ""
+}

--- a/internal/agent/gates_test.go
+++ b/internal/agent/gates_test.go
@@ -1,0 +1,103 @@
+package agent
+
+// Meta-test for the gate-rule table (run-state-machine.md §9.4): every rule
+// is audited mechanically so contributing a gate stays "append one row + one
+// fixture". The daemon-side fixture test (internal/daemon) additionally locks
+// each fixture's winner across the full reading precedence.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gateFixtures returns fixture file paths for (agent, kind):
+// testdata/gates/<agent>_<kind>*.txt.
+func gateFixtures(t *testing.T, agentName, kind string) []string {
+	t.Helper()
+	pattern := filepath.Join("testdata", "gates", agentName+"_"+kind+"*.txt")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob %s: %v", pattern, err)
+	}
+	return matches
+}
+
+func TestGateRuleTable(t *testing.T) {
+	for agentName, rules := range gateRules {
+		for _, rule := range rules {
+			t.Run(agentName+"/"+rule.Kind, func(t *testing.T) {
+				if len(rule.All) < 2 {
+					t.Fatalf("rule %s/%s has %d substrings; the false-positive budget requires >= 2 conjunctive substrings", agentName, rule.Kind, len(rule.All))
+				}
+				for _, sub := range rule.All {
+					if sub != strings.ToLower(sub) {
+						t.Fatalf("rule %s/%s substring %q is not lowercase; matching lowercases the pane first", agentName, rule.Kind, sub)
+					}
+					if strings.TrimSpace(sub) == "" {
+						t.Fatalf("rule %s/%s has an empty substring", agentName, rule.Kind)
+					}
+				}
+
+				fixtures := gateFixtures(t, agentName, rule.Kind)
+				if len(fixtures) == 0 {
+					t.Fatalf("rule %s/%s has no fixture; capture the real screen into testdata/gates/%s_%s.txt — never write rules from memory", agentName, rule.Kind, agentName, rule.Kind)
+				}
+				for _, fixture := range fixtures {
+					pane, err := os.ReadFile(fixture)
+					if err != nil {
+						t.Fatalf("read fixture %s: %v", fixture, err)
+					}
+					if got := DetectGate(agentName, string(pane)); got != rule.Kind {
+						t.Errorf("DetectGate(%s, %s) = %q, want %q", agentName, fixture, got, rule.Kind)
+					}
+					// Busy veto: the identical screen with an in-progress
+					// marker visible is never a gate (an agent quoting gate
+					// text in its transcript must not match).
+					busy := string(pane) + "\nesc to interrupt"
+					if got := DetectGate(agentName, busy); got != "" {
+						t.Errorf("DetectGate(%s, %s + busy marker) = %q, want busy veto", agentName, fixture, got)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestGateFixturesAllOwned rejects orphan fixtures: every file in
+// testdata/gates must correspond to a rule in the table.
+func TestGateFixturesAllOwned(t *testing.T) {
+	files, err := filepath.Glob(filepath.Join("testdata", "gates", "*.txt"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no gate fixtures found; the table meta-test depends on them")
+	}
+	for _, file := range files {
+		base := strings.TrimSuffix(filepath.Base(file), ".txt")
+		owned := false
+		for agentName, rules := range gateRules {
+			for _, rule := range rules {
+				if strings.HasPrefix(base, agentName+"_"+rule.Kind) {
+					owned = true
+				}
+			}
+		}
+		if !owned {
+			t.Errorf("fixture %s matches no gate rule; name it <agent>_<kind>*.txt for an existing rule", file)
+		}
+	}
+}
+
+// TestDetectGateNoRules: backends without rules (opencode, custom, unknown)
+// never detect gates.
+func TestDetectGateNoRules(t *testing.T) {
+	pane := "sign in with chatgpt\npress enter to continue"
+	for _, agentName := range []string{"opencode", "custom", "", "unknown-backend"} {
+		if got := DetectGate(agentName, pane); got != "" {
+			t.Errorf("DetectGate(%q) = %q, want \"\"", agentName, got)
+		}
+	}
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -114,6 +114,9 @@ type AgentManager interface {
 	GetStatus(run *model.Run, output string, state *RunState, outputChanged, hasPrompt bool) model.Status
 	CaptureOutput(run *model.Run) (string, error)
 	DetectPrompt(output string) bool
+	// DetectGate reports the interactive gate kind visible on a captured
+	// output ("" = none) — run-state-machine.md §9 observation O4e.
+	DetectGate(output string) string
 	SendMessage(ctx context.Context, run *model.Run, message string, opts *SendOptions) error
 }
 
@@ -130,7 +133,7 @@ func GetManager(run *model.Run) AgentManager {
 			RunRef:    run.Ref().String(),
 		}
 	}
-	return &MuxManager{SessionName: getSessionName(run)}
+	return &MuxManager{SessionName: getSessionName(run), Agent: run.Agent}
 }
 
 func getSessionName(run *model.Run) string {
@@ -142,6 +145,9 @@ func getSessionName(run *model.Run) string {
 
 type MuxManager struct {
 	SessionName string
+	// Agent is the backend name (model.Run.Agent); it selects the gate-rule
+	// table for DetectGate. Empty = no gate detection.
+	Agent string
 }
 
 func (m *MuxManager) IsAlive(run *model.Run) bool {
@@ -178,6 +184,10 @@ func (m *MuxManager) CaptureOutput(run *model.Run) (string, error) {
 
 func (m *MuxManager) DetectPrompt(output string) bool {
 	return IsWaitingForInput(output)
+}
+
+func (m *MuxManager) DetectGate(output string) string {
+	return DetectGate(m.Agent, output)
 }
 
 func (m *MuxManager) GetStatus(run *model.Run, output string, state *RunState, outputChanged, hasPrompt bool) model.Status {
@@ -308,6 +318,12 @@ func FormatOpenCodeMessages(messages []Message, maxLines int) string {
 
 func (m *OpenCodeManager) DetectPrompt(output string) bool {
 	return false
+}
+
+// DetectGate always reports none: opencode is observed via its server API,
+// and its login problems surface as O8 bootstrap failures instead.
+func (m *OpenCodeManager) DetectGate(output string) string {
+	return ""
 }
 
 const recentActivityThreshold = 30 * time.Second
@@ -446,16 +462,10 @@ func IsWaitingForInput(output string) bool {
 	lines := strings.ToLower(getLastLines(output, 40))
 
 	// Codex keeps shortcut hints visible even while actively working.
-	// Treat explicit in-progress markers as stronger signals than prompt hints.
-	busyPatterns := []string{
-		"esc to interrupt",
-		"working (",
-		"background terminal running",
-	}
-	for _, pattern := range busyPatterns {
-		if strings.Contains(lines, pattern) {
-			return false
-		}
+	// Treat explicit in-progress markers as stronger signals than prompt
+	// hints. The same veto applies to gate detection (gates.go).
+	if hasBusyMarker(lines) {
+		return false
 	}
 
 	promptPatterns := []string{

--- a/internal/agent/testdata/gates/claude_trust.txt
+++ b/internal/agent/testdata/gates/claude_trust.txt
@@ -1,0 +1,24 @@
+
+────────────────────────────────────────────────────────────────────────────────
+ Accessing workspace:
+
+ /private/tmp/claude-2145596008/-Users-s22625-repos-orch/78ae59d0-0a34-46cc-93a
+ e-f9cc248d9cc7/scratchpad/gate-trust-claude
+
+ Quick safety check: Is this a project you created or one you trust? (Like your
+ own code, a well-known open source project, or work from your team). If not,
+ take a moment to review what's in this folder first.
+
+ Claude Code'll be able to read, edit, and execute files here.
+
+ Security guide
+
+ ❯ 1. Yes, I trust this folder
+   2. No, exit
+
+ Enter to confirm · Esc to cancel
+
+
+
+
+

--- a/internal/agent/testdata/gates/codex_login.txt
+++ b/internal/agent/testdata/gates/codex_login.txt
@@ -1,0 +1,24 @@
+  Welcome to Codex, OpenAI's command-line coding agent
+
+  Sign in with ChatGPT to use Codex as part of your paid plan
+  or connect an API key for usage-based billing
+
+> 1. Sign in with ChatGPT
+     Usage included with Plus, Pro, Business, and Enterprise plans
+
+  2. Sign in with Device Code
+     Sign in from another device with a one-time code
+
+  3. Provide your own API key
+     Pay for what you use
+
+  Press enter to continue
+
+
+
+
+
+
+
+
+

--- a/internal/agent/testdata/gates/codex_trust.txt
+++ b/internal/agent/testdata/gates/codex_trust.txt
@@ -1,0 +1,24 @@
+> You are in /private/tmp/claude-2145596008/-Users-s22625-repos-orch/78ae59d0-0a
+
+  Do you trust the contents of this directory? Working with untrusted contents
+  comes with higher risk of prompt injection. Trusting the directory allows
+  project-local config, hooks, and exec policies to load.
+
+› 1. Yes, continue
+  2. No, quit
+
+  Press enter to continue
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -464,10 +464,12 @@ func (d *Daemon) runLiveness(run *model.Run) (alive, known bool) {
 	return state.WasAlive && state.DeadCheckCount == 0, true
 }
 
-// noteRunFeedback resets a run's prompt debounce when feedback is delivered
-// to its agent session: the idle prompt may still be on screen for the next
-// capture or two, and must not flip the run straight back to waiting before
-// the agent starts working on the feedback.
+// noteRunFeedback resets a run's input-reading debounce when feedback is
+// delivered to its agent session: the idle prompt may still be on screen for
+// the next capture or two, and must not flip the run straight back to
+// waiting before the agent starts working on the feedback. A standing gate
+// re-confirms after one streak threshold and returns the run to
+// waiting(gate_<kind>) — that is the signal that send did not help (§9.3).
 func (d *Daemon) noteRunFeedback(run *model.Run) {
 	if run == nil {
 		return
@@ -476,7 +478,8 @@ func (d *Daemon) noteRunFeedback(run *model.Run) {
 	defer d.mu.Unlock()
 
 	if state, ok := d.runStates[run.Ref().String()]; ok {
-		state.PromptStreak = 0
+		state.ReadingKind = ""
+		state.ReadingStreak = 0
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -63,8 +63,15 @@ type Daemon struct {
 
 	// remoteCaptureFn captures session output for runs executing on another
 	// host via the worker plane. Overridable in tests; defaults to the
-	// socket server's worker-lease capture.
-	remoteCaptureFn func(run *model.Run, projectID, projectRoot string, lines int) (string, error)
+	// socket server's worker-lease capture. The result carries the worker's
+	// observer identity and structured gone verdicts (§10.2).
+	remoteCaptureFn func(run *model.Run, projectID, projectRoot string, lines int) (*CaptureSessionResult, error)
+
+	// instanceNonce makes this daemon process a distinct local observation
+	// channel: localObserverID() = local:<nonce> (§10.2). Regenerated per
+	// process start, so a restarted daemon re-attests before its dead
+	// checks can support a failed verdict (L7').
+	instanceNonce string
 
 	// PR lookup functions are overridable in tests; defaults use the cached
 	// PR package lookups.
@@ -101,7 +108,14 @@ func New(factory StoreFactory) *Daemon {
 		runStates:     make(map[string]*RunState),
 		lastFetchAt:   make(map[string]time.Time),
 		fetchInFlight: make(map[string]bool),
+		instanceNonce: generateMonitorID()[:12],
 	}
+}
+
+// localObserverID identifies this daemon process as the local observation
+// channel instance (run-state-machine.md §10.2).
+func (d *Daemon) localObserverID() string {
+	return "local:" + d.instanceNonce
 }
 
 // SetInterval sets the monitoring interval

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -168,6 +168,7 @@ func gatherAgentSignal(run *model.Run, mgr agent.AgentManager, output string) ag
 		APILimited:    agent.IsAPILimited(output),
 		Failed:        agent.IsFailed(output),
 		PromptShowing: mgr.DetectPrompt(output),
+		Gate:          mgr.DetectGate(output),
 	}
 }
 
@@ -427,22 +428,27 @@ func (s *RunState) resetCaptureFailure() {
 	s.SuppressedCaptureLogs = 0
 }
 
-// recordPromptStreak is the pure prompt-debounce rule shared by stepRun and
-// RunState.recordPromptSignal: a prompt must persist for
-// waitingPromptStreakThreshold consecutive captures before it counts.
-func recordPromptStreak(streak int, hasPrompt bool) (int, bool) {
-	if hasPrompt {
-		streak++
-	} else {
-		streak = 0
+// recordInputReadingStreak is the pure input-request debounce rule (L10a,
+// generalizing the L6 prompt streak over reading kinds): a reading must
+// persist for waitingPromptStreakThreshold consecutive captures of the SAME
+// kind before it counts; any different reading (including "" = busy/none)
+// resets the streak. L6 is the reading = "prompt" special case.
+func recordInputReadingStreak(prevKind string, prevStreak int, reading string) (string, int, bool) {
+	if reading == "" {
+		return "", 0, false
 	}
-	return streak, hasPrompt && streak >= waitingPromptStreakThreshold
+	streak := 1
+	if reading == prevKind {
+		streak = prevStreak + 1
+	}
+	return reading, streak, streak >= waitingPromptStreakThreshold
 }
 
-func (s *RunState) recordPromptSignal(hasPrompt bool) bool {
-	streak, stable := recordPromptStreak(s.PromptStreak, hasPrompt)
-	s.PromptStreak = streak
-	return stable
+func (s *RunState) recordInputReading(reading string) bool {
+	kind, streak, confirmed := recordInputReadingStreak(s.ReadingKind, s.ReadingStreak, reading)
+	s.ReadingKind = kind
+	s.ReadingStreak = streak
+	return confirmed
 }
 
 func captureBackoffDuration(err error, failures int) time.Duration {

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -105,10 +105,10 @@ func (d *Daemon) monitorRun(run *model.Run, st store.Store, projectID, projectRo
 				d.logger.Printf("%s#%s: opencode bootstrap logs: %s", run.IssueID, run.RunID, logPath)
 			}
 		}
-		return d.applyGoneObservation(run, st, state, projectRoot, false)
+		return d.applyGoneObservation(run, st, state, projectRoot, false, d.localObserverID(), localGoneClass(run))
 	}
 
-	if _, err := d.applyStep(run, st, state, runObservation{Kind: obsSessionAlive}, projectRoot); err != nil {
+	if _, err := d.applyStep(run, st, state, runObservation{Kind: obsSessionAlive, Observer: d.localObserverID()}, projectRoot); err != nil {
 		return err
 	}
 
@@ -225,8 +225,15 @@ func (d *Daemon) applyRunEffects(run *model.Run, st store.Store, oldCore, core r
 // applyGoneObservation feeds one dead check through stepRun and, when the
 // policy requests it, gathers git/PR evidence and feeds that back as a
 // second observation. The shell never decides whether evidence is needed.
-func (d *Daemon) applyGoneObservation(run *model.Run, st store.Store, state *RunState, projectRoot string, remote bool) error {
-	effects, err := d.applyStep(run, st, state, runObservation{Kind: obsSessionGone, Remote: remote}, projectRoot)
+// observer/goneClass carry the observing channel's identity and its local
+// classification (§10.2) — attestation over them is stepRun policy.
+func (d *Daemon) applyGoneObservation(run *model.Run, st store.Store, state *RunState, projectRoot string, remote bool, observer, goneClass string) error {
+	effects, err := d.applyStep(run, st, state, runObservation{
+		Kind:      obsSessionGone,
+		Remote:    remote,
+		Observer:  observer,
+		GoneClass: goneClass,
+	}, projectRoot)
 	if err != nil {
 		return err
 	}
@@ -275,14 +282,17 @@ func (d *Daemon) monitorRemoteRun(run *model.Run, st store.Store, projectID, pro
 		capture = d.socketServer.captureRunOutputViaWorker
 	}
 
-	output, err := capture(run, projectID, projectRoot, remoteCaptureLines)
+	result, err := capture(run, projectID, projectRoot, remoteCaptureLines)
 	if err != nil {
-		if isRemoteSessionGone(err) {
-			// The worker answered authoritatively: the lease round-trip
-			// completed, so pace re-checks like successful captures instead
-			// of retrying every monitor tick.
+		if legacyRemoteSessionGone(err) {
+			// Legacy shim: an old worker without observer context reported
+			// the session gone as an error string. The observation carries
+			// no ObserverID, so it can never attest — it supports at most
+			// unknown(observer_unverified) (L11d safe degradation). The
+			// lease round-trip completed, so pace re-checks like successful
+			// captures instead of retrying every monitor tick.
 			state.RemoteCaptureAt = now
-			return d.applyGoneObservation(run, st, state, projectRoot, true)
+			return d.applyGoneObservation(run, st, state, projectRoot, true, "", goneClassUnclassified)
 		}
 
 		// Worker-plane infrastructure failure (worker offline, lease
@@ -302,15 +312,26 @@ func (d *Daemon) monitorRemoteRun(run *model.Run, st store.Store, projectID, pro
 		}
 		return nil
 	}
+	if result == nil {
+		return nil
+	}
+
+	if result.Gone != nil {
+		// The worker classified the session as gone where the facts are
+		// local (L11d) and identified itself; whether its testimony can
+		// support a death verdict is attestation policy in stepRun (L11a-c).
+		state.RemoteCaptureAt = now
+		return d.applyGoneObservation(run, st, state, projectRoot, true, result.ObserverID, result.Gone.Class)
+	}
 
 	state.resetCaptureFailure()
 	state.RemoteCaptureAt = now
 
-	if _, err := d.applyStep(run, st, state, runObservation{Kind: obsSessionAlive}, projectRoot); err != nil {
+	if _, err := d.applyStep(run, st, state, runObservation{Kind: obsSessionAlive, Observer: result.ObserverID}, projectRoot); err != nil {
 		return err
 	}
 
-	return d.processRunOutput(run, st, state, mgr, output)
+	return d.processRunOutput(run, st, state, mgr, result.Content)
 }
 
 // remoteRunWorkerEndpoint identifies the worker/session pair a remote run is
@@ -330,11 +351,14 @@ func remoteRunWorkerEndpoint(run *model.Run) string {
 	return workerID + ":" + sessionName
 }
 
-// isRemoteSessionGone reports whether a worker-lease capture error means the
-// session (or its run record) is genuinely gone on the execution host. Worker
-// plane infrastructure errors must NOT count as agent death — default to
-// false for anything ambiguous.
-func isRemoteSessionGone(err error) bool {
+// legacyRemoteSessionGone is the DEPRECATED string-matching shim for workers
+// that predate structured gone verdicts (§10.2). New workers classify gone
+// observations locally and ship them as CaptureSessionResult.Gone; errors
+// matched here carry no observer context, so they can never attest a death —
+// the resulting observation concludes at most unknown(observer_unverified)
+// (L11d). Delete this once no pre-attestation workers remain; never extend
+// the pattern list.
+func legacyRemoteSessionGone(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -351,6 +375,24 @@ func isRemoteSessionGone(err error) bool {
 		strings.Contains(msg, "no server running") ||
 		strings.Contains(msg, "can't find pane") ||
 		strings.Contains(msg, "can't find session")
+}
+
+// localGoneClass classifies a local-plane gone observation from the daemon
+// shell's own mux view (§10.2 — decided where the facts are local).
+// Diagnostic payload only.
+func localGoneClass(run *model.Run) string {
+	if run.Agent == string(agent.AgentOpenCode) {
+		// The opencode manager conflates server-down and session-missing in
+		// its boolean IsAlive; leave the class open rather than guess.
+		return goneClassUnclassified
+	}
+	sessions, _ := agent.GetMuxCache()
+	if sessions == nil {
+		// The session list itself could not be obtained: no mux server on
+		// this daemon's socket.
+		return goneClassServerAbsent
+	}
+	return goneClassSessionAbsent
 }
 
 func captureEndpointKey(run *model.Run, mgr agent.AgentManager) string {

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -279,6 +279,10 @@ func TestStatusChangeListenersFireOnceForMonitorTransitionPaths(t *testing.T) {
 			setupState: func(state *RunState) {
 				state.WasAlive = true
 				state.DeadCheckCount = deadChecksBeforeFailed
+				// Attested channel (L11b): the observer owning the dead-check
+				// streak is the one that last saw the run alive.
+				state.AliveObserver = "local:n1"
+				state.DeadCheckObserver = "local:n1"
 			},
 			obs:      runObservation{Kind: obsGitEvidence},
 			wantFrom: model.StatusRunning,
@@ -1022,9 +1026,12 @@ func TestMonitorAllObservesQueuedNeverAliveRun(t *testing.T) {
 			registerRepoContextForTest(t, d.socketServer, "project-queued", "", st)
 
 			captures := 0
-			d.remoteCaptureFn = func(*model.Run, string, string, int) (string, error) {
+			d.remoteCaptureFn = func(*model.Run, string, string, int) (*CaptureSessionResult, error) {
 				captures++
-				return "", errors.New("session_not_found")
+				return &CaptureSessionResult{
+					ObserverID: "worker:host-local:n1",
+					Gone:       &SessionGoneResult{Class: goneClassSessionAbsent},
+				}, nil
 			}
 
 			for i := 0; i < deadChecksBeforeFailed; i++ {
@@ -1060,9 +1067,12 @@ func TestMonitorAllObservesQueuedNeverAliveRun(t *testing.T) {
 func TestMonitorRemoteRunDetectsPROpenFromWorkerCapture(t *testing.T) {
 	d := newTestDaemon()
 	captures := 0
-	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (string, error) {
+	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (*CaptureSessionResult, error) {
 		captures++
-		return "work done\nopened https://github.com/org/repo/pull/99 for review\n", nil
+		return &CaptureSessionResult{
+			Content:    "work done\nopened https://github.com/org/repo/pull/99 for review\n",
+			ObserverID: "worker:host-CA-1:n1",
+		}, nil
 	}
 
 	run := newRemoteTestRun(model.StatusRunning)
@@ -1098,8 +1108,8 @@ func TestMonitorRemoteRunDetectsPROpenFromWorkerCapture(t *testing.T) {
 
 func TestMonitorRemoteRunInfraErrorBacksOffWithoutDeathCount(t *testing.T) {
 	d := newTestDaemon()
-	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (string, error) {
-		return "", errors.New(`no active worker available for target "host-CA-1"; start orch-worker with --worker-id host-CA-1 on the target host`)
+	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (*CaptureSessionResult, error) {
+		return nil, errors.New(`no active worker available for target "host-CA-1"; start orch-worker with --worker-id host-CA-1 on the target host`)
 	}
 
 	run := newRemoteTestRun(model.StatusRunning)
@@ -1127,8 +1137,11 @@ func TestMonitorRemoteRunInfraErrorBacksOffWithoutDeathCount(t *testing.T) {
 
 func TestMonitorRemoteRunSessionGoneNeverAliveMarksUnknown(t *testing.T) {
 	d := newTestDaemon()
-	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (string, error) {
-		return "", errors.New("session run-ISSUE-REMOTE-1-run-1 not found (run may not be active)")
+	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (*CaptureSessionResult, error) {
+		return &CaptureSessionResult{
+			ObserverID: "worker:host-CA-1:n1",
+			Gone:       &SessionGoneResult{Class: goneClassSessionAbsent},
+		}, nil
 	}
 
 	run := newRemoteTestRun(model.StatusRunning)
@@ -1156,9 +1169,12 @@ func TestMonitorRemoteRunSessionGoneNeverAliveMarksUnknown(t *testing.T) {
 func TestMonitorRemoteRunSessionGonePacesLeaseRoundTrips(t *testing.T) {
 	d := newTestDaemon()
 	captures := 0
-	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (string, error) {
+	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (*CaptureSessionResult, error) {
 		captures++
-		return "", errors.New("session run-ISSUE-REMOTE-1-run-1 not found (run may not be active)")
+		return &CaptureSessionResult{
+			ObserverID: "worker:host-CA-1:n1",
+			Gone:       &SessionGoneResult{Class: goneClassSessionAbsent},
+		}, nil
 	}
 
 	run := newRemoteTestRun(model.StatusRunning)
@@ -1182,8 +1198,11 @@ func TestMonitorRemoteRunSessionGonePacesLeaseRoundTrips(t *testing.T) {
 
 func TestMonitorRemoteRunSessionGoneWithRecordedPRInfersPROpen(t *testing.T) {
 	d := newTestDaemon()
-	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (string, error) {
-		return "", errors.New("session run-ISSUE-REMOTE-1-run-1 not found (run may not be active)")
+	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (*CaptureSessionResult, error) {
+		return &CaptureSessionResult{
+			ObserverID: "worker:host-CA-1:n1",
+			Gone:       &SessionGoneResult{Class: goneClassSessionAbsent},
+		}, nil
 	}
 
 	run := newRemoteTestRun(model.StatusRunning)
@@ -1212,8 +1231,11 @@ func TestMonitorRemoteRunSessionGoneWithRecordedPRInfersPROpen(t *testing.T) {
 
 func TestMonitorRemoteRunSessionGoneNeverAliveWithinGraceWaits(t *testing.T) {
 	d := newTestDaemon()
-	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (string, error) {
-		return "", errors.New("session run-ISSUE-REMOTE-1-run-1 not found (run may not be active)")
+	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (*CaptureSessionResult, error) {
+		return &CaptureSessionResult{
+			ObserverID: "worker:host-CA-1:n1",
+			Gone:       &SessionGoneResult{Class: goneClassSessionAbsent},
+		}, nil
 	}
 
 	run := newRemoteTestRun(model.StatusBooting)
@@ -1234,16 +1256,72 @@ func TestMonitorRemoteRunSessionGoneNeverAliveWithinGraceWaits(t *testing.T) {
 	}
 }
 
+// The worker that has been capturing the run all along reports it gone: the
+// channel is attested, so the death verdict concludes failed exactly as
+// before §10 (counterexample 10.5#2).
 func TestMonitorRemoteRunSessionGoneAfterAliveMarksFailed(t *testing.T) {
 	d := newTestDaemon()
-	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (string, error) {
-		return "", errors.New("not_found")
+	observer := "worker:host-CA-1:n1"
+	alive := true
+	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (*CaptureSessionResult, error) {
+		if alive {
+			return &CaptureSessionResult{Content: "agent working", ObserverID: observer}, nil
+		}
+		return &CaptureSessionResult{
+			ObserverID: observer,
+			Gone:       &SessionGoneResult{Class: goneClassSessionAbsent},
+		}, nil
 	}
 
 	run := newRemoteTestRun(model.StatusRunning)
-	st := &mockStoreForUpdate{issue: &model.Issue{ID: "ISSUE-REMOTE-1", Status: model.IssueStatusOpen}}
+	st := &mockStoreRecordingEvents{mockStoreForUpdate: mockStoreForUpdate{issue: &model.Issue{ID: "ISSUE-REMOTE-1", Status: model.IssueStatusOpen}}}
+	state := d.getOrCreateState(run)
+	mgr := agent.GetManager(run)
+
+	// One successful capture attests the channel for this run.
+	if err := d.monitorRemoteRun(run, st, "proj", "/root", state, mgr); err != nil {
+		t.Fatalf("monitorRemoteRun() alive capture error = %v", err)
+	}
+	if state.AliveObserver != observer {
+		t.Fatalf("AliveObserver = %q, want %q", state.AliveObserver, observer)
+	}
+
+	alive = false
+	for i := 0; i < deadChecksBeforeFailed; i++ {
+		state.RemoteCaptureAt = time.Now().Add(-2 * remoteCaptureInterval)
+		if err := d.monitorRemoteRun(run, st, "proj", "/root", state, mgr); err != nil {
+			t.Fatalf("monitorRemoteRun() call %d error = %v", i+1, err)
+		}
+	}
+
+	var failed bool
+	for _, event := range st.events {
+		if event.Type == model.EventTypeStatus && event.Name == string(model.StatusFailed) {
+			failed = true
+		}
+	}
+	if !failed {
+		t.Fatalf("attested dead channel must conclude failed, events=%+v", st.events)
+	}
+}
+
+// I9/L11c: the same gone reports from a channel that NEVER saw this run
+// alive (fresh worker instance after a restart, poisoned mux socket — the
+// 2026-07-07 incident) conclude unknown(observer_unverified), never failed.
+func TestMonitorRemoteRunSessionGoneUnattestedObserverMarksUnknown(t *testing.T) {
+	d := newTestDaemon()
+	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (*CaptureSessionResult, error) {
+		return &CaptureSessionResult{
+			ObserverID: "worker:host-CA-1:fresh-instance",
+			Gone:       &SessionGoneResult{Class: goneClassServerAbsent},
+		}, nil
+	}
+
+	run := newRemoteTestRun(model.StatusRunning)
+	st := &mockStoreRecordingEvents{mockStoreForUpdate: mockStoreForUpdate{issue: &model.Issue{ID: "ISSUE-REMOTE-1", Status: model.IssueStatusOpen}}}
 	state := d.getOrCreateState(run)
 	state.WasAlive = true
+	state.AliveObserver = "worker:host-CA-1:dead-old-instance"
 	mgr := agent.GetManager(run)
 
 	for i := 0; i < deadChecksBeforeFailed; i++ {
@@ -1253,12 +1331,24 @@ func TestMonitorRemoteRunSessionGoneAfterAliveMarksFailed(t *testing.T) {
 		}
 	}
 
-	if st.appendEventCalls != 1 {
-		t.Fatalf("expected exactly one failed status event, got %d", st.appendEventCalls)
+	for _, event := range st.events {
+		if event.Type == model.EventTypeStatus && event.Name == string(model.StatusFailed) {
+			t.Fatalf("unattested observer produced a failed verdict (I9 violation): %+v", st.events)
+		}
+	}
+	var unverified bool
+	for _, event := range st.events {
+		if event.Type == model.EventTypeStatus && event.Name == string(model.StatusUnknown) &&
+			event.Attrs[model.AttrStatusReason] == model.StatusReasonObserverUnverified {
+			unverified = true
+		}
+	}
+	if !unverified {
+		t.Fatalf("expected unknown(observer_unverified), events=%+v", st.events)
 	}
 }
 
-func TestIsRemoteSessionGoneClassification(t *testing.T) {
+func TestLegacyRemoteSessionGoneClassification(t *testing.T) {
 	gone := []string{
 		"not_found",
 		"session run-x-1 not found (run may not be active)",
@@ -1266,7 +1356,7 @@ func TestIsRemoteSessionGoneClassification(t *testing.T) {
 		"can't find pane run-x-1",
 	}
 	for _, msg := range gone {
-		if !isRemoteSessionGone(errors.New(msg)) {
+		if !legacyRemoteSessionGone(errors.New(msg)) {
 			t.Errorf("expected session-gone classification for %q", msg)
 		}
 	}
@@ -1279,7 +1369,7 @@ func TestIsRemoteSessionGoneClassification(t *testing.T) {
 		"dial tcp 1.2.3.4:7777: connect: connection refused",
 	}
 	for _, msg := range infra {
-		if isRemoteSessionGone(errors.New(msg)) {
+		if legacyRemoteSessionGone(errors.New(msg)) {
 			t.Errorf("expected infra classification for %q", msg)
 		}
 	}

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -37,28 +37,41 @@ func TestHashContentIgnoresStatusBar(t *testing.T) {
 	}
 }
 
-func TestRunStateRecordPromptSignalDebounce(t *testing.T) {
+func TestRunStateRecordInputReadingDebounce(t *testing.T) {
 	state := &RunState{}
 
-	if state.recordPromptSignal(true) {
+	if state.recordInputReading("prompt") {
 		t.Fatal("expected first prompt observation to be unstable")
 	}
-	if state.PromptStreak != 1 {
-		t.Fatalf("prompt streak after first prompt = %d, want 1", state.PromptStreak)
+	if state.ReadingKind != "prompt" || state.ReadingStreak != 1 {
+		t.Fatalf("reading after first prompt = (%q, %d), want (prompt, 1)", state.ReadingKind, state.ReadingStreak)
 	}
 
-	if !state.recordPromptSignal(true) {
+	if !state.recordInputReading("prompt") {
 		t.Fatal("expected second consecutive prompt observation to become stable")
 	}
-	if state.PromptStreak != 2 {
-		t.Fatalf("prompt streak after second prompt = %d, want 2", state.PromptStreak)
+	if state.ReadingStreak != 2 {
+		t.Fatalf("streak after second prompt = %d, want 2", state.ReadingStreak)
 	}
 
-	if state.recordPromptSignal(false) {
-		t.Fatal("expected non-prompt observation to clear stable state")
+	if state.recordInputReading("") {
+		t.Fatal("expected busy/none observation to clear stable state")
 	}
-	if state.PromptStreak != 0 {
-		t.Fatalf("prompt streak after reset = %d, want 0", state.PromptStreak)
+	if state.ReadingKind != "" || state.ReadingStreak != 0 {
+		t.Fatalf("reading after reset = (%q, %d), want (\"\", 0)", state.ReadingKind, state.ReadingStreak)
+	}
+
+	// A reading-kind change restarts the streak at 1 (L10a): a gate right
+	// after a prompt must re-earn its confirmation.
+	state.recordInputReading("prompt")
+	if state.recordInputReading("gate:login") {
+		t.Fatal("kind change must not be confirmed immediately")
+	}
+	if state.ReadingKind != "gate:login" || state.ReadingStreak != 1 {
+		t.Fatalf("reading after kind change = (%q, %d), want (gate:login, 1)", state.ReadingKind, state.ReadingStreak)
+	}
+	if !state.recordInputReading("gate:login") {
+		t.Fatal("expected second consecutive gate observation to become stable")
 	}
 }
 
@@ -355,15 +368,16 @@ func TestNoteRunFeedbackResetsPromptDebounce(t *testing.T) {
 	run := &model.Run{IssueID: "i1", RunID: "r1"}
 
 	state := d.getOrCreateState(run)
-	state.PromptStreak = 5 // idle at prompt for several captures
+	state.ReadingKind = "prompt"
+	state.ReadingStreak = 5 // idle at prompt for several captures
 
 	d.noteRunFeedback(run)
 
-	if state.PromptStreak != 0 {
-		t.Fatalf("expected prompt streak reset after feedback, got %d", state.PromptStreak)
+	if state.ReadingKind != "" || state.ReadingStreak != 0 {
+		t.Fatalf("expected input-reading reset after feedback, got (%q, %d)", state.ReadingKind, state.ReadingStreak)
 	}
 	// A lingering prompt on the very next capture must not be "stable" yet.
-	if state.recordPromptSignal(true) {
+	if state.recordInputReading("prompt") {
 		t.Fatal("single post-feedback prompt capture must not count as a stable prompt")
 	}
 }

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -790,13 +790,15 @@ func resolveWorkerTargetForRunFields(run *model.Run, projectRoot string) (*resol
 // captureRunOutputViaWorker captures session output for a run executing on
 // another host by delegating a capture_session effect to that host's worker.
 // Unlike the RPC path it waits with a short timeout so the daemon monitor
-// loop is never blocked for long.
-func (s *SocketServer) captureRunOutputViaWorker(run *model.Run, projectID, projectRoot string, lines int) (string, error) {
+// loop is never blocked for long. The result carries the worker's observer
+// identity and, when the worker determined the session is gone, its
+// structured gone verdict (§10.2) — the caller must check result.Gone.
+func (s *SocketServer) captureRunOutputViaWorker(run *model.Run, projectID, projectRoot string, lines int) (*CaptureSessionResult, error) {
 	if run == nil {
-		return "", fmt.Errorf("run required")
+		return nil, fmt.Errorf("run required")
 	}
 	if strings.TrimSpace(projectID) == "" {
-		return "", fmt.Errorf("no project context available for remote run %s#%s", run.IssueID, run.RunID)
+		return nil, fmt.Errorf("no project context available for remote run %s#%s", run.IssueID, run.RunID)
 	}
 	if lines <= 0 {
 		lines = 100
@@ -804,7 +806,7 @@ func (s *SocketServer) captureRunOutputViaWorker(run *model.Run, projectID, proj
 
 	target, err := resolveWorkerTargetForRunFields(run, projectRoot)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	payload := &WorkerEffectPayload{
@@ -819,20 +821,20 @@ func (s *SocketServer) captureRunOutputViaWorker(run *model.Run, projectID, proj
 
 	lease, err := s.acquireWorkerLease(projectID, "capture_session", string(run.IssueID), string(run.RunID), payload)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	completedLease, err := s.waitForWorkerLeaseCompletion(lease.LeaseID, remoteCaptureLeaseTimeout)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	effectResult, err := decodeWorkerEffectResult(completedLease.ResultJSON)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if effectResult.CaptureResult == nil {
-		return "", fmt.Errorf("worker lease completed without capture_result")
+		return nil, fmt.Errorf("worker lease completed without capture_result")
 	}
-	return effectResult.CaptureResult.Content, nil
+	return effectResult.CaptureResult, nil
 }
 
 func (s *SocketServer) handleProtoPing(_ *orchpb.PingRequest) *orchpb.Response {
@@ -2389,6 +2391,12 @@ func (s *SocketServer) handleProtoCaptureSession(req *orchpb.CaptureSessionReque
 		}
 		if effectResult.CaptureResult == nil {
 			return errorResponse("worker lease completed without capture_result")
+		}
+		if gone := effectResult.CaptureResult.Gone; gone != nil {
+			// Fail fast: a structured gone verdict must never surface as a
+			// silent empty capture to the client.
+			return errorResponse(fmt.Sprintf("session not found on worker %s for run %s#%s (%s)",
+				target.WorkerID, runCtx.run.IssueID, runCtx.run.RunID, gone.Class))
 		}
 
 		return &orchpb.Response{

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -321,6 +321,9 @@ type SocketServer struct {
 
 	currentWorkerID   string
 	currentWorkerHost string
+	// instanceNonce makes this process a distinct observation-channel
+	// instance (§10.2): observerID() = worker:<id>:<nonce> / local:<nonce>.
+	instanceNonce string
 
 	runEventBus *RunEventBus
 
@@ -387,6 +390,7 @@ func NewSocketServer(factory StoreFactory, logger Logger) *SocketServer {
 		openCodeServers:     make(map[string]*managedServer),
 		workerAuthToken:     strings.TrimSpace(os.Getenv("ORCH_WORKER_AUTH_TOKEN")),
 		runEventBus:         NewRunEventBus(),
+		instanceNonce:       generateMonitorID()[:12],
 	}
 	s.gitRunner = git.NewRunner()
 	s.procManager = newSocketProcessManager(s)

--- a/internal/daemon/status_commit.go
+++ b/internal/daemon/status_commit.go
@@ -29,10 +29,14 @@ func commitRunStatus(st store.Store, run *model.Run, status model.Status, reason
 	var fromStatus model.Status
 	if currentRun, err := st.GetRun(ref); err == nil && currentRun != nil {
 		fromStatus = currentRun.Status
-		// Re-affirming the current status is a no-op: appending duplicate
-		// status events bloats the run record and churns UpdatedAt, which
-		// breaks recency display/sorting for every client.
-		if fromStatus == status {
+		// Re-affirming the current (status, reason) pair is a no-op:
+		// appending duplicate status events bloats the run record and churns
+		// UpdatedAt, which breaks recency display/sorting for every client.
+		// The no-op identity is the PAIR (§9.3 D-G1): a run already waiting
+		// on its normal prompt that then hits a gate must not keep a stale
+		// reason forever, so a confirmed reading change re-appends and fires
+		// the listener once (L8/L10c).
+		if fromStatus == status && currentRun.StatusReason() == reason {
 			return fromStatus, false, nil
 		}
 		if !model.CanTransitionStatus(currentRun.Status, status, model.EventSourceDaemon) {

--- a/internal/daemon/step.go
+++ b/internal/daemon/step.go
@@ -67,6 +67,14 @@ type runCore struct {
 	PRRecorded     bool
 	WasAlive       bool
 	DeadCheckCount int
+	// AliveObserver is the ObserverID of the most recent successful
+	// alive/capture observation ("" = none since restart); DeadCheckObserver
+	// owns the current dead-check streak (run-state-machine.md §10.2). Both
+	// are ephemeral by law (§7 D-C1): a restart may soften or delay a
+	// would-be failed into unknown(observer_unverified) — never strengthen
+	// (L7').
+	AliveObserver     string
+	DeadCheckObserver string
 }
 
 // initialRunCore derives the fold-derivable runCore fields from the run's
@@ -216,6 +224,15 @@ type runObservation struct {
 	// obsSessionGone / obsGitEvidence
 	Remote bool
 
+	// obsSessionAlive / obsSessionGone: identity of the observing channel
+	// instance (worker:<id>:<nonce> / local:<nonce>; "" = legacy channel
+	// without observer context, which can never attest — §10.2).
+	Observer string
+	// obsSessionGone: observation-side gone classification
+	// (session_absent / server_absent / unclassified). Diagnostic payload
+	// only — the verification predicate is attestation, not the class.
+	GoneClass string
+
 	// obsCaptured
 	Output string
 	Signal agentSignal
@@ -306,6 +323,11 @@ func stepRun(view runView, core runCore, obs runObservation, now time.Time) (run
 	case obsSessionAlive:
 		core.WasAlive = true
 		core.DeadCheckCount = 0
+		core.DeadCheckObserver = ""
+		// A successful observation attests the channel for this run (L11b):
+		// only the channel that last saw the run alive may pronounce the
+		// no-evidence death verdicts.
+		core.AliveObserver = obs.Observer
 		return core, nil
 	case obsSessionGone:
 		return stepSessionGone(view, core, obs)
@@ -408,11 +430,19 @@ func stepPRState(view runView, core runCore, obs runObservation) (runCore, []run
 }
 
 func stepSessionGone(view runView, core runCore, obs runObservation) (runCore, []runEffect) {
-	core.DeadCheckCount++
+	// L11a streak continuity: a dead-check streak is evidence only within a
+	// single observer generation. A gone observation from a different
+	// observer restarts the streak at 1 and re-owns it.
+	if obs.Observer != core.DeadCheckObserver {
+		core.DeadCheckObserver = obs.Observer
+		core.DeadCheckCount = 1
+	} else {
+		core.DeadCheckCount++
+	}
 
 	if obs.Remote {
 		if core.DeadCheckCount < deadChecksBeforeFailed {
-			return core, []runEffect{logEffect("%s#%s: remote session not found on worker (check %d/%d)", view.IssueID, view.RunID, core.DeadCheckCount, deadChecksBeforeFailed)}
+			return core, []runEffect{logEffect("%s#%s: remote session not found on worker (check %d/%d, observer=%s, class=%s)", view.IssueID, view.RunID, core.DeadCheckCount, deadChecksBeforeFailed, obs.Observer, obs.GoneClass)}
 		}
 		// The session is gone on the execution host. A gone session must
 		// never mask completed work: ask for PR/git evidence before any
@@ -460,7 +490,13 @@ func stepGitEvidence(view runView, core runCore, obs runObservation, now time.Ti
 	}
 
 	// No evidence-based verdict. The fallback differs by channel and
-	// liveness history (run-state-machine.md §3).
+	// liveness history (run-state-machine.md §3), and every no-evidence
+	// death verdict additionally requires attestation (L11b): the channel
+	// pronouncing death must be the channel that last saw this run alive.
+	// N consecutive not-founds from a channel that never saw this run alive
+	// is testimony, not evidence (§10.1, I9).
+	attested := core.DeadCheckObserver != "" && core.DeadCheckObserver == core.AliveObserver
+
 	if obs.Remote {
 		if !core.WasAlive {
 			if withinNeverAliveGraceAt(view.StartedAt, now) {
@@ -472,6 +508,9 @@ func stepGitEvidence(view runView, core runCore, obs runObservation, now time.Ti
 			}
 			effects = append(effects, setStatusReasonEffect(model.StatusUnknown, model.StatusReasonNeverAlive))
 			return core, effects
+		}
+		if !attested {
+			return core, appendUnattestedVerdict(view, core, effects)
 		}
 		effects = append(effects, logEffect("%s#%s: remote agent confirmed dead after %d checks, marking failed", view.IssueID, view.RunID, core.DeadCheckCount))
 		effects = append(effects, setStatusEffect(model.StatusFailed))
@@ -498,6 +537,9 @@ func stepGitEvidence(view runView, core runCore, obs runObservation, now time.Ti
 		return core, effects
 	}
 
+	if !attested {
+		return core, appendUnattestedVerdict(view, core, effects)
+	}
 	if view.Agent == "opencode" {
 		effects = append(effects, logEffect("%s#%s: opencode session not found after %d checks, marking unknown", view.IssueID, view.RunID, core.DeadCheckCount))
 		effects = append(effects, setStatusReasonEffect(model.StatusUnknown, model.StatusReasonSessionLost))
@@ -506,6 +548,19 @@ func stepGitEvidence(view runView, core runCore, obs runObservation, now time.Ti
 	effects = append(effects, logEffect("%s#%s: agent confirmed dead after %d checks, marking failed", view.IssueID, view.RunID, core.DeadCheckCount))
 	effects = append(effects, setStatusEffect(model.StatusFailed))
 	return core, effects
+}
+
+// appendUnattestedVerdict is the L11c arm: the dead-check threshold passed
+// through a channel that never observed this run alive, so the standing
+// evidence supports at most unknown(observer_unverified) — never failed.
+// Recovery is automatic: unknown is non-terminal, and any successful capture
+// re-attests the channel and resumes normal inference.
+func appendUnattestedVerdict(view runView, core runCore, effects []runEffect) []runEffect {
+	if view.Status != model.StatusUnknown || view.StatusReason != model.StatusReasonObserverUnverified {
+		effects = append(effects, logEffect("%s#%s: session gone after %d checks, but observer %q never saw this run alive (last alive observer %q) — marking unknown, not failed",
+			view.IssueID, view.RunID, core.DeadCheckCount, core.DeadCheckObserver, core.AliveObserver))
+	}
+	return append(effects, setStatusReasonEffect(model.StatusUnknown, model.StatusReasonObserverUnverified))
 }
 
 // gitVerdict evaluates the evidence ladder. It returns "" when the evidence

--- a/internal/daemon/step.go
+++ b/internal/daemon/step.go
@@ -22,24 +22,30 @@ import (
 // depend on. It is derived from the store fold (run.DeriveState), never from
 // in-memory monitor bookkeeping.
 type runView struct {
-	Status    model.Status
-	Agent     string
-	Branch    string
-	PRUrl     string
-	StartedAt time.Time
-	IssueID   model.IssueID
-	RunID     model.RunID
+	Status model.Status
+	// StatusReason is the machine-readable reason on the run's current
+	// status event ("" = none). The pair (Status, StatusReason) is the
+	// no-op identity for status writes (§9.3 D-G1): a confirmed reading
+	// change re-appends even when the status itself is unchanged.
+	StatusReason string
+	Agent        string
+	Branch       string
+	PRUrl        string
+	StartedAt    time.Time
+	IssueID      model.IssueID
+	RunID        model.RunID
 }
 
 func runViewOf(run *model.Run) runView {
 	return runView{
-		Status:    run.Status,
-		Agent:     run.Agent,
-		Branch:    run.Branch,
-		PRUrl:     run.PRUrl,
-		StartedAt: run.StartedAt,
-		IssueID:   run.IssueID,
-		RunID:     run.RunID,
+		Status:       run.Status,
+		StatusReason: run.StatusReason(),
+		Agent:        run.Agent,
+		Branch:       run.Branch,
+		PRUrl:        run.PRUrl,
+		StartedAt:    run.StartedAt,
+		IssueID:      run.IssueID,
+		RunID:        run.RunID,
 	}
 }
 
@@ -48,10 +54,16 @@ func runViewOf(run *model.Run) runView {
 // lease pacing) stays on RunState itself — when to observe is mechanism,
 // what an observation means is policy.
 type runCore struct {
-	LastOutput     string
-	LastOutputAt   time.Time
-	OutputHash     string
-	PromptStreak   int
+	LastOutput   string
+	LastOutputAt time.Time
+	OutputHash   string
+	// ReadingKind/ReadingStreak are the kind-tagged input-request streak
+	// (run-state-machine.md §9.2): ReadingKind ∈ {"", "prompt",
+	// "gate:<kind>"}; consecutive captures with the same reading advance the
+	// streak, any different reading (including "" = busy/none) resets it.
+	// Both are ephemeral by law (§7 D-C1): reset on restart, delay-only.
+	ReadingKind    string
+	ReadingStreak  int
 	PRRecorded     bool
 	WasAlive       bool
 	DeadCheckCount int
@@ -126,6 +138,10 @@ type agentSignal struct {
 	APILimited    bool
 	Failed        bool
 	PromptShowing bool
+	// Gate is the interactive-gate kind detected on this capture ("" =
+	// none), produced by AgentManager.DetectGate (O4e). The busy-marker veto
+	// is applied gather-side, identically to PromptShowing.
+	Gate string
 }
 
 // gitEvidence is the raw fact set for a dead-session verdict, gathered by
@@ -564,9 +580,14 @@ func stepCaptured(view runView, core runCore, obs runObservation, now time.Time)
 	contentHash := hashContent(obs.Output)
 	outputChanged := contentHash != core.OutputHash
 
-	hasPrompt := obs.Signal.PromptShowing
-	streak, hasStablePrompt := recordPromptStreak(core.PromptStreak, hasPrompt)
-	core.PromptStreak = streak
+	reading := inputReading(obs.Signal)
+	kind, streak, confirmed := recordInputReadingStreak(core.ReadingKind, core.ReadingStreak, reading)
+	core.ReadingKind = kind
+	core.ReadingStreak = streak
+	confirmedReading := ""
+	if confirmed {
+		confirmedReading = reading
+	}
 
 	if outputChanged {
 		core.OutputHash = contentHash
@@ -578,8 +599,8 @@ func stepCaptured(view runView, core runCore, obs runObservation, now time.Time)
 	if len(hashPreview) > 8 {
 		hashPreview = hashPreview[:8]
 	}
-	effects = append(effects, debugEffect("%s#%s: pane hash=%s changed=%t prompt=%t stable_prompt=%t streak=%d",
-		view.IssueID, view.RunID, hashPreview, outputChanged, hasPrompt, hasStablePrompt, core.PromptStreak))
+	effects = append(effects, debugEffect("%s#%s: pane hash=%s changed=%t reading=%q confirmed=%q streak=%d",
+		view.IssueID, view.RunID, hashPreview, outputChanged, reading, confirmedReading, core.ReadingStreak))
 
 	if prURL := detectPRURL(obs.Output); prURL != "" && !core.PRRecorded {
 		core.PRRecorded = true
@@ -591,10 +612,10 @@ func stepCaptured(view runView, core runCore, obs runObservation, now time.Time)
 		return core, effects
 	}
 
-	newStatus, reason := agentVerdict(view, obs.Signal, outputChanged, hasStablePrompt)
-	if newStatus != "" && newStatus != view.Status {
+	newStatus, reason := agentVerdict(view, obs.Signal, outputChanged, confirmedReading)
+	if newStatus != "" && (newStatus != view.Status || reason != view.StatusReason) {
 		effects = append(effects,
-			logEffect("%s#%s: status change %s -> %s", view.IssueID, view.RunID, view.Status, newStatus),
+			logEffect("%s#%s: status change %s -> %s", view.IssueID, view.RunID, view.Status, statusWithReason(newStatus, reason)),
 			runEffect{Kind: effectSetStatus, Status: newStatus, Output: obs.Output, Reason: reason},
 		)
 	}
@@ -602,14 +623,53 @@ func stepCaptured(view runView, core runCore, obs runObservation, now time.Time)
 	return core, effects
 }
 
+// inputReading classifies a capture's input-request reading (§9.2): a gate
+// outranks the generic prompt heuristics (L10b), busy/none is "".
+func inputReading(sig agentSignal) string {
+	if sig.Gate != "" {
+		return "gate:" + sig.Gate
+	}
+	if sig.PromptShowing {
+		return "prompt"
+	}
+	return ""
+}
+
+// gateStatusReason is the machine-readable reason family for confirmed gate
+// readings: `gate_<kind>` (run-state-machine.md §5 status reasons).
+func gateStatusReason(kind string) string {
+	return "gate_" + kind
+}
+
+// statusWithReason renders a status plus its non-empty reason for log lines.
+func statusWithReason(status model.Status, reason string) string {
+	if reason == "" {
+		return string(status)
+	}
+	return fmt.Sprintf("%s(%s)", status, reason)
+}
+
 // agentVerdict applies the agent-specific reading of a captured output. For
 // resolved signals (opencode) the gatherer already produced the verdict; for
-// mux agents the historical MuxManager.GetStatus precedence applies.
-// The second return value is the machine-readable reason for the verdict
-// (model.AttrStatusReason); empty for self-explanatory statuses.
-func agentVerdict(view runView, sig agentSignal, outputChanged, hasStablePrompt bool) (model.Status, string) {
+// mux agents the reading precedence is L10b:
+//
+//	busy veto > gate > {exited, completed, api-limited, failed} > prompt
+//	          > output-changed
+//
+// A gate reading present on this capture masks every lower reading even
+// before its streak confirms (a curated conjunctive row outranks the loose
+// generic heuristics); the waiting verdict itself only fires once confirmed
+// (L10a). The second return value is the machine-readable reason for the
+// verdict (model.AttrStatusReason); empty for self-explanatory statuses.
+func agentVerdict(view runView, sig agentSignal, outputChanged bool, confirmedReading string) (model.Status, string) {
 	if sig.Resolved {
 		return sig.Status, ""
+	}
+	if sig.Gate != "" {
+		if confirmedReading == "gate:"+sig.Gate {
+			return model.StatusWaiting, gateStatusReason(sig.Gate)
+		}
+		return "", ""
 	}
 	switch {
 	case sig.Exited:
@@ -620,7 +680,7 @@ func agentVerdict(view runView, sig agentSignal, outputChanged, hasStablePrompt 
 		return model.StatusRateLimited, ""
 	case sig.Failed:
 		return model.StatusFailed, ""
-	case hasStablePrompt:
+	case confirmedReading == "prompt":
 		return model.StatusWaiting, ""
 	case outputChanged:
 		return model.StatusRunning, ""

--- a/internal/daemon/step_gate_test.go
+++ b/internal/daemon/step_gate_test.go
@@ -1,0 +1,253 @@
+package daemon
+
+// Law tests for interactive-gate detection (run-state-machine.md §9): the
+// L10a debounce, the L10b reading precedence, the L10c reason fidelity under
+// the D-G1 (status, reason) pair identity, and the fixture-locked end-to-end
+// precedence over the real captured gate screens in
+// internal/agent/testdata/gates.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/proboscis/orch/internal/agent"
+	"github.com/proboscis/orch/internal/model"
+)
+
+func gateObs(kind, output string) runObservation {
+	return runObservation{Kind: obsCaptured, Output: output, Signal: agentSignal{Gate: kind}}
+}
+
+// statusReasonEffectOf returns (status, reason) of the first effectSetStatus.
+func statusReasonEffectOf(effects []runEffect) (model.Status, string, bool) {
+	for _, e := range effects {
+		if e.Kind == effectSetStatus {
+			return e.Status, e.Reason, true
+		}
+	}
+	return "", "", false
+}
+
+// L10a gate debounce: a waiting(gate_<kind>) verdict requires
+// waitingPromptStreakThreshold consecutive captures with the same gate
+// reading; any busy capture or different reading resets the streak.
+func TestStepLawGateDebounce(t *testing.T) {
+	now := time.Now()
+	login := gateObs("login", "sign in with chatgpt\npress enter to continue")
+	busy := runObservation{Kind: obsCaptured, Output: "working...", Signal: agentSignal{}}
+	prompt := runObservation{Kind: obsCaptured, Output: "❯ ready", Signal: agentSignal{PromptShowing: true}}
+
+	view := stepTestView(model.StatusRunning, "codex", now.Add(-time.Hour))
+	core := runCore{WasAlive: true}
+
+	// Single gate observation: reading recorded, no verdict, and no lower
+	// verdict either (the gate masks output-changed).
+	var effects []runEffect
+	core, effects = stepRun(view, core, login, now)
+	if _, ok := statusEffectOf(effects); ok {
+		t.Fatalf("status effect after a single gate observation: %+v", effects)
+	}
+	if core.ReadingKind != "gate:login" || core.ReadingStreak != 1 {
+		t.Fatalf("core reading = (%q, %d), want (gate:login, 1)", core.ReadingKind, core.ReadingStreak)
+	}
+
+	// Second consecutive gate capture: waiting(gate_login).
+	core, effects = stepRun(view, core, login, now)
+	if status, reason, ok := statusReasonEffectOf(effects); !ok || status != model.StatusWaiting || reason != "gate_login" {
+		t.Fatalf("confirmed gate verdict = %+v, want waiting(gate_login)", effects)
+	}
+	view = foldStatus(view, effects)
+
+	// A busy capture resets the streak and flips the run back to running
+	// (output changed); a single later gate capture must not re-confirm.
+	core, effects = stepRun(view, core, busy, now)
+	view = foldStatus(view, effects)
+	if core.ReadingKind != "" || core.ReadingStreak != 0 {
+		t.Fatalf("busy capture did not reset the reading: (%q, %d)", core.ReadingKind, core.ReadingStreak)
+	}
+	core, effects = stepRun(view, core, login, now)
+	if _, ok := statusEffectOf(effects); ok {
+		t.Fatalf("verdict after streak reset + one gate capture: %+v", effects)
+	}
+
+	// Alternating readings never confirm: each kind change restarts at 1.
+	core = runCore{WasAlive: true}
+	view = stepTestView(model.StatusRunning, "codex", now.Add(-time.Hour))
+	seq := []runObservation{prompt, login, prompt, login, prompt, login}
+	for i, obs := range seq {
+		core, effects = stepRun(view, core, obs, now)
+		if status, _, ok := statusReasonEffectOf(effects); ok && status == model.StatusWaiting {
+			t.Fatalf("alternating readings confirmed waiting at tick %d (streak=%d)", i, core.ReadingStreak)
+		}
+		view = foldStatus(view, effects)
+	}
+}
+
+// L10b reading precedence: a gate reading present on a capture masks the
+// generic heuristics (exited/completed/api-limited/failed/prompt/output-
+// changed) while unconfirmed, and outranks them once confirmed.
+func TestStepLawGatePrecedence(t *testing.T) {
+	now := time.Now()
+	lowerSignals := []agentSignal{
+		{Exited: true},
+		{Completed: true},
+		{APILimited: true},
+		{Failed: true},
+		{PromptShowing: true},
+		{}, // output-changed only
+	}
+	for _, lower := range lowerSignals {
+		sig := lower
+		sig.Gate = "trust"
+		obs := runObservation{Kind: obsCaptured, Output: "do you trust the contents of this directory?\npress enter to continue", Signal: sig}
+
+		view := stepTestView(model.StatusRunning, "codex", now.Add(-time.Hour))
+		core := runCore{WasAlive: true}
+
+		var effects []runEffect
+		core, effects = stepRun(view, core, obs, now)
+		if _, ok := statusEffectOf(effects); ok {
+			t.Fatalf("lower signal %+v produced a verdict beneath an unconfirmed gate: %+v", lower, effects)
+		}
+		_, effects = stepRun(view, core, obs, now)
+		status, reason, ok := statusReasonEffectOf(effects)
+		if !ok || status != model.StatusWaiting || reason != "gate_trust" {
+			t.Fatalf("confirmed gate lost to lower signal %+v: %+v", lower, effects)
+		}
+	}
+}
+
+// L10c reason fidelity + D-G1: the waiting reason tracks the latest
+// confirmed reading — a reading change re-appends even when the status
+// itself stays waiting, in both directions (prompt → gate, gate → prompt).
+func TestStepLawGateReasonFidelity(t *testing.T) {
+	now := time.Now()
+	login := gateObs("login", "sign in with chatgpt\npress enter to continue")
+	prompt := runObservation{Kind: obsCaptured, Output: "❯ ready", Signal: agentSignal{PromptShowing: true}}
+
+	// Run already waiting at its normal prompt (reason ""), then hits a gate.
+	view := stepTestView(model.StatusWaiting, "codex", now.Add(-time.Hour))
+	core := runCore{WasAlive: true, ReadingKind: "prompt", ReadingStreak: 2}
+
+	var effects []runEffect
+	core, effects = stepRun(view, core, login, now)
+	if _, ok := statusEffectOf(effects); ok {
+		t.Fatalf("unconfirmed gate re-appended waiting: %+v", effects)
+	}
+	core, effects = stepRun(view, core, login, now)
+	status, reason, ok := statusReasonEffectOf(effects)
+	if !ok || status != model.StatusWaiting || reason != "gate_login" {
+		t.Fatalf("waiting(\"\") -> waiting(gate_login) re-append missing (D-G1): %+v", effects)
+	}
+	view = foldStatus(view, effects)
+
+	// Same confirmed reading again: no re-append (pair no-op).
+	core, effects = stepRun(view, core, login, now)
+	if _, ok := statusEffectOf(effects); ok {
+		t.Fatalf("re-affirming waiting(gate_login) appended again: %+v", effects)
+	}
+
+	// Gate cleared to the normal composer prompt: the changed output flips
+	// the run to running first (§9.5 counterexample 5 — no stale gate
+	// reason persists), then the confirmed prompt lands waiting("").
+	core, effects = stepRun(view, core, prompt, now)
+	if status, reason, ok := statusReasonEffectOf(effects); !ok || status != model.StatusRunning || reason != "" {
+		t.Fatalf("cleared gate (changed output) did not resume running: %+v", effects)
+	}
+	view = foldStatus(view, effects)
+	_, effects = stepRun(view, core, prompt, now)
+	status, reason, ok = statusReasonEffectOf(effects)
+	if !ok || status != model.StatusWaiting || reason != "" {
+		t.Fatalf("confirmed prompt after gate did not land waiting(\"\") (L10c): %+v", effects)
+	}
+}
+
+// §9.5 counterexample 5: a gate completed by the user changes the output;
+// the next changed capture flips the run back to running with no stale
+// waiting(gate_*).
+func TestStepGateClearedResumesRunning(t *testing.T) {
+	now := time.Now()
+	login := gateObs("login", "sign in with chatgpt\npress enter to continue")
+	working := runObservation{Kind: obsCaptured, Output: "fetching model catalog...", Signal: agentSignal{}}
+
+	view := stepTestView(model.StatusRunning, "codex", now.Add(-time.Hour))
+	core := runCore{WasAlive: true}
+
+	var effects []runEffect
+	core, effects = stepRun(view, core, login, now)
+	core, effects = stepRun(view, core, login, now)
+	view = foldStatus(view, effects)
+	if view.Status != model.StatusWaiting || view.StatusReason != "gate_login" {
+		t.Fatalf("setup: expected waiting(gate_login), got %s(%s)", view.Status, view.StatusReason)
+	}
+
+	_, effects = stepRun(view, core, working, now)
+	status, reason, ok := statusReasonEffectOf(effects)
+	if !ok || status != model.StatusRunning || reason != "" {
+		t.Fatalf("cleared gate did not resume running: %+v", effects)
+	}
+}
+
+// TestGateFixturePrecedence locks every gate fixture's intended winner
+// end-to-end (§9.4): the signal is gathered from the REAL captured pane
+// exactly as gatherAgentSignal does for mux agents, then run through stepRun
+// — the gate must win the full reading precedence on that pane, not just
+// match its substrings. This is also the §9.5 incident replay: a stable gate
+// pane confirms within waitingPromptStreakThreshold captures.
+func TestGateFixturePrecedence(t *testing.T) {
+	fixtures, err := filepath.Glob(filepath.Join("..", "agent", "testdata", "gates", "*.txt"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(fixtures) == 0 {
+		t.Fatal("no gate fixtures found")
+	}
+	now := time.Now()
+	for _, fixture := range fixtures {
+		base := strings.TrimSuffix(filepath.Base(fixture), ".txt")
+		agentName, rest, found := strings.Cut(base, "_")
+		if !found {
+			t.Fatalf("fixture %s: name must be <agent>_<kind>*.txt", fixture)
+		}
+		t.Run(base, func(t *testing.T) {
+			paneBytes, err := os.ReadFile(fixture)
+			if err != nil {
+				t.Fatalf("read %s: %v", fixture, err)
+			}
+			pane := string(paneBytes)
+
+			sig := agentSignal{
+				Exited:        agent.IsAgentExited(pane),
+				Completed:     agent.IsCompleted(pane),
+				APILimited:    agent.IsAPILimited(pane),
+				Failed:        agent.IsFailed(pane),
+				PromptShowing: agent.IsWaitingForInput(pane),
+				Gate:          agent.DetectGate(agentName, pane),
+			}
+			if sig.Gate == "" {
+				t.Fatalf("fixture does not detect any gate for agent %s", agentName)
+			}
+			if !strings.HasPrefix(rest, sig.Gate) {
+				t.Fatalf("fixture named %s detected gate %q", base, sig.Gate)
+			}
+
+			view := stepTestView(model.StatusRunning, agentName, now.Add(-time.Hour))
+			core := runCore{WasAlive: true}
+			obs := runObservation{Kind: obsCaptured, Output: pane, Signal: sig}
+
+			var effects []runEffect
+			core, effects = stepRun(view, core, obs, now)
+			if _, ok := statusEffectOf(effects); ok {
+				t.Fatalf("verdict on first capture (must debounce): %+v", effects)
+			}
+			_, effects = stepRun(view, core, obs, now)
+			status, reason, ok := statusReasonEffectOf(effects)
+			if !ok || status != model.StatusWaiting || reason != gateStatusReason(sig.Gate) {
+				t.Fatalf("gate did not win the reading precedence on the real pane: %+v", effects)
+			}
+		})
+	}
+}

--- a/internal/daemon/step_observer_test.go
+++ b/internal/daemon/step_observer_test.go
@@ -1,0 +1,150 @@
+package daemon
+
+// Law tests for observer attestation on death verdicts
+// (run-state-machine.md §10): L11a streak continuity, L11b attestation,
+// L11c unverified fallback, L7' verdict-strength monotonicity, and the I9
+// invariant, checked over the pure transition core.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/proboscis/orch/internal/model"
+)
+
+func goneFrom(observer, class string, remote bool) runObservation {
+	return runObservation{Kind: obsSessionGone, Remote: remote, Observer: observer, GoneClass: class}
+}
+
+// runGoneToVerdict drives gone observations from one observer until the
+// evidence request fires, then feeds empty git evidence and returns the
+// resulting view.
+func runGoneToVerdict(t *testing.T, view runView, core runCore, obs runObservation) (runView, runCore) {
+	t.Helper()
+	var effects []runEffect
+	for i := 0; i < deadChecksBeforeFailed+1; i++ {
+		core, effects = stepRun(view, core, obs, time.Now())
+		view = foldStatus(view, effects)
+		if effectsContain(effects, effectGatherGitEvidence) {
+			core, effects = stepRun(view, core, runObservation{Kind: obsGitEvidence, Remote: obs.Remote, Evidence: gitEvidence{RepoRootFound: true}}, time.Now())
+			view = foldStatus(view, effects)
+			return view, core
+		}
+	}
+	t.Fatalf("no evidence request after %d gone observations", deadChecksBeforeFailed+1)
+	return view, core
+}
+
+// L11a: DeadCheckCount accumulates only while the observation's ObserverID
+// equals DeadCheckObserver; a gone observation from a different observer
+// restarts the streak at 1 and re-owns it.
+func TestStepLawObserverStreakContinuity(t *testing.T) {
+	now := time.Now()
+	view := stepTestView(model.StatusRunning, "codex", now.Add(-time.Hour))
+	core := runCore{WasAlive: true, AliveObserver: "obs-a"}
+
+	core, _ = stepRun(view, core, goneFrom("obs-a", goneClassSessionAbsent, true), now)
+	core, _ = stepRun(view, core, goneFrom("obs-a", goneClassSessionAbsent, true), now)
+	if core.DeadCheckCount != 2 || core.DeadCheckObserver != "obs-a" {
+		t.Fatalf("streak = (%q, %d), want (obs-a, 2)", core.DeadCheckObserver, core.DeadCheckCount)
+	}
+
+	// A different observer's gone report is evidence only within its own
+	// generation: the streak restarts at 1 under the new owner.
+	core, _ = stepRun(view, core, goneFrom("obs-b", goneClassSessionAbsent, true), now)
+	if core.DeadCheckCount != 1 || core.DeadCheckObserver != "obs-b" {
+		t.Fatalf("streak after observer change = (%q, %d), want (obs-b, 1)", core.DeadCheckObserver, core.DeadCheckCount)
+	}
+}
+
+// §10.5 counterexample 1 — incident replay: a restarted worker with a
+// poisoned TMUX socket reports not-found with a fresh ObserverID while
+// AliveObserver points at the dead old instance. The verdict is
+// unknown(observer_unverified), never failed; the first successful capture
+// re-attests and the run resumes normal inference. No terminal status is
+// ever written.
+func TestStepObserverIncidentReplay(t *testing.T) {
+	now := time.Now()
+	view := stepTestView(model.StatusRunning, "codex", now.Add(-time.Hour))
+	core := runCore{WasAlive: true, AliveObserver: "worker:mac:old"}
+
+	view, core = runGoneToVerdict(t, view, core, goneFrom("worker:mac:new", goneClassSessionAbsent, true))
+	if view.Status != model.StatusUnknown || view.StatusReason != model.StatusReasonObserverUnverified {
+		t.Fatalf("poisoned-observer verdict = %s(%s), want unknown(observer_unverified)", view.Status, view.StatusReason)
+	}
+	if view.Status.IsTerminal() {
+		t.Fatal("unattested verdict must not be terminal")
+	}
+
+	// Operator fixes the env: the next successful capture re-attests the
+	// channel and normal inference resumes.
+	var effects []runEffect
+	core, effects = stepRun(view, core, runObservation{Kind: obsSessionAlive, Observer: "worker:mac:new"}, now)
+	view = foldStatus(view, effects)
+	if core.AliveObserver != "worker:mac:new" || core.DeadCheckCount != 0 {
+		t.Fatalf("re-attestation failed: AliveObserver=%q DeadCheckCount=%d", core.AliveObserver, core.DeadCheckCount)
+	}
+	core, effects = stepRun(view, core, runObservation{Kind: obsCaptured, Output: "agent working again", Signal: agentSignal{}}, now)
+	view = foldStatus(view, effects)
+	if view.Status != model.StatusRunning {
+		t.Fatalf("recovered run = %s, want running", view.Status)
+	}
+}
+
+// §10.5 counterexample 3: the tmux server exits because the last session
+// closed — the same long-lived observer reports server_absent. Still
+// attested: the class is diagnostic, not the predicate. Verdict failed as
+// today.
+func TestStepObserverServerAbsentUnderSteadyObserverFails(t *testing.T) {
+	now := time.Now()
+	view := stepTestView(model.StatusRunning, "codex", now.Add(-time.Hour))
+	core := runCore{WasAlive: true, AliveObserver: "worker:mac:w1"}
+
+	view, _ = runGoneToVerdict(t, view, core, goneFrom("worker:mac:w1", goneClassServerAbsent, true))
+	if view.Status != model.StatusFailed {
+		t.Fatalf("attested server_absent verdict = %s, want failed", view.Status)
+	}
+}
+
+// §10.5 counterexample 6 — mixed-version fleet: a legacy channel reports
+// gone without observer context (Observer ""). It can never attest, so the
+// verdict is at most unknown.
+func TestStepObserverLegacyChannelNeverFails(t *testing.T) {
+	now := time.Now()
+	for _, remote := range []bool{false, true} {
+		view := stepTestView(model.StatusRunning, "codex", now.Add(-time.Hour))
+		core := runCore{WasAlive: true, AliveObserver: "local:n1"}
+		view, _ = runGoneToVerdict(t, view, core, goneFrom("", goneClassUnclassified, remote))
+		if view.Status != model.StatusUnknown || view.StatusReason != model.StatusReasonObserverUnverified {
+			t.Fatalf("legacy-channel verdict (remote=%t) = %s(%s), want unknown(observer_unverified)", remote, view.Status, view.StatusReason)
+		}
+	}
+}
+
+// I9 property sweep: across every (alive-observer, gone-observer, plane,
+// agent) combination, a failed verdict is only ever reached when the gone
+// observer is the non-empty channel that last saw the run alive.
+func TestStepLawI9NoFailedWithoutAttestation(t *testing.T) {
+	now := time.Now()
+	observers := []string{"", "obs-a", "obs-b"}
+	for _, agentName := range stepTestAgents {
+		for _, remote := range []bool{false, true} {
+			for _, aliveObs := range observers {
+				for _, goneObs := range observers {
+					view := stepTestView(model.StatusRunning, agentName, now.Add(-time.Hour))
+					core := runCore{WasAlive: true, AliveObserver: aliveObs}
+					view, _ = runGoneToVerdict(t, view, core, goneFrom(goneObs, goneClassSessionAbsent, remote))
+
+					attested := goneObs != "" && goneObs == aliveObs
+					if view.Status == model.StatusFailed && !attested {
+						t.Fatalf("I9 violation: failed written by unattested channel (agent=%s remote=%t alive=%q gone=%q)",
+							agentName, remote, aliveObs, goneObs)
+					}
+					if attested && agentName != "opencode" && view.Status != model.StatusFailed {
+						t.Fatalf("attested death did not conclude failed (agent=%s remote=%t): got %s", agentName, remote, view.Status)
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/daemon/step_sim_test.go
+++ b/internal/daemon/step_sim_test.go
@@ -93,8 +93,8 @@ func TestSimPromptDebounceAndStreakReset(t *testing.T) {
 	simAssert(t, res,
 		[]model.Status{model.StatusWaiting, model.StatusRunning},
 		model.StatusRunning)
-	if res.core.PromptStreak != 1 {
-		t.Fatalf("PromptStreak = %d, want 1", res.core.PromptStreak)
+	if res.core.ReadingKind != "prompt" || res.core.ReadingStreak != 1 {
+		t.Fatalf("reading = (%q, %d), want (prompt, 1)", res.core.ReadingKind, res.core.ReadingStreak)
 	}
 }
 

--- a/internal/daemon/step_test.go
+++ b/internal/daemon/step_test.go
@@ -74,6 +74,8 @@ func stepTestObservations(now time.Time) []runObservation {
 		runObservation{Kind: obsCaptured, Output: "❯ ", Signal: agentSignal{PromptShowing: true}},
 		runObservation{Kind: obsCaptured, Output: "done", Signal: agentSignal{Completed: true}},
 		runObservation{Kind: obsCaptured, Output: "exited", Signal: agentSignal{Exited: true}},
+		runObservation{Kind: obsCaptured, Output: "sign in with chatgpt\npress enter to continue", Signal: agentSignal{Gate: "login"}},
+		runObservation{Kind: obsCaptured, Output: "do you trust the contents of this directory?", Signal: agentSignal{Gate: "trust", Exited: true}},
 		runObservation{Kind: obsCaptured, Output: "busy", Signal: agentSignal{Resolved: true, Status: model.StatusRunning}},
 		runObservation{Kind: obsCaptured, Output: "idle", Signal: agentSignal{Resolved: true, Status: model.StatusWaiting}},
 	)
@@ -91,11 +93,15 @@ func stepTestCores() []runCore {
 	var cores []runCore
 	for _, wasAlive := range []bool{false, true} {
 		for _, dead := range []int{0, 1, 2, 3, 4} {
-			for _, streak := range []int{0, 1, 2} {
+			for _, reading := range []struct {
+				kind   string
+				streak int
+			}{{"", 0}, {"prompt", 1}, {"prompt", 2}, {"gate:login", 1}, {"gate:login", 2}} {
 				cores = append(cores, runCore{
 					WasAlive:       wasAlive,
 					DeadCheckCount: dead,
-					PromptStreak:   streak,
+					ReadingKind:    reading.kind,
+					ReadingStreak:  reading.streak,
 				})
 			}
 		}
@@ -104,10 +110,14 @@ func stepTestCores() []runCore {
 }
 
 // foldStatus applies the setStatus effects of one step to the view, the way
-// a committed store write would before the next observation.
+// a committed store write would before the next observation. The reason
+// folds with the status: the pair is the D-G1 identity.
 func foldStatus(view runView, effects []runEffect) runView {
-	if status, ok := statusEffectOf(effects); ok {
-		view.Status = status
+	for _, e := range effects {
+		if e.Kind == effectSetStatus {
+			view.Status = e.Status
+			view.StatusReason = e.Reason
+		}
 	}
 	return view
 }
@@ -390,7 +400,7 @@ func TestStepUnknownVerdictsCarryReason(t *testing.T) {
 	}
 
 	// Capture verdict: agent exited, shell prompt showing.
-	status, reason := agentVerdict(stepTestView(model.StatusRunning, "codex", startedAt), agentSignal{Exited: true}, false, false)
+	status, reason := agentVerdict(stepTestView(model.StatusRunning, "codex", startedAt), agentSignal{Exited: true}, false, "")
 	if status != model.StatusUnknown || reason != model.StatusReasonAgentExited {
 		t.Fatalf("exited verdict = (%s, %q), want (unknown, %q)", status, reason, model.StatusReasonAgentExited)
 	}
@@ -443,7 +453,7 @@ func TestInitialRunCoreDerivation(t *testing.T) {
 			t.Fatalf("%s: WasAlive=%t PRRecorded=%t, want %t/%t",
 				tc.name, core.WasAlive, core.PRRecorded, tc.wantAlive, tc.wantPRRec)
 		}
-		if core.DeadCheckCount != 0 || core.PromptStreak != 0 || core.OutputHash != "" {
+		if core.DeadCheckCount != 0 || core.ReadingKind != "" || core.ReadingStreak != 0 || core.OutputHash != "" {
 			t.Fatalf("%s: ephemeral counters must start at zero", tc.name)
 		}
 		if !core.LastOutputAt.Equal(now) {
@@ -526,7 +536,7 @@ func TestStepLawPromptDebounce(t *testing.T) {
 	var effects []runEffect
 	core, effects = stepRun(view, core, prompt, now)
 	if status, ok := statusEffectOf(effects); ok && status == model.StatusWaiting {
-		t.Fatalf("waiting after a single prompt observation (streak=%d)", core.PromptStreak)
+		t.Fatalf("waiting after a single prompt observation (streak=%d)", core.ReadingStreak)
 	}
 	view = foldStatus(view, effects)
 
@@ -541,12 +551,12 @@ func TestStepLawPromptDebounce(t *testing.T) {
 	// straight back to waiting.
 	core, effects = stepRun(view, core, busy, now)
 	view = foldStatus(view, effects)
-	if core.PromptStreak != 0 {
-		t.Fatalf("busy capture did not reset streak: %d", core.PromptStreak)
+	if core.ReadingKind != "" || core.ReadingStreak != 0 {
+		t.Fatalf("busy capture did not reset streak: (%q, %d)", core.ReadingKind, core.ReadingStreak)
 	}
 	core, effects = stepRun(view, core, prompt, now)
 	if status, ok := statusEffectOf(effects); ok && status == model.StatusWaiting {
-		t.Fatalf("waiting after streak reset + one prompt (streak=%d)", core.PromptStreak)
+		t.Fatalf("waiting after streak reset + one prompt (streak=%d)", core.ReadingStreak)
 	}
 }
 

--- a/internal/daemon/step_test.go
+++ b/internal/daemon/step_test.go
@@ -365,11 +365,11 @@ func TestStepUnknownVerdictsCarryReason(t *testing.T) {
 	now := time.Now()
 	startedAt := now.Add(-2 * neverAliveVerdictGrace)
 
-	unknownReason := func(view runView, core runCore, remote bool) string {
+	unknownReason := func(view runView, core runCore, remote bool, observer string) string {
 		t.Helper()
 		for i := 0; i < deadChecksBeforeFailed+1; i++ {
 			var effects []runEffect
-			core, effects = stepRun(view, core, runObservation{Kind: obsSessionGone, Remote: remote}, now)
+			core, effects = stepRun(view, core, runObservation{Kind: obsSessionGone, Remote: remote, Observer: observer}, now)
 			if reason, ok := unknownReasonOf(effects); ok {
 				return reason
 			}
@@ -387,16 +387,25 @@ func TestStepUnknownVerdictsCarryReason(t *testing.T) {
 	}
 
 	// L3' never-alive arms, both planes.
-	if got := unknownReason(stepTestView(model.StatusBooting, "codex", startedAt), runCore{}, true); got != model.StatusReasonNeverAlive {
+	if got := unknownReason(stepTestView(model.StatusBooting, "codex", startedAt), runCore{}, true, "obs-1"); got != model.StatusReasonNeverAlive {
 		t.Fatalf("remote never-alive reason = %q, want %q", got, model.StatusReasonNeverAlive)
 	}
-	if got := unknownReason(stepTestView(model.StatusBooting, "codex", startedAt), runCore{}, false); got != model.StatusReasonNeverAlive {
+	if got := unknownReason(stepTestView(model.StatusBooting, "codex", startedAt), runCore{}, false, "obs-1"); got != model.StatusReasonNeverAlive {
 		t.Fatalf("local never-alive reason = %q, want %q", got, model.StatusReasonNeverAlive)
 	}
 
-	// opencode session-lost arm (was alive, local plane).
-	if got := unknownReason(stepTestView(model.StatusRunning, "opencode", startedAt), runCore{WasAlive: true}, false); got != model.StatusReasonSessionLost {
+	// opencode session-lost arm (was alive, local plane, attested channel).
+	if got := unknownReason(stepTestView(model.StatusRunning, "opencode", startedAt), runCore{WasAlive: true, AliveObserver: "obs-1"}, false, "obs-1"); got != model.StatusReasonSessionLost {
 		t.Fatalf("opencode session-lost reason = %q, want %q", got, model.StatusReasonSessionLost)
+	}
+
+	// L11c: the same standing evidence through an UNATTESTED channel (the
+	// observer never saw this run alive) concludes observer_unverified.
+	if got := unknownReason(stepTestView(model.StatusRunning, "opencode", startedAt), runCore{WasAlive: true, AliveObserver: "obs-old"}, false, "obs-new"); got != model.StatusReasonObserverUnverified {
+		t.Fatalf("opencode unattested reason = %q, want %q", got, model.StatusReasonObserverUnverified)
+	}
+	if got := unknownReason(stepTestView(model.StatusRunning, "codex", startedAt), runCore{WasAlive: true, AliveObserver: "obs-old"}, true, "obs-new"); got != model.StatusReasonObserverUnverified {
+		t.Fatalf("remote unattested reason = %q, want %q", got, model.StatusReasonObserverUnverified)
 	}
 
 	// Capture verdict: agent exited, shell prompt showing.
@@ -462,9 +471,15 @@ func TestInitialRunCoreDerivation(t *testing.T) {
 	}
 }
 
-// L7 restart transparency (the I2 fix): after a daemon restart, a run whose
-// log shows it was alive folds WasAlive back, so a gone session is judged a
-// real death (failed) rather than a never-alive boot (unknown).
+// L7 restart transparency (the I2 fix) + L7' verdict-strength monotonicity
+// (§10.5 counterexample 5): after a daemon restart, a run whose log shows it
+// was alive folds WasAlive back — it is never misjudged as a never-alive
+// boot. But the restart also reset AliveObserver, so the post-restart
+// channel is unattested: the gone verdict softens to
+// unknown(observer_unverified) instead of failed. Today's fold-derived
+// WasAlive alone would have allowed failed on hearsay — the pattern §10
+// retires. Once the channel re-attests (one successful capture), the same
+// evidence concludes failed again.
 func TestInitialRunCoreRestoresLivenessAcrossRestart(t *testing.T) {
 	now := time.Now()
 	startedAt := now.Add(-2 * neverAliveVerdictGrace)
@@ -474,20 +489,40 @@ func TestInitialRunCoreRestoresLivenessAcrossRestart(t *testing.T) {
 		model.NewStatusEvent(model.StatusRunning),
 	}}
 	core := initialRunCore(run, now)
+	if !core.WasAlive {
+		t.Fatal("WasAlive must fold back from the event log (L7/I2)")
+	}
+	if core.AliveObserver != "" || core.DeadCheckObserver != "" {
+		t.Fatal("observer attestation must NOT survive a restart (ephemeral by law)")
+	}
 
 	view := stepTestView(model.StatusRunning, "codex", startedAt)
 	var effects []runEffect
 	for i := 0; i < deadChecksBeforeFailed; i++ {
-		core, effects = stepRun(view, core, runObservation{Kind: obsSessionGone}, now)
+		core, effects = stepRun(view, core, runObservation{Kind: obsSessionGone, Observer: "local:new"}, now)
 		view = foldStatus(view, effects)
 	}
 	if !effectsContain(effects, effectGatherGitEvidence) {
 		t.Fatalf("expected evidence request at the dead-check threshold")
 	}
+	core, effects = stepRun(view, core, runObservation{Kind: obsGitEvidence, Evidence: gitEvidence{RepoRootFound: true}}, now)
+	view = foldStatus(view, effects)
+	if view.Status != model.StatusUnknown || view.StatusReason != model.StatusReasonObserverUnverified {
+		t.Fatalf("post-restart gone run judged %s(%s), want unknown(observer_unverified) (L7')", view.Status, view.StatusReason)
+	}
+
+	// The channel re-attests with one successful observation; the same
+	// standing evidence now concludes failed (attested death, L11b).
+	core, effects = stepRun(view, core, runObservation{Kind: obsSessionAlive, Observer: "local:new"}, now)
+	view = foldStatus(view, effects)
+	for i := 0; i < deadChecksBeforeFailed; i++ {
+		core, effects = stepRun(view, core, runObservation{Kind: obsSessionGone, Observer: "local:new"}, now)
+		view = foldStatus(view, effects)
+	}
 	_, effects = stepRun(view, core, runObservation{Kind: obsGitEvidence, Evidence: gitEvidence{RepoRootFound: true}}, now)
 	view = foldStatus(view, effects)
 	if view.Status != model.StatusFailed {
-		t.Fatalf("was-alive run after restart judged %s, want failed", view.Status)
+		t.Fatalf("re-attested channel's verdict = %s, want failed", view.Status)
 	}
 }
 

--- a/internal/daemon/worker_plane.go
+++ b/internal/daemon/worker_plane.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/proboscis/orch/internal/agent"
 	"github.com/proboscis/orch/internal/git"
 	"github.com/proboscis/orch/internal/model"
 )
@@ -129,7 +130,33 @@ type CaptureSessionResult struct {
 	Content       string `json:"content,omitempty"`
 	TimestampUnix int64  `json:"timestamp_unix,omitempty"`
 	Source        string `json:"source,omitempty"`
+	// ObserverID identifies the observing channel INSTANCE
+	// (worker:<id>:<nonce> / local:<nonce>), carried in the lease result
+	// rather than looked up from the registry: a lease answer may race a
+	// re-register, and the registry preserves RegisteredAt across it
+	// (run-state-machine.md §10.2).
+	ObserverID string `json:"observer_id,omitempty"`
+	// Gone, when set, reports that the observing side determined the
+	// session is gone (L11d classification locality): the capture lease
+	// SUCCEEDS with this structured verdict instead of failing with an
+	// error string the master would have to parse.
+	Gone *SessionGoneResult `json:"gone,omitempty"`
 }
+
+// SessionGoneResult classifies a gone observation where the facts are local
+// (run-state-machine.md §10.2). The class is diagnostic payload — the
+// verification predicate is attestation (L11b), never the class.
+type SessionGoneResult struct {
+	Class string `json:"class"`
+}
+
+// Gone-class vocabulary (§10.2). unclassified covers legacy/unknown
+// responses and is always unattested-safe: at most unknown.
+const (
+	goneClassSessionAbsent = "session_absent"
+	goneClassServerAbsent  = "server_absent"
+	goneClassUnclassified  = "unclassified"
+)
 
 type GetDiffStatsResult struct {
 	Additions    int      `json:"additions,omitempty"`
@@ -632,6 +659,49 @@ func decodeWorkerEffectResult(resultJSON string) (*WorkerEffectResult, error) {
 	return &result, nil
 }
 
+// classifyCaptureGone maps a capture error to a gone class ("" = not a gone
+// verdict: an infrastructure failure the lease reports as a plain error).
+// Classification happens on the observing side, where the mux socket the
+// error refers to is the one this process actually controls (L11d) — the
+// 2026-07-07 incident was a master classifying a poisoned worker's error
+// strings as session death.
+func classifyCaptureGone(run *model.Run, err error) string {
+	if err == nil {
+		return ""
+	}
+	var notFound *agent.SessionNotFoundError
+	if errors.As(err, &notFound) {
+		// Distinguish a responding mux server that lacks the session from
+		// no server on this observer's socket at all. Diagnostic only: the
+		// verification predicate is attestation, not the class.
+		mux := resolveCaptureMultiplexer(run)
+		lister, ok := mux.(interface{ ListSessions() ([]string, error) })
+		if !ok {
+			return goneClassUnclassified
+		}
+		if _, lerr := lister.ListSessions(); lerr != nil {
+			return goneClassServerAbsent
+		}
+		return goneClassSessionAbsent
+	}
+	var stopped *agent.ServerStoppedError
+	if errors.As(err, &stopped) {
+		return goneClassServerAbsent
+	}
+	return ""
+}
+
+// observerID identifies this process as an observation-channel instance
+// (run-state-machine.md §10.2). The nonce is generated once per process
+// start, so a restarted worker/daemon is a NEW observer that must re-attest
+// before its dead checks can support a failed verdict (L11b).
+func (s *SocketServer) observerID() string {
+	if strings.TrimSpace(s.currentWorkerID) != "" {
+		return "worker:" + strings.TrimSpace(s.currentWorkerID) + ":" + s.instanceNonce
+	}
+	return "local:" + s.instanceNonce
+}
+
 func workerLocalProjectMappingError(projectID, workerID string) error {
 	projectID = strings.TrimSpace(projectID)
 	workerID = strings.TrimSpace(workerID)
@@ -755,6 +825,19 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 			content, source, err = captureLocalMultiplexerSession(run, lines)
 		}
 		if err != nil {
+			// Session-gone is decided here, where the facts are local
+			// (L11d): the lease succeeds with a structured verdict. Only
+			// infrastructure failures (transient capture errors) still fail
+			// the lease.
+			if goneClass := classifyCaptureGone(run, err); goneClass != "" {
+				return &WorkerEffectResult{
+					CaptureResult: &CaptureSessionResult{
+						TimestampUnix: time.Now().Unix(),
+						ObserverID:    s.observerID(),
+						Gone:          &SessionGoneResult{Class: goneClass},
+					},
+				}, nil
+			}
 			return nil, err
 		}
 
@@ -763,6 +846,7 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 				Content:       content,
 				TimestampUnix: time.Now().Unix(),
 				Source:        source,
+				ObserverID:    s.observerID(),
 			},
 		}, nil
 	case "send_message":

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -267,6 +267,11 @@ const (
 	// StatusReasonAgentExited: the agent process exited without a verdict,
 	// shell prompt showing — check the transcript/worktree; retry plausible.
 	StatusReasonAgentExited = "agent_exited"
+	// StatusReasonObserverUnverified: the dead-check threshold was reached
+	// through an observation channel that never saw this run alive (L11c) —
+	// check the worker/daemon mux environment; the run self-recovers on the
+	// next successful capture.
+	StatusReasonObserverUnverified = "observer_unverified"
 )
 
 // NewStatusEventWithReason creates a status change event carrying a


### PR DESCRIPTION
Implements `docs/design/run-state-machine.md` §9 and §10 (both accepted 2026-07-08 via PR #489). Core-surface change: frontier + human, implemented in-session per the routing rule. Two commits, one per section.

## Commit 1 — §9 interactive-gate detection (O4e)

**Incident killed**: 2026-07-07, two codex runs sat ~2h at the codex login screen as `running`/ALIVE while `orch wait` never fired.

```
before:  gate screen → no reading → running forever (invisible stall)
after :  gate screen → O4e gate reading ×2 ticks → waiting(gate_login)
         → orch wait fires, ps shows waiting(gate_login), Slack notifies
```

- `internal/agent/gates.go`: compiled-in declarative gate table ({Kind, All} rows, ≥2 conjunctive lowercase substrings, shared busy veto); `AgentManager.DetectGate`
- **Real-pane fixtures** (codex login / codex trust / claude trust) captured from live tmux panes *before* writing pattern rows; meta-test audits every row mechanically
- `runCore.PromptStreak` → kind-tagged `{ReadingKind, ReadingStreak}` (L10a; L6 = the prompt special case)
- L10b precedence: busy veto > gate > {exited, completed, api-limited, failed} > prompt > output-changed
- **D-G1**: `commitRunStatus` no-op predicate is now the `(status, reason)` pair; `runView.StatusReason` lets the pure core decide reason re-appends (L10c)
- Laws L10a–c + fixture-locked end-to-end precedence: `step_gate_test.go`

## Commit 2 — §10 observer attestation for death verdicts

**Incident killed**: 2026-07-07 22:53, a restarted worker inherited a poisoned `TMUX` socket and its 3×"not found" marked two live runs `failed`.

```
default tmux server            agent-deck tmux server
┌────────────────────┐         ┌────────────────────┐
│ orch-xxx  (alive)  │         │                    │
└────────▲───────────┘         └─────────▲──────────┘
         │ nobody looks here             │ poisoned TMUX
   old worker (gone)               new worker ──"not found"×3──► failed ✗
after: unattested channel → unknown(observer_unverified), self-recovers ✓
```

- **Principle (I9)**: a death verdict requires positive evidence from an attested channel — not-founds from a channel that never saw this run alive are testimony, not evidence
- ObserverID = `worker:<id>:<nonce>` / `local:<nonce>`, nonce per process start, carried in the lease **result** payload (JSON — no proto change needed)
- Gone classification moves observation-side (L11d): `CaptureSessionResult.Gone{Class}`; the capture lease succeeds with a structured verdict; `isRemoteSessionGone` demoted to the frozen `legacyRemoteSessionGone` shim (unattested-only, deletable)
- `runCore.AliveObserver`/`DeadCheckObserver` (ephemeral); L11a streak continuity; L11b attestation gate on the no-evidence fallbacks; L11c `unknown(observer_unverified)` + automatic re-attestation recovery
- **L7'**: restarts soften/delay would-be `failed` into `unknown(observer_unverified)`, never strengthen (accepted tradeoff: post-restart dead runs conclude unknown, not failed)
- `orch capture` fails fast on structured gone verdicts (no silent empty output)
- Laws L11a–d/L7'/I9 as property tests incl. incident replay and an I9 sweep: `step_observer_test.go`

## Verification

- `go test ./...` green locally (sole failure `TestRunWithBuiltInAgents` is the known pre-existing environmental opencode-server issue, fails on main too)
- `make lint` clean (semgrep architecture rules + fixtures)
- No new status writer; no new `nosemgrep`; spec fold-in shipped in the same change set (§2/§3/§4/§5/§7 + §9/§10 status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)