### PR TITLE
Rewrite orch-monitor documentation for Python TUI

### DIFF
--- a/docs/orch-monitor.md
+++ b/docs/orch-monitor.md
@@ -1,292 +1,303 @@
 # orch-monitor TUI
 
-orch-monitor is a terminal user interface (TUI) for managing orch issues and runs visually. It provides a dashboard view of your workflow and integrates with the control agent for chat-based management.
+`orch-monitor` is orch's terminal user interface. It is implemented in Python
+with Textual and displays run and issue state supplied by the orch daemon. The
+default launcher also opens a control-agent terminal beside the dashboards.
 
-`orch-monitor` is the standalone Python TUI installed from `orch-monitor-tui`.
-It reads run, issue, and monitor-instance state from the orch daemon.
+The former Go `orch monitor` subcommand has been removed. Use the standalone
+`orch-monitor` executable for all TUI and monitor-instance operations.
 
 ## Installation
 
-The TUI is packaged separately and can be installed with uv:
+From the orch repository root, `make install` installs both the Go CLI and the
+Python TUI. Its `install-tui` dependency reinstalls the local TUI package:
 
 ```bash
-# Install from the orch-monitor-tui directory
-uv tool install ./orch-monitor-tui
-
-# Or install in development mode
-cd orch-monitor-tui
-uv pip install -e .
+make install
 ```
 
-Verify installation:
+To install only the TUI with uv:
+
+```bash
+uv tool install ./orch-monitor-tui
+```
+
+Confirm that the executable is available:
 
 ```bash
 orch-monitor --help
 ```
 
-## Launching
+## First launch
+
+Start with the bare command:
 
 ```bash
-# Start the TUI for the first time, or attach to an existing session
 orch-monitor
+```
 
-# Restart the layout and resume an existing control agent session
+On first use, the launcher connects to the daemon, resolves the current
+project, creates a tmux or Zellij session, and opens three working areas:
+
+```text
++---------------------------+------------------------------+
+| Runs dashboard            | Issues dashboard             |
+|                           +------------------------------+
+|                           | Control agent terminal       |
++---------------------------+------------------------------+
+```
+
+If that monitor session already exists, bare `orch-monitor` attaches to it.
+The control agent is a real terminal pane managed by the Python launcher; it is
+not a chat widget inside either Textual dashboard.
+
+### Restarting sessions
+
+Use `--new` to replace the multiplexer layout while preserving the saved
+control-agent session:
+
+```bash
 orch-monitor --new
+```
 
-# Restart with a fresh layout and control agent session
+When an existing layout is being replaced, `--new` first requires a resumable
+control-agent ID in `.orch/control-session.json`. If the file has no usable
+session, the command exits with an error before destroying the current layout.
+Use bare `orch-monitor` to attach to the layout as-is, or use
+`--new-control-agent` to deliberately start over.
+
+Use `--new-control-agent` to replace both the layout and control-agent session:
+
+```bash
 orch-monitor --new-control-agent
-
-# Specify a project identity (repo URL or repoid)
-orch-monitor --project github.com/owner/repo
 ```
 
-Use bare `orch-monitor` for the first launch. `--new` requires an existing
-control agent session to resume; use `--new-control-agent` when you want to
-replace that session too.
+This option implies `--new` and clears the saved control-agent session before
+launching the replacement layout.
 
-## Managing monitor instances
+## Command-line options
 
-The daemon tracks running monitor instances. Management commands are scoped to
-the resolved project identity, including when `--project` or `ORCH_PROJECT` is
-used.
+| Option | Behavior |
+|--------|----------|
+| `--project PROJECT` | Select a project by Git repository URL or normalized repository ID. |
+| `--runs` | Run only the Runs Textual dashboard; used by a multiplexer pane and useful for focused testing. |
+| `--issues` | Run only the Issues Textual dashboard; used by a multiplexer pane and useful for focused testing. |
+| `--agent AGENT` | Override the configured control-agent command. |
+| `--new` | Restart an existing layout and preserve its saved control-agent session. |
+| `--new-control-agent` | Restart the layout with a fresh control-agent session. |
+| `--multiplexer {tmux,zellij}`, `-m` | Override automatic multiplexer selection. |
+| `--verbose`, `-v` | Print launcher timing and diagnostic messages to standard error. |
+| `--remote ADDRESS` | Use a remote daemon address or alias, overriding `ORCH_REMOTE` and the client default. An empty value forces local routing. |
+| `--list` | List monitor instances registered for the selected project. |
+| `--kill MONITOR_ID` | Kill one registered monitor instance. |
+| `--kill-all` | Kill every registered monitor instance for the selected project. |
+
+`--list`, `--kill`, and `--kill-all` are mutually exclusive. Their project
+scope is resolved in the same way as the TUI, including `--project` and remote
+client configuration.
+
+Examples:
 
 ```bash
-# List registered monitors for the current project
-orch-monitor --list
-
-# Stop one monitor and its multiplexer session
-orch-monitor --kill MONITOR_ID
-
-# Stop every registered monitor for the current project
-orch-monitor --kill-all
-```
-
-`--list` prints each monitor's ID, PID, project, view, multiplexer session, and
-last heartbeat time. Use an ID from this output with `--kill`.
-
-These commands use the same daemon routing as the TUI. Pass `--remote` or set
-`ORCH_REMOTE` to manage monitors registered with a remote daemon:
-
-```bash
+orch-monitor --project github.com/proboscis/orch
+orch-monitor --multiplexer tmux
+orch-monitor --remote master.example:7777
 orch-monitor --remote master.example:7777 --list
-orch-monitor --remote master.example:7777 --kill MONITOR_ID
+orch-monitor --kill MONITOR_ID
 ```
