### PR TITLE
Remove vestigial global backend flag

### DIFF
--- a/claude-plugins/orch-toolset/skills/orch-toolset/reference.md
+++ b/claude-plugins/orch-toolset/skills/orch-toolset/reference.md
@@ -14,7 +14,6 @@ Common flags across `orch` commands:
 
 | Flag | Description |
 |------|-------------|
-| `--backend` | Issue store backend: `local` or `github` |
 | `--project` | Project identity / normalized repo ID |
 | `--remote` | Remote daemon address (same as `ORCH_REMOTE`) |
 | `--json` | JSON output |

--- a/docs/backends/file.md
+++ b/docs/backends/file.md
@@ -248,8 +248,8 @@ issues/runs/
 If you're moving from the GitHub backend to files:
 
 ```bash
-# Export issues (hypothetical command)
-orch issue export --backend github --output ./issues/
+# Export issues after selecting the GitHub issue backend in config (hypothetical command)
+orch issue export --output ./issues/
 
 # Or manually create issue files for each ticket
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ orch uses a layered configuration system with sensible defaults. Configuration c
 
 Settings are resolved in this order (highest priority first):
 
-1. **Command-line flags** (`--agent`, `--backend`, etc.)
+1. **Command-line flags** (`--project`, `--remote`, etc.)
 2. **Project config** (`.orch/config.yaml` in current or parent directory)
 3. **Environment variables** (`ORCH_AGENT`, etc.)
 4. **Global config** (`~/.config/orch/config.yaml`)

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -8,7 +8,6 @@ These flags work with all commands:
 
 | Flag | Description |
 |------|-------------|
-| `--backend <type>` | Issue store backend: `file` (default), `local`, or `github` (normally set via `issues.backend` in config) |
 | `--project <id-or-url>` | Project identity (repo ID or git remote URL, or `ORCH_PROJECT`) |
 | `--remote <addr>` | Connect to remote daemon address (or `ORCH_REMOTE`) |
 | `--json` | Output in JSON format |

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -36,7 +36,6 @@ type GlobalOptions struct {
 	Project     string
 	ProjectRoot string // deprecated compatibility field
 	Remote      string
-	Backend     string
 	JSON        bool
 	TSV         bool
 	Quiet       bool
@@ -139,7 +138,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&globalOpts.Project, "project", "", "Project identity (git repo URL or normalized repo ID; or set ORCH_PROJECT)")
 	rootCmd.PersistentFlags().StringVar(&globalOpts.Remote, "remote", "", "Connect to remote daemon address (or set ORCH_REMOTE)")
 
-	rootCmd.PersistentFlags().StringVar(&globalOpts.Backend, "backend", "file", "Issue store backend (local|github)")
 	rootCmd.PersistentFlags().BoolVar(&globalOpts.JSON, "json", false, "Output in JSON format")
 	rootCmd.PersistentFlags().BoolVar(&globalOpts.TSV, "tsv", false, "Output in TSV format (for fzf)")
 	rootCmd.PersistentFlags().BoolVar(&globalOpts.Quiet, "quiet", false, "Suppress human-readable output")

--- a/internal/cli/root_help_test.go
+++ b/internal/cli/root_help_test.go
@@ -64,3 +64,9 @@ func TestRootDoesNotExposeRemovedMonitorCommand(t *testing.T) {
 		}
 	}
 }
+
+func TestRootDoesNotExposeRemovedBackendFlag(t *testing.T) {
+	if flag := rootCmd.PersistentFlags().Lookup("backend"); flag != nil {
+		t.Fatalf("removed global backend flag is still registered: %s", flag.Name)
+	}
+}


### PR DESCRIPTION
## Summary

- remove the unused global `--backend` persistent flag and its dead `GlobalOptions.Backend` storage
- add regression coverage that prevents the root flag from being reintroduced
- remove issue-store/global `--backend` guidance from the CLI docs, configuration docs, file-backend migration example, and bundled orch-toolset reference
- preserve the separate, functional `orch agent --backend` subcommand flag

## Why

Issue-store selection is daemon/config driven through `issues.backend` (`local|github`). The former global flag defaulted to the invalid value `file`, did not override issue-store selection, and therefore advertised behavior it never provided.

## Acceptance evidence

- Built the production CLI with `go build -o /tmp/orch-dead-backend-flag-removal ./cmd/orch`.
- `/tmp/orch-dead-backend-flag-removal --help` lists all global flags and contains no `--backend`.
- `/tmp/orch-dead-backend-flag-removal --backend local version` fails immediately with exit 10 and `unknown flag: --backend`.
- `/tmp/orch-dead-backend-flag-removal --json agent --backend opencode --dry-run` succeeds and returns `{"ok":true,"backend":"opencode"}`, proving the agent-specific flag remains intact.
- `rg -n --fixed-strings -- '--backend' orch-monitor-tui` returns no matches (expected ripgrep exit 1), so the TUI does not pass the removed flag when spawning orch.
- The old Go monitor respawn implementation is already absent on current `main` (`internal/cli/monitor.go` was removed previously), so there is no remaining respawn echo to remove.
- `docs/reference/commands.md` now omits `--backend` from the global-flags table.

## Validation

Passed:

- `ORCH_SAFE_CLI_TEST=1 go test ./internal/cli -run TestRootDoesNotExposeRemovedBackendFlag -count=1`
- `ORCH_SAFE_CLI_TEST=1 go test $(go list ./... | rg -v '/test/integration$')`
- `go build ./...`
- `make lint`
- commit-time Go architecture lint

Full-suite note:

- `ORCH_SAFE_CLI_TEST=1 go test ./...` was run. All code packages passed, but `test/integration.TestRunWithBuiltInAgents` failed when the local OpenCode service returned HTTP 500 during session creation.
- The isolated rerun failed at the same external OpenCode call with a new server error reference (`err_fccfcf0b`), confirming the failure is repeatable in the current environment and unrelated to this CLI flag-only change.

Tracking issue: `dead-backend-flag-removal`
