### PR TITLE
Route worker-hosted dead checks through git evidence leases

### DIFF
--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -73,7 +73,7 @@ Facts the daemon can notice about a run, with their sources:
 | O4c | — derived: agent verdict (exited/completed/api-limited/failed) | mux string heuristics; opencode session-status HTTP API (busy/idle/retry/gone) | pure / HTTP |
 | O4d | — derived: PR URL in output | regex | pure |
 | O4e | — derived: interactive gate showing (kind) | `DetectGate` declarative table (`internal/agent/gates.go`), busy veto shared with O4b (§9) | pure |
-| O5 | git evidence (PR info, ahead count, uncommitted changes) | gh cache + git, gathered only after a dead verdict is near | subprocess |
+| O5 | git evidence (PR info, ahead count, uncommitted changes) | gh cache + local git, or worker `get_diff_stats`/`get_branch_state` leases for worker-hosted runs; gathered only after a dead verdict is near | subprocess / lease RTT |
 | O6 | user feedback delivered (`orch send` without `--no-enter`) | send paths | — |
 | O7 | user stop | stop path | — |
 | O8 | launch lifecycle progress (`launchSignal`: stage milestone or failed step) | launch ladders via `reportLaunchProgress` | — |
@@ -716,7 +716,7 @@ Invariant delta for the §4 table:
 | candidate | verdict | rationale |
 |-----------|---------|-----------|
 | (a) reset DeadCheckCount when the observer generation changes | adopted (L11a) — but **insufficient alone**: in the incident all three not-founds came from the *same new* worker instance; a reset at the generation boundary changes nothing there | correct streak hygiene, wrong lever for the incident |