-
-## Interface Overview
-
-The TUI is divided into three main panels:
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                         orch-monitor                            │
-├─────────────────────────┬───────────────────────────────────────┤
-│                         │                                       │
-│   Issues Panel          │   Runs Panel                          │
-│                         │                                       │
-│   > fix-bug-123        │   20260115-093012  running   5m ago   │
-│     add-feature-x       │   20260115-091530  pr_open   1h ago   │
-│     optimize-db         │                                       │
-│     update-deps         │                                       │
-│                         │                                       │
-├─────────────────────────┴───────────────────────────────────────┤
-│                                                                 │
-│   Control Agent Panel                                           │
-│                                                                 │
-│   Agent: How can I help you today?                              │
-│   You: Create an issue for fixing the login timeout             │
-│   Agent: I'll create that issue for you...                      │
-│                                                                 │
-│   > _                                                           │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-### Issues Panel (Left)
-
-Displays all issues in your issues directory:
-- Navigate with `j`/`k` or arrow keys
-- Selected issue highlighted with `>`
-- Shows issue status via color coding
-
-### Runs Panel (Right)
-
-Shows runs for the selected issue:
-- Lists all runs with their status and last update time
-- Automatically updates as runs progress
-- Empty if no runs exist for selected issue
-
-### Control Agent Panel (Bottom)
-
-Interactive chat with the control agent:
-- Type messages to create issues, start runs, check status
-- Agent can perform orch operations on your behalf
-- Maintains conversation history within the session
 
 ## Keybindings
 
-### Global
+The tables below are generated from the binding declarations in
+`orch_monitor_app.hy`, `runs_dashboard.hy`, `issues_dashboard.hy`,
+`agent_screen.hy`, and `widgets.py`.
+
+### Combined dashboard application
+
+These are the bindings on the reusable `OrchMonitorApp`. The default
+multiplexer layout runs the separate Runs and Issues applications documented
+below. In the combined application, the action selected by a key such as
+`Enter`, `f`, or `Ctrl+f` depends on which table has focus.
 
 | Key | Action |
 |-----|--------|
-| `?` | Show help overlay |
-| `Tab` | Switch focus between panels |
-| `q` | Quit orch-monitor |
-| `Ctrl+C` | Force quit |
+| `?` | Open help. |
+| `q` | Quit. |
+| `Ctrl+C` | Quit with priority. |
+| `r` | Refresh data. |
+| `Enter` | Select the highlighted run or issue. |
+| `a` | Attach to the highlighted run. |
+| `s` | Stop the highlighted run. |
+| `X` | Kill the highlighted run's terminal session. |
+| `n` | Start a new run for the highlighted issue. |
+| `o` | Open the highlighted issue in the editor. |
+| `x` | Close the highlighted issue. |
+| `f` | Open the filter for the focused table. |
+| `Ctrl+f` | Clear filters for the focused table. |
+| `d` | Show the highlighted run's diff. |
+| `Tab` | Switch focus between Runs and Issues. |
 
-### Issues Panel
-
-| Key | Action |
-|-----|--------|
-| `j` / `↓` | Move to next issue |
-| `k` / `↑` | Move to previous issue |
-| `Enter` | Focus on runs for this issue |
-| `n` | Start a new run for selected issue |
-| `e` | Edit the selected issue |
-| `r` | Refresh issues list |
-
-### Runs Panel
-
-| Key | Action |
-|-----|--------|
-| `j` / `↓` | Move to next run |
-| `k` / `↑` | Move to previous run |
-| `Enter` / `a` | Attach to selected run |
-| `d` | Show diff for selected run |
-| `s` | Stop selected run |
-| `l` | View run logs/events |
-| `c` | Continue selected run |
-| `r` | Refresh runs list |
-
-### Control Agent Panel
+### Runs dashboard (`--runs`)
 
 | Key | Action |
 |-----|--------|
-| `Enter` | Send message |
-| `Ctrl+L` | Clear chat history |
-| `Esc` | Return focus to issues panel |
+| `?` | Open help. |
+| `q` | Quit. |
+| `Ctrl+C` | Quit with priority. |
+| `r` | Refresh runs. |
+| `Enter` | Attach to the highlighted run. |
+| `s` | Stop the highlighted run. |
+| `X` | Kill the highlighted run's terminal session. |
+| `f` | Open run filters. |
+| `Ctrl+f` | Clear run filters. |
+| `d` | Show the highlighted run's diff. |
 
