### PR TITLE
docs: fill CLI and configuration reference gaps

### DIFF
--- a/docs/backends/file.md
+++ b/docs/backends/file.md
@@ -21,7 +21,8 @@ issues:
   path: ~/orch-issues
 ```
 
-Configure `issues.path` in `.orch/config.yaml` (recommended).
+`issues.path` is optional. When it is omitted, orch stores issues under
+`~/.local/share/orch/<repo-id>`.
 
 ### In-repo issues
 
@@ -122,32 +123,40 @@ Run files are created automatically by `orch run` and contain:
 
 ```yaml
 ---
-issue_id: fix-login-bug
-run_id: 20260120-163045
-agent: claude
-status: running
-worktree: /Users/me/.orch/worktrees/fix-login-bug/abc123_claude_20260120-163045
-branch: issue/fix-login-bug/run-20260120-163045
-session_name: run-fix-login-bug-20260120-163045
+issue: fix-login-bug
+run: 20260120-163045
 created: 2026-01-20T16:30:45+09:00
+agent: claude
+model: claude-opus-4-6
+model_variant: high
+target: mac
+profile: company
 ---
 ```
+
+The required run identity fields are `issue`, `run`, and `created`. Launch
+metadata such as `agent`, `model`, `model_variant`, `target`, and `profile` is
+included when supplied. Live state is not duplicated in frontmatter:
+`worktree`, `branch`, `session`, and `status` are derived from body events.
 
 ### Event log (body)
 
 ```markdown
-# Run: fix-login-bug#20260120-163045
+# Events
 
-## Events
-
-- 2026-01-20T16:30:45+09:00 | status | queued |
+- 2026-01-20T16:30:45+09:00 | status | queued
 - 2026-01-20T16:30:46+09:00 | status | booting | agent=claude
 - 2026-01-20T16:30:50+09:00 | artifact | worktree | path=/Users/me/.orch/worktrees/...
 - 2026-01-20T16:30:51+09:00 | artifact | branch | name=issue/fix-login-bug/run-20260120-163045
-- 2026-01-20T16:30:52+09:00 | status | running |
+- 2026-01-20T16:30:51+09:00 | artifact | session | name=run-fix-login-bug-20260120-163045 | multiplexer=tmux
+- 2026-01-20T16:30:52+09:00 | status | running
 - 2026-01-20T16:45:30+09:00 | artifact | pr | url=https://github.com/org/repo/pull/42
-- 2026-01-20T16:45:31+09:00 | status | pr_open |
+- 2026-01-20T16:45:31+09:00 | status | pr_open
 ```
+
+The body begins with one `# Events` heading. Event attributes add another
+pipe-delimited field; events without attributes end after the event name and
+have no trailing `|`.
 
 ## Creating Issues
 

--- a/docs/backends/github.md
+++ b/docs/backends/github.md
@@ -206,9 +206,15 @@ github:
 
 slack:
   enabled: true
-  webhook_url: ${SLACK_WEBHOOK}
   notify_on:
     - waiting
