### PR TITLE
chore: sanitize skills and docs — strip private identifiers, fix last stale paths

### DIFF
--- a/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
+++ b/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
@@ -81,7 +81,7 @@ Enter).
 6. Use `orch stop` only for actually stale or canceled work. Use `orch restart-from` only for
    failed, canceled, or unknown runs. Mark completed work with `orch resolve`.
 
-## Branch Resolution for `orch run` (verified 2026-07-05, doeff)
+## Branch Resolution for `orch run` (verified 2026-07-05)
 
 `orch run` creates the run's worktree branch (`issue/<ID>/run-<RUN_ID>`) from
 `--base-branch` (default: `base_branch` in `.orch/config.yaml`). The critical,
@@ -175,7 +175,7 @@ What to expect:
 Remote example:
 
 ```bash
-export ORCH_REMOTE=zeus:7777
+export ORCH_REMOTE=master-host:7777
 orch worker start
 orch worker status --json
 orch run plc-123
@@ -185,7 +185,7 @@ orch ps --json
 Interpretation:
 
 - the worker process started on **this** machine
-- the worker registered to `zeus:7777`
+- the worker registered to `master-host:7777`
 - the run's `target_host` / `HOST` tells you where the session actually runs
 
 ## Remote-Master Pitfalls (verified behaviors)
@@ -199,7 +199,7 @@ Interpretation:
   `no active worker available for target "host-<old-hostname>"`. Fix: update `targets:` in the
   config on the **master host**, then restart the master daemon.
 - **Per-project `.orch/config.yaml` is ALSO a target source and can shadow the fixed global
-  config** (verified 2026-07-05, doeff): the global `~/.config/orch/config.yaml` on the master
+  config** (verified 2026-07-05): the global `~/.config/orch/config.yaml` on the master
   had the corrected host, but runs for one project still resolved the old hostname because the
   project checkout's `.orch/config.yaml` `targets:` still carried it. After a host rename, sweep
   `targets:` in EVERY registered project checkout on the master
@@ -240,7 +240,7 @@ Interpretation:
   non-interactive ssh shell typically misses `~/.local/bin`. Fix:
   `orch worker stop`, then `export PATH="$HOME/.local/bin:$PATH"; orch worker start`.
 - **Execution-host toolchain rots silently — verify it before dispatching** (verified
-  2026-07-05, zeus): (a) the claude native-install `~/.local/bin/claude` symlink can dangle
+  2026-07-05, remote Linux host): (a) the claude native-install `~/.local/bin/claude` symlink can dangle
   after a version GC (`claude --version` via the absolute path is the check; rerun the
   installer to fix); (b) a missing multiplexer binary (tmux uninstalled) makes the run stick
   at `running`/ALIVE `no` with the worker log ending right after "Preparing worktree" and
@@ -248,7 +248,7 @@ Interpretation:
   `tmux -V` / `zellij --version` on the execution host when a run creates a worktree but never
   opens a session.
 - **File-backend issue store is fail-loud on ANY malformed issue file** (verified
-  2026-07-05, doeff-VAULT): a single file with broken frontmatter YAML (e.g. an unquoted
+  2026-07-05): a single file with broken frontmatter YAML (e.g. an unquoted
   colon in `title:`) or a status outside `open|closed|resolved` (seen: `done`,
   `in_progress`, `superseded`) makes EVERY `issue list`/`issue create` fail with the opaque
   `daemon error: store_error`. Diagnosis: the master's `~/Library/Logs/orch/daemon.log`
@@ -288,15 +288,15 @@ placement on the **master host**. THREE pieces are required:
 
    ```yaml
    targets:
-     - name: zeus
-       host: zeus
+     - name: remote
+       host: remote-host
    agent: codex
    base_branch: main
    pr_target_branch: main
    issues:
      backend: local
-     path: ~/repos/<repo>-issues     # external dir (doeff-VAULT / orch-issues / acp-issues
-                                     # pattern); in-repo VAULT also works (proboscis-ema)
+     path: ~/repos/<repo>-issues     # external issues dir (Obsidian-vault
+                                     # pattern); an in-repo vault dir also works
    github:
      owner: <org>
      repo: <repo>
