### PR TITLE
docs: reorganize quickstarts and index ADRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ orch attach my-task
 | **[orch-monitor TUI](./docs/orch-monitor.md)** | Visual dashboard for managing issues and runs |
 | **[Core Concepts](./docs/concepts.md)** | Issue, Run, Event, Status, Worktree explained |
 | **[Configuration](./docs/configuration.md)** | All config options with examples |
+| **Architecture Decision Records** | [ADR-0001: issue hex IDs](./docs/adr/ADR-0001-issue-hex-ids.md) · [ADR-0002: worker autostart](./docs/adr/ADR-0002-idempotent-worker-autostart.md) |
 
 ### Backends
 
@@ -96,15 +97,15 @@ orch attach my-task
 ```
 User runs: orch run my-issue
   → Creates worktree + branch
-  → Starts agent in tmux session
+  → Starts agent in a terminal multiplexer (tmux or zellij)
   → Returns immediately (non-blocking)
 
 User checks: orch ps
   → Shows all runs with status
 
 User interacts: orch attach my-issue
-  → Connects to tmux session
-  → Ctrl+B D to detach
+  → Connects to the terminal multiplexer session
+  → Detach with Ctrl+B D (tmux) or Ctrl+O D (zellij)
 ```
 
 ## Status Quick Reference

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Pick your path by what you are trying to do.
 |---|---|
 | Agents | [Claude](./agents/claude.md) · [Codex](./agents/codex.md) · [OpenCode](./agents/opencode.md) · [Gemini](./agents/gemini.md) · [Custom](./agents/custom.md) |
 | Issue backends | [File](./backends/file.md) · [GitHub](./backends/github.md) |
+| Architecture decisions | [ADR-0001: issue hex IDs](./adr/ADR-0001-issue-hex-ids.md) · [ADR-0002: worker autostart](./adr/ADR-0002-idempotent-worker-autostart.md) |
 | Reference | [Commands](./reference/commands.md) · [Statuses](./reference/statuses.md) · [Events](./reference/events.md) · [SQL Queries](./reference/query.md) |
 
 ## Contribute to orch
@@ -35,6 +36,10 @@ rubric) and the canonical E2E validation docs
 Agent-facing instructions live in [AGENTS.md](../AGENTS.md) at the repo root.
 
 ## Internal design records
+
+Architecture decisions live under [adr/](./adr/); start with
+[ADR-0001](./adr/ADR-0001-issue-hex-ids.md) for issue identity and
+[ADR-0002](./adr/ADR-0002-idempotent-worker-autostart.md) for worker startup.
 
 Everything under [design/](./design/) documents the coupling cores and their
 laws — most importantly the run-status law book

--- a/docs/daily-workflow.md
+++ b/docs/daily-workflow.md
@@ -1,6 +1,9 @@
 # Daily Workflow with orch
 
-This guide covers typical day-to-day usage patterns for working with orch and AI agents.
+This guide covers recurring work after orch is installed and your first run
+works. For the canonical create → run → observe → interact loop, start with
+[Getting Started](./getting-started.md) or the validated Japanese
+[local quickstart](./local-quickstart.ja.md).
 
 ## Morning Routine
 
@@ -32,56 +35,22 @@ gh pr view <pr-number> --web
 
 ## Starting New Work
 
-### 1. Create an Issue
-
-Issues define what you want the agent to accomplish:
+Create and edit a focused issue, then start its run:
 
 ```bash
-# Create and edit an issue
 orch issue create fix-login-timeout --title "Fix login session timeout" --edit
-```
-
-This opens your editor. Write a clear task description:
-
-```markdown
----
-type: issue
-id: fix-login-timeout
-title: Fix login session timeout
-status: open
----
-
-# Fix login session timeout
-
-Users report being logged out after 5 minutes of inactivity.
-
-## Current Behavior
-- Session expires after 5 minutes
-- No warning before logout
-
-## Expected Behavior  
-- Session should last 30 minutes
-- Show warning 5 minutes before expiry
-
-## Files to check
-- src/auth/session.ts
-- src/middleware/auth.ts
-```
-
-### 2. Start a Run
-
-```bash
-# Start an agent working on the issue
 orch run fix-login-timeout
 
-# With a specific agent
+# Alternatives: select an agent or enable verbose diagnostics
+# (run only the variant you need)
 orch run --agent opencode fix-login-timeout
-
-# With verbose output for debugging
 orch run --verbose fix-login-timeout
 ```
 
-The agent starts working in the background. You can continue with other tasks.
+The agent works in an isolated worktree in the background. Put current
+behavior, expected behavior, relevant files, and verification requirements in
+the issue body; the first-run guides cover heredoc creation, local `--no-pr`
+runs, and trust prompts in detail.
 
 ## Monitoring Progress
 