+```
+
+Set `ORCH_SLACK_WEBHOOK_URL` in the orch process environment; YAML
+`${...}` interpolation is not supported:
+
+```bash
+export ORCH_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/XXX/YYY/ZZZ
 ```
 
 ## Limitations

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -60,6 +60,20 @@ A **single execution attempt** for an issue.
 - `worktree` - Isolated git working directory
 - `branch` - Git branch for this run
 
+### Issue Hex ID
+
+Every file-backend issue also has a deterministic hex identifier defined by
+[ADR-0001](./adr/ADR-0001-issue-hex-ids.md): the lowercase SHA-256 hash of its
+human-readable issue ID.
+
+- The CLI displays the first 8 characters (for example, `afa27b44`).
+- Any unique lowercase prefix from 7 through 64 characters can be used
+  anywhere an issue ID is accepted.
+- Prefixes of 2 through 6 characters remain reserved for run short IDs, so
+  issue and run references are unambiguous.
+- An ambiguous issue prefix fails with the matching issue names; extend the
+  prefix to disambiguate it.
+
 ### Event
 
 An **append-only record** in a run's log.
@@ -85,13 +99,18 @@ stateDiagram-v2
     [*] --> queued: orch run
     queued --> booting: agent starting
     booting --> running: agent ready
+    booting --> failed: launch error
     running --> waiting: needs input
+    running --> rate_limited: API/rate limit issue
     running --> pr_open: PR created
     running --> done: complete
     running --> failed: error
     running --> canceled: stopped
+    running --> unknown: agent exited unexpectedly
     waiting --> running: input provided
     waiting --> canceled: stopped
+    rate_limited --> running: issue resolved
+    rate_limited --> canceled: stopped
     pr_open --> done: PR merged
     done --> [*]
     failed --> [*]
@@ -131,7 +150,7 @@ A **git worktree** created for each run.
 
 - Provides complete isolation from other runs
 - Each run works on its own copy of the codebase
-- Located in `~/.orch/worktrees/<issue>/<run>/` by default
+- Located in `~/.orch/worktrees/<issue>/<shortid>_<agent>_<runid>/` by default
 - Automatically created by `orch run`
 - Can be reused with `orch restart-from`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,8 +116,24 @@ pr_target_branch: develop
 # Directory for worktrees (default: ~/.orch/worktrees)
 worktree_dir: ~/.orch/worktrees
 
-# Terminal multiplexer: tmux or zellij (default: tmux)
-multiplexer: tmux
+# Multiplexer for agent sessions: tmux or zellij (default: tmux)
+agent_multiplexer: tmux
+
+# Multiplexer for orch monitor: zellij or tmux (default: zellij)
+monitor_multiplexer: zellij
+
+# `multiplexer` is a deprecated compatibility key. Use the two keys above.
+
+# =============================================================================
+# EXECUTION TARGETS
+# =============================================================================
+
+# Named worker hosts used by `orch run --on <name>`
+targets:
+  - name: mac
+    host: mac-host
+  - name: linux
+    host: linux-host
 
 # =============================================================================
 # ISSUES BACKEND
@@ -127,8 +143,9 @@ issues:
   # Backend type: local or github
   backend: local
   
-  # For local backend: path to issues directory
-  path: ~/orch-issues
+  # Optional path for the local backend. When omitted, defaults to
+  # ~/.local/share/orch/<repo-id>.
+  # path: ~/orch-issues
   
   # Alternative: path relative to project root
   # path: ./issues
@@ -234,6 +251,12 @@ monitor:
   default_issue_statuses:
     - open
 
+  # Initial issue tag filter (`any` = OR, `all` = AND)
+  default_issue_filter:
+    tags:
+      - active
+    tag_mode: any
+
 # Control agent settings (for interactive control from monitor)
 control_agent: opencode
 control_model: opus
@@ -269,19 +292,60 @@ All settings can be configured via environment variables:
 | `ORCH_ISSUES_BACKEND` | Issue store backend (`local` or `github`) | `local` |
 | `ORCH_MODEL` | Default model | `anthropic/claude-opus-4-5` |
 | `ORCH_MODEL_VARIANT` | Model variant | `max` |
-| `ORCH_MULTIPLEXER` | Terminal multiplexer | `tmux` |
+| `ORCH_WORKTREE_DIR` | Directory in which run worktrees are created | `~/.orch/worktrees` |
+| `ORCH_BASE_BRANCH` | Default base branch | `main` |
 | `ORCH_LOG_LEVEL` | Logging verbosity | `debug` |
 | `ORCH_PR_TARGET_BRANCH` | PR target branch | `develop` |
+| `ORCH_PROMPT_TEMPLATE` | Global prompt template content | `Read ORCH_PROMPT.md` |
+| `ORCH_AGENT_MULTIPLEXER` | Multiplexer for agent sessions | `tmux` |
+| `ORCH_MONITOR_MULTIPLEXER` | Multiplexer for `orch monitor` | `zellij` |
+| `ORCH_MULTIPLEXER` | Deprecated multiplexer compatibility setting | `tmux` |
+| `ORCH_NO_PR` | Omit PR creation instructions (`true`, `1`, or `yes`) | `true` |
+| `ORCH_OPENCODE_DEFAULT_MODEL` | Default OpenCode model | `anthropic/claude-opus-4-5` |
+| `ORCH_OPENCODE_DEFAULT_VARIANT` | Default OpenCode model variant | `max` |
+| `ORCH_CODEX_DEFAULT_MODEL` | Default Codex model | `gpt-5.2-codex` |
+| `ORCH_DEFAULT_PRESET` | Preset used when `--preset` is omitted | `opus-max` |
+| `ORCH_CONTROL_AGENT` | Agent used by the interactive control agent | `opencode` |
+| `ORCH_CONTROL_MODEL` | Model used by the interactive control agent | `opus` |
+| `ORCH_CONTROL_MODEL_VARIANT` | Control-agent model variant | `default` |
 | `ORCH_WORKER_AUTOSTART` | Set to `0` to disable worker autostart | `0` |
 | `ORCH_DEBUG` | Enable debug mode | `1` |
 | `ORCH_SLACK_WEBHOOK_URL` | Slack webhook | `https://hooks.slack.com/...` |
 | `ORCH_SLACK_BOT_TOKEN` | Slack bot token | `xoxb-...` |
 | `ORCH_SLACK_CHANNEL` | Slack channel | `#notifications` |
