### PR TITLE
feat(daemon): agent_auth launch preflight - fail fast on unusable codex CODEX_HOME

### DIFF
--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -252,7 +252,7 @@ travels as a machine-readable `reason` attribute on the status event
 | `never_alive` | L3' grace expiry, either plane | infrastructure problem (binary/auth/mux env); fix the host before retrying |
 | `session_lost` | opencode session not found after dead checks | backend lost observability; backend-specific triage |
 | `agent_exited` | capture verdict: process exited, shell prompt showing | check transcript/worktree; retry plausible |
-| `launch_<step>` | O8 bootstrap failure (`failed` verdict); `<step>` ∈ worktree, prompt, agent_command, multiplexer, opencode_server, session, opencode_bootstrap, bootstrap | the named bootstrap step broke; the paired error artifact carries the detail |
+| `launch_<step>` | O8 bootstrap failure (`failed` verdict); `<step>` ∈ worktree, prompt, agent_command, agent_auth, multiplexer, opencode_server, session, opencode_bootstrap, bootstrap | the named bootstrap step broke; the paired error artifact carries the detail |
 | `gate_<kind>` (`gate_login`, `gate_trust`, …) | O4e gate reading confirmed by L10a (`waiting` verdict) | `orch attach` and complete the gate interactively; `orch send` will NOT clear it — the run re-asserts `waiting(gate_<kind>)` while the gate persists |
 | `observer_unverified` | L11c: dead-check threshold reached through an unattested channel | the observer cannot see the session — check the worker/daemon mux environment (TMUX socket, #483 class) and worker process; the run self-recovers on the next successful capture |
 
@@ -403,7 +403,35 @@ Decisions taken:
 Whitelist meter: 47 → 10 annotations (socket.go 40 → 3; the remaining three
 are W6, W8 and `appendRunResolvedByUser`, all with §6 dispositions).
 
-## 8. Vocabulary drift at serialization boundaries (decided 2026-07-07)
+### D-B2 — agent_auth launch preflight (implemented 2026-07-10)
+
+Incident: six codex runs launched with a CODEX_HOME whose `auth.json` was
+missing. Each codex parked at the sign-in wizard; the runs reported live
+statuses for hours. Fail-fast demands the launch itself refuse.
+
+- **New ladder step `agent_auth`** between `stageLaunchReady` and the
+  multiplexer/spawn block, in both `processStartRunCore` and
+  `processContinueRunCore` (these execute on the worker, i.e. the execution
+  host, so `agent.AuthPreflight` stats exactly the filesystem the agent will
+  see, after the same `~` expansion the env injection uses). Failure emits
+  `launchFailed("agent_auth", err)` → `failed(launch_agent_auth)` through
+  the frozen O8 writer; no new status-write surface.
+- **Scope:** codex with an explicitly configured CODEX_HOME only. Agent
+  defaults (`~/.codex`) are not second-guessed, and an API key in the
+  environment (`OPENAI_API_KEY`/`CODEX_API_KEY`) satisfies the check —
+  loosening only, so a working setup can never be failed by preflight.
+  The `NoSession` workspace-only path skips it (no agent launches). The
+  control agent (`cli/agent.go`) bypasses the ladder and got its own
+  fail-fast at its launch site.
+- **Decision — the sign-in wizard itself stays `waiting(gate_login)`.**
+  The wizard is already detected by the §9 gate engine (`gates.go` login
+  rule; the fixture IS this screen). Reclassifying a confirmed boot-time
+  `gate:login` to `failed` was considered and rejected: the gate state is
+  recoverable (`orch attach` + device-code login persists into the shared
+  CODEX_HOME), and killing the session would destroy exactly that recovery
+  path. The unrecoverable case — no credentials at all — is now caught
+  before spawn by `agent_auth`; a wizard that appears despite passing
+  preflight (expired/invalid `auth.json`) is a genuine human gate.
 
 **Rule: vocabulary drift at serialization boundaries degrades to skip+log —
 never panics, never invents a status.**

--- a/internal/agent/adapter.go
+++ b/internal/agent/adapter.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -110,6 +111,31 @@ func (c *LaunchConfig) ClaudeConfigDirEnv() []string {
 		return []string{fmt.Sprintf("CLAUDE_CONFIG_DIR=%s", configDir)}
 	}
 	return nil
+}
+
+// AuthPreflight verifies, on the execution host, that the launch config's
+// credential directory can actually authenticate the agent. Without this
+// check a codex launched with an empty CODEX_HOME parks forever at the
+// sign-in wizard while the run reports a live status (fail-fast: the launch
+// must fail with the concrete profile path instead). Only codex with an
+// explicitly configured CODEX_HOME is checked; agents using their own
+// default directories are not second-guessed. An API key in the inherited
+// environment also authenticates codex, so its presence skips the check
+// (this can only loosen the preflight, never fail a working setup).
+func AuthPreflight(cfg *LaunchConfig) error {
+	if cfg == nil || cfg.Type != AgentCodex || strings.TrimSpace(cfg.CodexHome) == "" {
+		return nil
+	}
+	home := expandHomePath(cfg.CodexHome)
+	if _, err := os.Stat(filepath.Join(home, "auth.json")); err == nil {
+		return nil
+	}
+	for _, v := range []string{"OPENAI_API_KEY", "CODEX_API_KEY"} {
+		if os.Getenv(v) != "" {
+			return nil
+		}
+	}
+	return fmt.Errorf("codex auth missing: no auth.json in CODEX_HOME %s (configured as %q) and no OPENAI_API_KEY/CODEX_API_KEY in the environment; run: CODEX_HOME=%s codex login", home, cfg.CodexHome, home)
 }
 
 // expandHomePath expands a leading ~ in a path to $HOME.