-| (b) corroborating evidence before `failed` | adopted in two parts: the PR/git evidence ladder already corroborates and stays first (channel-independent); worker-side git evidence for worker-hosted runs is a **separate follow-up issue** (the master is structurally blind to the worker's worktree — `get_diff_stats`/`get_branch_state` capabilities already exist to close this). The "session-created-by-worker generation match" variant is subsumed by attestation: a creator observes its own session immediately, so it attests itself | |
+| (b) corroborating evidence before `failed` | adopted in two parts: the PR/git evidence ladder already corroborates and stays first (channel-independent); worker-side git evidence for worker-hosted runs was delivered as the **separate follow-up issue** recorded in §10.6 (the master is structurally blind to the worker's worktree, so `get_diff_stats`/`get_branch_state` leases close this). The "session-created-by-worker generation match" variant is subsumed by attestation: a creator observes its own session immediately, so it attests itself | |
 | (c) observer changed + not found ⇒ `unknown`, not `failed` | adopted in generalized form: the predicate is not "changed" but "**unattested for this run**" (L11b/L11c) | "changed" misses the incident (the new observer's streak was internally consistent) |
 | channel-level attestation ("observer saw ≥ 1 session of any kind") | **rejected** — two killing counterexamples: (i) the poisoned socket can contain *foreign* sessions (agent-deck's own), so ListSessions non-emptiness attests nothing; (ii) a poisoned worker that *launches a new run* creates and sees that session on the wrong server, attesting itself channel-wide while still blind to every pre-existing run. Attestation must be per-(run, observer-instance) | this is the cheaper design that almost worked; recorded so it is not re-proposed |
 
@@ -762,11 +762,12 @@ Invariant delta for the §4 table:
   the frozen `legacyRemoteSessionGone` shim (unattested-only, deletable
   once no pre-attestation workers remain), L11/L7'/I9 property tests,
   §2/§3/§4/§5 fold-in.
-- Separate issue (delegable once specced, still open —
-  `worker-side-git-corroboration`): worker-side git corroboration for
-  worker-hosted dead verdicts via existing `get_diff_stats`/
-  `get_branch_state` capabilities (closes the corroboration blindness
-  noted in 10.0; benefits the attested path too).
+- ~~Separate issue~~ **implemented 2026-07-10**
+  (`worker-side-git-corroboration`): worker-hosted O5 gathering routes the
+  ahead/diff and dirty-tree facts through the existing `get_diff_stats` and
+  `get_branch_state` leases. Lease failure produces no empty evidence
+  observation, so infrastructure blindness cannot become a death verdict;
+  the resulting facts still enter `step()` only as `obsGitEvidence`.
 - Cross-reference: this partially delivers the O12 (worker presence)
   backlog item of `docs/design/observation-coverage.md` by surfacing
   observer identity to `step()` as observation payload.

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -40,6 +40,7 @@ const (
 	// panes, and never block the monitor loop on a lease for long.
 	remoteCaptureInterval     = 15 * time.Second
 	remoteCaptureLeaseTimeout = 15 * time.Second
+	remoteGitEvidenceTimeout  = 15 * time.Second
 	remoteCaptureLines        = 200
 
 	// A run that was never observed alive gets this long from StartedAt
@@ -105,7 +106,7 @@ func (d *Daemon) monitorRun(run *model.Run, st store.Store, projectID, projectRo
 				d.logger.Printf("%s#%s: opencode bootstrap logs: %s", run.IssueID, run.RunID, logPath)
 			}
 		}
-		return d.applyGoneObservation(run, st, state, projectRoot, false, d.localObserverID(), localGoneClass(run))
+		return d.applyGoneObservation(run, st, state, projectID, projectRoot, false, d.localObserverID(), localGoneClass(run))
 	}
 
 	if _, err := d.applyStep(run, st, state, runObservation{Kind: obsSessionAlive, Observer: d.localObserverID()}, projectRoot); err != nil {
@@ -227,7 +228,7 @@ func (d *Daemon) applyRunEffects(run *model.Run, st store.Store, oldCore, core r
 // second observation. The shell never decides whether evidence is needed.
 // observer/goneClass carry the observing channel's identity and its local
 // classification (§10.2) — attestation over them is stepRun policy.
-func (d *Daemon) applyGoneObservation(run *model.Run, st store.Store, state *RunState, projectRoot string, remote bool, observer, goneClass string) error {
+func (d *Daemon) applyGoneObservation(run *model.Run, st store.Store, state *RunState, projectID, projectRoot string, remote bool, observer, goneClass string) error {
 	effects, err := d.applyStep(run, st, state, runObservation{
 		Kind:      obsSessionGone,
 		Remote:    remote,
@@ -240,7 +241,10 @@ func (d *Daemon) applyGoneObservation(run *model.Run, st store.Store, state *Run
 	if !effectsContain(effects, effectGatherGitEvidence) {
 		return nil
 	}
-	evidence := d.gatherGitEvidence(run, projectRoot)
+	evidence, err := d.gatherGitEvidence(run, projectID, projectRoot)
+	if err != nil {
+		return err
+	}
 	_, err = d.applyStep(run, st, state, runObservation{
 		Kind:     obsGitEvidence,
 		Evidence: evidence,
@@ -292,7 +296,7 @@ func (d *Daemon) monitorRemoteRun(run *model.Run, st store.Store, projectID, pro
 			// lease round-trip completed, so pace re-checks like successful
 			// captures instead of retrying every monitor tick.
 			state.RemoteCaptureAt = now
-			return d.applyGoneObservation(run, st, state, projectRoot, true, "", goneClassUnclassified)
+			return d.applyGoneObservation(run, st, state, projectID, projectRoot, true, "", goneClassUnclassified)
 		}
 
 		// Worker-plane infrastructure failure (worker offline, lease
@@ -321,7 +325,7 @@ func (d *Daemon) monitorRemoteRun(run *model.Run, st store.Store, projectID, pro
 		// local (L11d) and identified itself; whether its testimony can
 		// support a death verdict is attestation policy in stepRun (L11a-c).
 		state.RemoteCaptureAt = now
-		return d.applyGoneObservation(run, st, state, projectRoot, true, result.ObserverID, result.Gone.Class)
+		return d.applyGoneObservation(run, st, state, projectID, projectRoot, true, result.ObserverID, result.Gone.Class)
 	}
 
 	state.resetCaptureFailure()
@@ -790,10 +794,10 @@ func statusFromPROutcome(outcome prOutcome) model.Status {
 // projectRoot is the repo root registered with the daemon for the run's
 // project; it is the lookup root for worker-hosted runs whose worktree lives
 // on the execution host and is not visible from this machine.
-func (d *Daemon) gatherGitEvidence(run *model.Run, projectRoot string) gitEvidence {
+func (d *Daemon) gatherGitEvidence(run *model.Run, projectID, projectRoot string) (gitEvidence, error) {
 	ev := gitEvidence{}
 	if run.Branch == "" {
-		return ev
+		return ev, nil
 	}
 
 	repoRoot := ""
@@ -815,7 +819,7 @@ func (d *Daemon) gatherGitEvidence(run *model.Run, projectRoot string) gitEviden
 			ev.BranchPRURL = prInfo.URL
 			ev.BranchPROutcome = prOutcomeFromInfo(prInfo)
 			if statusFromPROutcome(ev.BranchPROutcome) != "" {
-				return ev
+				return ev, nil
 			}
 		}
 		if err != nil {
@@ -834,11 +838,20 @@ func (d *Daemon) gatherGitEvidence(run *model.Run, projectRoot string) gitEviden
 		}
 		// The verdict ladder ends at the PR-URL rung regardless of lookup
 		// success (it preserves pr_open) — no further facts needed.
-		return ev
+		return ev, nil
+	}
+
+	if d.runIsWorkerDelegated(run) {
+		stats, branchState, err := d.socketServer.getRunGitStateViaWorker(run, projectID, projectRoot)
+		if err != nil {
+			return ev, err
+		}
+		applyWorkerGitState(&ev, stats, branchState)
+		return ev, nil
 	}
 
 	if repoRoot == "" {
-		return ev
+		return ev, nil
 	}
 
 	baseBranch := "origin/main"
@@ -854,7 +867,41 @@ func (d *Daemon) gatherGitEvidence(run *model.Run, projectRoot string) gitEviden
 	}
 	ev.HasUncommitted = git.HasUncommittedChanges(run.WorktreePath)
 
-	return ev
+	return ev, nil
+}
+
+// applyWorkerGitState translates the existing worker get_diff_stats and
+// get_branch_state results into O5's established gitEvidence vocabulary.
+// The pure verdict policy only needs a positive ahead signal, so the worker's
+// changed-file count occupies AheadCount when an exact commit count is not
+// exposed by the existing lease capability.
+func applyWorkerGitState(ev *gitEvidence, stats *GetDiffStatsResult, branchState *GetBranchStateResult) {
+	state := orchpb.BranchState(branchState.State)
+	changedFiles := stats.FilesChanged
+	if changedFiles == 0 && (stats.Additions != 0 || stats.Deletions != 0 || len(stats.Files) != 0) {
+		changedFiles = 1
+	}
+
+	ev.RepoRootFound = state != orchpb.BranchState_BRANCH_STATE_UNSPECIFIED || changedFiles > 0
+	if !ev.RepoRootFound {
+		return
+	}
+
+	ev.AheadKnown = true
+	ev.AheadCount = changedFiles
+	ev.HasUncommitted = state == orchpb.BranchState_BRANCH_STATE_DIRTY
+
+	// Current workers report DIRTY/MERGED/CLEAN, while the proto vocabulary
+	// also permits richer ahead/diverged/conflict states. Preserve positive
+	// evidence if a newer worker returns one of those states without stats.
+	switch state {
+	case orchpb.BranchState_BRANCH_STATE_AHEAD,
+		orchpb.BranchState_BRANCH_STATE_DIVERGED,
+		orchpb.BranchState_BRANCH_STATE_CONFLICT:
+		if ev.AheadCount == 0 {
+			ev.AheadCount = 1
+		}
+	}
 }
 
 // inferStatusFromGitState infers a run's status from git state when the agent
@@ -862,7 +909,11 @@ func (d *Daemon) gatherGitEvidence(run *model.Run, projectRoot string) gitEviden
 // for callers outside the stepRun flow (tests): the decision ladder itself
 // lives in gitVerdict (step.go) so it cannot drift from the monitor plane.
 func (d *Daemon) inferStatusFromGitState(run *model.Run, st store.Store, wasAlive bool, projectRoot string) model.Status {
-	evidence := d.gatherGitEvidence(run, projectRoot)
+	evidence, err := d.gatherGitEvidence(run, "", projectRoot)
+	if err != nil {
+		d.debug("%s#%s: infer: git evidence error: %v", run.IssueID, run.RunID, err)
+		return ""
+	}
 	status, effects := gitVerdict(runViewOf(run), runCore{WasAlive: wasAlive}, evidence, time.Now())
 	for _, e := range effects {
 		switch e.Kind {

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/proboscis/orch/api/orchpb"
 	"github.com/proboscis/orch/internal/agent"
 	"github.com/proboscis/orch/internal/model"
 	"github.com/proboscis/orch/internal/pr"
@@ -980,6 +981,179 @@ func newRemoteTestRun(status model.Status) *model.Run {
 		TargetWorkerID: "host-CA-1",
 		SessionName:    "run-ISSUE-REMOTE-1-run-1",
 		Multiplexer:    "tmux",
+	}
+}
+
+func TestMonitorRemoteRunUsesWorkerGitEvidenceForDeadVerdict(t *testing.T) {
+	tests := []struct {
+		name        string
+		branchState orchpb.BranchState
+		diffStats   *GetDiffStatsResult
+		wantStatus  model.Status
+	}{
+		{
+			name:        "uncommitted worker changes keep run waiting",
+			branchState: orchpb.BranchState_BRANCH_STATE_DIRTY,
+			diffStats:   &GetDiffStatsResult{},
+			wantStatus:  model.StatusWaiting,
+		},
+		{
+			name:        "clean worker tree preserves dead-session fallback",
+			branchState: orchpb.BranchState_BRANCH_STATE_CLEAN,
+			diffStats:   &GetDiffStatsResult{},
+			wantStatus:  model.StatusFailed,
+		},
+		{
+			name:        "committed worker diff keeps run waiting",
+			branchState: orchpb.BranchState_BRANCH_STATE_CLEAN,
+			diffStats:   &GetDiffStatsResult{Additions: 3, FilesChanged: 1, Files: []string{"worker.go"}},
+			wantStatus:  model.StatusWaiting,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := newTestDaemon()
+			server := NewSocketServer(nil, d.logger)
+			d.socketServer = server
+
+			workerID := HostWorkerID("CA-1")
+			if _, ttl := server.registerWorker(workerID, "executor", "CA-1", "external", []string{"get_diff_stats", "get_branch_state"}); ttl <= 0 {
+				t.Fatal("expected positive heartbeat TTL for git-evidence worker")
+			}
+
+			observer := "worker:host-CA-1:n1"
+			alive := true
+			d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (*CaptureSessionResult, error) {
+				if alive {
+					return &CaptureSessionResult{Content: "agent working", ObserverID: observer}, nil
+				}
+				return &CaptureSessionResult{
+					ObserverID: observer,
+					Gone:       &SessionGoneResult{Class: goneClassSessionAbsent},
+				}, nil
+			}
+
+			run := newRemoteTestRun(model.StatusRunning)
+			run.Branch = "feature/worker-evidence"
+			run.WorktreePath = "/worker-only/worktree"
+			run.StartedAt = time.Now().Add(-time.Hour)
+			st := &mockStoreRecordingEvents{
+				mockStoreForUpdate: mockStoreForUpdate{issue: &model.Issue{ID: run.IssueID, Status: model.IssueStatusOpen}},
+				run:                run,
+			}
+			state := d.getOrCreateState(run)
+			mgr := agent.GetManager(run)
+
+			// First attest the same worker observation channel that will report
+			// the session gone.
+			if err := d.monitorRemoteRun(run, st, "project-worker", "/master/without-worker-worktree", state, mgr); err != nil {
+				t.Fatalf("monitorRemoteRun() alive capture error = %v", err)
+			}
+			alive = false
+
+			leaseResults := make(chan error, 1)
+			go func() {
+				seen := 0
+				deadline := time.Now().Add(5 * time.Second)
+				for seen < 2 && time.Now().Before(deadline) {
+					lease := server.leaseWorkForWorker(workerID)
+					if lease == nil {
+						time.Sleep(10 * time.Millisecond)
+						continue
+					}
+
+					var result *WorkerEffectResult
+					switch lease.Effect {
+					case "get_diff_stats":
+						result = &WorkerEffectResult{DiffStatsResult: tt.diffStats}
+					case "get_branch_state":
+						result = &WorkerEffectResult{BranchStateResult: &GetBranchStateResult{State: int32(tt.branchState)}}
+					default:
+						leaseResults <- errors.New("monitor dispatched an unexpected worker effect: " + lease.Effect)
+						return
+					}
+					if err := server.acknowledgeWorkerLease(workerID, lease.LeaseID, true, "", EncodeWorkerEffectResult(result)); err != nil {
+						leaseResults <- err
+						return
+					}
+					seen++
+				}
+				if seen != 2 {
+					leaseResults <- errors.New("timed out waiting for both worker git-evidence leases")
+					return
+				}
+				leaseResults <- nil
+			}()
+
+			for i := 0; i < deadChecksBeforeFailed; i++ {
+				state.RemoteCaptureAt = time.Now().Add(-2 * remoteCaptureInterval)
+				if err := d.monitorRemoteRun(run, st, "project-worker", "/master/without-worker-worktree", state, mgr); err != nil {
+					t.Fatalf("monitorRemoteRun() dead check %d error = %v", i+1, err)
+				}
+			}
+
+			if err := <-leaseResults; err != nil {
+				t.Fatal(err)
+			}
+			if run.Status != tt.wantStatus {
+				t.Fatalf("run.Status = %s, want %s", run.Status, tt.wantStatus)
+			}
+			if len(st.events) != 1 || st.events[0].Type != model.EventTypeStatus || st.events[0].Name != string(tt.wantStatus) {
+				t.Fatalf("status events = %+v, want exactly one %s event", st.events, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestMonitorRemoteRunWorkerGitEvidenceFailureDoesNotVerdict(t *testing.T) {
+	d := newTestDaemon()
+	d.socketServer = NewSocketServer(nil, d.logger)
+
+	observer := "worker:host-CA-1:n1"
+	alive := true
+	d.remoteCaptureFn = func(run *model.Run, projectID, projectRoot string, lines int) (*CaptureSessionResult, error) {
+		if alive {
+			return &CaptureSessionResult{Content: "agent working", ObserverID: observer}, nil
+		}
+		return &CaptureSessionResult{
+			ObserverID: observer,
+			Gone:       &SessionGoneResult{Class: goneClassSessionAbsent},
+		}, nil
+	}
+
+	run := newRemoteTestRun(model.StatusRunning)
+	run.Branch = "feature/worker-evidence-error"
+	run.WorktreePath = "/worker-only/worktree"
+	run.StartedAt = time.Now().Add(-time.Hour)
+	st := &mockStoreRecordingEvents{
+		mockStoreForUpdate: mockStoreForUpdate{issue: &model.Issue{ID: run.IssueID, Status: model.IssueStatusOpen}},
+		run:                run,
+	}
+	state := d.getOrCreateState(run)
+	mgr := agent.GetManager(run)
+
+	if err := d.monitorRemoteRun(run, st, "project-worker", "/master/without-worker-worktree", state, mgr); err != nil {
+		t.Fatalf("monitorRemoteRun() alive capture error = %v", err)
+	}
+	alive = false
+
+	for i := 0; i < deadChecksBeforeFailed-1; i++ {
+		state.RemoteCaptureAt = time.Now().Add(-2 * remoteCaptureInterval)
+		if err := d.monitorRemoteRun(run, st, "project-worker", "/master/without-worker-worktree", state, mgr); err != nil {
+			t.Fatalf("monitorRemoteRun() early dead check %d error = %v", i+1, err)
+		}
+	}
+	state.RemoteCaptureAt = time.Now().Add(-2 * remoteCaptureInterval)
+	err := d.monitorRemoteRun(run, st, "project-worker", "/master/without-worker-worktree", state, mgr)
+	if err == nil || !strings.Contains(err.Error(), "worker get_diff_stats lease") {
+		t.Fatalf("monitorRemoteRun() error = %v, want explicit get_diff_stats lease error", err)
+	}
+	if run.Status != model.StatusRunning {
+		t.Fatalf("run.Status = %s, want running after evidence infrastructure failure", run.Status)
+	}
+	if len(st.events) != 0 {
+		t.Fatalf("evidence infrastructure failure must not produce a status event, got %+v", st.events)
 	}
 }
 

--- a/internal/daemon/worker_git_evidence.go
+++ b/internal/daemon/worker_git_evidence.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/proboscis/orch/internal/model"
+)
+
+// getRunGitStateViaWorker gathers the worker-local facts used by the O5
+// dead-session evidence ladder. It deliberately reuses the existing
+// get_diff_stats and get_branch_state capabilities instead of introducing a
+// monitor-specific worker effect.
+func (s *SocketServer) getRunGitStateViaWorker(run *model.Run, projectID, projectRoot string) (*GetDiffStatsResult, *GetBranchStateResult, error) {
+	if run == nil {
+		return nil, nil, fmt.Errorf("run required")
+	}
+	if strings.TrimSpace(projectID) == "" {
+		return nil, nil, fmt.Errorf("no project context available for remote run %s#%s", run.IssueID, run.RunID)
+	}
+
+	target, err := resolveWorkerTargetForRunFields(run, projectRoot)
+	if err != nil {
+		return nil, nil, err
+	}
+	snapshot := newRunSnapshot(run)
+
+	diffPayload := &WorkerEffectPayload{
+		GetDiffStats: &GetDiffStatsPayload{
+			Target:         strings.TrimSpace(run.Target),
+			TargetHost:     target.Host,
+			TargetWorkerID: target.WorkerID,
+			RunSnapshot:    snapshot,
+		},
+	}
+	diffResult, err := s.runGitEvidenceLease(run, projectID, "get_diff_stats", diffPayload)
+	if err != nil {
+		return nil, nil, err
+	}
+	if diffResult.DiffStatsResult == nil {
+		return nil, nil, fmt.Errorf("worker get_diff_stats lease for run %s#%s completed without diff_stats_result", run.IssueID, run.RunID)
+	}
+
+	branchPayload := &WorkerEffectPayload{
+		GetBranchState: &GetBranchStatePayload{
+			Target:         strings.TrimSpace(run.Target),
+			TargetHost:     target.Host,
+			TargetWorkerID: target.WorkerID,
+			RunSnapshot:    snapshot,
+		},
+	}
+	branchResult, err := s.runGitEvidenceLease(run, projectID, "get_branch_state", branchPayload)
+	if err != nil {
+		return nil, nil, err
+	}
+	if branchResult.BranchStateResult == nil {
+		return nil, nil, fmt.Errorf("worker get_branch_state lease for run %s#%s completed without branch_state_result", run.IssueID, run.RunID)
+	}
+
+	return diffResult.DiffStatsResult, branchResult.BranchStateResult, nil
+}
+
+func (s *SocketServer) runGitEvidenceLease(run *model.Run, projectID, effect string, payload *WorkerEffectPayload) (*WorkerEffectResult, error) {
+	lease, err := s.acquireWorkerLease(projectID, effect, string(run.IssueID), string(run.RunID), payload)
+	if err != nil {
+		return nil, fmt.Errorf("worker %s lease for run %s#%s: %w", effect, run.IssueID, run.RunID, err)
+	}
+	completedLease, err := s.waitForWorkerLeaseCompletion(lease.LeaseID, remoteGitEvidenceTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("worker %s lease for run %s#%s: %w", effect, run.IssueID, run.RunID, err)
+	}
+	result, err := decodeWorkerEffectResult(completedLease.ResultJSON)
+	if err != nil {
+		return nil, fmt.Errorf("decode worker %s result for run %s#%s: %w", effect, run.IssueID, run.RunID, err)
+	}
+	return result, nil
+}


### PR DESCRIPTION
## Summary

- route worker-hosted O5 git corroboration through the existing `get_diff_stats` and `get_branch_state` worker lease capabilities
- translate worker dirty/diff facts into the existing `obsGitEvidence` payload without adding an observation kind or changing `stepRun` policy
- fail explicitly when either evidence lease fails, without feeding empty evidence into the dead-session ladder
- update the run-state-machine design record to describe the implemented worker evidence source

Issue: `worker-side-git-corroboration`

## Acceptance evidence

1. **Worker-hosted uncommitted changes conclude `waiting`, not `failed`.**
   - `TestMonitorRemoteRunUsesWorkerGitEvidenceForDeadVerdict/uncommitted_worker_changes_keep_run_waiting` passes.
2. **Clean worker-side trees preserve the existing dead-session ladder.**
   - `TestMonitorRemoteRunUsesWorkerGitEvidenceForDeadVerdict/clean_worker_tree_preserves_dead-session_fallback` passes and concludes `failed` for the attested Codex fixture.
3. **Existing lease capabilities feed the existing O5 observation.**
   - The monitor dispatches both `get_diff_stats` and `get_branch_state`; the result is applied as `obsGitEvidence`.
   - `internal/daemon/step.go` is unchanged.
4. **Evidence infrastructure failure cannot masquerade as a clean tree.**
   - `TestMonitorRemoteRunWorkerGitEvidenceFailureDoesNotVerdict` passes and verifies an explicit `get_diff_stats` lease error with no status event.

Verbose focused run:

```text
=== RUN   TestMonitorRemoteRunUsesWorkerGitEvidenceForDeadVerdict/uncommitted_worker_changes_keep_run_waiting
=== RUN   TestMonitorRemoteRunUsesWorkerGitEvidenceForDeadVerdict/clean_worker_tree_preserves_dead-session_fallback
=== RUN   TestMonitorRemoteRunUsesWorkerGitEvidenceForDeadVerdict/committed_worker_diff_keeps_run_waiting
--- PASS: TestMonitorRemoteRunUsesWorkerGitEvidenceForDeadVerdict (0.71s)
--- PASS: TestMonitorRemoteRunWorkerGitEvidenceFailureDoesNotVerdict (0.04s)
PASS
```

## Validation

- `go test ./internal/daemon -count=1` — pass
- all non-external-integration Go packages — pass
- `go build ./...` — pass
- `make lint` — pass, 0 architecture findings
- full `go test ./... -count=1` — the package/unit portion passed; `TestRunWithBuiltInAgents` failed because the installed OpenCode server returned HTTP 500 while creating a session. The identical failure was reproduced from an untouched `origin/main` worktree, so it is unrelated to this change.