+| `ORCH_GITHUB_OWNER` | GitHub issue-backend repository owner | `your-org` |
+| `ORCH_GITHUB_REPO` | GitHub issue-backend repository name | `your-repo` |
+| `ORCH_GITHUB_LABEL_FILTER` | Only sync GitHub issues with this label | `orch` |
 
 ### Removed Variables
 
 `ORCH_VAULT` and `ORCH_ISSUES_ROOT` are no longer used at runtime.
 Configure issue storage with `issues.path` in `.orch/config.yaml`.
+
+## Execution Targets
+
+`targets` is the routing table for multi-host execution. Each entry maps the
+stable name used by users and profiles to the host identity of a registered
+worker. The daemon resolves this table, records the selected target in the run
+event stream, and routes later session-control operations to the same host.
+
+```yaml
+targets:
+  - name: mac
+    host: mac-host
+  - name: gpu
+    host: gpu-worker-01
+```
+
+Select a target when starting a run:
+
+```bash
+orch run --on mac my-issue
+```
+
+Both `name` and `host` are required and must be non-empty. `local` is reserved
+for the daemon's local worker and does not need a `targets` entry. Target names
+are also used by agent-profile `target` and `allowed_targets` settings.
 
 ## Prompt Templates
 
@@ -324,13 +388,19 @@ opencode:
     {{issue}}
 ```
 
-## Terminal Multiplexer
+## Terminal Multiplexers
 
-orch supports both tmux (default) and zellij:
+Agent sessions and the monitor have separate multiplexer settings. Agent
+sessions default to tmux; `orch monitor` defaults to zellij.
 
 ```yaml
-multiplexer: zellij
+agent_multiplexer: tmux
+monitor_multiplexer: zellij
 ```
+
+The old `multiplexer` key is deprecated. It remains a compatibility fallback
+for the monitor but does not override the agent-session default; use
+`agent_multiplexer` for runs.
 
 Or per-command:
 
@@ -339,10 +409,9 @@ orch run --multiplexer zellij my-issue
 ```
 
 **Detach keys:**
+
 - tmux: `Ctrl+B D`
 - zellij: `Ctrl+O D`
-
-**Note:** Some features like `orch monitor` require tmux for multi-pane layouts.
 
 ## Slack Notifications
 
@@ -406,9 +475,15 @@ github:
 
 slack:
   enabled: true
-  webhook_url: ${SLACK_WEBHOOK_URL}
   notify_on:
     - waiting