@@ -98,15 +67,9 @@ orch ps --status running,waiting
 orch show fix-login-timeout
 ```
 
-### Status Meanings
-
-| Status | What it means | Your action |
-|--------|---------------|-------------|
-| `running` | Agent is actively working | Wait, or watch with `attach` |
-| `waiting` | Agent needs input or is stuck | Use `attach` or `send` to help |
-| `pr_open` | Agent created a PR | Review the PR |
-| `done` | Work completed successfully | Celebrate! |
-| `failed` | Something went wrong | Check logs, possibly restart |
+For the complete status vocabulary and transition rules, see
+[Statuses](./reference/statuses.md). A `waiting` run may need input or may have
+finished its turn; use `orch capture` to distinguish the two.
 
 ## Interacting with Agents
 
@@ -114,6 +77,7 @@ orch show fix-login-timeout
 
 | Situation | Use | Why |
 |-----------|-----|-----|
+| Need to inspect a `waiting` run | `capture` | Read the current terminal without taking it over |
 | Need to have a conversation | `attach` | Interactive back-and-forth |
 | Agent is stuck on something | `attach` | See what's happening, provide guidance |
 | Quick instruction or clarification | `send` | Don't need to watch the response |
@@ -260,60 +224,6 @@ It's often fine to leave agents running overnight:
 - PRs will be ready for review
 
 Just be mindful of API costs for long-running agents.
-
-## Example Day
-
-```bash
-# === Morning ===
-
-# Check overnight progress
-orch ps
-
-# Two runs finished with PRs
-orch diff fix-bug-123
-orch diff add-feature-x
-gh pr view 42 --web
-gh pr view 43 --web
-
-# === Start new work ===
-
-# Create today's tasks
-orch issue create optimize-db-queries --title "Optimize slow database queries" --edit
-orch issue create update-deps --title "Update npm dependencies" --edit
-
-# Start the agents
-orch run optimize-db-queries
-orch run update-deps
-
-# === Midday check ===
-
-orch ps
-# ISSUE                STATUS   RUN                 AGENT   UPDATED
-# optimize-db-queries  running  20260115-093012     claude  5m ago
-# update-deps          waiting  20260115-093045     claude  2m ago
-
-# Help the waiting agent
-orch attach update-deps
-# Agent: "Should I update React to v19 or stay on v18?"
-# You: "Stay on v18 for now, we're not ready for the migration"
-
-# === Afternoon ===
-
-orch ps
-# ISSUE                STATUS   RUN                 AGENT   UPDATED
-# optimize-db-queries  pr_open  20260115-093012     claude  1h ago
-# update-deps          running  20260115-093045     claude  30m ago
-
-# Review the finished PR
-orch diff optimize-db-queries
-gh pr view 45
-
-# === End of day ===
-
-orch ps
-# Both done with PRs
-# Review tomorrow, signing off
-```
 
 ## Next Steps
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,8 +26,8 @@ Before installing orch, ensure you have:
 # Verify Go
 go version
 
-# Verify tmux
-tmux -V
+# Verify the terminal multiplexer you plan to use
+tmux -V                 # or: zellij --version
 
 # Verify your LLM CLI (example with claude)
 claude --version
@@ -158,42 +158,35 @@ issues:
 EOF
 ```
 
-Note: the store keeps issue files under an `issues/` subdirectory of the
-configured path (or `Issues/` if one already exists) — with the config above,
-`orch issue create` writes to `./issues/issues/<id>.md`. Prefer
-`orch issue create` over placing files by hand so they land where the store
-actually reads them.
-
 ## Create your first issue
 
-An issue is a markdown file describing a task for the agent:
+Create issues through the CLI so orch validates them and writes them to the
+configured issue store:
 
 ```bash
-# Create an issue file
-cat > ~/orch-issues/issues/my-first-issue.md << 'EOF'
----
-type: issue
-id: my-first-issue
-title: Add a hello world function
-status: open
----
-
-# Add a hello world function
-
+orch issue create my-first-issue --title "Add a hello world function" <<'EOF'
 Create a simple function in this repository that prints "Hello, World!".
 
-## Requirements
-- Create a new file with appropriate naming for the project
-- The function should be callable
-- Add a brief comment explaining what it does
+Requirements:
+- Create a new file with an appropriate name for the project.
+- Make the function callable.
+- Add a brief comment explaining what it does.
 EOF
 ```
 
-Or use the CLI:
+Use `--edit` instead when you want to write the body in your editor:
 
 ```bash
 orch issue create my-first-issue --title "Add a hello world function" --edit
 ```