-## Status Colors
+The standalone Runs pane does not bind `a`; use `Enter` to attach there. The
+`a` binding belongs to the combined application.
 
-The TUI uses colors to indicate run status at a glance:
+### Issues dashboard (`--issues`)
 
-| Color | Status | Meaning |
-|-------|--------|---------|
-| 🟢 Green | `running` | Agent is actively working |
-| 🟡 Yellow | `waiting` | Agent needs your input |
-| 🔵 Blue | `pr_open` | PR created, ready for review |
-| ⚪ White | `done` | Completed successfully |
-| 🔴 Red | `failed` | Error occurred |
-| ⚫ Gray | `queued` | Waiting to start |
+| Key | Action |
+|-----|--------|
+| `?` | Open help. |
+| `q` | Quit. |
+| `Ctrl+C` | Quit with priority. |
+| `r` | Refresh issues. |
+| `Enter` | Open the highlighted issue in the editor. |
+| `o` | Open the highlighted issue in the editor. |
+| `n` | Start a new run for the highlighted issue. |
+| `x` | Close the highlighted issue. |
+| `f` | Open issue filters. |
+| `Ctrl+f` | Clear issue filters. |
 
-## Working with the Control Agent
+Run and issue tables also support `j`/`k` for row movement and `g`/`G` for the
+top and bottom. Textual's normal arrow-key table navigation remains available.
 
-The control agent understands natural language for common operations:
+### Agent selection screen
 
-### Creating Issues
+Pressing `n` on an issue opens the agent selector.
 
-```
-You: Create an issue to fix the login timeout bug
-Agent: I'll create that issue. What details should I include?
-You: Session expires after 5 minutes, should be 30. Check src/auth/
-Agent: Created issue 'fix-login-timeout'. Would you like me to start a run?
-```
+| Key | Action |
+|-----|--------|
+| `Esc` | Cancel. |
+| `Enter` | Start with the selected agent or preset. |
+| `j`, `k` | Move down or up. |
+| `1` through `9` | Immediately select the corresponding entry. |
 
-### Starting Runs
+### Run detail tabs
 
-```
-You: Start a run for fix-login-timeout
-Agent: Starting run for fix-login-timeout with claude agent...
-       Run 20260115-142030 is now running.
-```
+The Runs dashboard detail area has Stats, Issue, and Changes tabs.
 
-### Checking Status
+| Key | Action |
+|-----|--------|
+| `Tab` | Select the next detail tab. |
+| `1` | Select Stats. |
+| `2` | Select Issue. |
+| `3` | Select Changes. |
+| `j`, `Down` | Scroll down. |
+| `k`, `Up` | Scroll up. |
+| `g` | Jump to the top. |
+| `G` | Jump to the bottom. |
 
-```
-You: What's running right now?
-Agent: You have 2 active runs:
-       - fix-login-timeout: running (started 10m ago)
-       - update-deps: waiting (needs input about React version)
-```
+## Status colors
 
-### Getting Help
+The Runs table shortens status names and applies the following colors:
 
-```
-You: How do I see the diff for a completed run?
-Agent: You can press 'd' while a run is selected in the Runs panel,
-       or from the command line: orch diff <run-ref>
-```
+| Status | Display | Color | Meaning |
+|--------|---------|-------|---------|
+| `queued` | `queue` | white | The run is waiting to start. |
+| `booting` | `boot` | green | The agent is starting. |
+| `running` | `run` | green | The agent is working. |
+| `waiting` | `wait` | yellow | The agent is waiting for input. |
+| `rate_limited` | `rlimit` | yellow | Progress is paused by an API rate limit. |
+| `pr_open` | `pr` | cyan | The run has an open pull request. |
+| `done` | `done` | blue | The run completed. |
+| `failed` | `fail` | red | The run failed. |
+| `canceled` | `cancel` | dim | The run was canceled. |
+| `unknown` | `?` | magenta | The daemon returned an unclassified run state. |
 
-## Workflow Example
+## Filters and configuration
 
-1. **Launch orch-monitor**
-   ```bash
-   orch-monitor
-   ```
+Press `f` in a dashboard to edit filters. Filter state is persisted in
+`.orch/monitor-filters.yaml`; `Ctrl+f` clears the filters for the focused
+dashboard.
 
