### PR TITLE
feat: one-line agent install — runbook + README paste line + skill local-setup truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ Orchestrator for managing multiple LLM CLIs (Claude, Codex, Gemini, OpenCode) us
 
 orch runs AI coding agents non-interactively in the background, creating isolated git worktrees for each task. Check status with `orch ps`, interact when needed with `orch attach`.
 
+## Install via your AI agent (one line)
+
+Paste this into your coding agent (Claude Code, Codex, OpenCode, …):
+
+```
+Fetch https://raw.githubusercontent.com/proboscis/orch/main/docs/agent-install.md and follow it exactly: install the orch binary, install the orch skill into this agent, then walk me through my first orch run interactively.
+```
+
+The agent installs the binary, installs the [orch skill](./claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md)
+into its own skills directory (so every future session knows orch), and then
+runs the first tutorial together with you. Manual setup is below.
+
 ## Quick Start
 
 ```bash
@@ -40,6 +52,7 @@ orch attach my-task
 | Guide | Description |
 |-------|-------------|
 | **[Getting Started](./docs/getting-started.md)** | Install → First issue → First run → See it work |
+| **[Agent Install Runbook](./docs/agent-install.md)** | One-liner setup executed by your own AI agent (binary + skill + guided first run) |
 | **[ローカルクイックスタート (日本語)](./docs/local-quickstart.ja.md)** | 1 台のマシンで試す最短経路(クラスタ設定なし) |
 | **[Remote Usage](./docs/remote-usage.md)** | Run orch against a remote daemon over TCP |
 | **[Daily Workflow](./docs/daily-workflow.md)** | Morning routine, parallel runs, reviewing PRs |

--- a/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
+++ b/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
@@ -6,7 +6,7 @@ description: |
   restart-from, orch worker start/status/stop, orch attach/capture/send/exec, and remote execution
   via ORCH_REMOTE and target_host. Trigger terms: orch, orchestrator, worker, master, ORCH_REMOTE,
   target_host, run management, issue management, agent runs, worktree.
-version: 1.3.0
+version: 1.4.0
 ---
 
 # Orch Toolset
@@ -32,7 +32,7 @@ Important remote rule:
 
   ```yaml
   remote:
