### PR TITLE
Add orch-monitor instance management commands

### DIFF
--- a/docs/orch-monitor.md
+++ b/docs/orch-monitor.md
@@ -2,10 +2,8 @@
 
 orch-monitor is a terminal user interface (TUI) for managing orch issues and runs visually. It provides a dashboard view of your workflow and integrates with the control agent for chat-based management.
 
-`orch monitor` and `orch-monitor` are separate frontends. `orch monitor` is the
-built-in Go TUI shipped as an `orch` subcommand, while `orch-monitor` is the
-optional standalone Python TUI installed from `orch-monitor-tui`. Both read the
-same daemon state, but they have separate binaries, launch flows, and docs.
+`orch-monitor` is the standalone Python TUI installed from `orch-monitor-tui`.
+It reads run, issue, and monitor-instance state from the orch daemon.
 
 ## Installation
 
@@ -45,6 +43,34 @@ orch-monitor --project github.com/owner/repo
 Use bare `orch-monitor` for the first launch. `--new` requires an existing
 control agent session to resume; use `--new-control-agent` when you want to
 replace that session too.
+
+## Managing monitor instances
+
+The daemon tracks running monitor instances. Management commands are scoped to
+the resolved project identity, including when `--project` or `ORCH_PROJECT` is
+used.
+
+```bash
+# List registered monitors for the current project
+orch-monitor --list
+
+# Stop one monitor and its multiplexer session
+orch-monitor --kill MONITOR_ID
+
+# Stop every registered monitor for the current project
+orch-monitor --kill-all
+```
+
+`--list` prints each monitor's ID, PID, project, view, multiplexer session, and
+last heartbeat time. Use an ID from this output with `--kill`.
+
+These commands use the same daemon routing as the TUI. Pass `--remote` or set
+`ORCH_REMOTE` to manage monitors registered with a remote daemon:
+
+```bash
+orch-monitor --remote master.example:7777 --list
+orch-monitor --remote master.example:7777 --kill MONITOR_ID
+```
 
 ## Interface Overview
 

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -2809,10 +2809,15 @@ func (s *SocketServer) handleProtoHeartbeat(req *orchpb.HeartbeatRequest) *orchp
 }
 
 func (s *SocketServer) handleProtoListMonitors(req *orchpb.ListMonitorsRequest) *orchpb.Response {
+	project := strings.TrimSpace(req.Project)
+	if !req.All && project == "" {
+		return errorResponse("list_monitors requires a project scope; pass all to list across projects")
+	}
+
 	s.monitorsMu.RLock()
 	monitorConnections := make([]MonitorConnection, 0, len(s.monitors))
 	for _, conn := range s.monitors {
-		if !req.All && req.Project != "" && conn.Project != req.Project {
+		if !req.All && conn.Project != project {
 			continue
 		}
 		monitorConnections = append(monitorConnections, *conn)
@@ -2855,6 +2860,10 @@ func (s *SocketServer) handleProtoKillMonitor(req *orchpb.KillMonitorRequest) *o
 	if req.MonitorId == "" && !req.All {
 		return errorResponse("monitor_id required or use --all")
 	}
+	project := strings.TrimSpace(req.Project)
+	if req.MonitorId == "" && req.All && !req.Global && project == "" {
+		return errorResponse("kill_all requires a project scope; pass global to kill across projects")
+	}
 
 	s.monitorsMu.RLock()
 	toKill := make([]MonitorConnection, 0)
@@ -2864,7 +2873,7 @@ func (s *SocketServer) handleProtoKillMonitor(req *orchpb.KillMonitorRequest) *o
 		}
 	} else {
 		for _, conn := range s.monitors {
-			if req.Global || req.Project == "" || conn.Project == req.Project {
+			if req.Global || conn.Project == project {
 				toKill = append(toKill, *conn)
 			}
 		}
@@ -2885,7 +2894,12 @@ func (s *SocketServer) handleProtoKillMonitor(req *orchpb.KillMonitorRequest) *o
 			continue
 		}
 		if err := s.killMonitorProcess(conn); err != nil {
-			return errorResponse(fmt.Sprintf("failed to kill monitor %s: %v", conn.ID, err))
+			return errorResponse(fmt.Sprintf(
+				"failed to kill monitor %s after killing %d monitor registrations: %v",
+				conn.ID,
+				killedCount,
+				err,
+			))
 		}
 		s.monitorsMu.Lock()
 		for id, registered := range s.monitors {
@@ -2896,7 +2910,7 @@ func (s *SocketServer) handleProtoKillMonitor(req *orchpb.KillMonitorRequest) *o
 		}
 		s.monitorsMu.Unlock()
 	}
-	s.logger.Printf("killed %d monitor registrations (project=%s, all=%t)", killedCount, req.Project, req.All)
+	s.logger.Printf("killed %d monitor registrations (project=%s, all=%t)", killedCount, project, req.All)
 
 	return &orchpb.Response{
 		Ok: true,

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -2810,13 +2810,25 @@ func (s *SocketServer) handleProtoHeartbeat(req *orchpb.HeartbeatRequest) *orchp
 
 func (s *SocketServer) handleProtoListMonitors(req *orchpb.ListMonitorsRequest) *orchpb.Response {
 	s.monitorsMu.RLock()
-	defer s.monitorsMu.RUnlock()
-
-	var monitors []*orchpb.MonitorInfo
+	monitorConnections := make([]MonitorConnection, 0, len(s.monitors))
 	for _, conn := range s.monitors {
 		if !req.All && req.Project != "" && conn.Project != req.Project {
 			continue
 		}
+		monitorConnections = append(monitorConnections, *conn)
+	}
+	s.monitorsMu.RUnlock()
+
+	sort.Slice(monitorConnections, func(i, j int) bool {
+		if monitorConnections[i].StartedAt.Equal(monitorConnections[j].StartedAt) {
+			return monitorConnections[i].ID < monitorConnections[j].ID
+		}
+		return monitorConnections[i].StartedAt.Before(monitorConnections[j].StartedAt)
+	})
+
+	monitors := make([]*orchpb.MonitorInfo, 0, len(monitorConnections))
+	for i := range monitorConnections {
+		conn := &monitorConnections[i]
 		monitors = append(monitors, &orchpb.MonitorInfo{
 			Id:                conn.ID,
 			Pid:               int32(conn.PID),
@@ -2840,24 +2852,51 @@ func (s *SocketServer) handleProtoListMonitors(req *orchpb.ListMonitorsRequest) 
 }
 
 func (s *SocketServer) handleProtoKillMonitor(req *orchpb.KillMonitorRequest) *orchpb.Response {
-	s.monitorsMu.Lock()
-	defer s.monitorsMu.Unlock()
+	if req.MonitorId == "" && !req.All {
+		return errorResponse("monitor_id required or use --all")
+	}
+
+	s.monitorsMu.RLock()
+	toKill := make([]MonitorConnection, 0)
+	if req.MonitorId != "" {
+		if conn, ok := s.monitors[req.MonitorId]; ok {
+			toKill = append(toKill, *conn)
+		}
+	} else {
+		for _, conn := range s.monitors {
+			if req.Global || req.Project == "" || conn.Project == req.Project {
+				toKill = append(toKill, *conn)
+			}
+		}
+	}
+	s.monitorsMu.RUnlock()
+
+	if len(toKill) == 0 && req.MonitorId != "" {
+		return errorResponse(fmt.Sprintf("monitor not found: %s", req.MonitorId))
+	}
 
 	var killedCount int32
-
-	if req.MonitorId != "" {
-		if _, ok := s.monitors[req.MonitorId]; ok {
-			delete(s.monitors, req.MonitorId)
-			killedCount = 1
+	for i := range toKill {
+		conn := &toKill[i]
+		s.monitorsMu.RLock()
+		_, stillRegistered := s.monitors[conn.ID]
+		s.monitorsMu.RUnlock()
+		if !stillRegistered {
+			continue
 		}
-	} else if req.All {
-		for id, conn := range s.monitors {
-			if req.Global || (req.Project != "" && conn.Project == req.Project) || req.Project == "" {
+		if err := s.killMonitorProcess(conn); err != nil {
+			return errorResponse(fmt.Sprintf("failed to kill monitor %s: %v", conn.ID, err))
+		}
+		s.monitorsMu.Lock()
+		for id, registered := range s.monitors {
+			if id == conn.ID || (conn.SessionName != "" && registered.SessionName == conn.SessionName) {
 				delete(s.monitors, id)
 				killedCount++
 			}
 		}
+		s.monitorsMu.Unlock()
 	}
+	s.logger.Printf("killed %d monitor registrations (project=%s, all=%t)", killedCount, req.Project, req.All)
 
 	return &orchpb.Response{
 		Ok: true,

--- a/internal/daemon/proto_handler_test.go
+++ b/internal/daemon/proto_handler_test.go
@@ -68,6 +68,46 @@ func TestHandleProtoListMonitorsScopesAndSortsInDaemon(t *testing.T) {
 	}
 }
 
+func TestHandleProtoListMonitorsRejectsEmptyProjectScope(t *testing.T) {
+	server := newTestServer(t, &mockStore{})
+	server.monitors = map[string]*MonitorConnection{
+		"project-a": {ID: "project-a", Project: "project-a"},
+		"project-b": {ID: "project-b", Project: "project-b"},
+	}
+
+	resp := server.handleProtoListMonitors(&orchpb.ListMonitorsRequest{})
+
+	if resp.Ok {
+		t.Fatal("empty project scope unexpectedly listed every monitor")
+	}
+	if !strings.Contains(resp.Error, "requires a project scope") {
+		t.Fatalf("error = %q, want actionable project-scope error", resp.Error)
+	}
+}
+
+func TestHandleProtoKillMonitorRejectsEmptyProjectScope(t *testing.T) {
+	server := newTestServer(t, &mockStore{})
+	server.monitors = map[string]*MonitorConnection{
+		"project-a": {ID: "project-a", PID: -1, Project: "project-a"},
+		"project-b": {ID: "project-b", PID: -1, Project: "project-b"},
+	}
+
+	resp := server.handleProtoKillMonitor(&orchpb.KillMonitorRequest{All: true})
+
+	if resp.Ok {
+		t.Fatal("empty project scope unexpectedly killed every monitor")
+	}
+	if !strings.Contains(resp.Error, "kill_all requires a project scope") {
+		t.Fatalf("error = %q, want actionable project-scope error", resp.Error)
+	}
+	server.monitorsMu.RLock()
+	remainingRegistrations := len(server.monitors)
+	server.monitorsMu.RUnlock()
+	if remainingRegistrations != 2 {
+		t.Fatalf("registrations after rejected kill = %d, want 2", remainingRegistrations)
+	}
+}
+
 func TestHandleProtoKillMonitorTerminatesRegisteredProcess(t *testing.T) {
 	server := newTestServer(t, &mockStore{})
 	process := exec.Command("sleep", "30")

--- a/internal/daemon/proto_handler_test.go
+++ b/internal/daemon/proto_handler_test.go
@@ -4,16 +4,193 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
 
 	orchpb "github.com/proboscis/orch/api/orchpb"
 	"github.com/proboscis/orch/internal/model"
+	"github.com/proboscis/orch/internal/multiplexer"
 )
 
 type timingTestLogger struct {
 	buf bytes.Buffer
+}
+
+func TestHandleProtoListMonitorsScopesAndSortsInDaemon(t *testing.T) {
+	server := newTestServer(t, &mockStore{})
+	baseTime := time.Unix(1_700_000_000, 0)
+	server.monitors = map[string]*MonitorConnection{
+		"newer": {
+			ID:        "newer",
+			PID:       202,
+			Project:   "project-a",
+			View:      "issues",
+			StartedAt: baseTime.Add(time.Minute),
+			LastSeen:  baseTime.Add(time.Minute),
+		},
+		"other-project": {
+			ID:        "other-project",
+			PID:       303,
+			Project:   "project-b",
+			View:      "runs",
+			StartedAt: baseTime.Add(-time.Minute),
+			LastSeen:  baseTime.Add(-time.Minute),
+		},
+		"older": {
+			ID:          "older",
+			PID:         101,
+			Project:     "project-a",
+			View:        "runs",
+			SessionName: "orch-monitor-project-a",
+			StartedAt:   baseTime,
+			LastSeen:    baseTime,
+		},
+	}
+
+	resp := server.handleProtoListMonitors(&orchpb.ListMonitorsRequest{
+		Project: "project-a",
+	})
+
+	if !resp.Ok {
+		t.Fatalf("handleProtoListMonitors() error = %s", resp.Error)
+	}
+	monitors := resp.GetListMonitors().GetMonitors()
+	if len(monitors) != 2 {
+		t.Fatalf("monitor count = %d, want 2", len(monitors))
+	}
+	if monitors[0].GetId() != "older" || monitors[1].GetId() != "newer" {
+		t.Fatalf("monitor order = [%s, %s], want [older, newer]", monitors[0].GetId(), monitors[1].GetId())
+	}
+	if monitors[0].GetSessionName() != "orch-monitor-project-a" {
+		t.Fatalf("session_name = %q, want orch-monitor-project-a", monitors[0].GetSessionName())
+	}
+}
+
+func TestHandleProtoKillMonitorTerminatesRegisteredProcess(t *testing.T) {
+	server := newTestServer(t, &mockStore{})
+	process := exec.Command("sleep", "30")
+	if err := process.Start(); err != nil {
+		t.Fatalf("start monitor process: %v", err)
+	}
+	processDone := make(chan error, 1)
+	go func() {
+		processDone <- process.Wait()
+	}()
+	t.Cleanup(func() {
+		if process.Process != nil {
+			_ = process.Process.Kill()
+		}
+		select {
+		case <-processDone:
+		default:
+		}
+	})
+
+	server.monitors = map[string]*MonitorConnection{
+		"mon-123": {
+			ID:          "mon-123",
+			PID:         process.Process.Pid,
+			Project:     "project-a",
+			View:        "runs",
+			SessionName: "missing-test-session",
+			StartedAt:   time.Now(),
+			LastSeen:    time.Now(),
+		},
+		"mon-sibling": {
+			ID:          "mon-sibling",
+			PID:         -1,
+			Project:     "project-a",
+			View:        "issues",
+			SessionName: "missing-test-session",
+			StartedAt:   time.Now(),
+			LastSeen:    time.Now(),
+		},
+	}
+
+	resp := server.handleProtoKillMonitor(&orchpb.KillMonitorRequest{
+		MonitorId: "mon-123",
+		Project:   "project-a",
+	})
+
+	if !resp.Ok {
+		t.Fatalf("handleProtoKillMonitor() error = %s", resp.Error)
+	}
+	if got := resp.GetKillMonitor().GetKilledCount(); got != 2 {
+		t.Fatalf("killed_count = %d, want 2 registrations in the session", got)
+	}
+	select {
+	case <-processDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("registered monitor process was not terminated")
+	}
+	server.monitorsMu.RLock()
+	remainingRegistrations := len(server.monitors)
+	server.monitorsMu.RUnlock()
+	if remainingRegistrations != 0 {
+		t.Fatalf("%d registrations remain for killed session", remainingRegistrations)
+	}
+}
+
+func TestCleanupStaleMonitorsStillRemovesOnlyExpiredHeartbeats(t *testing.T) {
+	server := newTestServer(t, &mockStore{})
+	now := time.Now()
+	server.monitors = map[string]*MonitorConnection{
+		"stale": {
+			ID:       "stale",
+			PID:      101,
+			LastSeen: now.Add(-61 * time.Second),
+		},
+		"fresh": {
+			ID:       "fresh",
+			PID:      202,
+			LastSeen: now.Add(-59 * time.Second),
+		},
+	}
+
+	server.cleanupStaleMonitors()
+
+	server.monitorsMu.RLock()
+	_, staleExists := server.monitors["stale"]
+	_, freshExists := server.monitors["fresh"]
+	server.monitorsMu.RUnlock()
+	if staleExists {
+		t.Fatal("stale monitor remains registered")
+	}
+	if !freshExists {
+		t.Fatal("fresh monitor was incorrectly reaped")
+	}
+}
+
+func TestKillMonitorSessionRemovesTmuxSession(t *testing.T) {
+	mux := multiplexer.NewTmuxMultiplexer()
+	if !mux.IsAvailable() {
+		t.Skip("tmux is not available")
+	}
+	sessionName := fmt.Sprintf("orch-monitor-kill-test-%d", time.Now().UnixNano())
+	if err := mux.NewSession(&multiplexer.SessionConfig{
+		SessionName: sessionName,
+		Command:     "sleep 30",
+	}); err != nil {
+		t.Fatalf("create tmux session: %v", err)
+	}
+	t.Cleanup(func() {
+		if mux.HasSession(sessionName) {
+			_ = mux.KillSession(sessionName)
+		}
+	})
+
+	killed, err := killMonitorSession(sessionName)
+	if err != nil {
+		t.Fatalf("killMonitorSession() error = %v", err)
+	}
+	if !killed {
+		t.Fatal("killMonitorSession() reported no matching session")
+	}
+	if mux.HasSession(sessionName) {
+		t.Fatal("tmux session remains after killMonitorSession()")
+	}
 }
 
 type waitForRunsStatusStore struct {

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -5572,6 +5572,18 @@ func (s *SocketServer) handleKillMonitor(req SendRequest, encoder *json.Encoder)
 }
 
 func (s *SocketServer) killMonitorProcess(conn *MonitorConnection) error {
+	if conn.SessionName != "" {
+		killed, err := killMonitorSession(conn.SessionName)
+		if err != nil {
+			return err
+		}
+		if killed {
+			s.logger.Printf("killed monitor session %s for %s", conn.SessionName, conn.ID)
+			return nil
+		}
+		s.logger.Printf("monitor session %s not found for %s; falling back to pid %d", conn.SessionName, conn.ID, conn.PID)
+	}
+
 	if conn.PID <= 0 {
 		return fmt.Errorf("invalid pid")
 	}
@@ -5589,6 +5601,37 @@ func (s *SocketServer) killMonitorProcess(conn *MonitorConnection) error {
 		return err
 	}
 	return nil
+}
+
+func killMonitorSession(sessionName string) (bool, error) {
+	preferredType := multiplexer.GetDefault().Type()
+	multiplexerTypes := []multiplexer.Type{preferredType}
+	for _, candidate := range []multiplexer.Type{
+		multiplexer.TypeTmux,
+		multiplexer.TypeZellij,
+	} {
+		if candidate != preferredType {
+			multiplexerTypes = append(multiplexerTypes, candidate)
+		}
+	}
+
+	for _, multiplexerType := range multiplexerTypes {
+		mux, err := multiplexer.GetMultiplexer(multiplexerType)
+		if err != nil || mux == nil || !mux.HasSession(sessionName) {
+			continue
+		}
+		if err := mux.KillSession(sessionName); err != nil {
+			return false, fmt.Errorf(
+				"failed to kill %s session %s: %w",
+				multiplexerType,
+				sessionName,
+				err,
+			)
+		}
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func (s *SocketServer) StartStaleMonitorCleanup() {

--- a/orch-monitor-tui/orch_monitor/__main__.py
+++ b/orch-monitor-tui/orch_monitor/__main__.py
@@ -10,12 +10,14 @@ import subprocess
 import sys
 import time
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Protocol
 
 import hy  # noqa: F401 - Enable Hy imports
 from rich.console import Console
 from rich.markup import escape as rich_escape
+from returns.result import Failure
 
 # Shared console for startup output
 _console = Console(stderr=True)
@@ -57,7 +59,7 @@ from .multiplexer import (
     get_multiplexer,
     validate_multiplexer_config,
 )
-from .orch_api import OrchAPI, create_orch_api
+from .orch_api import MonitorInfo, MonitorManagementAPI, OrchAPI, create_orch_api
 
 
 def _escape_kdl_string(s: str) -> str:
@@ -1168,7 +1170,7 @@ def launch_monitor_layout(
     _launcher_logger.info("launch complete")
 
 
-def main():
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Orch monitor TUI")
     parser.add_argument(
         "--project",
@@ -1221,6 +1223,110 @@ def main():
         'Use --remote="" to force local.',
     )
 
+    monitor_actions = parser.add_mutually_exclusive_group()
+    monitor_actions.add_argument(
+        "--list",
+        action="store_true",
+        dest="list_monitors",
+        help="List monitor instances registered for this project",
+    )
+    monitor_actions.add_argument(
+        "--kill",
+        metavar="MONITOR_ID",
+        dest="kill_monitor",
+        help="Kill one registered monitor instance",
+    )
+    monitor_actions.add_argument(
+        "--kill-all",
+        action="store_true",
+        help="Kill all registered monitor instances for this project",
+    )
+    return parser
+
+
+def _format_last_seen(last_seen_unix: int) -> str:
+    if last_seen_unix <= 0:
+        return "-"
+    return (
+        datetime.fromtimestamp(last_seen_unix, tz=timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _print_monitor_table(monitors: list[MonitorInfo]) -> None:
+    if not monitors:
+        print("No monitors running")
+        return
+
+    headers: tuple[str, ...] = (
+        "ID",
+        "PID",
+        "PROJECT",
+        "VIEW",
+        "SESSION",
+        "LAST_SEEN",
+    )
+    rows: list[tuple[str, ...]] = [
+        (
+            monitor.id,
+            str(monitor.pid),
+            monitor.project or "-",
+            monitor.view or "-",
+            monitor.session_name or "-",
+            _format_last_seen(monitor.last_seen_unix),
+        )
+        for monitor in monitors
+    ]
+    widths: list[int] = [
+        max(len(header), *(len(row[index]) for row in rows))
+        for index, header in enumerate(headers)
+    ]
+
+    def format_row(row: tuple[str, ...]) -> str:
+        return "  ".join(
+            value.ljust(widths[index]) for index, value in enumerate(row)
+        ).rstrip()
+
+    print(format_row(headers))
+    for row in rows:
+        print(format_row(row))
+
+
+def _run_monitor_action(
+    api: MonitorManagementAPI, args: argparse.Namespace, project_scope: str
+) -> int:
+    if args.list_monitors:
+        list_result = api.list_monitors(project_scope)
+        if isinstance(list_result, Failure):
+            print(f"Error: {list_result.failure()}", file=sys.stderr)
+            return 1
+        _print_monitor_table(list_result.unwrap())
+        return 0
+
+    monitor_id: str = args.kill_monitor or ""
+    kill_all: bool = args.kill_all
+    kill_result = api.kill_monitor(monitor_id, kill_all, project_scope)
+    if isinstance(kill_result, Failure):
+        print(f"Error: {kill_result.failure()}", file=sys.stderr)
+        return 1
+
+    killed_count: int = kill_result.unwrap()
+    if killed_count == 0:
+        target: str = f"project {project_scope}" if kill_all else monitor_id
+        print(f"Error: no registered monitor found for {target}", file=sys.stderr)
+        return 1
+    if kill_all:
+        noun: str = "monitor" if killed_count == 1 else "monitors"
+        print(f"Killed {killed_count} {noun} for project {project_scope}")
+    else:
+        print(f"Killed monitor: {monitor_id}")
+    return 0
+
+
+def main() -> None:
+    parser = _build_parser()
+
     args = parser.parse_args()
 
     if args.project:
@@ -1254,6 +1360,24 @@ def main():
     project_scope = get_project_scope(bootstrap)
     if project_scope:
         os.environ["ORCH_PROJECT"] = project_scope
+
+    monitor_action_requested: bool = bool(
+        args.list_monitors or args.kill_monitor or args.kill_all
+    )
+    if monitor_action_requested:
+        success, error_msg = ensure_daemon(project_root, project_scope, bootstrap)
+        if not success:
+            print(f"Error: {error_msg}", file=sys.stderr)
+            sys.exit(1)
+        api = create_orch_api(
+            bootstrap.socket_path,
+            project_root,
+            fallback_to_cli=False,
+        )
+        exit_code: int = _run_monitor_action(api, args, project_scope or "")
+        if exit_code:
+            sys.exit(exit_code)
+        return
 
     # Determine if we should show spinners (only for layout mode, not single panes)
     show_spinner = not args.runs and not args.issues

--- a/orch-monitor-tui/orch_monitor/__main__.py
+++ b/orch-monitor-tui/orch_monitor/__main__.py
@@ -91,6 +91,9 @@ def _setup_launcher_logging() -> None:
 
 
 CONTROL_PROMPT_FILE = "ORCH_CONTROL_PROMPT.md"
+MONITOR_PROJECT_SCOPE_ERROR = (
+    "project scope required for monitor management; set --project/ORCH_PROJECT"
+)
 
 
 # Real OS limit for sockaddr_un.sun_path: macOS = 104, Linux = 108. zellij validates
@@ -1296,6 +1299,10 @@ def _print_monitor_table(monitors: list[MonitorInfo]) -> None:
 def _run_monitor_action(
     api: MonitorManagementAPI, args: argparse.Namespace, project_scope: str
 ) -> int:
+    if not project_scope.strip():
+        print(f"Error: {MONITOR_PROJECT_SCOPE_ERROR}", file=sys.stderr)
+        return 1
+
     if args.list_monitors:
         list_result = api.list_monitors(project_scope)
         if isinstance(list_result, Failure):
@@ -1317,7 +1324,11 @@ def _run_monitor_action(
         print(f"Error: no registered monitor found for {target}", file=sys.stderr)
         return 1
     if kill_all:
-        noun: str = "monitor" if killed_count == 1 else "monitors"
+        noun: str = (
+            "monitor registration"
+            if killed_count == 1
+            else "monitor registrations"
+        )
         print(f"Killed {killed_count} {noun} for project {project_scope}")
     else:
         print(f"Killed monitor: {monitor_id}")
@@ -1365,6 +1376,9 @@ def main() -> None:
         args.list_monitors or args.kill_monitor or args.kill_all
     )
     if monitor_action_requested:
+        if not (project_scope or "").strip():
+            print(f"Error: {MONITOR_PROJECT_SCOPE_ERROR}", file=sys.stderr)
+            sys.exit(1)
         success, error_msg = ensure_daemon(project_root, project_scope, bootstrap)
         if not success:
             print(f"Error: {error_msg}", file=sys.stderr)

--- a/orch-monitor-tui/orch_monitor/client_bootstrap.py
+++ b/orch-monitor-tui/orch_monitor/client_bootstrap.py
@@ -32,9 +32,13 @@ def _resolve_orch_binary() -> str:
 @lru_cache(maxsize=1)
 def load_client_bootstrap() -> ClientBootstrap:
     orch_bin = _resolve_orch_binary()
+    command: list[str] = [orch_bin]
+    if "ORCH_REMOTE" in os.environ:
+        command.extend(["--remote", os.environ["ORCH_REMOTE"]])
+    command.extend(["debug", "client-bootstrap", "--json"])
     try:
         result = subprocess.run(
-            [orch_bin, "debug", "client-bootstrap", "--json"],
+            command,
             capture_output=True,
             text=True,
             timeout=5,

--- a/orch-monitor-tui/orch_monitor/daemon_api.py
+++ b/orch-monitor-tui/orch_monitor/daemon_api.py
@@ -47,6 +47,7 @@ from .orch_api import (
     IssueStatus,
     ListIssuesResponse,
     ListRunsResponse,
+    MonitorInfo,
     NotFoundError,
     OrchError,
     Run,
@@ -162,27 +163,36 @@ class MonitorHeartbeat:
         self._client = client
         self._project = project
         self._view = view
+        self._pid: Optional[int] = None
         self._monitor_id: Optional[str] = None
         self._session_name: str = ""
         self._heartbeat_thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
 
-    def start(self, session_name: str = "") -> Optional[str]:
+    def start(
+        self,
+        session_name: str = "",
+        pid: Optional[int] = None,
+        monitor_id: Optional[str] = None,
+    ) -> Optional[str]:
         import os
 
-        if not self._client.is_available():
+        if monitor_id is None and not self._client.is_available():
             return None
 
+        self._pid = pid if pid is not None else os.getpid()
         self._session_name = session_name
-        result = self._client.register_monitor(
-            pid=os.getpid(),
-            monitor_type="python",
-            view=self._view,
-            project=self._project,
-            session_name=session_name,
-        )
-        if isinstance(result, Success):
-            self._monitor_id = result.unwrap()
+        self._monitor_id = monitor_id
+        if self._monitor_id is None:
+            result = self._client.register_monitor(
+                pid=self._pid,
+                monitor_type="python",
+                view=self._view,
+                project=self._project,
+                session_name=session_name,
+            )
+            if isinstance(result, Success):
+                self._monitor_id = result.unwrap()
 
         if self._monitor_id:
             self._start_heartbeat_thread()
@@ -223,7 +233,7 @@ class MonitorHeartbeat:
                 success = isinstance(result, Success) and result.unwrap()
                 if not success:
                     reg_result = self._client.register_monitor(
-                        pid=os.getpid(),
+                        pid=self._pid if self._pid is not None else os.getpid(),
                         monitor_type="python",
                         view=self._view,
                         project=self._project,
@@ -259,6 +269,7 @@ class DaemonOrchAPI:
         self._remote_addr = bootstrap.remote_addr
         self._project_scope = bootstrap.project_id
         self._project_id = bootstrap.project_id or None
+        self._monitor_session_name = bootstrap.monitor_session_name
         self._base_branch = base_branch
         self._daemon = ProtoDaemonClient(
             socket_path,
@@ -583,12 +594,14 @@ class DaemonOrchAPI:
         project: str,
         session_name: str = "",
     ) -> Result[str, OrchError]:
+        project_scope = self._project_scope or project
+        resolved_session_name = session_name or self._monitor_session_name
         result = self._daemon.register_monitor(
             pid=pid,
             monitor_type=monitor_type,
             view=view,
-            project=project,
-            session_name=session_name,
+            project=project_scope,
+            session_name=resolved_session_name,
         )
         if isinstance(result, Failure):
             return _map_daemon_error(result.failure())
@@ -596,8 +609,10 @@ class DaemonOrchAPI:
         if monitor_id is None:
             return Failure(OrchError("Failed to register monitor"))
 
-        self._monitor_heartbeat = MonitorHeartbeat(self._daemon, project, view)
-        self._monitor_heartbeat.start(session_name)
+        self._monitor_heartbeat = MonitorHeartbeat(
+            self._daemon, project_scope, view
+        )
+        self._monitor_heartbeat.start(resolved_session_name, pid, monitor_id)
 
         return Success(monitor_id)
 
@@ -605,6 +620,7 @@ class DaemonOrchAPI:
         if self._monitor_heartbeat:
             self._monitor_heartbeat.stop()
             self._monitor_heartbeat = None
+            return Success(None)
 
         result = self._daemon.unregister_monitor(monitor_id)
         if isinstance(result, Failure):
@@ -622,3 +638,30 @@ class DaemonOrchAPI:
         if not success:
             return Failure(OrchError("Heartbeat failed"))
         return Success(None)
+
+    def list_monitors(
+        self, project: str, list_all: bool = False
+    ) -> Result[list[MonitorInfo], OrchError]:
+        result = self._daemon.list_monitors(project, list_all)
+        if isinstance(result, Failure):
+            return _map_daemon_error(result.failure())
+        monitors = [
+            MonitorInfo(
+                id=monitor.id,
+                pid=monitor.pid,
+                project=monitor.project,
+                view=monitor.view,
+                session_name=monitor.session_name,
+                last_seen_unix=monitor.last_heartbeat_unix,
+            )
+            for monitor in result.unwrap()
+        ]
+        return Success(monitors)
+
+    def kill_monitor(
+        self, monitor_id: str, kill_all: bool, project: str
+    ) -> Result[int, OrchError]:
+        result = self._daemon.kill_monitor(monitor_id, kill_all, project)
+        if isinstance(result, Failure):
+            return _map_daemon_error(result.failure())
+        return Success(result.unwrap())

--- a/orch-monitor-tui/orch_monitor/daemon_api.py
+++ b/orch-monitor-tui/orch_monitor/daemon_api.py
@@ -15,6 +15,12 @@ import hy  # noqa: F401 - Enable Hy imports
 
 from returns.result import Failure, Result, Success
 
+from orch_monitor.multiplexer import (
+    MultiplexerType,
+    detect_current_multiplexer,
+    get_multiplexer,
+)
+
 # Import client from Hy module (returns Result types)
 from .client_bootstrap import load_client_bootstrap
 from .proto_client import ProtoDaemonClient
@@ -59,6 +65,34 @@ from .orch_api import (
 from .orch_api import DaemonNotRunningError as ApiDaemonNotRunningError
 
 _logger = logging.getLogger("orch_monitor.daemon_api")
+
+
+def _verified_monitor_session_name(expected_session_name: str) -> str:
+    """Return the expected session only when this process is inside it."""
+    expected_session: str = expected_session_name.strip()
+    if not expected_session:
+        return ""
+
+    current_multiplexer_type: Optional[MultiplexerType]
+    current_multiplexer_type = detect_current_multiplexer()
+    if current_multiplexer_type is None:
+        return ""
+
+    try:
+        current_session: Optional[str] = get_multiplexer(
+            current_multiplexer_type
+        ).get_current_session()
+    except OSError as error:
+        _logger.warning(
+            "Failed to identify current %s session: %s",
+            current_multiplexer_type.value,
+            error,
+        )
+        return ""
+
+    if (current_session or "").strip() != expected_session:
+        return ""
+    return expected_session
 
 
 def _map_proto_error(err: Exception) -> Failure:
@@ -199,12 +233,18 @@ class MonitorHeartbeat:
 
         return self._monitor_id
 
-    def stop(self) -> None:
+    def stop(self) -> Result[bool, ProtoDaemonError]:
         self._stop_heartbeat_thread()
 
-        if self._monitor_id and self._client.is_available():
-            self._client.unregister_monitor(self._monitor_id)
+        if not self._monitor_id:
+            return Success(True)
+
+        result: Result[bool, ProtoDaemonError] = self._client.unregister_monitor(
+            self._monitor_id
+        )
+        if isinstance(result, Success) and result.unwrap():
             self._monitor_id = None
+        return result
 
     def _start_heartbeat_thread(self) -> None:
         if self._heartbeat_thread is not None:
@@ -594,8 +634,12 @@ class DaemonOrchAPI:
         project: str,
         session_name: str = "",
     ) -> Result[str, OrchError]:
-        project_scope = self._project_scope or project
-        resolved_session_name = session_name or self._monitor_session_name
+        project_scope: str = self._project_scope or project
+        expected_session_name: str = session_name or self._monitor_session_name
+        resolved_session_name: str = _verified_monitor_session_name(
+            expected_session_name
+        )
+        result: Result[Optional[str], ProtoDaemonError]
         result = self._daemon.register_monitor(
             pid=pid,
             monitor_type=monitor_type,
@@ -618,8 +662,12 @@ class DaemonOrchAPI:
 
     def unregister_monitor(self, monitor_id: str) -> Result[None, OrchError]:
         if self._monitor_heartbeat:
-            self._monitor_heartbeat.stop()
+            result: Result[bool, ProtoDaemonError] = self._monitor_heartbeat.stop()
             self._monitor_heartbeat = None
+            if isinstance(result, Failure):
+                return _map_daemon_error(result.failure())
+            if not result.unwrap():
+                return Failure(OrchError("Failed to unregister monitor"))
             return Success(None)
 
         result = self._daemon.unregister_monitor(monitor_id)

--- a/orch-monitor-tui/orch_monitor/orch_api.py
+++ b/orch-monitor-tui/orch_monitor/orch_api.py
@@ -132,6 +132,16 @@ class ListIssuesResponse:
     total: int
 
 
+@dataclass(frozen=True)
+class MonitorInfo:
+    id: str
+    pid: int
+    project: str
+    view: str
+    session_name: str
+    last_seen_unix: int
+
+
 @dataclass
 class ControlAgentLaunch:
     command: str
@@ -175,6 +185,15 @@ class StartRunResult:
     run_id: str
     branch: str
     worktree_path: str
+
+
+class MonitorManagementAPI(Protocol):
+    def list_monitors(
+        self, project: str, list_all: bool = False
+    ) -> Result[list[MonitorInfo], OrchError]: ...
+    def kill_monitor(
+        self, monitor_id: str, kill_all: bool, project: str
+    ) -> Result[int, OrchError]: ...
 
 
 @runtime_checkable
@@ -250,6 +269,12 @@ class OrchAPI(Protocol):
     ) -> Result[str, OrchError]: ...
     def unregister_monitor(self, monitor_id: str) -> Result[None, OrchError]: ...
     def heartbeat(self, monitor_id: str) -> Result[None, OrchError]: ...
+    def list_monitors(
+        self, project: str, list_all: bool = False
+    ) -> Result[list[MonitorInfo], OrchError]: ...
+    def kill_monitor(
+        self, monitor_id: str, kill_all: bool, project: str
+    ) -> Result[int, OrchError]: ...
 
 
 def create_orch_api(

--- a/orch-monitor-tui/orch_monitor/proto_client.hy
+++ b/orch-monitor-tui/orch_monitor/proto_client.hy
@@ -634,6 +634,25 @@
     (setv req.heartbeat.monitor_id monitor-id)
     (._send-ok self req "Heartbeat failed")
     True)
+
+  (defn list-monitors [self project [list-all False]]
+    "List registered monitors. Returns Result[list[MonitorInfo], ProtoDaemonError]."
+    (daemon-result "list_monitors"
+      (setv req (pb.Request))
+      (set-> req.list_monitors.project project
+             req.list_monitors.all list-all)
+      (setv resp (._send-ok self req "Failed to list monitors"))
+      (list resp.list_monitors.monitors)))
+
+  (defn kill-monitor [self monitor-id kill-all project]
+    "Kill registered monitors. Returns Result[int, ProtoDaemonError]."
+    (daemon-result "kill_monitor"
+      (setv req (pb.Request))
+      (set-> req.kill_monitor.monitor_id monitor-id
+             req.kill_monitor.all kill-all
+             req.kill_monitor.project project)
+      (setv resp (._send-ok self req "Failed to kill monitor"))
+      resp.kill_monitor.killed_count))
   
   (defn close [self]
     "Close the persistent connection."

--- a/orch-monitor-tui/tests/test_daemon_api.py
+++ b/orch-monitor-tui/tests/test_daemon_api.py
@@ -1,8 +1,10 @@
-"""Tests for daemon API error mapping behavior."""
+"""Tests for daemon API behavior."""
 
-from returns.result import Failure
+from unittest.mock import MagicMock
 
-from orch_monitor.daemon_api import _map_daemon_error
+from returns.result import Failure, Success
+
+from orch_monitor.daemon_api import DaemonOrchAPI, _map_daemon_error
 from orch_monitor.orch_api import DaemonNotRunningError, OrchError
 from orch_monitor.types import (
     ProtoDaemonConnectionRefusedError,
@@ -33,3 +35,37 @@ class TestDaemonErrorMapping:
         assert isinstance(err, OrchError)
         assert not isinstance(err, DaemonNotRunningError)
         assert "timed out" in str(err).lower()
+
+
+class TestMonitorRegistration:
+    def test_uses_resolved_project_and_session_without_duplicate_registration(self):
+        daemon = MagicMock()
+        daemon.is_available.return_value = True
+        daemon.register_monitor.return_value = Success("mon-123")
+        daemon.unregister_monitor.return_value = Success(True)
+        api = DaemonOrchAPI.__new__(DaemonOrchAPI)
+        api._daemon = daemon
+        api._project_scope = "proboscis-orch"
+        api._monitor_session_name = "orch-monitor-proboscis-orch"
+        api._monitor_heartbeat = None
+
+        result = api.register_monitor(
+            pid=123,
+            monitor_type="python",
+            view="runs",
+            project="/local/path/to/orch",
+        )
+
+        assert result == Success("mon-123")
+        daemon.register_monitor.assert_called_once_with(
+            pid=123,
+            monitor_type="python",
+            view="runs",
+            project="proboscis-orch",
+            session_name="orch-monitor-proboscis-orch",
+        )
+
+        unregister_result = api.unregister_monitor("mon-123")
+
+        assert unregister_result == Success(None)
+        daemon.unregister_monitor.assert_called_once_with("mon-123")

--- a/orch-monitor-tui/tests/test_daemon_api.py
+++ b/orch-monitor-tui/tests/test_daemon_api.py
@@ -4,7 +4,9 @@ from unittest.mock import MagicMock
 
 from returns.result import Failure, Success
 
+from orch_monitor import daemon_api
 from orch_monitor.daemon_api import DaemonOrchAPI, _map_daemon_error
+from orch_monitor.multiplexer import MultiplexerType
 from orch_monitor.orch_api import DaemonNotRunningError, OrchError
 from orch_monitor.types import (
     ProtoDaemonConnectionRefusedError,
@@ -38,7 +40,9 @@ class TestDaemonErrorMapping:
 
 
 class TestMonitorRegistration:
-    def test_uses_resolved_project_and_session_without_duplicate_registration(self):
+    def test_uses_verified_project_and_session_without_duplicate_registration(
+        self, monkeypatch
+    ):
         daemon = MagicMock()
         daemon.is_available.return_value = True
         daemon.register_monitor.return_value = Success("mon-123")
@@ -48,6 +52,18 @@ class TestMonitorRegistration:
         api._project_scope = "proboscis-orch"
         api._monitor_session_name = "orch-monitor-proboscis-orch"
         api._monitor_heartbeat = None
+        multiplexer = MagicMock()
+        multiplexer.get_current_session.return_value = "orch-monitor-proboscis-orch"
+        monkeypatch.setattr(
+            daemon_api,
+            "detect_current_multiplexer",
+            lambda: MultiplexerType.TMUX,
+        )
+        monkeypatch.setattr(
+            daemon_api,
+            "get_multiplexer",
+            lambda _: multiplexer,
+        )
 
         result = api.register_monitor(
             pid=123,
@@ -69,3 +85,72 @@ class TestMonitorRegistration:
 
         assert unregister_result == Success(None)
         daemon.unregister_monitor.assert_called_once_with("mon-123")
+
+    def test_standalone_pane_does_not_claim_layout_session(self, monkeypatch):
+        daemon = MagicMock()
+        daemon.register_monitor.return_value = Success("mon-standalone")
+        daemon.unregister_monitor.return_value = Success(True)
+        api = DaemonOrchAPI.__new__(DaemonOrchAPI)
+        api._daemon = daemon
+        api._project_scope = "proboscis-orch"
+        api._monitor_session_name = "orch-monitor-proboscis-orch"
+        api._monitor_heartbeat = None
+        multiplexer = MagicMock()
+        multiplexer.get_current_session.return_value = "unrelated-tmux-session"
+        monkeypatch.setattr(
+            daemon_api,
+            "detect_current_multiplexer",
+            lambda: MultiplexerType.TMUX,
+        )
+        monkeypatch.setattr(
+            daemon_api,
+            "get_multiplexer",
+            lambda _: multiplexer,
+        )
+
+        result = api.register_monitor(
+            pid=456,
+            monitor_type="python",
+            view="runs",
+            project="/local/path/to/orch",
+        )
+
+        assert result == Success("mon-standalone")
+        daemon.register_monitor.assert_called_once_with(
+            pid=456,
+            monitor_type="python",
+            view="runs",
+            project="proboscis-orch",
+            session_name="",
+        )
+        assert api.unregister_monitor("mon-standalone") == Success(None)
+
+    def test_unregister_propagates_heartbeat_unregister_failure(self, monkeypatch):
+        daemon = MagicMock()
+        daemon.register_monitor.return_value = Success("mon-123")
+        daemon.unregister_monitor.return_value = Failure(
+            ProtoDaemonConnectionRefusedError("daemon connection refused")
+        )
+        api = DaemonOrchAPI.__new__(DaemonOrchAPI)
+        api._daemon = daemon
+        api._project_scope = "proboscis-orch"
+        api._monitor_session_name = "orch-monitor-proboscis-orch"
+        api._monitor_heartbeat = None
+        monkeypatch.setattr(
+            daemon_api,
+            "_verified_monitor_session_name",
+            lambda expected_session_name: expected_session_name,
+        )
+
+        register_result = api.register_monitor(
+            pid=123,
+            monitor_type="python",
+            view="runs",
+            project="proboscis-orch",
+        )
+        unregister_result = api.unregister_monitor("mon-123")
+
+        assert register_result == Success("mon-123")
+        assert isinstance(unregister_result, Failure)
+        assert isinstance(unregister_result.failure(), DaemonNotRunningError)
+        assert "connection refused" in str(unregister_result.failure())

--- a/orch-monitor-tui/tests/test_monitor_commands.py
+++ b/orch-monitor-tui/tests/test_monitor_commands.py
@@ -1,0 +1,173 @@
+"""Tests for orch-monitor monitor-management commands."""
+
+import argparse
+import os
+from pathlib import Path
+
+import pytest
+from returns.result import Failure, Result, Success
+
+from orch_monitor.__main__ import (
+    _build_parser,
+    _print_monitor_table,
+    _run_monitor_action,
+    main,
+)
+from orch_monitor.client_bootstrap import ClientBootstrap
+from orch_monitor.orch_api import MonitorInfo, OrchError
+
+
+class _FakeMonitorAPI:
+    def __init__(self) -> None:
+        self.list_result: Result[list[MonitorInfo], OrchError] = Success([])
+        self.kill_result: Result[int, OrchError] = Success(0)
+        self.list_calls: list[tuple[str, bool]] = []
+        self.kill_calls: list[tuple[str, bool, str]] = []
+
+    def list_monitors(self, project: str, list_all: bool = False):
+        self.list_calls.append((project, list_all))
+        return self.list_result
+
+    def kill_monitor(self, monitor_id: str, kill_all: bool, project: str):
+        self.kill_calls.append((monitor_id, kill_all, project))
+        return self.kill_result
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    values: dict[str, object] = {
+        "list_monitors": False,
+        "kill_monitor": None,
+        "kill_all": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_list_prints_required_monitor_fields_in_daemon_order(capsys) -> None:
+    api = _FakeMonitorAPI()
+    api.list_result = Success(
+        [
+            MonitorInfo(
+                id="mon-older",
+                pid=101,
+                project="proboscis-orch",
+                view="runs",
+                session_name="orch-monitor-one",
+                last_seen_unix=1_700_000_000,
+            ),
+            MonitorInfo(
+                id="mon-newer",
+                pid=202,
+                project="proboscis-orch",
+                view="issues",
+                session_name="orch-monitor-two",
+                last_seen_unix=1_700_000_100,
+            ),
+        ]
+    )
+
+    exit_code: int = _run_monitor_action(
+        api, _args(list_monitors=True), "proboscis-orch"
+    )
+
+    assert exit_code == 0
+    assert api.list_calls == [("proboscis-orch", False)]
+    output: str = capsys.readouterr().out
+    assert "ID" in output
+    assert "PID" in output
+    assert "PROJECT" in output
+    assert "VIEW" in output
+    assert "SESSION" in output
+    assert "LAST_SEEN" in output
+    assert output.index("mon-older") < output.index("mon-newer")
+    assert "2023-11-14T22:13:20Z" in output
+
+
+def test_print_monitor_table_reports_empty_registry(capsys) -> None:
+    _print_monitor_table([])
+
+    assert capsys.readouterr().out == "No monitors running\n"
+
+
+def test_kill_targets_one_monitor_in_project_scope(capsys) -> None:
+    api = _FakeMonitorAPI()
+    api.kill_result = Success(1)
+
+    exit_code: int = _run_monitor_action(
+        api, _args(kill_monitor="mon-123"), "proboscis-orch"
+    )
+
+    assert exit_code == 0
+    assert api.kill_calls == [("mon-123", False, "proboscis-orch")]
+    assert capsys.readouterr().out == "Killed monitor: mon-123\n"
+
+
+def test_kill_all_is_project_scoped(capsys) -> None:
+    api = _FakeMonitorAPI()
+    api.kill_result = Success(2)
+
+    exit_code: int = _run_monitor_action(
+        api, _args(kill_all=True), "proboscis-orch"
+    )
+
+    assert exit_code == 0
+    assert api.kill_calls == [("", True, "proboscis-orch")]
+    assert capsys.readouterr().out == (
+        "Killed 2 monitors for project proboscis-orch\n"
+    )
+
+
+def test_monitor_action_surfaces_daemon_failure(capsys) -> None:
+    api = _FakeMonitorAPI()
+    api.list_result = Failure(OrchError("remote daemon unavailable"))
+
+    exit_code: int = _run_monitor_action(
+        api, _args(list_monitors=True), "proboscis-orch"
+    )
+
+    assert exit_code == 1
+    assert "remote daemon unavailable" in capsys.readouterr().err
+
+
+def test_parser_rejects_multiple_monitor_actions() -> None:
+    parser = _build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--list", "--kill", "mon-123"])
+
+
+def test_main_routes_list_through_remote_bootstrap(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("ORCH_PROJECT", raising=False)
+    monkeypatch.delenv("ORCH_REMOTE", raising=False)
+    bootstrap = ClientBootstrap(
+        project_root=tmp_path,
+        project_id="proboscis-orch",
+        remote_addr="master.example:7777",
+        socket_path=tmp_path / "daemon.sock",
+        monitor_session_name="orch-monitor-proboscis-orch",
+    )
+    api = _FakeMonitorAPI()
+    api.list_result = Success([])
+
+    def fake_load_bootstrap() -> ClientBootstrap:
+        assert os.environ["ORCH_REMOTE"] == "master.example:7777"
+        return bootstrap
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["orch-monitor", "--list", "--remote", "master.example:7777"],
+    )
+    monkeypatch.setattr(
+        "orch_monitor.__main__.load_client_bootstrap", fake_load_bootstrap
+    )
+    monkeypatch.setattr(
+        "orch_monitor.__main__.ensure_daemon", lambda *_: (True, "")
+    )
+    monkeypatch.setattr(
+        "orch_monitor.__main__.create_orch_api",
+        lambda *_args, **_kwargs: api,
+    )
+
+    main()
+
+    assert api.list_calls == [("proboscis-orch", False)]

--- a/orch-monitor-tui/tests/test_monitor_commands.py
+++ b/orch-monitor-tui/tests/test_monitor_commands.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from returns.result import Failure, Result, Success
@@ -113,8 +114,29 @@ def test_kill_all_is_project_scoped(capsys) -> None:
     assert exit_code == 0
     assert api.kill_calls == [("", True, "proboscis-orch")]
     assert capsys.readouterr().out == (
-        "Killed 2 monitors for project proboscis-orch\n"
+        "Killed 2 monitor registrations for project proboscis-orch\n"
     )
+
+
+@pytest.mark.parametrize(
+    "action_args",
+    [
+        {"list_monitors": True},
+        {"kill_monitor": "mon-123"},
+        {"kill_all": True},
+    ],
+)
+def test_monitor_actions_reject_empty_project_scope(
+    action_args: dict[str, object], capsys
+) -> None:
+    api = _FakeMonitorAPI()
+
+    exit_code: int = _run_monitor_action(api, _args(**action_args), "")
+
+    assert exit_code == 1
+    assert api.list_calls == []
+    assert api.kill_calls == []
+    assert "project scope required" in capsys.readouterr().err
 
 
 def test_monitor_action_surfaces_daemon_failure(capsys) -> None:
@@ -171,3 +193,36 @@ def test_main_routes_list_through_remote_bootstrap(monkeypatch, tmp_path: Path) 
     main()
 
     assert api.list_calls == [("proboscis-orch", False)]
+
+
+def test_main_rejects_empty_scope_before_starting_daemon(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    monkeypatch.delenv("ORCH_PROJECT", raising=False)
+    bootstrap = ClientBootstrap(
+        project_root=tmp_path,
+        project_id="",
+        remote_addr=None,
+        socket_path=tmp_path / "daemon.sock",
+        monitor_session_name="orch-monitor-unknown",
+    )
+    ensure_daemon = MagicMock()
+    create_orch_api = MagicMock()
+    monkeypatch.setattr("sys.argv", ["orch-monitor", "--kill-all"])
+    monkeypatch.setattr(
+        "orch_monitor.__main__.load_client_bootstrap",
+        lambda: bootstrap,
+    )
+    monkeypatch.setattr("orch_monitor.__main__.ensure_daemon", ensure_daemon)
+    monkeypatch.setattr(
+        "orch_monitor.__main__.create_orch_api",
+        create_orch_api,
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        main()
+
+    assert exit_info.value.code == 1
+    ensure_daemon.assert_not_called()
+    create_orch_api.assert_not_called()
+    assert "project scope required" in capsys.readouterr().err

--- a/orch-monitor-tui/tests/test_proto_client.py
+++ b/orch-monitor-tui/tests/test_proto_client.py
@@ -337,3 +337,62 @@ class TestProtoDaemonAvailability:
             if socket_path.exists():
                 socket_path.unlink(missing_ok=True)
             shutil.rmtree(socket_dir, ignore_errors=True)
+
+
+class TestProtoMonitorManagement:
+    def test_list_monitors_sends_project_scope(self):
+        client = ProtoDaemonClient(Path("/tmp/unused.sock"), None)
+        captured_requests: list[pb.Request] = []
+
+        def fake_send(request: pb.Request) -> pb.Response:
+            captured_requests.append(request)
+            return pb.Response(
+                ok=True,
+                list_monitors=pb.ListMonitorsResponse(
+                    monitors=[
+                        pb.MonitorInfo(
+                            id="mon-123",
+                            pid=123,
+                            project="proboscis-orch",
+                            view="runs",
+                            session_name="orch-monitor-test",
+                            last_heartbeat_unix=1_700_000_000,
+                        )
+                    ]
+                ),
+            )
+
+        client._send = fake_send
+
+        result = client.list_monitors("proboscis-orch", False)
+
+        assert isinstance(result, Success)
+        assert [monitor.id for monitor in result.unwrap()] == ["mon-123"]
+        assert len(captured_requests) == 1
+        request = captured_requests[0]
+        assert request.WhichOneof("request") == "list_monitors"
+        assert request.list_monitors.project == "proboscis-orch"
+        assert request.list_monitors.all is False
+
+    def test_kill_monitor_sends_scoped_request(self):
+        client = ProtoDaemonClient(Path("/tmp/unused.sock"), None)
+        captured_requests: list[pb.Request] = []
+
+        def fake_send(request: pb.Request) -> pb.Response:
+            captured_requests.append(request)
+            return pb.Response(
+                ok=True,
+                kill_monitor=pb.KillMonitorResponse(killed_count=2),
+            )
+
+        client._send = fake_send
+
+        result = client.kill_monitor("", True, "proboscis-orch")
+
+        assert result == Success(2)
+        assert len(captured_requests) == 1
+        request = captured_requests[0]
+        assert request.WhichOneof("request") == "kill_monitor"
+        assert request.kill_monitor.monitor_id == ""
+        assert request.kill_monitor.all is True
+        assert request.kill_monitor.project == "proboscis-orch"

--- a/orch-monitor-tui/tests/test_session_name.py
+++ b/orch-monitor-tui/tests/test_session_name.py
@@ -40,6 +40,42 @@ def test_bootstrap_uses_go_resolved_monitor_session_name(monkeypatch):
     assert bootstrap.monitor_session_name == "orch-monitor-owner-orch"
 
 
+@pytest.mark.parametrize(
+    "remote_override",
+    ["", "master.example:7777"],
+)
+def test_bootstrap_passes_explicit_remote_override(
+    monkeypatch, remote_override: str
+) -> None:
+    load_client_bootstrap.cache_clear()
+    monkeypatch.setenv("ORCH_REMOTE", remote_override)
+    payload = {
+        "project_root": "/repo/orch",
+        "project_id": "repoid:owner-orch",
+        "remote_addr": remote_override,
+        "socket_path": "/tmp/orch.sock",
+        "monitor_session_name": "orch-monitor-owner-orch",
+    }
+    captured_commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs):
+        captured_commands.append(command)
+        return CompletedProcess(command, 0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(client_bootstrap.subprocess, "run", fake_run)
+
+    load_client_bootstrap()
+
+    assert len(captured_commands) == 1
+    assert captured_commands[0][1:] == [
+        "--remote",
+        remote_override,
+        "debug",
+        "client-bootstrap",
+        "--json",
+    ]
+
+
 def test_bootstrap_fails_fast_on_bad_cli(monkeypatch):
     load_client_bootstrap.cache_clear()
 


### PR DESCRIPTION
## Summary

- add `orch-monitor --list`, `--kill MONITOR_ID`, and project-scoped `--kill-all`
- route list/kill through the existing protobuf daemon API, including explicit `--remote` / `ORCH_REMOTE` propagation (including `--remote=""`)
- make daemon monitor listing scoped and daemon-sorted, and make kill terminate the registered process or exact tmux/zellij session
- register Python monitor views with the daemon-resolved project identity and session name without duplicate registration
- document the new monitor-management flags

Tracking issue: `orch-monitor-list-kill`

## Acceptance evidence

### Two monitors list with required fields and project scope

Using an isolated daemon and two real registered Python monitor processes in separate tmux sessions:

```text
ID                                PID    PROJECT         VIEW    SESSION                      LAST_SEEN
559c78b8fc0ca22b440092c6e01fd2b4  15308  proboscis-orch  runs    orch-monitor-accept-a-15285  2026-07-10T09:35:07Z
1d565c98bb9aa2b6402324dd05e79448  15309  proboscis-orch  issues  orch-monitor-accept-b-15285  2026-07-10T09:35:07Z
```

Daemon tests also verify that a monitor from another project is excluded and that ordering is performed server-side.

### Kill one monitor and its multiplexer session

```text
Killed monitor: 559c78b8fc0ca22b440092c6e01fd2b4
session_killed=true
other_session_alive=true
```

A follow-up list contained only the second monitor. A real tmux integration test also exercises the daemon session-kill helper.

### Kill all and stale reaper

```text
Killed 1 monitor for project proboscis-orch
remaining_session_killed=true
No monitors running
```

`TestCleanupStaleMonitorsStillRemovesOnlyExpiredHeartbeats` verifies the existing 60-second stale-heartbeat boundary is unchanged.

### Remote routing

Tests cover both explicit local override (`ORCH_REMOTE=""`) and a non-empty remote address, and verify that the Python bootstrap passes the explicit override into `orch debug client-bootstrap`.

## Validation

- `uv run pytest tests/ -q`: 328 passed, 11 skipped
- focused Python monitor/client/routing tests: 37 passed
- `go build ./...`: passed
- focused daemon list/kill/session/stale tests: passed
- `make lint`: passed
- Ruff: passed
- Pyright (changed typed surfaces): 0 errors

Full `make test` passed every Go package through the changed daemon/CLI/monitor/multiplexer surfaces. The unrelated external integration `TestRunWithBuiltInAgents` failed twice because the OpenCode server returned HTTP 500 while creating an OpenCode session (refs `err_ab12d13f` and `err_7c2d04d6`); the focused retry reproduced the same external failure.