@@ -310,15 +310,15 @@ placement on the **master host**. THREE pieces are required:
 
    ```yaml
    version: 1
-   project_id: CyberAgentAILab-agent-control-plane
-   display_name: agent-control-plane
+   project_id: your-org-your-repo
+   display_name: your-repo
    workspace:
-       root: /home/kento/repos/agent-control-plane
+       root: /home/user/repos/your-repo
    ```
 
    `project_id` is the normalized origin URL, `<org>-<repo>`
-   (`git@github.com:CyberAgentAILab/agent-control-plane.git` →
-   `CyberAgentAILab-agent-control-plane`). `project_id` and `workspace.root` are
+   (`git@github.com:your-org/your-repo.git` →
+   `your-org-your-repo`). `project_id` and `workspace.root` are
    required; a mapping whose root doesn't exist is silently broken (same "no
    store available" error even though the yaml is present).
 
@@ -344,11 +344,11 @@ Verified behaviors:
   ```yaml
   claude:
     profiles:
-      nameissoap:
-        config_dir: ~/.config/claude-nameissoap   # ~ expands on the EXECUTION host
-      cryptic:
-        config_dir: ~/.config/claude-cryptic
-        # optional: target: zeus / allowed_targets: [zeus]
+      personal:
+        config_dir: ~/.config/claude-personal   # ~ expands on the EXECUTION host
+      work:
+        config_dir: ~/.config/claude-work
+        # optional: target: remote / allowed_targets: [remote]
   ```
 
 - The daemon reads this at startup only — **restart the master daemon after adding profiles**.

--- a/claude-plugins/orch-toolset/skills/orch-toolset/reference.md
+++ b/claude-plugins/orch-toolset/skills/orch-toolset/reference.md
@@ -29,12 +29,12 @@ The default master and named master aliases live in `client.yaml` — global at
 
 ```yaml
 remote:
-  default: "zeus:7777"
+  default: "master-host:7777"
   hosts:
-    zeus:
-      addr: "zeus:7777"
+    primary:
+      addr: "master-host:7777"
     mac:
-      addr: "CA-20035844:7777"
+      addr: "laptop-host:7777"
 ```
 
 Keep `hosts:` addresses in sync with actual hostnames — stale entries from a machine
@@ -79,7 +79,7 @@ Notes:
 - Local backend requires `ISSUE_ID`.
 - GitHub backend can omit `ISSUE_ID` because GitHub assigns it.
 - **Requires explicit project identity**: pass `--project <origin URL>` (e.g.
-  `--project git@github.com:proboscis/proboscis-ema.git`) or set `ORCH_PROJECT`. Running
+  `--project git@github.com:your-org/your-repo.git`) or set `ORCH_PROJECT`. Running
   inside a git repo with `origin` set is NOT sufficient — observed failure
   `project identity required` against daemon @6b2bceb1.
 - With a remote master and the file backend, the issue file is created on the **master's**
@@ -124,7 +124,7 @@ Create a run, create its worktree, and launch the selected agent.
 orch run plc-123
 orch run plc-123 --agent codex
 orch run plc-123 --agent opencode --model anthropic/claude-opus-4-6 --model-variant max
-orch run plc-123 --on zeus
+orch run plc-123 --on remote
 orch run plc-123 --reuse
 orch run plc-123 --json
 ```
@@ -186,7 +186,7 @@ orch restart-from --branch "issue/plc-123/run-20260312-101500" --issue plc-123
 
 ### `orch wait`
 
-Block until a run reaches a "needs attention" state (`waiting`, `pr_open`, `blocked`,
+Block until a run reaches a "needs attention" state (`waiting`, `pr_open`,
 `failed`, etc). This is the **canonical way to wait for an agent** — do not poll
 `orch ps` in a loop.
 
@@ -201,7 +201,7 @@ orch wait <RUN_REF1> <RUN_REF2> ...          # wait on any of N runs
 Output is a single JSON line on the run that triggered:
 
 ```json
