### PR TITLE
docs: local quickstart (ja) + align docs with the master/worker reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,14 @@ curl -sSL https://raw.githubusercontent.com/proboscis/orch/main/install.sh | bas
 # Or with Go
 go install github.com/proboscis/orch/cmd/orch@latest
 
+# One-time, inside your git repo (needs an `origin` remote — orch derives
+# project identity from its URL):
+mkdir -p .orch && printf 'agent: claude\nbase_branch: main\n' > .orch/config.yaml
+orch daemon repo register "$(pwd)"   # map project identity -> this checkout
+orch worker start                    # launches agent sessions; required even locally
+
 # Create an issue
-mkdir -p issues && cat > issues/my-task.md << 'EOF'
----
-type: issue
-id: my-task
-title: Add hello world function
-status: open
----
-Add a hello world function to the project.
-EOF
+orch issue create my-task --title "Add hello world function"
 
 # Run an agent
 orch run my-task
@@ -34,13 +32,15 @@ orch ps
 orch attach my-task
 ```
 
-**[Read the full Getting Started guide](./docs/getting-started.md)**
+**[Read the full Getting Started guide](./docs/getting-started.md)** —
+日本語版のローカル入門は **[ローカルクイックスタート](./docs/local-quickstart.ja.md)**。
 
 ## Documentation
 
 | Guide | Description |
 |-------|-------------|
 | **[Getting Started](./docs/getting-started.md)** | Install → First issue → First run → See it work |
+| **[ローカルクイックスタート (日本語)](./docs/local-quickstart.ja.md)** | 1 台のマシンで試す最短経路(クラスタ設定なし) |
 | **[Remote Usage](./docs/remote-usage.md)** | Run orch against a remote daemon over TCP |
 | **[Daily Workflow](./docs/daily-workflow.md)** | Morning routine, parallel runs, reviewing PRs |
 | **[orch-monitor TUI](./docs/orch-monitor.md)** | Visual dashboard for managing issues and runs |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -169,10 +169,29 @@ The **git repository** where `.orch/` configuration lives.
 
 Contains:
 - `.orch/config.yaml` - Project configuration
-- `.orch/daemon.log` - Background daemon logs
-- `.orch/daemon.sock` - Daemon communication socket
 
 This is separate from Issues Root - your code lives in Project Root, while tasks/issues can be stored elsewhere.
+
+The daemon itself is global (one per machine, not per project). Its files live
+in XDG locations, not in the project root:
+
+- Logs: `~/Library/Logs/orch/daemon.log` (macOS) / `~/.local/state/orch/daemon.log` (Linux)
+- Socket, PID, lock: `~/Library/Caches/orch/run/` (macOS) / `$XDG_RUNTIME_DIR/orch/` (Linux)
+- Project registry: `~/.config/orch/projects/<project_id>.yaml` (written by `orch daemon repo register`)
+
+### Daemon and Worker
+
+Two long-lived processes cooperate to execute runs:
+
+- The **daemon** (master) owns all issue/run/event state and resolves project
+  identities. It starts automatically on your first orch command.
+- The **worker** launches and supervises the actual agent sessions on its
+  host. It does **not** start automatically — run `orch worker start` once per
+  boot. Without a worker, `orch run` fails with `no active workers available`.
+
+On a single machine you run both locally and never notice the split. The same
+model scales to multiple hosts: workers on other machines register to one
+daemon (see [Remote Usage](./remote-usage.md)).
 
 ### RUN_REF
 
@@ -209,13 +228,17 @@ A **6-character hex identifier** for quick reference.
 │                      Project Root                           │
 │  ┌────────────────┐                                        │
 │  │ .orch/         │                                        │
-│  │  ├─ config.yaml│  (configuration)                       │
-│  │  ├─ daemon.log │  (monitoring logs)                     │
-│  │  └─ daemon.sock│  (IPC)                                 │
+│  │  └─ config.yaml│  (configuration)                       │
 │  └────────────────┘                                        │
 │  ┌────────────────┐                                        │
 │  │ src/           │  (your code)                           │
 │  └────────────────┘                                        │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                Global daemon + worker (per machine)         │
+│  daemon: state, identity   logs/socket in XDG dirs          │
+│  worker: launches agent sessions (`orch worker start`)      │
 └─────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────┐

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,16 @@ orch --remote master-host:7777 daemon repo list
 In remote mode, orch resolves project identity from `--project`/`ORCH_PROJECT`
 and daemon repo mappings.
 
+Note: repo registration is not remote-specific — the **local** daemon needs it
+too. For a local checkout, register by path from the repository root:
+
+```bash
+orch daemon repo register "$(pwd)"
+```
+
+The mapping lands in `~/.config/orch/projects/<project_id>.yaml` (project_id =
+origin URL normalized to `<owner>-<repo>`) and takes effect immediately.
+
 ## Quick Start
 
 Create `.orch/config.yaml` in your project root:

--- a/docs/daily-workflow.md
+++ b/docs/daily-workflow.md
@@ -7,6 +7,10 @@ This guide covers typical day-to-day usage patterns for working with orch and AI
 Start your day by checking what happened overnight:
 
 ```bash