--- a/internal/agent/adapter_test.go
+++ b/internal/agent/adapter_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -164,4 +165,61 @@ func assertEnvContains(t *testing.T, env []string, want string) {
 		}
 	}
 	t.Fatalf("env missing %q in %s", want, strings.Join(env, ", "))
+}
+
+// Fail-fast law (run-state-machine.md §5 L9, launch step agent_auth): a codex
+// launch with an explicitly configured CODEX_HOME that cannot authenticate
+// must fail at preflight instead of parking at the sign-in wizard.
+func TestAuthPreflight(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("CODEX_API_KEY", "")
+
+	authed := t.TempDir()
+	if err := os.WriteFile(authed+"/auth.json", []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	empty := t.TempDir()
+
+	if err := AuthPreflight(nil); err != nil {
+		t.Fatalf("nil config must pass: %v", err)
+	}
+	if err := AuthPreflight(&LaunchConfig{Type: AgentClaude, CodexHome: empty}); err != nil {
+		t.Fatalf("non-codex agent must pass: %v", err)
+	}
+	if err := AuthPreflight(&LaunchConfig{Type: AgentCodex}); err != nil {
+		t.Fatalf("codex without configured CODEX_HOME must pass (agent default not second-guessed): %v", err)
+	}
+	if err := AuthPreflight(&LaunchConfig{Type: AgentCodex, CodexHome: authed}); err != nil {
+		t.Fatalf("codex with auth.json must pass: %v", err)
+	}
+
+	err := AuthPreflight(&LaunchConfig{Type: AgentCodex, CodexHome: empty})
+	if err == nil {
+		t.Fatal("codex with empty CODEX_HOME must fail preflight")
+	}
+	if !strings.Contains(err.Error(), empty) || !strings.Contains(err.Error(), "auth.json") {
+		t.Fatalf("preflight error must name the concrete path, got: %v", err)
+	}
+
+	// ~ expansion happens against the execution host's HOME.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	if err := os.MkdirAll(fakeHome+"/.codex/profiles/p", 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := AuthPreflight(&LaunchConfig{Type: AgentCodex, CodexHome: "~/.codex/profiles/p"}); err == nil {
+		t.Fatal("tilde CODEX_HOME without auth.json must fail preflight")
+	}
+	if err := os.WriteFile(fakeHome+"/.codex/profiles/p/auth.json", []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := AuthPreflight(&LaunchConfig{Type: AgentCodex, CodexHome: "~/.codex/profiles/p"}); err != nil {
+		t.Fatalf("tilde CODEX_HOME with auth.json must pass: %v", err)
+	}
+
+	// An API key in the environment authenticates codex without auth.json.
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	if err := AuthPreflight(&LaunchConfig{Type: AgentCodex, CodexHome: empty}); err != nil {
+		t.Fatalf("API key in env must skip the auth.json requirement: %v", err)
+	}
 }

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -365,6 +365,13 @@ func createMultiplexerSession(orchDir, projectRoot string, agentType agent.Agent
 		return fmt.Errorf("failed to create launch command: %w", err)
 	}
 
+	// The control agent bypasses the run launch ladder, so it needs its own
+	// fail-fast: a codex control agent with an empty CODEX_HOME would park
+	// at the sign-in wizard inside the new session.
+	if err := agent.AuthPreflight(launchCfg); err != nil {
+		return fmt.Errorf("control agent auth preflight failed: %w", err)
+	}
+
 	// Get working directory
 	workDir, err := os.Getwd()
 	if err != nil {

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -3957,6 +3957,14 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 		}, nil
 	}
 