+
+### Advanced: issue file layout
+
+The file backend stores generated documents under an `issues/` subdirectory
+of the configured `issues.path`, or under `Issues/` when that directory already
+exists. For example, `path: ./issues` normally stores this issue at
+`./issues/issues/my-first-issue.md`. Treat this as storage detail; use
+`orch issue create`, `orch issue show`, and `orch issue list` for normal work.
 
 ## Daemon and worker start automatically
 
@@ -213,13 +206,17 @@ with `orch worker start`.
 Start an agent to work on the issue:
 
 ```bash
-orch run my-first-issue
+orch run my-first-issue --no-pr
 ```
 
+`--no-pr` keeps this first exercise local. Omit it in a repository where you
+want the agent to commit, push, and open a pull request.
+
 This will:
+
 1. Create a new git worktree for isolation
 2. Create a new git branch
-3. Start a tmux session with your configured agent
+3. Start your configured agent in a terminal multiplexer (tmux or zellij)
 4. Send the issue content as the initial prompt
 
 The command returns immediately - the agent runs in the background.
@@ -234,7 +231,7 @@ On a fresh machine or directory, agent CLIs show a one-time interactive gate
 orch capture my-first-issue   # see what the agent is asking
 orch send my-first-issue ""   # empty message = press Enter (accept the default)
 # or take over the terminal directly:
-orch attach my-first-issue    # answer, then detach with Ctrl+B D
+orch attach my-first-issue    # answer, then detach (see below)
 ```
 
 ## Check status
@@ -245,11 +242,9 @@ See what's running:
 orch ps
 ```
 
-Example output:
-```
-ISSUE            STATUS   RUN                 AGENT   UPDATED
-my-first-issue   running  20260120-163045     claude  2m ago
-```
+The run normally moves through `booting` and `running`, then reaches
+`waiting` when the agent's input box is available. Use `orch capture` before
+deciding whether it needs an answer or has finished its turn.
 
 ### Status meanings
 
@@ -265,27 +260,30 @@ my-first-issue   running  20260120-163045     claude  2m ago
 
 ## Interact with the agent
 
-Attach to the agent's terminal session:
+Attach to the agent's terminal multiplexer session:
 
 ```bash
 orch attach my-first-issue
 ```
 
-This opens the tmux session where you can:
+This opens the tmux or zellij session where you can:
+
 - Watch the agent work in real-time
 - Type messages to the agent
 - Paste images (if the agent supports it)
 - Provide input when the agent asks questions
 
-**Detach without stopping the agent**: Press `Ctrl+B` then `D`
+**Detach without stopping the agent**: press `Ctrl+B` then `D` in tmux, or
+`Ctrl+O` then `D` in zellij.
 
 ## See the result
 
-When the agent finishes (status becomes `done` or `pr_open`):
+Wait for the agent to finish its current turn, then read its report before
+inspecting the result:
 
 ```bash
-# Check final status
-orch ps
+orch wait my-first-issue --timeout 600
+orch capture my-first-issue
 
 # View run details
 orch show my-first-issue
@@ -303,6 +301,9 @@ orch stop my-first-issue
 
 # Stop a specific run
 orch stop my-first-issue#20260120-163045
+
+# Mark the issue complete when you have accepted the result
+orch resolve my-first-issue
 ```
 
 ## Next steps


### PR DESCRIPTION
## Summary

- add ADR-0001/ADR-0002 navigation to both documentation indexes
- make `orch issue create` the primary first-issue path and move file layout into an advanced note
- align the English first-run flow with the validated Japanese local quickstart
- refocus the daily guide on recurring operations and remove its duplicate first-run tutorial and fabricated `orch ps` tables
- describe agent sessions as terminal multiplexer sessions (tmux or zellij)

## Acceptance evidence

- `docs/README.md` local-link check: `docs/README.md local links: OK`
- CLI-first ordering check: `issue-create-first ordering: OK (CLI line 167, layout line 183)`
- stale sample check: `fabricated five-column ps examples: absent`
- requested wording check: `hard-coded tmux-session wording in requested files: absent`
- compiled CLI checks passed for `issue create`, `run`, `ps`, `capture`, `send`, `attach`, `wait`, and `resolve`
- coordinated with `docs-misleading-fixes` to keep its independent config/remote corrections out of the two removed status examples
- coordinated with `remove-orch-monitor-cli`; its current docs tree has zero references to the removed `orch monitor` command, and this branch introduces none

## Verification

- GitHub `Architecture Lint`: pass
- GitHub `E2E PR CI`: pass
- GitHub full `Test Suite`: pass
- `go build ./...`
- deterministic Go packages: `go list ./... | rg -v '/test/integration$' | xargs go test`
- targeted CLI issue-create/layout/resolve tests (6/6 pass)
- `make lint`
- `git diff --check`

A local real-agent run saw OpenCode return HTTP 500 while creating a session; the unchanged path passed in GitHub's E2E and full test jobs.

Reference: `docs-reorg`