-{"run_id":"32c5b6","status":"waiting","issue":"unhandled-effect-class","pr_url":"https://github.com/proboscis/doeff/pull/399"}
+{"run_id":"32c5b6","status":"waiting","issue":"my-issue","pr_url":"https://github.com/your-org/your-repo/pull/399"}
 ```
 
 Returns exit `0` immediately if the run is already in an attention state. Returns
@@ -324,10 +324,10 @@ Start the managed local worker process.
 orch worker start
 
 # Start a local worker that registers to a remote master
-ORCH_REMOTE=zeus:7777 orch worker start
+ORCH_REMOTE=master-host:7777 orch worker start
 
 # Start a specific worker ID
-ORCH_REMOTE=zeus:7777 orch worker start --worker-id host-mac
+ORCH_REMOTE=master-host:7777 orch worker start --worker-id host-mac
 ```
 
 Important behavior:
@@ -341,8 +341,8 @@ Important behavior:
 Inspect the managed local worker and its master registration.
 
 ```bash
-ORCH_REMOTE=zeus:7777 orch worker status
-ORCH_REMOTE=zeus:7777 orch worker status --json
+ORCH_REMOTE=master-host:7777 orch worker status
+ORCH_REMOTE=master-host:7777 orch worker status --json
 ```
 
 Interpretation:
@@ -370,9 +370,9 @@ Example JSON shape:
 Stop the managed local worker process.
 
 ```bash
-ORCH_REMOTE=zeus:7777 orch worker stop
-ORCH_REMOTE=zeus:7777 orch worker stop --all
-ORCH_REMOTE=zeus:7777 orch worker stop --worker-id host-mac
+ORCH_REMOTE=master-host:7777 orch worker stop
+ORCH_REMOTE=master-host:7777 orch worker stop --all
+ORCH_REMOTE=master-host:7777 orch worker stop --worker-id host-mac
 ```
 
 ---
@@ -517,7 +517,7 @@ This is for `waiting` runs, not for general live-run control.
 ### Remote master, local worker
 
 ```bash
-export ORCH_REMOTE=zeus:7777
+export ORCH_REMOTE=master-host:7777
 
 orch worker start
 orch worker status --json
@@ -528,13 +528,13 @@ orch ps --json
 Expected interpretation:
 
 - worker process is on the local machine
-- master state is on `zeus:7777`
+- master state is on `master-host:7777`
 - `ps` / `show --json` tell you the actual execution host via `HOST` / `target_host`
 
 ### Operator-host control of remote run
 
 ```bash
-export ORCH_REMOTE=zeus:7777
+export ORCH_REMOTE=master-host:7777
 
 orch capture plc-123#20260312-101500
 orch send plc-123#20260312-101500 "Please reply with ACK"

--- a/docs/agents/claude.md
+++ b/docs/agents/claude.md
@@ -192,7 +192,7 @@ EOF
 
 2. Check daemon logs:
    ```bash
-   tail -f .orch/daemon.log
+   tail -f ~/Library/Logs/orch/daemon.log   # Linux: ~/.local/state/orch/daemon.log
    ```
 
 3. Attach and check Claude's state:

--- a/docs/agents/custom.md
+++ b/docs/agents/custom.md
@@ -307,7 +307,7 @@ orch run --verbose my-issue --agent custom --agent-cmd "my-agent"
 If orch can't detect your agent's state:
 1. Configure explicit completion/error patterns
 2. Ensure agent outputs recognizable messages
-3. Check daemon logs: `tail -f .orch/daemon.log`
+3. Check daemon logs: `tail -f ~/Library/Logs/orch/daemon.log   # Linux: ~/.local/state/orch/daemon.log`
 
 ### Environment issues
 

--- a/docs/e2e-master-worker-client.md
+++ b/docs/e2e-master-worker-client.md
@@ -281,9 +281,9 @@ Automation entrypoint:
 Target used in examples:
 
 - host: `zeus`
