### PR TITLE
docs: fix copy-paste-breaking examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ Existing violations are tracked; do not add new ones.
 - Use the established error handling conventions
 - Run `go build ./...` and `go test ./...` before creating PRs
 - Run `make lint` to check for architecture boundary violations
-- Proto changes require regeneration: `make proto`
+- Proto changes require regeneration: `./api/generate.sh`
 
 ### Python (orch-monitor-tui)
 
@@ -180,7 +180,8 @@ Existing violations are tracked; do not add new ones.
 ## Testing
 
 - Unit tests are required for new daemon functionality
-- Integration tests in `internal/e2e/` for end-to-end flows
+- Integration tests live in `test/integration/`; end-to-end flows are scripted
+  in `scripts/e2e-*.sh`
 - TUI changes should be manually tested with `orch monitor`
 
 Canonical E2E instruction docs:
@@ -207,7 +208,7 @@ The opencode server may have stopped while the run shows as "waiting".
 
 After modifying `api/orch.proto`:
 ```bash
-make proto  # Regenerates Go and Python bindings
+./api/generate.sh  # Regenerates Go and Python bindings
 ```
 
 ### Worktree issues

--- a/docs/backends/file.md
+++ b/docs/backends/file.md
@@ -187,8 +187,8 @@ orch issue list
 # Filtered by status
 orch issue list --status open
 
-# With run information
-orch issue list --with-runs
+# Show the latest run for an issue
+orch show my-issue
 ```
 
 ## Best Practices

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -326,9 +326,15 @@ A visual dashboard for managing issues and runs:
 # Install the TUI
 uv tool install ./orch-monitor-tui
 
-# Launch it
-orch-monitor --new
+# Launch or attach to it
+orch-monitor
+
+# Restart with a fresh layout and control agent session
+orch-monitor --new-control-agent
 ```
+
+Use bare `orch-monitor` for the first launch. The `--new` flag only restarts
+the layout while resuming an existing control agent session.
 
 Features:
 - See all issues and runs at a glance

--- a/docs/orch-monitor.md
+++ b/docs/orch-monitor.md
@@ -29,15 +29,22 @@ orch-monitor --help
 ## Launching
 
 ```bash
-# Start the TUI
+# Start the TUI for the first time, or attach to an existing session
 orch-monitor
 
-# Start with a fresh control agent session
+# Restart the layout and resume an existing control agent session
 orch-monitor --new
+
+# Restart with a fresh layout and control agent session
+orch-monitor --new-control-agent
 
 # Specify a project identity (repo URL or repoid)
 orch-monitor --project github.com/owner/repo
 ```
+
+Use bare `orch-monitor` for the first launch. `--new` requires an existing
+control agent session to resume; use `--new-control-agent` when you want to
+replace that session too.
 
 ## Interface Overview
 
@@ -187,7 +194,7 @@ Agent: You can press 'd' while a run is selected in the Runs panel,
 
 1. **Launch orch-monitor**
    ```bash
-   orch-monitor --new
+   orch-monitor
    ```
 
 2. **Create an issue via control agent**
@@ -237,7 +244,7 @@ If the TUI seems unresponsive:
 If control agent isn't responding:
 1. It may be thinking - wait a moment
 2. Press `Ctrl+L` to clear and try again
-3. Restart with `--new` flag
+3. Restart with the `--new-control-agent` flag
 
 ## Configuration
 

--- a/docs/reference/query.md
+++ b/docs/reference/query.md
@@ -79,7 +79,7 @@ Extended issues view with computed columns:
 
 | Column | Description |
 |--------|-------------|
-| (all from issues) | Base issue columns |
+| (all from issues except `body`) | Base issue columns except the Markdown body |
 | run_count | Number of runs for this issue |
 | tags | Comma-separated tags |
 

--- a/internal/cli/tutorial.go
+++ b/internal/cli/tutorial.go
@@ -249,7 +249,8 @@ command.
 
 Launch the TUI:
 
-    orch-monitor --new      # Start fresh session
+    orch-monitor                      # First launch or attach
+    orch-monitor --new-control-agent  # Replace layout and control agent session
 
 Quick Start:
   1. Navigate with arrow keys, Tab to switch panels

--- a/orch-monitor-tui/README.md
+++ b/orch-monitor-tui/README.md
@@ -40,7 +40,10 @@ mkdir -p .orch
 ### 2. Launch orch-monitor
 
 ```bash
-orch-monitor --new  # Start fresh session
+orch-monitor  # First launch, or attach to an existing session
+
+# To replace both the layout and control agent session:
+orch-monitor --new-control-agent
 ```
 
 ### 3. Meet the Control Agent


### PR DESCRIPTION
## Summary

- make first-launch `orch-monitor` examples use the bare command and document the distinct `--new` / `--new-control-agent` behavior
- replace nonexistent proto and integration-test paths with `./api/generate.sh`, `test/integration/`, and `scripts/e2e-*.sh`
- replace the nonexistent `orch issue list --with-runs` flag with `orch show`
- document that `issues_v` intentionally excludes the issue `body` column
- update the duplicate standalone TUI README and built-in tutorial guidance so they do not reintroduce the stale `--new` wording

Reference: `docs-copy-paste-breakers`

## Verification evidence

- Built the current CLI with `go build -o /tmp/orch-docs-copy-paste-verification/bin/orch ./cmd/orch`; `orch version` reported `dev` for `darwin/arm64`.
- Ran the corrected file-backend commands against that binary in an isolated daemon/project:
  - `orch issue list` listed the verification issue.
  - `orch issue list --status open` listed the same open issue.
  - `orch show plc125` resolved `plc125#20231219-140000` and printed its events/artifacts.
- Ran `orch query "SELECT name FROM pragma_table_info('issues_v')" --format tsv`; the columns were `id`, `title`, `topic`, `summary`, `status`, `path`, `run_count`, and `tags`.
- Confirmed `orch query "SELECT body FROM issues_v"` fails with `no such column: body`.
- Ran `./api/generate.sh`; it regenerated both bindings successfully and left no generated-code diff.
- Ran `bash -n scripts/e2e-*.sh`; all E2E scripts passed shell syntax validation.
- Exercised the bare first-launch monitor path with the repository Python package and a mocked multiplexer; it reached layout creation without a session preflight error. Also confirmed both monitor help surfaces expose `--new-control-agent`.
- Focused Python session tests: `3 passed`.
- `make lint`: passed with zero architecture findings.
- `go build ./...`: passed.
- `go test ./... -skip '^TestRunWithBuiltInAgents$'`: passed, including `test/integration`.
- `go test ./...` was also run. Its only failure was the environment-dependent `TestRunWithBuiltInAgents`: the local OpenCode server returned HTTP 500 while creating an OpenCode session. A focused rerun reproduced the same external server error; the Codex and Claude lanes passed before the OpenCode lane failed, and the suite passes with only that test skipped.