-2. **Create an issue via control agent**
-   - Focus on the control agent panel (Tab)
-   - Type: "Create an issue to add dark mode support"
-   - Provide details when prompted
-
-3. **Start a run**
-   - Select the new issue in the Issues panel
-   - Press `n` to start a new run
-   - Or ask the control agent: "Start a run for add-dark-mode"
-
-4. **Monitor progress**
-   - Watch the status change in the Runs panel
-   - Status updates automatically
-
-5. **Help if waiting**
-   - If status turns yellow (waiting), press `a` to attach
-   - Provide the needed input
-   - Press `Ctrl+B D` to detach
-
-6. **Review when done**
-   - When status turns blue (pr_open), press `d` to see diff
-   - Review and merge the PR
-
-## Tips
-
-### Efficient Navigation
-
-- Use `Tab` to quickly switch between panels
-- `j`/`k` for vim-style navigation
-- `?` anytime you forget a keybinding
-
-### Multi-tasking
-
-- Start several runs, then monitor all from one place
-- Control agent can manage multiple issues while you watch progress
-- Use the Runs panel to quickly switch between active runs
-
-### Troubleshooting
-
-If the TUI seems unresponsive:
-1. Press `r` to refresh the current panel
-2. Check if a run is actually waiting (`orch ps` in another terminal)
-3. Try `q` and restart if needed
-
-If control agent isn't responding:
-1. It may be thinking - wait a moment
-2. Press `Ctrl+L` to clear and try again
-3. Restart with the `--new-control-agent` flag
-
-## Configuration
-
-The TUI respects orch configuration from `.orch/config.yaml`:
+The `monitor` section of `.orch/config.yaml` supplies initial filters when no
+persisted monitor filter file exists. `monitor.default_issue_filter` can
+select issue tags and choose OR or AND matching:
 
 ```yaml
-# Affects TUI behavior
-agent: claude          # Default agent for new runs
-base_branch: main      # Default base branch
+monitor:
+  default_run_statuses:
+    - queued
+    - booting
+    - running
+    - waiting
+    - rate_limited
+    - pr_open
+  default_issue_statuses:
+    - open
+  default_issue_filter:
+    tags:
+      - active
+    tag_mode: any  # any = OR, all = AND
 ```
 
-The monitor resolves configuration from `ORCH_PROJECT` and
-`.orch/config.yaml` (`issues.path`).
+Once filters have been saved interactively, the persisted file takes
+precedence over these defaults.
 
-## See Also
+## Control agent
 
