### PR TITLE
fix(daemon): enforce pr-attach law (L-PR1) - stop foreign PRs from corrupting run status

### DIFF
--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -771,3 +771,53 @@ Invariant delta for the §4 table:
 - Cross-reference: this partially delivers the O12 (worker presence)
   backlog item of `docs/design/observation-coverage.md` by surfacing
   observer identity to `step()` as observation payload.
+
+## 11. PR attachment law (pr-attach, decided 2026-07-10)
+
+Incident: the captured-pane PR scrape (`detectPRURL` over raw O4 output)
+attached any `…/pull/N` URL visible in a run's terminal to that run — with no
+ownership check. A foreign PR (#499) attached to a fresh run, and when that
+PR merged, the URL-keyed outcome lookup folded `pr_open → done` and
+auto-resolved the run's issue (`updateStatus` → `SetIssueStatus(resolved)`).
+A foreign merge corrupted the store of record of an unrelated run.
+
+### 11.1 Law
+
+> **L-PR1 (pr-attach).** A `pr` artifact may be appended to a run **iff** the
+> PR's `headRefName` equals the run's `branch` artifact and that branch is
+> non-empty. A run with no branch artifact never receives a `pr` artifact.
+
+Corollary: every status transition driven by PR state (`pr_open`,
+merged → `done`, closed → `canceled`) is downstream of L-PR1, because each
+one keys off `run.PRUrl`, which folds only from `pr` artifacts.
+
+### 11.2 Enforcement (two layers, gather-impure / decide-pure preserved)
+
+1. **Gatherer** — `processRunOutput` scrapes the pane and verifies ownership
+   via `verifyScrapedPRURL` (`gh pr view <url> --json …,headRefName`, cached)
+   before threading the URL into the observation as
+   `obsCaptured.CapturedPRURL`. `stepRun` never sees an unverified URL and
+   never scrapes `obs.Output` itself.
+2. **Executor choke point** — `recordPRArtifact`, the single executor for
+   `effectRecordPR` (producers: verified pane scrape, branch-scoped
+   `DiscoveredPRURL`, branch-scoped `gitVerdict`), re-verifies L-PR1 and
+   refuses with an explicit error on mismatch, empty branch, or
+   unverifiable head. The existing `PRRecorded` veto turns a refusal into
+   a retry on the next capture, so transient lookup failures self-heal.
+
+Cache note: `pr.Info`/`cacheEntry` gained `HeadRefName`; entries persisted
+before this law (URL set, head empty) are treated as stale and refetched.
+
+Accepted narrowing: GitLab merge-request URLs can no longer attach via the
+pane scrape (`gh` cannot resolve their head branch). PR outcome tracking was
+already GitHub-only, so no working behavior is lost.
+
+### 11.3 Violation tests
+
+- `step_test.go` — a captured observation whose raw `Output` contains a PR
+  URL but whose `CapturedPRURL` is empty emits no `effectRecordPR` and no
+  `pr_open`; a verified `CapturedPRURL` emits both and latches `PRRecorded`.
+- `monitor_test.go` — `verifyScrapedPRURL` accepts only head == branch;
+  `recordPRArtifact` refuses foreign/unverifiable URLs and empty-branch runs.
+- `pr/cache_test.go` — `HeadRefName` round-trips through lookup and cache;
+  pre-law entries are treated as stale.

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -10,6 +10,7 @@ package daemon
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -146,12 +147,47 @@ func (d *Daemon) monitorRun(run *model.Run, st store.Store, projectID, projectRo
 // worker-delegated runs.
 func (d *Daemon) processRunOutput(run *model.Run, st store.Store, state *RunState, mgr agent.AgentManager, output string) error {
 	signal := gatherAgentSignal(run, mgr, output)
-	_, err := d.applyStep(run, st, state, runObservation{
+	obs := runObservation{
 		Kind:   obsCaptured,
 		Output: output,
 		Signal: signal,
-	}, "")
+	}
+	// PR-URL detection is a scrape over arbitrary pane text: anything the
+	// agent prints (git log, gh output, prompt context) can contain a PR
+	// URL that belongs to a different run. Verify ownership here, impurely,
+	// so the pure core only ever sees a URL that satisfies the pr-attach
+	// law (headRefName == run branch, non-empty).
+	if !state.runCore.PRRecorded && run.PRUrl == "" {
+		if url := detectPRURL(output); url != "" && d.verifyScrapedPRURL(run, url) {
+			obs.CapturedPRURL = url
+		}
+	}
+	_, err := d.applyStep(run, st, state, obs, "")
 	return err
+}
+
+// verifyScrapedPRURL reports whether a PR URL scraped from a run's pane
+// actually belongs to that run: the PR's head branch must equal the run's
+// recorded branch artifact (pr-attach law, run-state-machine.md §11). A run
+// without a branch artifact can never adopt a scraped URL, and a URL whose
+// head branch cannot be resolved (lookup error, foreign host) is treated as
+// not verified — the next capture retries.
+func (d *Daemon) verifyScrapedPRURL(run *model.Run, url string) bool {
+	if run.Branch == "" {
+		d.debug("%s#%s: ignoring scraped PR URL %s: run has no branch artifact", run.IssueID, run.RunID, url)
+		return false
+	}
+	info, err := d.lookupPRInfoByURL(url)
+	if err != nil || info == nil {
+		d.debug("%s#%s: ignoring scraped PR URL %s: head branch unverifiable (err=%v)", run.IssueID, run.RunID, url, err)
+		return false
+	}
+	if info.HeadRefName != run.Branch {
+		d.logger.Printf("%s#%s: ignoring scraped PR URL %s: head %q does not match run branch %q (pr-attach law)",
+			run.IssueID, run.RunID, url, info.HeadRefName, run.Branch)
+		return false
+	}
+	return true
 }
 
 // gatherAgentSignal produces the agent-specific reading of a captured output
@@ -669,7 +705,25 @@ func (d *Daemon) detectPRCreation(output string) string {
 	return detectPRURL(output)
 }
 
+// recordPRArtifact is the single executor for effectRecordPR. It re-verifies
+// the pr-attach law (run-state-machine.md §11) as defense-in-depth so that no
+// current or future effect producer can attach a PR whose head branch does
+// not match the run's branch artifact.
 func (d *Daemon) recordPRArtifact(run *model.Run, prURL string, st store.Store) error {
+	if run.Branch == "" {
+		return fmt.Errorf("refusing to record PR %s: run has no branch artifact (pr-attach law)", prURL)
+	}
+	info, err := d.lookupPRInfoByURL(prURL)
+	if err != nil {
+		return fmt.Errorf("refusing to record PR %s: head branch unverifiable: %w", prURL, err)
+	}
+	if info == nil || info.HeadRefName != run.Branch {
+		head := ""
+		if info != nil {
+			head = info.HeadRefName
+		}
+		return fmt.Errorf("refusing to record PR %s: head %q does not match run branch %q (pr-attach law)", prURL, head, run.Branch)
+	}
 	ref := &model.RunRef{IssueID: run.IssueID, RunID: run.RunID}
 	event := model.NewArtifactEvent("pr", map[string]string{
 		"url": prURL,

--- a/internal/daemon/monitor_test.go
+++ b/internal/daemon/monitor_test.go
@@ -1248,8 +1248,14 @@ func TestMonitorRemoteRunDetectsPROpenFromWorkerCapture(t *testing.T) {
 			ObserverID: "worker:host-CA-1:n1",
 		}, nil
 	}
+	// pr-attach law (run-state-machine.md §11): the scraped URL only attaches
+	// because its head branch matches the run's branch artifact.
+	d.lookupPRInfoByURLFn = func(prURL string) (*pr.Info, error) {
+		return &pr.Info{URL: prURL, Number: 99, State: "OPEN", HeadRefName: "issue/ISSUE-REMOTE-1/run-1"}, nil
+	}
 
 	run := newRemoteTestRun(model.StatusRunning)
+	run.Branch = "issue/ISSUE-REMOTE-1/run-1"
 	st := &mockStoreRecordingEvents{mockStoreForUpdate: mockStoreForUpdate{issue: &model.Issue{ID: "ISSUE-REMOTE-1", Status: model.IssueStatusOpen}}}
 	state := d.getOrCreateState(run)
 	mgr := agent.GetManager(run)
@@ -1277,6 +1283,86 @@ func TestMonitorRemoteRunDetectsPROpenFromWorkerCapture(t *testing.T) {
 	}
 	if captures != 1 {
 		t.Fatalf("expected second call within interval to skip capture, got %d captures", captures)
+	}
+}
+
+// L-PR1 (run-state-machine.md §11) — gatherer verification: a scraped PR URL
+// belongs to a run iff the PR head branch equals the run's non-empty branch.
+func TestVerifyScrapedPRURL(t *testing.T) {
+	d := newTestDaemon()
+	run := &model.Run{IssueID: "i", RunID: "r", Branch: "issue/i/run-r"}
+
+	d.lookupPRInfoByURLFn = func(prURL string) (*pr.Info, error) {
+		return &pr.Info{URL: prURL, State: "OPEN", HeadRefName: "issue/i/run-r"}, nil
+	}
+	if !d.verifyScrapedPRURL(run, "https://github.com/o/r/pull/7") {
+		t.Fatal("matching head branch must verify")
+	}
+
+	d.lookupPRInfoByURLFn = func(prURL string) (*pr.Info, error) {
+		return &pr.Info{URL: prURL, State: "OPEN", HeadRefName: "issue/other/run-x"}, nil
+	}
+	if d.verifyScrapedPRURL(run, "https://github.com/o/r/pull/499") {
+		t.Fatal("foreign head branch must not verify")
+	}
+
+	d.lookupPRInfoByURLFn = func(prURL string) (*pr.Info, error) {
+		return nil, errors.New("gh unavailable")
+	}
+	if d.verifyScrapedPRURL(run, "https://github.com/o/r/pull/7") {
+		t.Fatal("unverifiable head must not verify")
+	}
+
+	noBranch := &model.Run{IssueID: "i", RunID: "r"}
+	looked := false
+	d.lookupPRInfoByURLFn = func(prURL string) (*pr.Info, error) {
+		looked = true
+		return nil, nil
+	}
+	if d.verifyScrapedPRURL(noBranch, "https://github.com/o/r/pull/7") {
+		t.Fatal("run without branch artifact must never adopt a scraped URL")
+	}
+	if looked {
+		t.Fatal("empty-branch run must be refused before any lookup")
+	}
+}
+
+// L-PR1 (run-state-machine.md §11) — executor choke point: recordPRArtifact
+// refuses foreign or unverifiable PRs and empty-branch runs.
+func TestRecordPRArtifactEnforcesPRAttachLaw(t *testing.T) {
+	d := newTestDaemon()
+	st := &mockStoreRecordingEvents{mockStoreForUpdate: mockStoreForUpdate{issue: &model.Issue{ID: "i", Status: model.IssueStatusOpen}}}
+
+	if err := d.recordPRArtifact(&model.Run{IssueID: "i", RunID: "r"}, "https://github.com/o/r/pull/7", st); err == nil {
+		t.Fatal("empty-branch run must be refused")
+	}
+
+	run := &model.Run{IssueID: "i", RunID: "r", Branch: "issue/i/run-r"}
+	d.lookupPRInfoByURLFn = func(prURL string) (*pr.Info, error) {
+		return &pr.Info{URL: prURL, State: "OPEN", HeadRefName: "issue/other/run-x"}, nil
+	}
+	if err := d.recordPRArtifact(run, "https://github.com/o/r/pull/499", st); err == nil {
+		t.Fatal("foreign PR must be refused")
+	}
+	if len(st.events) != 0 {
+		t.Fatalf("refused PR must not append events, got %d", len(st.events))
+	}
+
+	d.lookupPRInfoByURLFn = func(prURL string) (*pr.Info, error) {
+		return nil, errors.New("gh unavailable")
+	}
+	if err := d.recordPRArtifact(run, "https://github.com/o/r/pull/7", st); err == nil {
+		t.Fatal("unverifiable head must be refused")
+	}
+
+	d.lookupPRInfoByURLFn = func(prURL string) (*pr.Info, error) {
+		return &pr.Info{URL: prURL, State: "OPEN", HeadRefName: "issue/i/run-r"}, nil
+	}
+	if err := d.recordPRArtifact(run, "https://github.com/o/r/pull/7", st); err != nil {
+		t.Fatalf("matching PR must record: %v", err)
+	}
+	if len(st.events) != 1 || st.events[0].Name != "pr" {
+		t.Fatalf("expected exactly one pr artifact event, got %+v", st.events)
 	}
 }
 

--- a/internal/daemon/step.go
+++ b/internal/daemon/step.go
@@ -236,6 +236,11 @@ type runObservation struct {
 	// obsCaptured
 	Output string
 	Signal agentSignal
+	// CapturedPRURL is a PR URL scraped from the pane that the gatherer has
+	// already verified against the run: the PR's headRefName equals the
+	// run's non-empty branch artifact (pr-attach law, run-state-machine.md
+	// §11). stepRun must never adopt a PR URL from raw Output.
+	CapturedPRURL string
 
 	// obsGitEvidence
 	Evidence gitEvidence
@@ -657,7 +662,7 @@ func stepCaptured(view runView, core runCore, obs runObservation, now time.Time)
 	effects = append(effects, debugEffect("%s#%s: pane hash=%s changed=%t reading=%q confirmed=%q streak=%d",
 		view.IssueID, view.RunID, hashPreview, outputChanged, reading, confirmedReading, core.ReadingStreak))
 
-	if prURL := detectPRURL(obs.Output); prURL != "" && !core.PRRecorded {
+	if prURL := obs.CapturedPRURL; prURL != "" && !core.PRRecorded {
 		core.PRRecorded = true
 		effects = append(effects,
 			logEffect("%s#%s: PR created: %s", view.IssueID, view.RunID, prURL),

--- a/internal/daemon/step_test.go
+++ b/internal/daemon/step_test.go
@@ -426,6 +426,54 @@ func unknownReasonOf(effects []runEffect) (string, bool) {
 	return "", false
 }
 
+// L-PR1 (run-state-machine.md §11): stepRun must never adopt a PR URL from
+// raw captured output — only a gatherer-verified CapturedPRURL may attach,
+// and it latches PRRecorded.
+func TestStepCapturedPRAttachLaw(t *testing.T) {
+	now := time.Now()
+	view := runView{Status: model.StatusRunning, Agent: "codex", Branch: "issue/i/run-1", IssueID: "i", RunID: "run-1"}
+
+	// Raw output containing a PR URL but no verified CapturedPRURL: no attach.
+	core, effects := stepRun(view, runCore{WasAlive: true}, runObservation{
+		Kind:   obsCaptured,
+		Output: "merged https://github.com/o/r/pull/499 earlier today",
+	}, now)
+	if core.PRRecorded {
+		t.Fatal("unverified pane URL must not latch PRRecorded")
+	}
+	for _, e := range effects {
+		if e.Kind == effectRecordPR {
+			t.Fatalf("unverified pane URL must not emit effectRecordPR (got %s)", e.PRURL)
+		}
+		if e.Kind == effectSetStatus && e.Status == model.StatusPROpen {
+			t.Fatal("unverified pane URL must not transition to pr_open")
+		}
+	}
+
+	// Gatherer-verified URL: attach + pr_open + latch.
+	verified := "https://github.com/o/r/pull/7"
+	core, effects = stepRun(view, runCore{WasAlive: true}, runObservation{
+		Kind:          obsCaptured,
+		Output:        "opened " + verified + " for review\n",
+		CapturedPRURL: verified,
+	}, now)
+	if !core.PRRecorded {
+		t.Fatal("verified CapturedPRURL must latch PRRecorded")
+	}
+	var gotRecord, gotPROpen bool
+	for _, e := range effects {
+		if e.Kind == effectRecordPR && e.PRURL == verified {
+			gotRecord = true
+		}
+		if e.Kind == effectSetStatus && e.Status == model.StatusPROpen {
+			gotPROpen = true
+		}
+	}
+	if !gotRecord || !gotPROpen {
+		t.Fatalf("verified CapturedPRURL must record PR and set pr_open (record=%t pr_open=%t)", gotRecord, gotPROpen)
+	}
+}
+
 // D-C1 (run-state-machine.md §7): the fold-derivable runCore fields are
 // reconstructed from the event log at monitor registration; the ephemeral
 // counters start at zero.

--- a/internal/pr/cache.go
+++ b/internal/pr/cache.go
@@ -29,19 +29,21 @@ var ghClient = github.NewCLIClient()
 
 // Info holds details about a pull request.
 type Info struct {
-	URL    string
-	Number int
-	State  string // OPEN, MERGED, CLOSED
+	URL         string
+	Number      int
+	State       string // OPEN, MERGED, CLOSED
+	HeadRefName string // PR head branch; required to verify a PR belongs to a run (pr-attach law)
 }
 
 // InfoMap holds PR information keyed by branch name.
 type InfoMap map[string]*Info
 
 type cacheEntry struct {
-	URL       string    `json:"url,omitempty"`
-	Number    int       `json:"number,omitempty"`
-	State     string    `json:"state,omitempty"`
-	CheckedAt time.Time `json:"checked_at"`
+	URL         string    `json:"url,omitempty"`
+	Number      int       `json:"number,omitempty"`
+	State       string    `json:"state,omitempty"`
+	HeadRefName string    `json:"head_ref_name,omitempty"`
+	CheckedAt   time.Time `json:"checked_at"`
 }
 
 type cache struct {
@@ -185,6 +187,11 @@ func isCacheEntryFresh(entry cacheEntry, now time.Time) bool {
 	if entry.CheckedAt.IsZero() {
 		return false
 	}
+	// Entries persisted before the pr-attach law carry no head branch and
+	// cannot answer ownership checks — treat them as stale so they refetch.
+	if entry.URL != "" && entry.HeadRefName == "" {
+		return false
+	}
 	return now.Sub(entry.CheckedAt) < cacheEntryTTL(entry)
 }
 
@@ -193,9 +200,10 @@ func infoFromCacheEntry(entry cacheEntry) *Info {
 		return nil
 	}
 	return &Info{
-		URL:    entry.URL,
-		Number: entry.Number,
-		State:  entry.State,
+		URL:         entry.URL,
+		Number:      entry.Number,
+		State:       entry.State,
+		HeadRefName: entry.HeadRefName,
 	}
 }
 
@@ -208,6 +216,7 @@ func saveLookupCacheEntry(c *cache, key string, info *Info, checkedAt time.Time)
 		entry.URL = info.URL
 		entry.Number = info.Number
 		entry.State = info.State
+		entry.HeadRefName = info.HeadRefName
 	}
 	c.Entries[key] = entry
 	if info != nil && info.URL != "" {
@@ -230,15 +239,16 @@ func lookupInfo(client github.Client, repoRoot, branch string) (*Info, error) {
 	if client == nil {
 		client = ghClient
 	}
-	output, err := client.RunInDir(repoRoot, "pr", "list", "--head", branch, "--state", "all", "--json", "url,number,state", "--limit", "1")
+	output, err := client.RunInDir(repoRoot, "pr", "list", "--head", branch, "--state", "all", "--json", "url,number,state,headRefName", "--limit", "1")
 	if err != nil {
 		return nil, err
 	}
 
 	var prs []struct {
-		URL    string `json:"url"`
-		Number int    `json:"number"`
-		State  string `json:"state"`
+		URL         string `json:"url"`
+		Number      int    `json:"number"`
+		State       string `json:"state"`
+		HeadRefName string `json:"headRefName"`
 	}
 	if err := json.Unmarshal(output, &prs); err != nil {
 		return nil, err
@@ -247,9 +257,10 @@ func lookupInfo(client github.Client, repoRoot, branch string) (*Info, error) {
 		return nil, nil
 	}
 	return &Info{
-		URL:    prs[0].URL,
-		Number: prs[0].Number,
-		State:  prs[0].State,
+		URL:         prs[0].URL,
+		Number:      prs[0].Number,
+		State:       prs[0].State,
+		HeadRefName: prs[0].HeadRefName,
 	}, nil
 }
 
@@ -257,24 +268,26 @@ func lookupInfoByURL(client github.Client, prURL string) (*Info, error) {
 	if client == nil {
 		client = ghClient
 	}
-	output, err := client.Run("pr", "view", prURL, "--json", "url,number,state")
+	output, err := client.Run("pr", "view", prURL, "--json", "url,number,state,headRefName")
 	if err != nil {
 		return nil, err
 	}
 
 	var pr struct {
-		URL    string `json:"url"`
-		Number int    `json:"number"`
-		State  string `json:"state"`
+		URL         string `json:"url"`
+		Number      int    `json:"number"`
+		State       string `json:"state"`
+		HeadRefName string `json:"headRefName"`
 	}
 	if err := json.Unmarshal(output, &pr); err != nil {
 		return nil, err
 	}
 
 	return &Info{
-		URL:    pr.URL,
-		Number: pr.Number,
-		State:  pr.State,
+		URL:         pr.URL,
+		Number:      pr.Number,
+		State:       pr.State,
+		HeadRefName: pr.HeadRefName,
 	}, nil
 }
 

--- a/internal/pr/cache_test.go
+++ b/internal/pr/cache_test.go
@@ -39,7 +39,7 @@ func (f *fakeGitHubClient) RunInDir(dir string, args ...string) ([]byte, error) 
 func TestLookupInfoWithClient_UsesInjectedClient(t *testing.T) {
 	client := &fakeGitHubClient{
 		available: true,
-		output:    []byte(`[{"url":"https://github.com/acme/repo/pull/7","number":7,"state":"OPEN"}]`),
+		output:    []byte(`[{"url":"https://github.com/acme/repo/pull/7","number":7,"state":"OPEN","headRefName":"feature/test"}]`),
 	}
 
 	info, err := LookupInfoWithClient(client, "/tmp/repo", "feature/test")
@@ -68,7 +68,7 @@ func TestPopulateRunInfoWithClient_UsesInjectedClient(t *testing.T) {
 
 	client := &fakeGitHubClient{
 		available: true,
-		output:    []byte(`[{"url":"https://github.com/acme/repo/pull/19","number":19,"state":"OPEN"}]`),
+		output:    []byte(`[{"url":"https://github.com/acme/repo/pull/19","number":19,"state":"OPEN","headRefName":"feature/test"}]`),
 	}
 
 	runs := []*model.Run{
@@ -101,7 +101,7 @@ func TestPopulateRunInfo_RespectsMaxFetches(t *testing.T) {
 
 	client := &fakeGitHubClient{
 		available: true,
-		output:    []byte(`[{"url":"https://github.com/acme/repo/pull/1","number":1,"state":"OPEN"}]`),
+		output:    []byte(`[{"url":"https://github.com/acme/repo/pull/1","number":1,"state":"OPEN","headRefName":"feature/test"}]`),
 	}
 
 	runs := make([]*model.Run, 6)
@@ -126,7 +126,7 @@ func TestPopulateRunInfo_RespectsMinFetchInterval(t *testing.T) {
 
 	client := &fakeGitHubClient{
 		available: true,
-		output:    []byte(`[{"url":"https://github.com/acme/repo/pull/1","number":1,"state":"OPEN"}]`),
+		output:    []byte(`[{"url":"https://github.com/acme/repo/pull/1","number":1,"state":"OPEN","headRefName":"feature/test"}]`),
 	}
 
 	runs := []*model.Run{
@@ -163,10 +163,11 @@ func TestPopulateRunInfo_CacheHitSkipsAPI(t *testing.T) {
 	preCached := cache{
 		Entries: map[string]cacheEntry{
 			branch: {
-				URL:       "https://github.com/acme/repo/pull/77",
-				Number:    77,
-				State:     "OPEN",
-				CheckedAt: time.Now(),
+				URL:         "https://github.com/acme/repo/pull/77",
+				Number:      77,
+				State:       "OPEN",
+				HeadRefName: branch,
+				CheckedAt:   time.Now(),
 			},
 		},
 	}
@@ -204,7 +205,7 @@ func TestLookupInfoWithClient_MustUseCache(t *testing.T) {
 
 	client := &fakeGitHubClient{
 		available: true,
-		output:    []byte(`[{"url":"https://github.com/acme/repo/pull/42","number":42,"state":"OPEN"}]`),
+		output:    []byte(`[{"url":"https://github.com/acme/repo/pull/42","number":42,"state":"OPEN","headRefName":"feature/must-cache"}]`),
 	}
 	repoRoot := t.TempDir()
 	branch := "feature/must-cache"
@@ -249,10 +250,11 @@ func TestLookupInfoWithClient_CacheHitSkipsAPI(t *testing.T) {
 		LastFetch: time.Now(),
 		Entries: map[string]cacheEntry{
 			branch: {
-				URL:       "https://github.com/acme/repo/pull/99",
-				Number:    99,
-				State:     "MERGED",
-				CheckedAt: time.Now(),
+				URL:         "https://github.com/acme/repo/pull/99",
+				Number:      99,
+				State:       "MERGED",
+				HeadRefName: branch,
+				CheckedAt:   time.Now(),
 			},
 		},
 	}
@@ -260,7 +262,7 @@ func TestLookupInfoWithClient_CacheHitSkipsAPI(t *testing.T) {
 
 	client := &fakeGitHubClient{
 		available: true,
-		output:    []byte(`[{"url":"https://github.com/acme/repo/pull/999","number":999,"state":"OPEN"}]`),
+		output:    []byte(`[{"url":"https://github.com/acme/repo/pull/999","number":999,"state":"OPEN","headRefName":"feature/cache-hit"}]`),
 	}
 
 	info, err := LookupInfoWithClient(client, repoRoot, branch)
@@ -292,7 +294,7 @@ func TestLookupInfoByURL_MustUseCache(t *testing.T) {
 
 	client := &fakeGitHubClient{
 		available: true,
-		output:    []byte(`{"url":"https://github.com/acme/repo/pull/42","number":42,"state":"OPEN"}`),
+		output:    []byte(`{"url":"https://github.com/acme/repo/pull/42","number":42,"state":"OPEN","headRefName":"feature/by-url"}`),
 	}
 	ghClient = client
 
@@ -332,7 +334,7 @@ func TestLookupInfoByURL_CacheHitSkipsAPI(t *testing.T) {
 
 	client := &fakeGitHubClient{
 		available: true,
-		output:    []byte(`{"url":"https://github.com/acme/repo/pull/55","number":55,"state":"MERGED"}`),
+		output:    []byte(`{"url":"https://github.com/acme/repo/pull/55","number":55,"state":"MERGED","headRefName":"feature/url-hit"}`),
 	}
 	ghClient = client
 
@@ -402,12 +404,34 @@ func TestOpenPRCacheExpiresFast(t *testing.T) {
 func TestMergedPRCacheStaysFresh(t *testing.T) {
 	now := time.Now()
 	entry := cacheEntry{
-		URL:       "https://github.com/acme/repo/pull/1",
-		Number:    1,
-		State:     "MERGED",
-		CheckedAt: now.Add(-1 * time.Hour),
+		URL:         "https://github.com/acme/repo/pull/1",
+		Number:      1,
+		State:       "MERGED",
+		HeadRefName: "feature/merged",
+		CheckedAt:   now.Add(-1 * time.Hour),
 	}
 	if !isCacheEntryFresh(entry, now) {
 		t.Fatal("MERGED PR cached 1 hour ago should still be fresh")
+	}
+}
+
+// L-PR1 (run-state-machine.md §11): entries persisted before the pr-attach
+// law (URL set, head branch missing) cannot answer ownership checks and are
+// treated as stale so they refetch.
+func TestPreLawCacheEntryIsStale(t *testing.T) {
+	now := time.Now()
+	entry := cacheEntry{
+		URL:       "https://github.com/acme/repo/pull/1",
+		Number:    1,
+		State:     "MERGED",
+		CheckedAt: now.Add(-1 * time.Minute),
+	}
+	if isCacheEntryFresh(entry, now) {
+		t.Fatal("entry without HeadRefName must be stale regardless of TTL")
+	}
+	// Negative entries (no PR found) carry no URL and stay cacheable.
+	negative := cacheEntry{CheckedAt: now.Add(-1 * time.Second)}
+	if !isCacheEntryFresh(negative, now) {
+		t.Fatal("negative cache entry must remain fresh")
 	}
 }


### PR DESCRIPTION
## Root cause (observed live 2026-07-10)

The captured-pane PR scrape attached **any** `pull/N` URL visible in a run's terminal to that run, with zero ownership check (`stepCaptured` → `detectPRURL` over raw output). A foreign PR (#499) attached to the fresh docs-reorg run; when #499 merged, the URL-keyed outcome lookup folded `pr_open → done` and **auto-resolved the docs-reorg issue while its real PR #500 was still open**. A foreign merge corrupted the store of record of an unrelated run.

Full diagnosis with evidence chain: issue `daemon-pr-misassociation` (37eabedf).

## Law (new §11 in docs/design/run-state-machine.md)

> **L-PR1 (pr-attach).** A `pr` artifact may attach to a run **iff** the PR's `headRefName` equals the run's non-empty `branch` artifact.

## Enforcement (gather-impure / decide-pure preserved)

1. **Gatherer** — `processRunOutput` verifies scraped URLs (`verifyScrapedPRURL`: `gh pr view --json headRefName`, cached) and threads only verified URLs into `obsCaptured.CapturedPRURL`. `stepRun` no longer scrapes `obs.Output`.
2. **Executor choke point** — `recordPRArtifact` (single executor for `effectRecordPR`) re-verifies L-PR1 and refuses on mismatch / empty branch / unverifiable head. The existing `PRRecorded` veto turns refusals into next-capture retries.
3. `pr.Info`/`cacheEntry` gain `HeadRefName`; both `gh` queries fetch it; **pre-law cache entries (URL set, head missing) are treated as stale** and refetched.

## Violation tests

- `TestStepCapturedPRAttachLaw` — raw output with a PR URL emits nothing; verified `CapturedPRURL` records + latches
- `TestVerifyScrapedPRURL`, `TestRecordPRArtifactEnforcesPRAttachLaw` — gatherer + executor refusals
- `TestPreLawCacheEntryIsStale` — cache backward-compat
- `TestMonitorRemoteRunDetectsPROpenFromWorkerCapture` tightened (it encoded the unconditional-scrape bug)

## Accepted narrowing

GitLab MR URLs no longer attach via the pane scrape (`gh` cannot resolve their head branch) — PR outcome tracking was already GitHub-only, so no working behavior is lost.

## Routing note

Coupling-core change (`step.go`/`monitor.go` transition surface): authored frontier + law revision shipped in the same change set per AGENTS.md; human review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)