+	// Fail fast before spawning anything when the configured credential dir
+	// cannot authenticate the agent (launch ladder step agent_auth). This
+	// runs on the execution host, so it stats the filesystem the agent sees.
+	if err := agent.AuthPreflight(launchCfg); err != nil {
+		s.reportLaunchProgress(st, run, launchFailed("agent_auth", err))
+		return nil, err
+	}
+
 	muxType, _ := multiplexer.ParseType(opts.Multiplexer)
 
 	var mux multiplexer.Multiplexer
@@ -4396,6 +4404,14 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 	if parseMuxErr != nil {
 		s.reportLaunchProgress(st, run, launchFailed("multiplexer", parseMuxErr))
 		return nil, fmt.Errorf("invalid multiplexer %q: %w", effectiveMux, parseMuxErr)
+	}
+
+	// Fail fast before spawning anything when the configured credential dir
+	// cannot authenticate the agent (launch ladder step agent_auth). This
+	// runs on the execution host, so it stats the filesystem the agent sees.
+	if err := agent.AuthPreflight(launchCfg); err != nil {
+		s.reportLaunchProgress(st, run, launchFailed("agent_auth", err))
+		return nil, err
 	}
 
 	var mux multiplexer.Multiplexer

--- a/internal/daemon/step_test.go
+++ b/internal/daemon/step_test.go
@@ -737,4 +737,13 @@ func TestStepLaunchFailureCarriesReason(t *testing.T) {
 	if effects[0].Kind != effectSetStatus || effects[0].Status != model.StatusFailed || effects[0].Reason != "launch_bootstrap" {
 		t.Fatalf("first effect = %+v, want failed with reason launch_bootstrap", effects[0])
 	}
+
+	// agent_auth preflight failure (fail-fast on unusable credential dir)
+	// rides the same generic ladder: failed(launch_agent_auth) + error artifact.
+	obs = runObservation{Kind: obsLaunchProgress, Launch: launchFailed("agent_auth", fmt.Errorf("codex auth missing: no auth.json"))}
+	_, effects = stepRun(view, runCore{}, obs, now)
+	if len(effects) != 3 || effects[0].Kind != effectRecordError ||
+		effects[1].Kind != effectSetStatus || effects[1].Status != model.StatusFailed || effects[1].Reason != "launch_agent_auth" {
+		t.Fatalf("agent_auth failure = %+v, want error artifact + failed(launch_agent_auth)", effects)
+	}
 }


### PR DESCRIPTION
## Incident (2026-07-10)

Six codex runs launched with a CODEX_HOME whose `auth.json` was missing (the profile dir had been renamed out from under `.orch/config.yaml`). Every codex parked at the first-run sign-in wizard; orch reported the runs as live/waiting for hours with zero signal. Issue: `codex-auth-preflight` (18ff2098, never-again).

## Change

- **`agent.AuthPreflight`**: codex with an explicitly configured CODEX_HOME must contain `auth.json` (checked after the same `~` expansion the env injection uses). An API key in the environment satisfies the check — loosening only, a working setup can never be failed. Agent-default dirs and other agents pass through.
- **New launch ladder step `agent_auth`** between `stageLaunchReady` and the spawn block, in BOTH `processStartRunCore` and `processContinueRunCore` — these execute on the worker (execution host), so the stat sees exactly the filesystem the agent will see. Failure emits `launchFailed("agent_auth")` → `failed(launch_agent_auth)` + error artifact **through the existing frozen O8 writer** (`reportLaunchProgress`); no new status-write surface, no `step()` policy change.
- **Control agent** (`cli/agent.go`) bypasses the ladder → its own fail-fast before `mux.NewSession`.
- **Law**: run-state-machine.md **D-B2** records the step + the explicit decision that the sign-in wizard itself **stays** `waiting(gate_login)` — it is already detected by the §9 gate engine and is recoverable via `orch attach` + device-code login; the unrecoverable no-credentials case is now caught before spawn.

## Verify

- `TestAuthPreflight` (agent pkg), `TestStepLaunchFailureCarriesReason` extended with `launch_agent_auth`
- `go build ./...`, agent/daemon/cli tests, `make lint` all green locally
- Manual repro: point a codex profile at an empty dir → run fails immediately with `failed(launch_agent_auth)` and the concrete path in the error artifact (previously: silent login-TUI hang)

## Routing note

Touches the launch ladder call sites (core watchlist) but only adds a step through the sanctioned frozen writer; law revision shipped in the same change set. Human review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)