-- [Daily Workflow](./daily-workflow.md) - Command-line workflow patterns
-- [Commands Reference](./reference/commands.md) - Full CLI reference
-- [orch agent](./reference/commands.md#orch-agent) - Standalone control agent
+During a normal daemon-backed layout launch, the launcher requests the
+control-agent configuration and repository context from the daemon. It writes
+the returned prompt to `ORCH_CONTROL_PROMPT.md` in the project root, then starts
+the configured agent with an instruction to read that file. The generated
+prompt is runtime state and is ignored by Git.
+
+The resumable control-agent ID is stored locally in:
+
+```text
+.orch/control-session.json
+```
+
+The file records `session_id` and `agent_type`. `--new` checks it before
+replacing an existing layout; `--new-control-agent` clears it. The file is also
+ignored by Git.
+
+The control agent can run non-interactive orch commands such as `orch issue
+create`, `orch run`, `orch ps`, `orch capture`, `orch send`, and `orch stop`.
+Use the pane as an agent terminal; its input behavior is provided by the
+selected agent, not by Textual keybindings.
+
+## Architecture
+
+The daemon is the source of truth for run, issue, monitor, and Git state. The
+Python processes request data and actions through the daemon API; they keep
+display formatting, control-agent session persistence, and terminal
+interaction in the client.
+
+```text
++-------------------+       daemon API       +----------------------+
+| Python Textual UI | <--------------------> | orch daemon          |
+| + layout launcher |                        | authoritative state  |
++-------------------+                        +----------------------+
+```
+
+The launcher automatically reconnects to or starts the daemon when necessary.
+If startup or repair fails, it exits with the daemon error and suggests
+`orch repair`.
+
+## Typical workflow
+
+1. Launch with `orch-monitor`.
+2. Select the Issues pane and highlight an issue.
+3. Press `n`, then select an agent with `Enter` or `1` through `9`.
+4. Watch the run in the Runs pane.
+5. Press `Enter` in the Runs pane to attach when interaction is needed.
+6. Press `d` to inspect the run diff.
+
+## See also
+
+- [Configuration](./configuration.md)
+- [Command reference](./reference/commands.md)
+- [Daily workflow](./daily-workflow.md)

--- a/docs/orch-monitor.md
+++ b/docs/orch-monitor.md
@@ -40,11 +40,11 @@ On first use, the launcher connects to the daemon, resolves the current
 project, creates a tmux or Zellij session, and opens three working areas:
 
 ```text
-+---------------------------+------------------------------+
-| Runs dashboard            | Issues dashboard             |
-|                           +------------------------------+
-|                           | Control agent terminal       |
-+---------------------------+------------------------------+
++------------------------------------------+
+| Runs dashboard (full width)              |
++---------------+--------------------------+
+| Issues        | Control agent terminal   |
++---------------+--------------------------+
 ```
 
 If that monitor session already exists, bare `orch-monitor` attaches to it.
@@ -235,6 +235,7 @@ monitor:
     - waiting
     - rate_limited
     - pr_open
+    - failed
   default_issue_statuses:
     - open
   default_issue_filter:

--- a/orch-monitor-tui/README.md
+++ b/orch-monitor-tui/README.md
@@ -35,11 +35,11 @@ The launcher resolves the project and daemon, then opens this multiplexer
 layout:
 
 ```text
-+---------------------------+------------------------------+
-| Runs dashboard            | Issues dashboard             |
-|                           +------------------------------+
-|                           | Control agent terminal       |
-+---------------------------+------------------------------+
++------------------------------------------+
+| Runs dashboard (full width)              |
++---------------+--------------------------+
+| Issues        | Control agent terminal   |
++---------------+--------------------------+
 ```
 
 Bare `orch-monitor` attaches when the project already has a live monitor
@@ -175,6 +175,7 @@ monitor:
     - waiting
     - rate_limited
     - pr_open
+    - failed
   default_issue_statuses:
     - open
   default_issue_filter:

--- a/orch-monitor-tui/README.md
+++ b/orch-monitor-tui/README.md
@@ -1,289 +1,218 @@
-# Orch Monitor TUI (Python/Textual)
+# orch-monitor
 
-Python Textual-based terminal user interface for orch.
+`orch-monitor` is orch's Python/Textual terminal user interface. It presents
+daemon-backed Runs and Issues dashboards and launches a control-agent terminal
+beside them in a tmux or Zellij session.
 
-## Features
+This is the only orch TUI. The former Go `orch monitor` subcommand has been
+removed; use the standalone `orch-monitor` executable.
 
-- **Issue Dashboard**: View all issues with status filtering
-- **Run Dashboard**: Monitor active and completed runs with real-time status
-- **Detail Panels**: View issue content and run events
-- **Keybindings**: Quick navigation and actions
-- **Real-time Updates**: Automatic refresh with daemon-based data
-- **Multiplexer Support**: Works with both tmux and zellij
+## Install
 
-## Quick Start (Onboarding)
-
-New to orch-monitor? Here's how to get started:
-
-1. **Install orch-monitor**: `uv tool install /path/to/orch/orch-monitor-tui`
-2. **Launch the TUI**: `orch-monitor` (or `orch-monitor --new-control-agent` for fresh start)
-3. **Press `?`** to see all keybindings and workflow tips
-4. **Navigate** with arrow keys, **Tab** to switch panels
-5. **Start a run** on an issue with `n`, select an agent
-6. **Monitor progress** in the Runs panel
-7. **Attach** to a running agent with `a` or Enter
-
-> **Tip**: Press `?` anytime within the TUI for a quick reference of keybindings and workflow.
-
-## Workflow Guide
-
-This section describes the end-to-end workflow for using orch-monitor TUI with the control agent to manage issue-driven development.
-
-### 1. Setup Repository with Orch
+From the orch repository root, install the CLI and TUI together:
 
 ```bash
-cd your-repo
-mkdir -p .orch
-# Configure `.orch/config.yaml` with agent/runtime preferences.
+make install
 ```
 
-### 2. Launch orch-monitor
+Or install only this package:
 
 ```bash
-orch-monitor  # First launch, or attach to an existing session
-
-# To replace both the layout and control agent session:
-orch-monitor --new-control-agent
+uv tool install ./orch-monitor-tui
 ```
 
-### 3. Meet the Control Agent
+The package exposes the `orch-monitor` console script.
 
-The control agent runs in the bottom pane. You can:
-- Ask how to use orch-monitor
-- Get help with commands
-- Discuss project plans
+## Start
 
-### 4. Create Issues via Discussion
-
-Talk with the control agent to create issue files:
-- Describe what you want to build
-- Control agent creates the issue markdown file
-- Issue appears in the **Issues Panel** (left side)
-
-### 5. Start a Run
-
-Multiple ways to start a run on an issue:
-- **Click** on an issue in the Issues panel
-- **Arrow keys + `n`** to select issue and start new run
-- **Ask control agent**: "run orch-123"
-
-Select your agent: claude / opencode / codex
-
-### 6. Monitor the Run
-
-The run appears in the **Runs Panel** (top):
-- Watch status: queued → booting → running → pr_open → done
-- See elapsed time, agent, branch info
-
-### 7. Interact with Running Agents
-
-While a run is active:
-- **Select run + Enter** or **click**: Attach to see agent output
-- **`a`**: Attach to selected run's terminal session
-- Ask control agent to send messages via `orch send`
-
-### 8. Review and Merge
-
-When run creates a PR:
-- Status shows `pr_open`
-- Review the PR on GitHub
-- Ask control agent to review the work
-- Merge when satisfied
-
-### 9. Control Agent Commands
-
-The control agent can:
-- `orch run <issue>` - Start a run
-- `orch send <run> [message]` - Send a message to a running agent, or read it from stdin/heredoc
-- `orch capture <run>` - Capture agent's last output
-- `orch stop <run>` - Stop a run
-- `orch ps` - List all runs
-- Review work and provide feedback
-
-### 10. Parallel Development
-
-Run multiple issues in parallel:
-- Each run gets its own git worktree
-- Agents work independently
-- Monitor all runs from single TUI
-- Merge PRs as they complete
-
-### The Development Loop
-
-```
-Create Issue → Start Run → Monitor → Review PR → Merge → Repeat
-     ↑                                                    |
-     └────────────────────────────────────────────────────┘
-```
-
-Enjoy making as many issue files with control agent and running them in parallel on worktrees!
-
-## Prerequisites
-
-The TUI requires the orch daemon to be running. The daemon starts automatically when you run any `orch` command (e.g., `orch ps`).
-
-```
-+-----------------------------+
-|     Python Textual TUI      |
-|        DaemonClient         |
-+-----------+-----------------+
-            | Unix socket (JSON)
-            v
-+-----------------------------+
-|         Go Daemon           |
-|   (single source of truth)  |
-+-----------------------------+
-```
-
-## Installation
-
-```bash
-uv tool install /path/to/orch/orch-monitor-tui
-```
-
-Or from git:
-
-```bash
-uv tool install "git+https://github.com/proboscis/orch#subdirectory=orch-monitor-tui"
-```
-
-## Usage
-
-Run from any directory (uses `ORCH_PROJECT` or `.orch/config.yaml`):
+Use the bare command for the first launch:
 
 ```bash
 orch-monitor
 ```
 
-Or pin a project explicitly:
+The launcher resolves the project and daemon, then opens this multiplexer
+layout:
 
-```bash
-orch-monitor --project github.com/owner/repo
+```text
++---------------------------+------------------------------+
+| Runs dashboard            | Issues dashboard             |
+|                           +------------------------------+
+|                           | Control agent terminal       |
++---------------------------+------------------------------+
 ```
 
-### Terminal Multiplexer
+Bare `orch-monitor` attaches when the project already has a live monitor
+session.
 
-By default, orch-monitor auto-detects the multiplexer (prefers the one you're inside, or falls back to tmux):
-
-```bash
-# Use tmux (default)
-orch-monitor
-
-# Use zellij
-orch-monitor --multiplexer zellij
-orch-monitor -m zellij
-
-# Or set via environment variable
-export ORCH_MULTIPLEXER=zellij
-orch-monitor
-```
-
-### Session Management
+### Layout and control-agent restarts
 
 ```bash
-# Restart layout only (preserves control agent session/conversation)
+# Replace the layout and resume its saved control-agent session.
 orch-monitor --new
 
-# Restart both layout AND control agent (fresh start)
+# Replace both the layout and control-agent session.
 orch-monitor --new-control-agent
-
-# Or explicitly combine flags
-orch-monitor --new --new-control-agent
 ```
 
-The `--new` flag restarts the multiplexer layout while preserving your control agent's conversation context. This is useful when:
-- Layout gets corrupted or panes are misaligned
-- You want to refresh the TUI panels without losing your chat history
+When replacing an existing layout, `--new` requires a usable saved session in
+`.orch/control-session.json`. It fails before killing the current layout when
+that state is missing. `--new-control-agent` implies `--new` and clears the old
+control-agent state intentionally.
 
-Use `--new-control-agent` when you want a completely fresh start, including a new control agent session.
+The launcher requests repository context and control-agent configuration from
+the daemon, writes the returned content to `ORCH_CONTROL_PROMPT.md`, and asks
+the selected agent to read it. Both this generated prompt and
+`.orch/control-session.json` are ignored by Git.
 
-### Other Options
+## Launcher options
+
+| Option | Purpose |
+|--------|---------|
+| `--project PROJECT` | Select a project by Git repository URL or normalized repository ID. |
+| `--runs` | Open only the Runs dashboard. |
+| `--issues` | Open only the Issues dashboard. |
+| `--agent AGENT` | Override the configured control agent. |
+| `--new` | Recreate the layout while retaining the saved control-agent session. |
+| `--new-control-agent` | Recreate the layout and control-agent session. |
+| `--multiplexer {tmux,zellij}`, `-m` | Override multiplexer selection. |
+| `--verbose`, `-v` | Print launcher diagnostics to standard error. |
+| `--remote ADDRESS` | Override remote daemon routing; an empty value forces local routing. |
+| `--list` | List registered monitor instances for the project. |
+| `--kill MONITOR_ID` | Kill one registered monitor instance. |
+| `--kill-all` | Kill all registered monitor instances for the project. |
+
+For example:
 
 ```bash
-# Use a different control agent
-orch-monitor --agent claude
-```
-
-If the daemon is not running, the TUI will show an error notification. Start the daemon with:
-
-```bash
-orch ps
-```
-
-### Development
-
-```bash
-cd orch-monitor-tui
-uv sync
-uv run python -m orch_monitor
+orch-monitor --project github.com/proboscis/orch
+orch-monitor --multiplexer tmux
+orch-monitor --remote master.example:7777 --list
 ```
 
 ## Keybindings
 
+All dashboard applications bind `?` for help, `q` to quit, `Ctrl+C` to quit
+with priority, and `r` to refresh. Run and issue tables support `j`/`k` for row
+movement and `g`/`G` for top and bottom.
+
+### Combined application
+
+`OrchMonitorApp` is the reusable combined application. The default
+multiplexer layout runs the separate Runs and Issues applications documented
+below.
+
 | Key | Action |
 |-----|--------|
-| `?` | Show help screen with keybindings and workflow tips |
-| `q` | Quit |
-| `r` | Refresh data |
-| `tab` | Switch between Runs/Issues tabs |
-| `f` | Filter runs by status |
-| `ctrl+f` | Clear all filters |
-| `up/down` | Navigate list |
-| `enter` | Select item (attach to run / open issue in `$EDITOR`*) |
-| `a` | Attach to selected run's session |
-| `s` | Stop selected run |
-| `X` | Kill session (force terminate) |
-| `n` | Create new run for selected issue |
-| `o` | Open issue in `$EDITOR`* |
-| `x` | Close issue |
+| `Enter` | Select the highlighted run or issue. |
+| `a` | Attach to a run. |
+| `s` | Stop a run. |
+| `X` | Kill a run's terminal session. |
+| `n` | Start a run for an issue. |
+| `o` | Open an issue in the editor. |
+| `x` | Close an issue. |
+| `f` | Filter the focused table. |
+| `Ctrl+f` | Clear filters on the focused table. |
+| `d` | Show a run diff. |
+| `Tab` | Switch between Runs and Issues. |
 
-*When running inside a multiplexer (tmux/zellij), opening issues in `$EDITOR` creates a new multiplexer tab/window, allowing you to edit without leaving the monitor. Outside a multiplexer, the TUI suspends while the editor is open.
+### Runs pane (`--runs`)
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Attach to the highlighted run. |
+| `s` | Stop the highlighted run. |
+| `X` | Kill the highlighted run's terminal session. |
+| `f` | Open run filters. |
+| `Ctrl+f` | Clear run filters. |
+| `d` | Show the highlighted run's diff. |
+
+The Runs pane uses `Enter`, not `a`, for attach. The `a` binding exists on the
+combined application.
+
+### Issues pane (`--issues`)
+
+| Key | Action |
+|-----|--------|
+| `Enter`, `o` | Open the highlighted issue in the editor. |
+| `n` | Open the agent selector for a new run. |
+| `x` | Close the highlighted issue. |
+| `f` | Open issue filters. |
+| `Ctrl+f` | Clear issue filters. |
+
+The agent selector uses `Esc` to cancel, `Enter` to confirm, `j`/`k` to move,
+and `1` through `9` for quick selection.
+
+The Runs detail panel uses `Tab` to move between tabs, `1`/`2`/`3` for Stats,
+Issue, and Changes, `j`/`k` or arrows to scroll, and `g`/`G` for top and bottom.
+
+## Status display
+
+| Status | Short display | Color |
+|--------|---------------|-------|
+| `queued` | `queue` | white |
+| `booting` | `boot` | green |
+| `running` | `run` | green |
+| `waiting` | `wait` | yellow |
+| `rate_limited` | `rlimit` | yellow |
+| `pr_open` | `pr` | cyan |
+| `done` | `done` | blue |
+| `failed` | `fail` | red |
+| `canceled` | `cancel` | dim |
+| `unknown` | `?` | magenta |
 
 ## Configuration
 
-The TUI respects the same configuration as the Go `orch` CLI:
+The TUI uses orch project/client resolution and reads `.orch/config.yaml`.
+Monitor defaults are nested under `monitor`:
 
-- `ORCH_PROJECT` environment variable (project identity: repo URL or normalized repo ID)
-- `.orch/config.yaml` found by searching upward from current directory
-- `.orch/config.yaml` in the selected project workspace
+```yaml
+monitor:
+  default_run_statuses:
+    - queued
+    - booting
+    - running
+    - waiting
+    - rate_limited
+    - pr_open
+  default_issue_statuses:
+    - open
+  default_issue_filter:
+    tags:
+      - active
+    tag_mode: any  # any = OR, all = AND
+```
+
+These defaults initialize the UI when `.orch/monitor-filters.yaml` does not
+exist. Interactive filter changes are persisted in that file and take
+precedence on later launches.
 
 ## Architecture
 
+The daemon is the authoritative source for issue, run, monitor, and Git state.
+The TUI requests state and actions through the daemon API and keeps display
+formatting, control-agent session persistence, and terminal interaction local.
+
+```text
++----------------------+       daemon API       +----------------------+
+| Textual dashboards   | <--------------------> | orch daemon          |
+| + layout launcher    |                        | authoritative state  |
++----------------------+                        +----------------------+
 ```
-orch_monitor/
-  __init__.py    - Package initialization
-  __main__.py    - Entry point and layout launchers
-  app.py         - Main Textual application (RunsDashboard, IssuesDashboard, OrchMonitorApp)
-  config.py      - Configuration management and socket path resolution
-  daemon.py      - DaemonClient for communicating with Go daemon via Unix socket
-  models.py      - Data models (Issue, Run, Event, Status)
-  multiplexer.py - Multiplexer abstraction (Strategy pattern for tmux/zellij)
-  widgets.py     - Custom Textual widgets (RunTable, IssueTable, DetailPanel)
+
+`orch_monitor/app.py` re-exports the Hy dashboard implementations;
+`orch_monitor/__main__.py` provides the console entrypoint and layout
+launchers. `widgets.py` contains the tables and detail tabs, while
+`multiplexer.py` implements tmux and Zellij integration.
+
+## Development
+
+```bash
+cd orch-monitor-tui
+uv sync --all-extras
+uv run python -m orch_monitor --help
+uv run pytest tests/ -v
 ```
 
-The TUI uses a daemon-centric architecture:
-- Runs/issues data comes from the Go daemon via Unix socket
-- Control-agent prompt/config comes from daemon (`get_control_agent_config`)
-- Control-agent session file is managed locally at `.orch/control-session.json`
-- Automatic refresh via polling (configurable interval)
-
-## Daemon Communication
-
-The TUI communicates with the orch daemon via Unix socket at `$PROJECT_ROOT/.orch/daemon.sock`:
-
-- `list_runs` - List all runs with optional status filter
-- `list_issues` - List all issues
-- `get_run` - Get details for a specific run
-- `get_issue` - Get details for a specific issue
-- `get_control_agent_config` - Fetch control-agent prompt and launch config
-- `send` - Send a message to a running agent
-
-## Differences from Go Monitor
-
-This Python TUI provides a simpler, more focused interface:
-
-- No integrated chat pane (use `orch attach` for direct interaction)
-- Simplified layout with tabs instead of multi-pane tmux windows
-- Focus on monitoring and quick actions
-
-The Go monitor remains available for users who prefer the integrated experience.
+See the [full orch-monitor guide](../docs/orch-monitor.md) for workflow details
+and the complete binding reference.


### PR DESCRIPTION
## Summary

- Rewrite `docs/orch-monitor.md` around the Python/Textual `orch-monitor` as the sole TUI and add the Go-monitor removal migration note.
- Document installation, first launch, `--new` versus `--new-control-agent`, all current launcher/management flags, the daemon-backed control-agent prompt/session files, monitor filters, and the complete status palette.
- Regenerate binding references from the live Hy/Python classes, including the separate combined app, Runs pane, Issues pane, agent selector, table navigation, and run-detail tabs.
- Refresh `orch-monitor-tui/README.md` and remove its stale claims that the control pane is absent and the Go monitor remains available.

Tracking issue: `docs-orch-monitor-rewrite`

## Acceptance evidence

- **Python TUI and migration:** both docs state that `orch-monitor` is the only TUI and that the former Go `orch monitor` subcommand was removed.
- **Install and launch surface:** `uv run orch-monitor --help` completed and listed `--project`, `--runs`, `--issues`, `--agent`, `--new`, `--new-control-agent`, `--multiplexer`, `--verbose`, `--remote`, `--list`, `--kill`, and `--kill-all`. The documented `make install` path is backed by Makefile's `install-tui` dependency.
- **Executable bindings:** importing the live classes reported:
  - `OrchMonitorApp`: `question_mark q ctrl+c r enter a s X n o x f ctrl+f d tab`
  - `RunsDashboard`: `question_mark q ctrl+c r enter s X f ctrl+f d`
  - `IssuesDashboard`: `question_mark q ctrl+c r enter n o x f ctrl+f`
  - `AgentSelectScreen`: `escape enter k j 1 2 3 4 5 6 7 8 9`
  - `TabbedStatsPanel`: `tab 1 2 3 j k down up g G`
  - `CursorPreservingTable`: `j k g G`
- **No fictional bindings:** a fixed-string scan found zero occurrences of the removed fictional keys in either rewritten document.
- **Interactive walkthrough:** launched the real `orch-monitor --runs` and `orch-monitor --issues` entrypoints in PTYs against the daemon. Runs loaded data and opened/canceled Help and Filter; Issues loaded data and opened/canceled Help and Agent Select; both quit cleanly. A final `orch-monitor --list` returned `No monitors running`.
- **Status/config behavior:** executing `short_agent_status` and `color_agent_status` confirmed all ten documented displays/colors, including `booting`, `rate_limited`, `canceled`, and `unknown`. `Config._parse_monitor_config` returned `IssueDefaultFilter(tags=['active'], tag_mode='all')`.
- **Control-agent state:** source and tests confirm prompt generation at `ORCH_CONTROL_PROMPT.md`, local session persistence at `.orch/control-session.json`, the `--new` preflight error, and `--new-control-agent` clearing behavior.
- **Artifact hygiene:** `test ! -e ORCH_CONTROL_PROMPT.md` passed; `git ls-files ORCH_CONTROL_PROMPT.md` returned no tracked file; `git check-ignore -v` matched `ORCH_CONTROL_PROMPT.md` and `**/.orch/control-session.json`. This cleanup was already present on `main`, so no redundant hygiene diff was needed.

## Checks

- `uv run pytest tests/ -q` — **334 passed, 11 skipped**
- `go build ./...` — **passed**
- `make lint` — **passed**, including TUI lint and architecture fixtures
- `git diff --check` — **passed**
- `go test ./...` — all reported Go packages passed, but the external integration `TestRunWithBuiltInAgents` failed when OpenCode session creation returned HTTP 500. A focused rerun reproduced the same external OpenCode 500 (`err_ec0b6d53`); no documentation code is involved.