+# Verify the worker is alive first — workers do not survive reboots,
+# and without one every `orch run` fails with `no active workers available`
+orch worker status   # if not running: orch worker start
+
 # Check status of all runs
 orch ps
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,10 @@ Before installing orch, ensure you have:
    - [OpenCode](https://github.com/sst/opencode) (`opencode`)
    - [Codex](https://github.com/openai/codex) (`codex`)
    - [Gemini CLI](https://github.com/google/gemini-cli) (`gemini`)
-4. **Git** - For worktree management
+4. **Git** - For worktree management. Your repository must have an `origin`
+   remote — orch derives the project identity from its URL. (For a local
+   sandbox the URL does not need to exist on GitHub; it is used as an
+   identity.)
 5. **GitHub CLI** (`gh`) - Required for the PR workflow. Run `gh auth login` before creating PRs.
 6. **uv** - Required only when installing or developing the Python TUI (`orch-monitor`)
 
@@ -99,6 +102,22 @@ base_branch: main
 EOF
 ```
 
+### Register the project with the daemon (required)
+
+The daemon resolves every command through a project identity derived from
+your `origin` remote URL (normalized to `<owner>-<repo>`). Map that identity
+to your checkout once:
+
+```bash
+orch daemon repo register "$(pwd)"
+# => Registered repo mapping: <owner>-<repo> -> /path/to/your/repo
+```
+
+Without this mapping, commands fail with
+`unknown project_id "…" (register daemon project mapping)`. The mapping is
+stored in `~/.config/orch/projects/<project_id>.yaml` and takes effect
+immediately — no daemon restart needed.
+
 ### Setting up the issues directory
 
 orch needs a place to store issues. Configure it in `.orch/config.yaml`.
@@ -129,6 +148,12 @@ issues:
   path: ./issues
 EOF
 ```
+
+Note: the store keeps issue files under an `issues/` subdirectory of the
+configured path (or `Issues/` if one already exists) — with the config above,
+`orch issue create` writes to `./issues/issues/<id>.md`. Prefer
+`orch issue create` over placing files by hand so they land where the store
+actually reads them.
 
 ## Create your first issue
 
@@ -161,6 +186,20 @@ Or use the CLI:
 orch issue create my-first-issue --title "Add a hello world function" --edit
 ```
 
+## Start the local worker (required)
+
+The daemon starts automatically on your first orch command, but the
+**worker** — the process that actually launches agent sessions — does not:
+
+```bash
+orch worker start
+orch worker status   # expect: Local Process: running / Master Registration: active
+```
+
+Without a worker, `orch run` fails with `no active workers available`.
+Workers do not survive reboots — re-run `orch worker start` after restarting
+your machine.
+
 ## Run your first agent
 
 Start an agent to work on the issue:
@@ -176,6 +215,19 @@ This will:
 4. Send the issue content as the initial prompt
 
 The command returns immediately - the agent runs in the background.
+
+### First run: expect a trust prompt
+
+On a fresh machine or directory, agent CLIs show a one-time interactive gate
+(e.g. "Do you trust the contents of this directory?") and the run parks at
+`waiting`. This is the normal interaction loop, not a failure:
+
+```bash
+orch capture my-first-issue   # see what the agent is asking
+orch send my-first-issue ""   # empty message = press Enter (accept the default)
+# or take over the terminal directly:
+orch attach my-first-issue    # answer, then detach with Ctrl+B D
+```
 
 ## Check status
 
@@ -198,7 +250,7 @@ my-first-issue   running  20260120-163045     claude  2m ago
 | `queued` | Run created, starting soon |
 | `booting` | Agent is launching |
 | `running` | Agent is actively working |
-| `waiting` | Agent needs your input |
+| `waiting` | The agent's input box is free — it needs your input, or just finished its turn (`orch capture` to tell which) |
 | `pr_open` | Agent created a PR |
 | `done` | Task completed |
 | `failed` | Something went wrong |
@@ -316,6 +368,24 @@ orch diff --stat my-issue
 
 ## Troubleshooting
 
+### `project identity required: failed to resolve git remote`
+
+The repository has no `origin` remote, or you ran the command outside the
+repository. Add a remote (`git remote add origin …`) and run orch commands
+from inside the repo — they are project-scoped by your current directory.
+Alternatively set `ORCH_PROJECT` explicitly.
+
+### `unknown project_id "…" (register daemon project mapping)`
+
+The project is not registered with the daemon. Run
+`orch daemon repo register "$(pwd)"` from the repository root (see
+[Register the project with the daemon](#register-the-project-with-the-daemon-required)).
+
+### `no active workers available`
+
+The local worker is not running (it does not survive reboots). Run
+`orch worker start`.
+
 ### Run fails immediately
 
 Enable debug output:
@@ -345,6 +415,12 @@ orch repair
 
 ### Check daemon logs
 
+The daemon is global (one per machine, not per project):
+
 ```bash
-tail -f .orch/daemon.log
+# macOS
+tail -f ~/Library/Logs/orch/daemon.log
+
+# Linux (XDG state dir)
+tail -f ~/.local/state/orch/daemon.log
 ```

--- a/docs/local-quickstart.ja.md
+++ b/docs/local-quickstart.ja.md
@@ -1,0 +1,163 @@
+# orch ローカルクイックスタート(クラスタ設定なし)
+
+このガイドは 1 台のマシンだけで orch を試すための最短経路です — ローカル
+daemon、ローカル worker、ローカルの agent セッションのみを使い、リモート
+master・`client.yaml`・SSH は一切登場しません。掲載している手順はすべて
+orch `v1.4.0-beta` 相当のバイナリで実際に実行・検証済みです。
+
+英語の全体ガイドは [Getting Started](./getting-started.md) を参照してください。
+
+## 1. 前提ツール
+
+| ツール | 用途 | 確認コマンド |
+|--------|------|--------------|
+| `git` | worktree 管理 | `git --version` |
+| `tmux` | agent セッションの実行環境 | `tmux -V` |
+| agent CLI(いずれか 1 つ、**ログイン済み**) | 実際に作業する主体 | `codex --version` / `claude --version` |
+| `gh`(任意) | PR ワークフローを試す場合のみ | `gh auth status` |
+
+agent CLI(`codex` / `claude`)には orch を使う前に一度対話ログインして
+ください。orch はその認証状態をそのまま使います — API キーを orch や
+エージェントに渡す必要はありません(渡さないでください)。
+
+orch 本体のインストール:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/proboscis/orch/main/install.sh | bash
+orch --help   # 動作確認
+```
+
+## 2. サンドボックスプロジェクトの準備(初回のみ、約 2 分)
+
+最初の run は実プロジェクトではなく使い捨ての repo で試すことを勧めます。
+
+```bash
+mkdir ~/orch-sandbox && cd ~/orch-sandbox
+git init -b main
+echo "# orch sandbox" > README.md
+
+# orch はプロジェクトの同一性(project identity)を origin URL から導出します。
+# 基本ループを試すだけなら GitHub 上に実在しなくても構いません
+# (URL は識別子として使われるだけ)。PR ワークフローまで試すなら
+# 実在する自分の repo URL を使ってください。
+git remote add origin https://github.com/<you>/orch-sandbox.git
+
+mkdir .orch
+cat > .orch/config.yaml << 'EOF'
+agent: codex          # または claude
+base_branch: main
+issues:
+  backend: local
+  path: ./issues      # issue の markdown を repo 内に置く
+EOF
+
+git add -A && git commit -m "init orch sandbox"
+```
+
+このプロジェクトを daemon に登録します(identity → checkout の対応付け):
+
+```bash
+orch daemon repo register "$(pwd)"
+# => Registered repo mapping: <you>-orch-sandbox -> /Users/<you>/orch-sandbox
+```
+
+daemon の再起動は不要です。登録内容は
+`~/.config/orch/projects/<project_id>.yaml` に保存されます。
+
+> **補足**: issue ファイルは `path` 直下ではなく `<path>/issues/`
+> (`Issues/` ディレクトリが既にあればそちら)に作られます。
+
+## 3. ローカル worker の起動(必須)
+
+daemon は最初の orch コマンドで自動起動しますが、**agent セッションを
+実際に起動する worker は自動では立ち上がりません**。worker なしで
+`orch run` すると `no active workers available` で失敗します。
+
+```bash
+orch worker start
+orch worker status   # Local Process: running / Master Registration: active を確認
+```
+
+worker はマシンの再起動後には残りません。突然 run が
+`no active workers available` で失敗するようになったら
+`orch worker start` を再実行してください。
+
+## 4. ゴールデンパス
+
+orch のコマンドはカレントディレクトリからプロジェクトを解決します —
+**サンドボックス repo の中で**実行してください。
+
+```bash
+cd ~/orch-sandbox
+
+# 1. タスクを issue として記述する
+orch issue create hello-world --title "Add a hello world script" << 'EOF'
+Create hello.py at the repository root that prints "Hello, World!" when run
+with python3. Keep it to a few lines. Do not create anything else.
+EOF
+
+# 2. agent を起動する(--no-pr: まずは PR なしで)
+orch run hello-world --no-pr
+
+# 3. 観察する
+orch ps                      # booting → running → waiting と遷移する
+orch capture hello-world     # agent のターミナル画面のスナップショット
+```
+
+### 初回 run では agent が trust 確認を出す
+
+まっさらなマシン/ディレクトリでは、agent CLI が初回に対話ゲート
+(「Do you trust the contents of this directory?」など)を表示し、run は
+`waiting` で停止します。これは故障ではなく、orch の対話ループそのものです:
+
+```bash
+orch capture hello-world     # 何を聞かれているか確認する
+orch send hello-world ""     # 空メッセージ = Enter 送信(デフォルト選択を受理)
+# あるいはターミナルを直接操作する:
+orch attach hello-world      # 対話後、Ctrl+B D でデタッチ
+```
+
+### 完了を待って結果を確認する
+
+```bash
+orch wait hello-world --timeout 600
+```
+
+`waiting` は「agent の入力欄が空いている」ことを意味します — trust ゲート
+通過後の `waiting` は通常「agent がそのターンを終えた」合図です。
+**結論を出す前に必ず `orch capture` で agent の報告を読んでください。**
+成果物は隔離された worktree にあります(パスは `orch ps` /
+`orch show hello-world` で表示されます):
+
+```bash
+python3 ~/.orch/worktrees/hello-world/<run-dir>/hello.py   # → Hello, World!
+```
+
+### 片付け
+
+```bash
+orch stop hello-world      # セッションを終了する(状態は canceled になる)
+orch resolve hello-world   # issue を完了扱いにする
+```
+
+実在する GitHub repo と認証済みの `gh` があれば、`--no-pr` を外すだけで
+agent は commit → push → PR 作成まで行い、run は `pr_open` であなたの
+レビューを待ちます。これが本来の日常ワークフローです。
+
+## 5. 遭遇しうるエラー(すべて意図的に再現して確認済み)
+
+| 症状 | 原因 | 対処 |
+|------|------|------|
+| `project identity required: failed to resolve git remote` | origin remote が無い、または repo の外で実行 | `git remote add origin …`、repo 内に `cd`(または `ORCH_PROJECT` を設定) |
+| `unknown project_id "…" (register daemon project mapping)` | 手順 2 の登録漏れ | `orch daemon repo register "$(pwd)"` |
+| `no active workers available` | worker 未起動(再起動後を含む) | `orch worker start` |
+| `capture`/`send` が `run not found` | 別プロジェクトのディレクトリに居る(CWD でプロジェクト解決) | サンドボックス repo に `cd` してから実行 |
+| 起動直後から `waiting` のまま | agent の trust/onboarding ダイアログ | `orch capture` で確認 → `orch send <run> ""` か `orch attach` |
+| すべての issue コマンドが `daemon error: store_error` | 壊れた issue ファイルが 1 つでもあると store 全体が fail-loud | frontmatter の `status` は `open`/`closed`/`resolved` のみ。daemon ログ(macOS: `~/Library/Logs/orch/daemon.log`、Linux: `~/.local/state/orch/daemon.log`)が対象ファイル名を報告する |
+
+## 6. 今回あえて使わなかったもの
+
+`client.yaml`、`ORCH_REMOTE`、`config.targets`、`--on <target>`、SSH —
+これらはすべてマルチホスト(クラスタ)運用のための構成要素で、ローカル
+テストには不要です。クラスタ構成は [Remote Usage](./remote-usage.md) を
+参照してください。


### PR DESCRIPTION
## What

ベータテスター(同僚)受け入れ前の docs 真実化。全手順をクリーンな scratch repo で実機検証し、既存 docs に無い**必須手順 3 点**を発見したので反映する。

### 実機検証で確定した truth(docs が沈黙していたもの)

1. **project identity は origin remote 由来** — origin が無いと全コマンドが `project identity required` で停止(ローカル利用でも)
2. **project 登録が必須** — `orch daemon repo register "$(pwd)"`(ローカルパス登録が動作、mapping YAML 自動生成、daemon 再起動不要)。未登録は `unknown project_id`
3. **worker はローカル実行でも必須** — daemon は自動起動するが worker は `orch worker start` が要る。未起動は `no active workers available`。reboot で消える

さらに初回 run は agent CLI の trust gate で `waiting` に停まる(`orch send <run> ""` = Enter で通過)— これも golden path に組み込んだ。

### 変更

- **docs/local-quickstart.ja.md(新規)**: 日本語のローカル最短経路。全コマンド実行済み・全エラー意図的に再現済みの対処表付き
- **README**: Quick Start に registration/worker を追加。hand-written issue file の例は store から不可視(store は `<path>/issues/` を読む)ため `orch issue create` に置換
- **getting-started**: Register/Worker セクション追加、trust gate 手順、`waiting` の正確な意味、daemon log の実パス(global daemon の XDG 位置: macOS `~/Library/Logs/orch/`)、新 troubleshooting 3 種
- **concepts**: legacy per-project `.orch/daemon.log`/`daemon.sock` 記述を削除し Daemon and Worker 概念を追加(実装: `internal/xdg/paths.go` / `internal/daemon/pid.go` の Legacy* が根拠)
- **daily-workflow**: morning routine の先頭に `orch worker status`
- **configuration**: registration はローカル daemon にも必要である旨

## Verification

- 手順どおりにゼロから実行: register-by-path → worker start → issue create → run → trust gate を send "" で通過 → 成果物確認 → stop/resolve(orch v1.3.0-beta-5-ga59cd9f4、2026-07-08)
- 対処表の 6 エラーはすべて意図的に再現して文言を採取

## Follow-up(このPRでは触らない)

- `internal/daemon/socket.go:2384` の 案内文字列が今も `.orch/daemon.log` を指す(コード側の stale hint — docs スコープ外なので別 issue が妥当)

🤖 Generated with [Claude Code](https://claude.com/claude-code)