### PR TITLE
fix: align embedded help text (orch tutorial, control-agent prompt) with reality

### DIFF
--- a/internal/cli/tutorial.go
+++ b/internal/cli/tutorial.go
@@ -43,6 +43,10 @@ This guide covers setup and basic usage.
 1. INITIAL SETUP
 --------------------------------------------------------------------------------
 
+Prerequisite: your repo needs an 'origin' remote — orch derives the project
+identity from its URL (normalized to <owner>-<repo>). Without one, every
+command fails with 'project identity required'.
+
 Create config directory in your repo root:
 
     mkdir -p .orch
@@ -57,6 +61,19 @@ This creates the structure:
     ~/my-project-issues/
     ├── issues/       # issue markdown files
     └── runs/         # run logs (auto-created)
+
+Register the project with the daemon (required — maps the identity to this
+checkout, stored in ~/.config/orch/projects/<project_id>.yaml, effective
+immediately):
+
+    orch daemon repo register "$(pwd)"
+
+Start the local worker (required even for purely local runs — the daemon
+starts automatically on your first command, the worker does not, and it does
+not survive reboots):
+
+    orch worker start
+    orch worker status
 
 --------------------------------------------------------------------------------
 2. CONFIGURE DEFAULT AGENT AND MODEL
@@ -88,9 +105,16 @@ Create an issue:
 
     orch issue create my-001 --title "My first task" --body "Description here"
 
-Or manually create ~/my-project-issues/issues/my-001.md:
+Or manually create ~/my-project-issues/issues/my-001.md — YAML frontmatter is
+required, and the store is strict about it (one malformed file breaks every
+issue command; status must be open/closed/resolved):
 
-    # My first task
+    ---
+    type: issue
+    id: my-001
+    title: My first task
+    status: open
+    ---
 
     Description here.
 
@@ -101,6 +125,13 @@ Start a run:
 Check status:
 
     orch ps
+
+First run on a fresh machine: the agent CLI shows a one-time trust prompt
+("Do you trust the contents of this directory?") and the run parks at
+'waiting'. This is the normal interaction loop, not a failure:
+
+    orch capture my-001     # see what the agent is asking
+    orch send my-001 ""     # empty message = press Enter (accept the default)
 
 Interact with the agent:
 
@@ -134,18 +165,32 @@ frontends.
     Status      Meaning                   Action
     ------      -------                   ------
     running     Agent is working          Wait or 'attach' to watch
-    waiting     Agent needs input         'attach' to help
+    waiting     Input box is free: needs  'capture' to read, then
+                input OR finished a turn  'send'/'attach' to answer
     pr_open     PR created                Review the PR
     done        Work complete             'orch resolve <issue>' to ack
     failed      Error occurred            Check logs, 'restart-from'
 
 To check why a run is waiting:
 
+    orch capture <run>
     orch show <run>
 
 --------------------------------------------------------------------------------
 6. WHEN THINGS GO WRONG
 --------------------------------------------------------------------------------
+
+'no active workers available' — the worker is not running (it does not
+survive reboots):
+
+    orch worker start
+
+'project identity required' — no 'origin' remote, or you are outside the
+repo (commands are project-scoped by your current directory).
+
+'unknown project_id "..." (register daemon project mapping)':
+
+    orch daemon repo register "$(pwd)"
 
 Fix daemon, orphaned sessions, stale states:
 
@@ -253,8 +298,8 @@ Point every command at a shared master daemon via client.yaml
     remote:
       default: "<master-host>:7777"
 
-Each host that should execute runs needs a local worker registered to the
-master:
+As with local use, each host that should execute runs needs its own worker —
+started on that host, registered to the master:
 
     orch worker start
     orch worker status

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -2381,7 +2381,7 @@ The following commands are interactive and will hang if called by an AI agent:
 - Issue not showing in list: `+"`orch validate-issue-files <issue-id>`"+` to check for formatting errors
 - Validate all issue files: `+"`orch validate-issue-files`"+` to find malformed issues
 - Orphaned sessions: `+"`orch repair`"+`
-- View daemon logs: Check `+"`.orch/daemon.log`"+` in project root
+- View daemon logs: `+"`~/Library/Logs/orch/daemon.log`"+` (macOS) / `+"`~/.local/state/orch/daemon.log`"+` (Linux) — the daemon is global, not per-project
 - Force stop all: `+"`orch stop --all`"+`
 
 ## Instructions


### PR DESCRIPTION
## What

`orch tutorial`(同梱ガイド)と control-agent prompt の埋め込みテキストが、PR #491 で真実化した docs と食い違ったまま(= master/worker 化前の記述)だったのを修正。ベータテスターが最初に読む面なので release 前に揃える。

- **tutorial.go**: origin remote 前提 / `daemon repo register` / `worker start`(ローカルでも必須)/ 手書き issue 例への必須 frontmatter / 初回 trust gate の対話手順(`send ""` = Enter)/ waiting の正確な意味 / エラー 3 種の troubleshooting / Section 9 の「worker は remote 専用」に読める文言の修正
- **socket.go**: control-agent prompt の daemon log 案内を legacy `.orch/daemon.log` から global daemon の XDG 実パスへ(#491 で宣言済みの follow-up)

## Verification

- `go build ./...` green、`go run ./cmd/orch tutorial` で新テキストのレンダリング確認
- 記載内容は PR #491 と同一の実機検証(2026-07-08、クリーン scratch repo でエラー再現込み)に基づく

🤖 Generated with [Claude Code](https://claude.com/claude-code)