-- repo: `/home/kento/repos/doeff`
-- issues path: use the actual `issues.path` from `/home/kento/repos/doeff/.orch/config.yaml`
-  (for example `/home/kento/repos/doeff-VAULT`)
+- repo: `/home/user/repos/doeff`
+- issues path: use the actual `issues.path` from `/home/user/repos/doeff/.orch/config.yaml`
+  (for example `/home/user/repos/doeff-VAULT`)
 
 ```bash
 TS="$(date +%Y%m%d-%H%M%S)"
@@ -302,7 +302,7 @@ ssh zeus "$ENV_PREFIX orch master status"
 ssh zeus "$ENV_PREFIX orch worker status"
 
 # create sample issue
-ssh zeus "cat > /home/kento/repos/doeff-VAULT/issues/$ISSUE_ID.md <<'EOF'
+ssh zeus "cat > /home/user/repos/doeff-VAULT/issues/$ISSUE_ID.md <<'EOF'
 ---
 type: issue
 id: $ISSUE_ID
@@ -319,7 +319,7 @@ EOF"
 # If the managed clone created from the repo URL does not contain the required
 # project config (for example `.orch/config.yaml` is not committed), register
 # the operational project root instead.
-ssh zeus "$ENV_PREFIX orch daemon repo register /home/kento/repos/doeff"
+ssh zeus "$ENV_PREFIX orch daemon repo register /home/user/repos/doeff"
 
 # runtime commands use repo identity scope
 PROJECT_ID="proboscis-doeff"
@@ -340,7 +340,7 @@ gh pr create --repo proboscis/doeff --title 'chore(e2e): sample zeus run $ISSUE_
 EOF
 chmod +x /tmp/orch-zeus-agent-$ISSUE_ID.sh"
 
-ssh zeus "$ENV_PREFIX bash -lc 'cd /home/kento/repos/doeff && orch --project $PROJECT_ID run $ISSUE_ID --run-id $RUN_ID --agent custom --agent-cmd '\\''bash /tmp/orch-zeus-agent-$ISSUE_ID.sh'\\'' --json'"
+ssh zeus "$ENV_PREFIX bash -lc 'cd /home/user/repos/doeff && orch --project $PROJECT_ID run $ISSUE_ID --run-id $RUN_ID --agent custom --agent-cmd '\\''bash /tmp/orch-zeus-agent-$ISSUE_ID.sh'\\'' --json'"
 
 # find and close the sample PR
 BRANCH="issue/$ISSUE_ID/run-$RUN_ID"
@@ -351,7 +351,7 @@ ssh zeus "gh pr close <PR_NUMBER> --repo proboscis/doeff --comment 'Closing samp
 ssh zeus "$ENV_PREFIX orch --project $PROJECT_ID stop $ISSUE_ID#$RUN_ID --force"
 
 # cleanup
-ssh zeus "rm -f /home/kento/repos/doeff-VAULT/issues/$ISSUE_ID.md /tmp/orch-zeus-agent-$ISSUE_ID.sh"
+ssh zeus "rm -f /home/user/repos/doeff-VAULT/issues/$ISSUE_ID.md /tmp/orch-zeus-agent-$ISSUE_ID.sh"
 ssh zeus "$ENV_PREFIX orch worker stop --all"
 ```
 
@@ -437,7 +437,7 @@ PROJECT_ID="proboscis-doeff"
 BRANCH="issue/$ISSUE_ID/run-$RUN_ID"
 
 # create sample issue in the Zeus-backed issue store
-ssh zeus "cat > /home/kento/repos/doeff-VAULT/issues/$ISSUE_ID.md <<'EOF'
+ssh zeus "cat > /home/user/repos/doeff-VAULT/issues/$ISSUE_ID.md <<'EOF'
 ---
 type: issue
 id: $ISSUE_ID
@@ -449,7 +449,7 @@ status: open
 EOF"
 
 # ensure Zeus resolves project identity to the operational root it should use
-ssh zeus 'orch daemon repo register /home/kento/repos/doeff'
+ssh zeus 'orch daemon repo register /home/user/repos/doeff'
 
 # ensure the target Mac worker is connected to Zeus
 # normal case: start the default host worker on the target host
