### PR TITLE
docs: correct misleading remote configuration guidance

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,8 +7,8 @@ orch uses a layered configuration system with sensible defaults. Configuration c
 Settings are resolved in this order (highest priority first):
 
 1. **Command-line flags** (`--agent`, `--backend`, etc.)
-2. **Environment variables** (`ORCH_AGENT`, etc.)
-3. **Project config** (`.orch/config.yaml` in current or parent directory)
+2. **Project config** (`.orch/config.yaml` in current or parent directory)
+3. **Environment variables** (`ORCH_AGENT`, etc.)
 4. **Global config** (`~/.config/orch/config.yaml`)
 5. **Built-in defaults**
 
@@ -41,15 +41,22 @@ orch --remote cloud ps
 orch --remote "" ps
 ```
 
-On the server side, expose the daemon over TCP and register the repository URL:
+The daemon listens on `0.0.0.0:7777` by default, including when a command
+auto-starts it. Register the repository URL on the server-side daemon:
 
 ```bash
-# On remote server
-orch daemon start --listen tcp://0.0.0.0:7777
-
 # From client machine
 orch --remote master-host:7777 daemon repo register https://github.com/your-org/your-project.git
 orch --remote master-host:7777 daemon repo list
+```
+
+Because the default exposes the TCP API on every network interface, limit
+access with a firewall or restart the daemon bound to a trusted interface. For
+example, use loopback when clients connect through an SSH tunnel:
+
+```bash
+orch daemon kill
+orch daemon start --listen tcp://127.0.0.1:7777
 ```
 
 In remote mode, orch resolves project identity from `--project`/`ORCH_PROJECT`
@@ -265,6 +272,7 @@ All settings can be configured via environment variables:
 | `ORCH_MULTIPLEXER` | Terminal multiplexer | `tmux` |
 | `ORCH_LOG_LEVEL` | Logging verbosity | `debug` |
 | `ORCH_PR_TARGET_BRANCH` | PR target branch | `develop` |
+| `ORCH_WORKER_AUTOSTART` | Set to `0` to disable worker autostart | `0` |
 | `ORCH_DEBUG` | Enable debug mode | `1` |
 | `ORCH_SLACK_WEBHOOK_URL` | Slack webhook | `https://hooks.slack.com/...` |
 | `ORCH_SLACK_BOT_TOKEN` | Slack bot token | `xoxb-...` |

--- a/docs/remote-usage.md
+++ b/docs/remote-usage.md
@@ -12,7 +12,7 @@ identity through repo mappings.
 ```text
 Local client                         Remote host
 ┌──────────────────────────────┐      ┌────────────────────────────────────┐
-│ orch CLI / monitor           │ TCP  │ orch daemon (--listen)            │
+│ orch CLI / monitor           │ TCP  │ orch daemon (0.0.0.0:7777 default)│
 │ --remote master-host:7777    │─────▶│ repo mapping: repoid -> path      │
 └──────────────────────────────┘      └────────────────────────────────────┘
 ```
@@ -21,7 +21,7 @@ Local client                         Remote host
 
 1. orch installed on client and server.
 2. Network route to server (VPN/Tailscale/SSH tunnel).
-3. Project repository is available on the remote host.
+3. The project repository is available on each host that may execute work.
 
 ### Quick checks
 
@@ -35,11 +35,24 @@ orch --version
 
 ## Server Setup
 
-### 1. Start daemon with TCP listener
+### 1. Confirm or restrict the TCP listener
+
+The daemon listens on `0.0.0.0:7777` by default. This also applies when an
+ordinary orch command auto-starts the daemon; `--listen` is not required to
+enable remote access.
 
 ```bash
-# On remote server
-orch daemon start --listen tcp://0.0.0.0:7777
+# On remote server: starts with the default 0.0.0.0:7777 listener
+orch daemon start
+```
+
+This default exposes the orch TCP API on every network interface. Limit port
+`7777` to trusted networks with a firewall, or restart the daemon on a more
+restrictive address. For an SSH-tunnel-only setup, bind to loopback:
+
+```bash
+orch daemon kill
+orch daemon start --listen tcp://127.0.0.1:7777
 ```
 
 ### 2. Register repository URL for remote resolution
@@ -109,6 +122,13 @@ orch --remote master-host:7777 --project yourorg-yourrepo capture my-issue
 
 - `--project` / `ORCH_PROJECT` provides project identity scope.
 - Remote commands depend on daemon-side repo registration (`daemon repo register`).
+- Before `orch run` dispatches to a remote master, the client idempotently
+  starts its local managed worker and registers it to that master. The client
+  host can therefore execute untargeted runs from that master.
+- Set `ORCH_WORKER_AUTOSTART=0` on the client to disable that pre-dispatch
+  worker start. The same setting on the master disables automatic startup of
+  its colocated worker; workers must then be started manually with
+  `orch worker start`.
 
 ## Troubleshooting
 