+```
+
+Set the webhook through the supported environment override (config-file
+`${...}` interpolation is not performed):
+
+```bash
+export ORCH_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/XXX/YYY/ZZZ
 ```
 
 ### Multiple models

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -127,9 +127,10 @@ Without this mapping, commands fail with
 stored in `~/.config/orch/projects/<project_id>.yaml` and takes effect
 immediately — no daemon restart needed.
 
-### Setting up the issues directory
+### Setting up the issues directory (optional)
 
-orch needs a place to store issues. Configure it in `.orch/config.yaml`.
+By default, orch stores issues in `~/.local/share/orch/<repo-id>`. Configure
+`issues.path` in `.orch/config.yaml` only when you want a different location.
 
 **Option A: Use a separate issues directory (recommended for teams)**
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -8,7 +8,7 @@ These flags work with all commands:
 
 | Flag | Description |
 |------|-------------|
-| `--backend <type>` | Issue store backend: `local`, `github` (normally set via `issues.backend` in config) |
+| `--backend <type>` | Issue store backend: `file` (default), `local`, or `github` (normally set via `issues.backend` in config) |
 | `--project <id-or-url>` | Project identity (repo ID or git remote URL, or `ORCH_PROJECT`) |
 | `--remote <addr>` | Connect to remote daemon address (or `ORCH_REMOTE`) |
 | `--json` | Output in JSON format |
@@ -129,7 +129,7 @@ orch run ISSUE_ID [flags]
 |------|-------------|
 | `--agent <type>` | Agent: `claude`, `codex`, `gemini`, `opencode`, `custom` |
 | `--agent-cmd <cmd>` | Custom agent command (with `--agent custom`) |
-| `--base-branch <branch>` | Base branch for worktree (default: `main`) |
+| `--base-branch <branch>` | Explicit base branch for the worktree; when omitted, the daemon checks issue `base_branch`, config `base_branch`, then `main` |
 | `--branch <name>` | Branch name (default: `issue/<ID>/run-<RUN_ID>`) |
 | `--codex-profile <name>` | Codex execution profile from config (`codex.profiles`) |
 | `--dry-run` | Show what would be done without doing it |
@@ -142,7 +142,7 @@ orch run ISSUE_ID [flags]
 | `--preset <name>` | Use named preset from config |
 | `--profile <name>` | Agent profile |
 | `--prompt-template <file>` | Custom prompt template file |
-| `--reuse` | Reuse latest run if waiting |
+| `--reuse` | Reuse the latest run if it is `waiting` or `rate_limited` |
 | `--run-id <id>` | Manually specify run ID |
 | `--session-name <name>` | Session name (default: `run-<ISSUE>-<RUN>`) |
 | `--tmux` | Run in tmux session (default: true) |
@@ -225,7 +225,7 @@ orch ps [flags]
 | `--sort <field>` | Sort by: `updated`, `started` |
 | `--since <timestamp>` | Show runs since timestamp |
 | `--absolute-time` | Show absolute timestamps |
-| `--all` | Include resolved runs |
+| `-a, --all` | Include resolved runs |
 | `--no-alive` | Skip agent alive checks for faster listing |
 | `--no-git` | Skip git merge state checks for faster listing |
 | `-v, --verbose` | Show additional debug info (daemon log location) |
@@ -372,6 +372,13 @@ Do NOT use `orch restart-from` for send failures - the run is likely still alive
 orch send RUN_REF [MESSAGE] [flags]
 ```
 
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--no-enter` | Do not press Enter after sending (ignored for opencode agents) |
+| `--dry-run` | Validate the run and control path without sending a message |
+
 ### Examples
 
 ```bash
@@ -424,6 +431,12 @@ Capture current output from a running agent.
 orch capture RUN_REF [flags]
 ```
 
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--lines <n>` | Number of lines to capture (default: `100`) |
+
 ---
 
 ## orch capture-all
@@ -433,6 +446,12 @@ Capture output from all running agents.
 ```bash
 orch capture-all [flags]
 ```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--lines <n>` | Number of lines to capture per agent (default: `100`) |
 
 ---
 
@@ -619,6 +638,12 @@ Mark an issue as resolved.
 orch resolve ISSUE_ID [flags]
 ```
 
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Resolve even if the issue has no completed runs |
+
 ---
 
 ## orch tick
@@ -634,7 +659,7 @@ orch tick [RUN_REF] [flags]
 | Flag | Description |
 |------|-------------|
 | `--all` | Process all waiting runs |
-| `--only-waiting` | Only process waiting runs |
+| `--only-waiting` | Only process waiting or rate-limited runs (default: `true`) |
 | `--agent <type>` | Agent for resumption |
 | `--max <n>` | Max runs to process |
 