-    default: "zeus:7777"
+    default: "master-host:7777"
   ```
 
 - It does **not** mean `worker start` happens on the remote host.
@@ -44,11 +44,37 @@ Important remote rule:
   master repo's issues, and `issue create` fails with `project identity required` even inside
   a git repo with `origin` set.
 
+## Local Single-Machine Setup (required once per repo — verified 2026-07-08)
+
+Three requirements hold even with NO remote master, and their absence is the
+most common first-run failure:
+
+1. **`origin` remote required.** Project identity is derived from the origin
+   URL (normalized `<owner>-<repo>`). Without one, every command fails with
+   `project identity required`. The URL need not exist on GitHub for local
+   testing — it is used as an identity.
+2. **Project registration required.** The daemon (local or remote) resolves
+   commands through a registry mapping. Register the checkout by path:
+   `orch daemon repo register "$(pwd)"` — writes
+   `~/.config/orch/projects/<project_id>.yaml`, effective immediately, no
+   daemon restart. Missing → `unknown project_id "…" (register daemon project
+   mapping)`.
+3. **Worker required even for purely local runs.** The daemon auto-starts on
+   the first command; the worker does not, and it does not survive reboots.
+   Missing → `orch run` fails with `no active workers available`. Fix:
+   `orch worker start`, verify with `orch worker status`.
+
+Also expect the agent CLI's one-time trust dialog on a fresh
+machine/directory: the run parks at `waiting` right after boot; read it with
+`orch capture <run>` and accept with `orch send <run> ""` (empty message =
+Enter).
+
 ## Core Workflow
 
 1. Create or inspect the issue with `orch issue create`, `orch issue list`, or `orch open`.
-2. If using a remote master, start or verify the **local** worker first:
-   `ORCH_REMOTE=<master> orch worker start`
+2. Ensure the worker is up first — required for local AND remote execution:
+   `orch worker start` / `orch worker status` (with a remote master:
+   `ORCH_REMOTE=<master> orch worker start`).
 3. Start work with `orch run <issue-id>`.
 4. Track state with `orch ps` and inspect details with `orch show`.
 5. Interact with the live run via `orch capture`, `orch send`, and `orch attach`.

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -1,0 +1,144 @@
+# orch — Agent Install Runbook
+
+**Audience: you, an AI coding agent** (Claude Code, Codex, OpenCode, or
+similar). Your user pasted a one-liner asking you to set up orch. Follow the
+steps below in order. Run the commands yourself, show the user what happened,
+and ask before anything irreversible. The end state is:
+
+1. the `orch` binary installed and working,
+2. the orch skill installed into **this agent's** skills directory so every
+   future session knows how to drive orch,
+3. the user has completed one real orch run, guided by you.
+
+Do NOT run `orch attach` or `orch monitor` yourself — they are interactive
+and will hang a non-interactive agent. Use `orch capture` and `orch send`
+instead; offer `attach` to the user as a command *they* can type.
+
+---
+
+## Step 0 — Detect the environment
+
+- OS: macOS or Linux (this runbook covers both).
+- Which agent are you? This decides the skill directory in Step 3.
+- Ask the user which agent CLI orch should launch for runs (claude / codex /
+  gemini / opencode). It must already be logged in — orch reuses its
+  credential state. Never handle raw API keys.
+
+## Step 1 — Check prerequisites
+
+```bash
+git --version        # required
+tmux -V              # required (agent sessions run inside tmux)
+gh auth status       # optional; needed only for the PR workflow
+<agent-cli> --version   # the CLI chosen above, e.g. codex --version
+```
+
+Report anything missing to the user and offer to install it
+(`brew install tmux gh` / `apt install tmux gh`).
+
+## Step 2 — Install the orch binary
+
+```bash
+curl -sSL https://raw.githubusercontent.com/proboscis/orch/main/install.sh | bash
+orch --help   # verify; if "command not found", ensure ~/.local/bin is on PATH
+```
+
+## Step 3 — Install the orch skill into this agent
+
+The skill teaches future sessions the orch execution model (daemon/worker,
+project registration, run lifecycle, troubleshooting). Install it for the
+agent you are running as — ask the user if they also want it installed for
+their other agents.
+
+```bash
+git clone --depth 1 https://github.com/proboscis/orch /tmp/orch-skill-install
+SKILL_SRC=/tmp/orch-skill-install/claude-plugins/orch-toolset/skills/orch-toolset
+
+# Claude Code
+mkdir -p ~/.claude/skills && cp -r "$SKILL_SRC" ~/.claude/skills/orch-toolset
+
+# Codex (same SKILL.md format)
+mkdir -p ~/.codex/skills && cp -r "$SKILL_SRC" ~/.codex/skills/orch-toolset
+
+rm -rf /tmp/orch-skill-install
+```
+
+For an agent without a skills directory (e.g. OpenCode), append the
+"Core Workflow" and "Quick Reference" sections of `SKILL.md` to the agent's
+global instructions file instead (e.g. `~/.config/opencode/AGENTS.md`),
+wrapped in `<!-- orch-skill start/end -->` markers so a re-install can
+replace the block idempotently.
+
+Verify: list the target directory and confirm `SKILL.md` is present. Note to
+the user that the skill loads in **new** sessions, not the current one.
+
+## Step 4 — Guided first run (do this together with the user)
+
+Ask the user: try orch on an existing repo, or on a throwaway sandbox?
+For a sandbox:
+
+```bash
+mkdir ~/orch-sandbox && cd ~/orch-sandbox && git init -b main
+echo "# orch sandbox" > README.md
+git remote add origin https://github.com/<user>/orch-sandbox.git   # identity only; needn't exist
+mkdir .orch && printf 'agent: %s\nbase_branch: main\n' "<chosen-agent>" > .orch/config.yaml
+git add -A && git commit -m "init orch sandbox"
+```
+
+Then walk through this sequence, explaining each step:
+
+```bash
+# 1. One-time wiring (both REQUIRED — most common first-run failures)
+orch daemon repo register "$(pwd)"   # maps project identity -> this checkout
+orch worker start                     # launches agent sessions; not automatic;
+orch worker status                    # does not survive reboots
+
+# 2. Describe a task and launch an agent on it
+orch issue create hello-world --title "Add a hello world script" \
+  --body "Create hello.py at the repo root that prints Hello, World!"
+orch run hello-world --no-pr          # drop --no-pr when the repo really exists on GitHub
+
+# 3. Observe
+orch ps                               # booting -> running -> waiting
+orch capture hello-world              # read the agent's screen
+```
+
+**Expect a trust prompt on the first run**: the agent CLI asks
+"Do you trust the contents of this directory?" and the run parks at
+`waiting`. Show the user the captured screen, then answer it:
+
+```bash
+orch send hello-world ""              # empty message = press Enter (accept default)
+```
+
+Wait for the turn to finish and show the user the result:
+
+```bash
+orch wait hello-world --timeout 600
+orch capture hello-world              # the agent's report
+ls ~/.orch/worktrees/hello-world/*/   # the isolated worktree with the changes
+```
+
+Finish: `orch stop hello-world` then `orch resolve hello-world`. Explain
+that with a real GitHub repo (and `gh` logged in), dropping `--no-pr` makes
+the agent commit, push, and open a PR — the run then parks at `pr_open`.
+
+### If something fails
+
+| Error | Fix |
+|-------|-----|
+| `project identity required` | repo has no `origin` remote, or you are outside the repo |
+| `unknown project_id "…"` | run `orch daemon repo register "$(pwd)"` |
+| `no active workers available` | run `orch worker start` |
+| `store_error` on issue commands | a malformed issue file; frontmatter `status` must be open/closed/resolved |
+
+## Step 5 — Wrap up
+
+Tell the user:
+
+- new agent sessions will load the orch skill automatically,
+- `orch tutorial` shows the built-in reference anytime,
+- deeper docs: [Getting Started](./getting-started.md),
+  [ローカルクイックスタート (日本語)](./local-quickstart.ja.md),
+  [Daily Workflow](./daily-workflow.md), and
+  [Remote Usage](./remote-usage.md) for multi-host clusters.


### PR DESCRIPTION
## What

ベータテスターの受け入れ導線を 1 行に短縮する。ユーザーは自分の coding agent にこの 1 行を貼るだけ:

```
Fetch https://raw.githubusercontent.com/proboscis/orch/main/docs/agent-install.md and follow it exactly: install the orch binary, install the orch skill into this agent, then walk me through my first orch run interactively.
```

agent は runbook を読み、(1) install.sh で binary、(2) orch skill を自分の skills ディレクトリへ(将来の全セッションが orch を知る状態に)、(3) ユーザー同伴で初回 run チュートリアル、を実行する。

## 変更

- **docs/agent-install.md(新規)**: agent 向け runbook。skill の設置先は claude `~/.claude/skills/` / codex `~/.codex/skills/`(同一 SKILL.md 形式、実機で互換確認)。skills 機構の無い agent には global instructions への marker 付き追記。guided first run は PR #491/#492 で真実化した手順と同一(register → worker → trust gate → capture/send)。agent が `attach`/`monitor` を自分で実行すると hang する旨を明記
- **README**: 冒頭に one-liner セクション、docs 表に runbook 行
- **claude-plugins/orch-toolset SKILL.md**: 「worker は remote のときだけ」という stale(#491 で直した docs と同じ欠落)を修正し、Local Single-Machine Setup(origin remote / registration / worker / trust dialog)を新設。version 1.3.0→1.4.0。client.yaml 例の実ホスト名を汎用名 `master-host:7777` に変更

## Verification

- runbook のコマンド列は 2026-07-08 の実機検証(クリーン scratch repo、エラー 6 種の意図的再現込み)と同一
- codex の skill 形式互換は `~/.codex/skills/*/SKILL.md`(同一 frontmatter)で確認
- docs のみ + skill テキストのため build 影響なし

## Note

- reference.md / SKILL.md に残る `zeus` 参照は実測記録(verified notes)の一部でそのまま。sanitize するなら別 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)