@@ -462,7 +462,7 @@ ssh mac 'ORCH_REMOTE=zeus:7777 orch worker status'
 # Run from the operational project root on Zeus so the daemon can discover the
 # correct project config for local-mode CLI execution before dispatching to the
 # remote target.
-ssh zeus "cd /home/kento/repos/doeff && orch --project $PROJECT_ID run $ISSUE_ID \
+ssh zeus "cd /home/user/repos/doeff && orch --project $PROJECT_ID run $ISSUE_ID \
   --run-id $RUN_ID \
   --on mac \
   --agent custom \
@@ -479,7 +479,7 @@ ssh zeus "orch --project $PROJECT_ID capture $ISSUE_ID#$RUN_ID"
 # stop and clean up
 ssh zeus "orch --project $PROJECT_ID stop $ISSUE_ID#$RUN_ID --force"
 ssh mac 'ORCH_REMOTE=zeus:7777 orch worker stop --all'
-ssh zeus "rm -f /home/kento/repos/doeff-VAULT/issues/$ISSUE_ID.md"
+ssh zeus "rm -f /home/user/repos/doeff-VAULT/issues/$ISSUE_ID.md"
 ```
 
 Expected outcomes:

--- a/docs/fail-fast-plan.md
+++ b/docs/fail-fast-plan.md
@@ -68,7 +68,7 @@ bad
   run          -> "no active workers available"
 
 good
-  worker start -> "managed worker host-zeus exited before registering ..."
+  worker start -> "managed worker host-remote exited before registering ..."
                 -> "check /.../orch/workers/<profile>.log ..."
-                -> "run orch --remote=... worker run --worker-id host-zeus manually ..."
+                -> "run orch --remote=... worker run --worker-id host-remote manually ..."
 ```

--- a/docs/reference/statuses.md
+++ b/docs/reference/statuses.md
@@ -267,7 +267,7 @@ slack:
 
 ### Handling failed runs
 
-1. Check daemon logs: `tail .orch/daemon.log`
+1. Check daemon logs: `tail ~/Library/Logs/orch/daemon.log  # Linux: ~/.local/state/orch/daemon.log`
 2. Attach to see error: `orch attach run-ref`
 3. Check if issue is retriable
 4. Use `orch restart-from` to retry from last state


### PR DESCRIPTION
## What

beta 配布前の sanitize 一括。**エージェントの skills ディレクトリに永続インストールされる skill** と公開 docs から、私的識別子を全除去した。

| 種別 | 置換 |
|---|---|
| 実ホスト名 | `zeus:7777` → `master-host:7777`、`CA-20035844` → `laptop-host` |
| 実 claude profile 名 | `nameissoap`/`cryptic` → `personal`/`work` |
| employer 組織名 | project mapping 例の `CyberAgentAILab/agent-control-plane` → `your-org/your-repo` |
| 実ユーザー home | `/home/kento` → `/home/user`(SKILL.md 1 + e2e runbook 11) |
| repo 固有 verified ノート | `(verified 2026-07-05, doeff)` 等 → 日付のみ |

あわせて stale の残りも掃除:
- `orch wait` の状態列挙から存在しない `blocked` を除去(reference.md)
- legacy `.orch/daemon.log` の最後の 3 参照(docs/agents/claude.md, custom.md, docs/reference/statuses.md)を global daemon の XDG 実パスへ(#491/#492 の完遂)

## 残置(意図的)

- e2e ラボ文書(e2e-master-worker-client.md / e2e-automation-plan.md)の `zeus` は `scripts/e2e-*-zeus.sh` という**実在スクリプト名への機能参照**のため残置。ラボの host 名変更はスクリプト rename を伴うため別判断
- `claude-plugins/orch`(重複 plugin、`orch continue` 等の stale を含む)は **git 管理外(未公開)** — repo には存在せず対応不要。ローカルの削除はメンテナ判断

## Verification

- `grep -rn "kento|nameissoap|cryptic|CyberAgent|CA-20035844|proboscis-ema" claude-plugins/ docs/ README.md` → 0 件
- docs のみのため build 影響なし。skill は runbook が main から clone するため release bump 不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)