@@ -678,8 +703,17 @@ See [Query Reference](./query.md) for detailed SQL examples.
 Show database schema for SQL queries.
 
 ```bash
-orch schema
+orch schema [table] [flags]
 ```
+
+Omit `table` to list all tables and views, or provide a table/view name to
+show its columns.
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `-f, --format <format>` | Output format: `table`, `json`, or `tsv` (default: `table`) |
 
 ---
 
@@ -741,6 +775,15 @@ Execute a command in a run's worktree.
 orch exec RUN_REF -- COMMAND [args...]
 ```
 
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--env <KEY=VALUE>` | Add an environment variable; may be repeated |
+| `--no-orch-env` | Do not inject the run's `ORCH_*` environment variables |
+| `--shell` | Run the command through `sh -c` |
+| `--quiet` | Suppress human-readable output |
+
 ### Examples
 
 ```bash
@@ -755,11 +798,25 @@ orch exec my-issue -- git status
 
 ## orch delete
 
-Delete runs and their resources.
+Delete runs and their resources. **This command is destructive:** run records
+are removed, and worktrees or branches are also removed when their respective
+flags are supplied. Use `--dry-run` to inspect the selection first.
 
 ```bash
-orch delete RUN_REF [flags]
+orch delete [RUN_REF | ISSUE_ID] [flags]
 ```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Delete all matching runs for the specified issue |
+| `--force` | Skip the confirmation prompt |
+| `--dry-run` | Show what would be deleted without deleting it |
+| `--with-worktree` | Also remove each run's git worktree |
+| `--with-branch` | Also remove each run's git branch |
+| `--older-than <duration>` | Delete runs older than a duration such as `7d`, `2w`, or `1m` |
+| `--status <status>` | Only delete runs in `done`, `failed`, or `canceled` status |
 
 ---
 
@@ -768,8 +825,18 @@ orch delete RUN_REF [flags]
 Remove run worktrees while preserving run history.
 
 ```bash
-orch clean RUN_REF [flags]
+orch clean [RUN_REF | ISSUE_ID] [flags]
 ```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Clean all matching runs, globally or for the specified issue |
+| `--older-than <duration>` | Clean runs older than a duration such as `7d`, `2w`, or `1m` |
+| `--status <statuses>` | Comma-separated statuses to clean: `failed`, `canceled`, or `done` |
+| `--force` | Skip the confirmation prompt |
+| `--dry-run` | Show what would be cleaned without removing worktrees |
 
 Examples:
 
@@ -819,6 +886,12 @@ Kill running daemon(s).
 ```bash
 orch daemon kill
 ```
+
+#### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Kill all running daemons (an alias for the global-daemon behavior) |
 
 ### orch daemon list
 
@@ -924,8 +997,14 @@ orch worker stop [flags]
 Debug a run by showing daemon perspective.
 
 ```bash
-orch debug RUN_REF
+orch debug RUN_REF [flags]
 ```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Request JSON output |
 
 ---
 
@@ -964,11 +1043,18 @@ orch events -f --issue my-issue
 
 ## orch log
 
-View orch logs.
+View orch logs. The `daemon` subcommand reads the global daemon log.
 
 ```bash
-orch log [flags]
+orch log daemon [flags]
 ```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `-f, --follow` | Follow daemon log output |
+| `-n, --lines <n>` | Number of lines to show (default: `100`) |
 
 ---
 
@@ -977,8 +1063,15 @@ orch log [flags]
 List opencode provider models.
 
 ```bash
-orch models
+orch models [flags]
 ```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--port <port>` | OpenCode server port (default: `4096`) |
+| `--timeout <seconds>` | Request timeout in seconds (default: `5`) |
 
 ---
 
@@ -989,6 +1082,18 @@ Notification management commands.
 ```bash
 orch notify [subcommand]
 ```
+
+### orch notify test
+
+Send a test notification using the configured Slack notifier.
+
+```bash
+orch notify test [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-m, --message <text>` | Custom test message |
 
 ---
 