@@ -138,26 +158,26 @@ Then scope runtime commands by project identity (repo ID):
 orch --remote master-host:7777 --project yourorg-yourrepo ps --json
 ```
 
-### "Issue not found" during `run` with remote master + external worker
+### Issue resolution and worker project mappings
 
-When worker execution happens on a different host than the master, the worker must
-be able to resolve the project root and issue content referenced by the lease.
-If the worker cannot read those issue files, `run` can fail with `issue not found`
-even when `issue show` succeeds on the master.
-
-Checklist:
+The master resolves the issue before dispatch and sends an issue snapshot in
+the worker lease. A worker does not need a duplicate copy of the master's
+issue file. If `run` reports `issue not found`, verify that the issue exists in
+the selected project on the master:
 
 ```bash
-# master-side mapping exists
 orch --remote master-host:7777 daemon repo list
-
-# run this on the worker host; it reports the local background process plus
-# that worker's registration state on the configured master
-orch --remote master-host:7777 worker status --json
+orch --remote master-host:7777 --project yourorg-yourrepo issue show my-issue
 ```
 
-Then confirm worker host project/config alignment (`--project`, `.orch/config.yaml`,
-and `issues.path`) for the same project identity.
+The executing worker does still need a local checkout registered under the
+same project identity. If it reports `no local project mapping`, run this on
+that worker host from the checkout:
+
+```bash
+orch --remote="" daemon repo register "$(pwd)"
+orch --remote master-host:7777 worker status --json
+```
 
 ## See Also
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -192,9 +192,10 @@ func newDaemonStartCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start the daemon in the background",
-		Long: `Start the orch daemon in the background.
+		Long: fmt.Sprintf(`Start the orch daemon in the background.
 
-Use --listen to additionally expose the proto API on TCP (e.g. for remote clients).`,
+The proto API listens on %s by default. Use --listen to bind it to another
+address, such as tcp://127.0.0.1:7777 for SSH-tunnel-only access.`, daemon.DefaultTCPListenAddr),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDaemonStart()
 		},


### PR DESCRIPTION
## Summary

- correct configuration precedence so project `.orch/config.yaml` is documented above environment variables
- document that daemon TCP exposure defaults to `0.0.0.0:7777`, including autostart, plus loopback/firewall restriction guidance
- document ADR-0002 remote-master worker autostart and the `ORCH_WORKER_AUTOSTART=0` off-switch
- replace stale worker-side `issue not found` advice with master issue-snapshot and worker local-project-mapping guidance
- align `orch daemon start --help` with the implemented TCP default

The synthetic `orch ps` examples in `docs/getting-started.md` and `docs/daily-workflow.md` are intentionally left to #500, which removes those examples while reorganizing the quickstart docs. This avoids overlapping edits requested by that run.

Issue: `docs-misleading-fixes`

## Acceptance evidence

1. **Configuration precedence**
   - `internal/config/config.go` loads global config, then environment variables, then project config.
   - `go test ./internal/config -run '^TestLoadPrecedence$' -count=1` passes and proves project config wins over `ORCH_AGENT`.
2. **Real `orch ps` shape**
   - `go run ./cmd/orch ps --limit 2` produced the 16-column header beginning `ID ISSUE ISSUE-ST CLI ...` with six-hex IDs and abbreviated `run` states.
   - #500 removes the misleading five-column synthetic examples.
3. **TCP default and restriction**
   - `go run ./cmd/orch daemon start --help` reports `0.0.0.0:7777` as the default and now explains `--listen tcp://127.0.0.1:7777` for tunnel-only access.
   - Guides state that command-triggered daemon autostart uses the same default.
4. **ADR-0002 worker behavior**
   - `go test ./internal/cli -run '^(TestShortAgentStatus|TestEnsureLocalWorkerForRemoteMaster|TestEnsureLocalWorkerForRemoteMasterDisabledByEnv)$' -count=1` passes.
   - `go test ./internal/daemon -run '^(TestAcquireLeaseAutostartsColocatedWorkerForLocalTarget|TestAcquireLeaseAutostartDisabledByEnv|TestProcessStartRunCoreUsesSnapshotWithEmptyWorkerIssueStore)$' -count=1` passes.

## Validation

- `go build ./...` — passed
- `make lint` — passed (0 architecture findings; fixture suites passed)
- `git diff --check` — passed
- targeted config/CLI/daemon tests above — passed
- `go test ./...` — all ordinary packages passed; the suite exited nonzero only in `test/integration` because the real OpenCode server returned HTTP 500 `UnknownError` while creating a session. A focused rerun of `TestRunWithBuiltInAgents` reproduced the same external OpenCode 500 with a new reference ID. This branch does not change OpenCode, session creation, or integration-test code.