--- a/docs/reference/statuses.md
+++ b/docs/reference/statuses.md
@@ -10,6 +10,7 @@ stateDiagram-v2
 
     queued --> booting: agent starting
     booting --> running: agent ready
+    booting --> failed: launch error
 
     running --> waiting: needs human input
     running --> rate_limited: API/rate limit issue
@@ -201,7 +202,7 @@ SELECT
   issue_id,
   run_id,
   status,
-  datetime('now') - started_at as duration_seconds
+  ROUND((julianday('now') - julianday(started_at)) * 86400) AS duration_seconds
 FROM runs
 WHERE status = 'running';
 

--- a/install.sh
+++ b/install.sh
@@ -449,14 +449,12 @@ create_default_config() {
 # orch configuration
 # https://github.com/proboscis/orch
 
-multiplexer: tmux
+agent_multiplexer: tmux
 
-# llm:
-#   provider: openai
-#   model: gpt-4
-
+# issues.path is optional. When omitted, orch uses
+# ~/.local/share/orch/<repo-id>.
 # issues:
-#   root: ~/repos/my-issues
+#   path: ~/repos/my-issues
 EOF
     success "Created ${CONFIG_DIR}/config.yaml"
 }


### PR DESCRIPTION
## Summary

- add the missing CLI flag tables, positional syntax, aliases, subcommands, and corrected defaults/behavior
- document multi-host `targets`, current multiplexer keys, monitor issue filters, optional issue paths, and all audited environment overrides
- align file-backend run examples, issue hex IDs, worktree naming, status transitions/SQL, Slack webhook setup, and the generated installer config with implementation

## Acceptance evidence

| Area | Runtime/source verification |
|---|---|
| CLI flags and defaults | Built `./cmd/orch`, then checked live `--help` for `delete`, `send`, `schema`, `exec`, `log daemon`, `capture`, `capture-all`, `resolve`, `clean`, `models`, `debug`, `daemon kill`, `notify test`, `ps`, `run`, and `tick`. Help confirmed every documented flag/alias/default, including backend default `file`, unset `--base-branch`, `waiting or rate_limited` reuse, and `--only-waiting` default `true`. |
| Configuration | Source-to-doc assertions found all 16 requested environment variables in both `docs/configuration.md` and their implementation, plus `targets`, `agent_multiplexer`, and `monitor.default_issue_filter`. `TestLoadDefaultIssuesPath`, `TestRepoConfigWithoutIssuesPathUsesDefault`, `TestLoadTargetsAndGetTarget`, env-model tests, and issue-path tests passed. |
| File backend and IDs | `TestCreateRun`, `TestEventString`, `TestIssueHexIDGolden`, `TestIssueShortHexID`, `TestIsIssueHexRef`, `TestResolveIssueByHexRef`, and `TestRunLookupsAcceptIssueHexRef` passed. These cover frontmatter creation, no-trailing-pipe event rendering, and 7–64 character issue-hex lookup. |
| Status SQL | Executed the documented `ROUND((julianday(...) - julianday(...)) * 86400)` expression with SQLite; a one-second interval returned `1.0`. |
| Installer template | `bash -n install.sh` passed. Executed `create_default_config` in a temporary config directory and confirmed `agent_multiplexer: tmux` and `issues.path`, with deprecated `multiplexer`, `llm`, and `issues.root` absent. |
| Repository checks | `go build ./...` passed. `git diff --check` passed, and all changed Markdown files have balanced fences. |

## Tests

- PASS: `ORCH_SAFE_CLI_TEST=1 GOGC=50 GOMEMLIMIT=2GiB go test -skip '^TestRunWithBuiltInAgents$' -p 1 -parallel 1 -timeout 20m ./...`
- KNOWN EXCEPTION: unfiltered `make test` passes every package but `TestRunWithBuiltInAgents`, where the orch-managed OpenCode 1.17.13 server returns HTTP 500 creating a session. The failure reproduced in isolation with changing OpenCode error refs. The same session POST against both the preserved state and a fresh standalone OpenCode runtime returned HTTP 200, narrowing this to the pre-existing orch-managed real-agent launch boundary; the integration harness writes its own config and does not consume any file changed by this PR.

Tracking issue: `docs-reference-gaps`
