### PR TITLE
feat(daemon): loopback-default TCP listener - multi-host becomes opt-in (ADR-0003)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Pick your path by what you are trying to do.
 |---|---|
 | Agents | [Claude](./agents/claude.md) · [Codex](./agents/codex.md) · [OpenCode](./agents/opencode.md) · [Gemini](./agents/gemini.md) · [Custom](./agents/custom.md) |
 | Issue backends | [File](./backends/file.md) · [GitHub](./backends/github.md) |
-| Architecture decisions | [ADR-0001: issue hex IDs](./adr/ADR-0001-issue-hex-ids.md) · [ADR-0002: worker autostart](./adr/ADR-0002-idempotent-worker-autostart.md) |
+| Architecture decisions | [ADR-0001: issue hex IDs](./adr/ADR-0001-issue-hex-ids.md) · [ADR-0002: worker autostart](./adr/ADR-0002-idempotent-worker-autostart.md) · [ADR-0003: loopback-default listen](./adr/ADR-0003-loopback-default-listen.md) |
 | Reference | [Commands](./reference/commands.md) · [Statuses](./reference/statuses.md) · [Events](./reference/events.md) · [SQL Queries](./reference/query.md) |
 
 ## Contribute to orch

--- a/docs/adr/ADR-0003-loopback-default-listen.md
+++ b/docs/adr/ADR-0003-loopback-default-listen.md
@@ -1,0 +1,47 @@
+# ADR-0003: Loopback-default TCP listener — multi-host is opt-in
+
+- Status: accepted
+- Date: 2026-07-10
+
+## Context
+
+The daemon's TCP control socket is unauthenticated: any host that can reach
+it can create/stop runs, read issues, and execute the full proto API. Until
+this ADR the daemon bound `0.0.0.0:7777` **by default**, including when an
+ordinary orch command auto-started it. A first-time user running the
+install one-liner on a laptop silently exposed an unauthenticated control
+plane to their LAN. The 2026-07-10 documentation audit flagged this as the
+top pre-publication risk; single-host users — the default audience of a
+published tool — get no benefit from the open bind.
+
+The single-host zero-config flow does not need TCP from other hosts at all:
+the ADR-0002 colocated worker registers to its local master via the
+explicit `--remote=` local path, and every opencode-server consumer (prompt
+injection, `opencode attach`, `orch models`) connects via `127.0.0.1` on
+the same host.
+
+## Decision
+
+1. `DefaultTCPListenAddr` is `127.0.0.1:7777`. The daemon (including
+   auto-started daemons) binds loopback only by default.
+2. Multi-host operation is an **explicit opt-in**: start the master with
+   `--listen tcp://0.0.0.0:7777`, or better a specific trusted interface
+   (e.g. a Tailscale address). `scripts/deploy-all.sh` — a multi-host
+   deploy by definition — passes `--listen` explicitly
+   (`MASTER_LISTEN`, default `0.0.0.0:7777`).
+3. The daemon logs a warning whenever it binds a non-loopback address,
+   naming the exposure.
+4. The opencode server is started with `--hostname 127.0.0.1` (was
+   `0.0.0.0`) — all consumers are same-host.
+
+## Consequences
+
+- Existing multi-host operators must add `--listen tcp://0.0.0.0:7777` (or
+  an interface address) to their master start command once. Workers and
+  clients are unaffected; they dial out.
+- Single-host users are unaffected functionally and no longer expose an
+  unauthenticated port.
+- SSH-tunnel-only setups now work with the default (no flag needed).
+- The TCP API remains unauthenticated; this ADR narrows the default
+  exposure but does not add authentication. An auth layer stays a
+  separate decision.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,8 +41,10 @@ orch --remote cloud ps
 orch --remote "" ps
 ```
 
-The daemon listens on `0.0.0.0:7777` by default, including when a command
-auto-starts it. Register the repository URL on the server-side daemon:
+The daemon's TCP listener binds loopback (`127.0.0.1:7777`) by default —
+remote access is an explicit opt-in: start the master with
+`--listen tcp://0.0.0.0:7777` (ADR-0003). Register the repository URL on
+the server-side daemon:
 
 ```bash
 # From client machine

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -834,7 +834,7 @@ orch daemon start
 
 | Flag | Description |
 |------|-------------|
-| `--listen <addr>` | TCP listen address for remote clients (default: `0.0.0.0:7777`) |
+| `--listen <addr>` | TCP listen address for remote clients (default: `127.0.0.1:7777` — loopback only; multi-host requires an explicit non-loopback address, e.g. `tcp://0.0.0.0:7777`, ADR-0003) |
 
 ### orch daemon kill
 

--- a/docs/remote-usage.md
+++ b/docs/remote-usage.md
@@ -12,7 +12,7 @@ identity through repo mappings.
 ```text
 Local client                         Remote host
 ┌──────────────────────────────┐      ┌────────────────────────────────────┐
-│ orch CLI / monitor           │ TCP  │ orch daemon (0.0.0.0:7777 default)│
+│ orch CLI / monitor           │ TCP  │ orch daemon (--listen opt-in)     │
 │ --remote master-host:7777    │─────▶│ repo mapping: repoid -> path      │
 └──────────────────────────────┘      └────────────────────────────────────┘
 ```
@@ -35,25 +35,26 @@ orch --version
 
 ## Server Setup
 
-### 1. Confirm or restrict the TCP listener
+### 1. Opt in to the TCP listener (multi-host is opt-in — ADR-0003)
 
-The daemon listens on `0.0.0.0:7777` by default. This also applies when an
-ordinary orch command auto-starts the daemon; `--listen` is not required to
-enable remote access.
-
-```bash
-# On remote server: starts with the default 0.0.0.0:7777 listener
-orch daemon start
-```
-
-This default exposes the orch TCP API on every network interface. Limit port
-`7777` to trusted networks with a firewall, or restart the daemon on a more
-restrictive address. For an SSH-tunnel-only setup, bind to loopback:
+By default the daemon binds `127.0.0.1:7777` (loopback only), including when
+an ordinary orch command auto-starts it. Nothing is reachable from other
+hosts until you opt in. The TCP API is **unauthenticated**: whoever can
+reach the port controls the daemon, so bind the narrowest interface that
+works and keep port `7777` limited to trusted networks (VPN/Tailscale or a
+firewall).
 
 ```bash
+# On the server that should act as master — explicit multi-host opt-in:
 orch daemon kill
-orch daemon start --listen tcp://127.0.0.1:7777
+orch daemon start --listen tcp://0.0.0.0:7777
+
+# Better: bind a specific trusted interface (e.g. the Tailscale address)
+orch daemon start --listen tcp://100.64.0.12:7777
 ```
+
+The daemon logs a warning whenever it binds a non-loopback address. For an
+SSH-tunnel-only setup, keep the loopback default and tunnel port 7777.
 
 ### 2. Register repository URL for remote resolution
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -194,8 +194,10 @@ func newDaemonStartCmd() *cobra.Command {
 		Short: "Start the daemon in the background",
 		Long: fmt.Sprintf(`Start the orch daemon in the background.
 
-The proto API listens on %s by default. Use --listen to bind it to another
-address, such as tcp://127.0.0.1:7777 for SSH-tunnel-only access.`, daemon.DefaultTCPListenAddr),
+The proto API listens on %s by default (loopback only — the API is
+unauthenticated). Multi-host use is an explicit opt-in: bind a reachable
+address with --listen, e.g. tcp://0.0.0.0:7777 or a specific trusted
+interface (ADR-0003).`, daemon.DefaultTCPListenAddr),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDaemonStart()
 		},

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -26,10 +26,14 @@ import (
 )
 
 const (
-	DefaultInterval      = 5 * time.Second
-	StallThreshold       = 60 * time.Second
-	FetchInterval        = 90 * time.Second
-	DefaultTCPListenAddr = "0.0.0.0:7777"
+	DefaultInterval = 5 * time.Second
+	StallThreshold  = 60 * time.Second
+	FetchInterval   = 90 * time.Second
+	// DefaultTCPListenAddr binds the daemon's TCP control socket to loopback
+	// only. The socket is unauthenticated, so exposing it beyond the local
+	// host is an explicit multi-host opt-in: start the master with
+	// --listen tcp://0.0.0.0:7777 (or a specific interface). ADR-0003.
+	DefaultTCPListenAddr = "127.0.0.1:7777"
 )
 
 type Daemon struct {

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -151,6 +151,21 @@ func normalizeTCPListenAddr(raw string) (string, error) {
 	return addr, nil
 }
 
+// isLoopbackListenAddr reports whether a normalized host:port listen address
+// binds only the loopback interface. An empty host (":7777") binds every
+// interface and is NOT loopback.
+func isLoopbackListenAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
 type SendRequest struct {
 	Type        string   `json:"type"`
 	IssueID     string   `json:"issue_id"`
@@ -1146,6 +1161,9 @@ func (s *SocketServer) Start() error {
 		}
 		s.tcpListener = tcpListener
 		s.logger.Printf("socket server listening on tcp://%s", tcpListener.Addr().String())
+		if !isLoopbackListenAddr(tcpAddr) {
+			s.logger.Printf("WARNING: TCP control socket bound to non-loopback %s — any host that can reach this port has full unauthenticated control of this daemon (multi-host opt-in, ADR-0003)", tcpAddr)
+		}
 		go s.acceptLoop(tcpListener)
 	}
 
@@ -1663,7 +1681,10 @@ func (s *SocketServer) startServerProcess(projectRoot string, port int) (*manage
 		return nil, fmt.Errorf("failed to create log file: %w", err)
 	}
 
-	cmd := exec.Command(opencodeBin, "serve", "--port", fmt.Sprintf("%d", port), "--hostname", "0.0.0.0")
+	// Loopback only: every consumer (prompt injection, opencode attach,
+	// orch models) connects via 127.0.0.1 on the same host, and the server
+	// is unauthenticated (ADR-0003).
+	cmd := exec.Command(opencodeBin, "serve", "--port", fmt.Sprintf("%d", port), "--hostname", "127.0.0.1")
 	cmd.Dir = projectRoot
 	repoID, err := s.repoIDForProjectRoot(projectRoot)
 	if err != nil {

--- a/internal/daemon/socket_listen_test.go
+++ b/internal/daemon/socket_listen_test.go
@@ -1,0 +1,32 @@
+package daemon
+
+import "testing"
+
+// ADR-0003: the daemon's unauthenticated TCP control socket binds loopback
+// by default; multi-host exposure is an explicit --listen opt-in.
+func TestDefaultTCPListenAddrIsLoopback(t *testing.T) {
+	if !isLoopbackListenAddr(DefaultTCPListenAddr) {
+		t.Fatalf("DefaultTCPListenAddr %q must be loopback (ADR-0003)", DefaultTCPListenAddr)
+	}
+}
+
+func TestIsLoopbackListenAddr(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1:7777", true},
+		{"localhost:7777", true},
+		{"[::1]:7777", true},
+		{"0.0.0.0:7777", false},
+		{":7777", false},            // empty host binds every interface
+		{"100.64.0.12:7777", false}, // specific non-loopback interface
+		{"[::]:7777", false},
+		{"garbage", false},
+	}
+	for _, tc := range cases {
+		if got := isLoopbackListenAddr(tc.addr); got != tc.want {
+			t.Errorf("isLoopbackListenAddr(%q) = %t, want %t", tc.addr, got, tc.want)
+		}
+	}
+}

--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -14,12 +14,16 @@ set -euo pipefail
 # Configuration (env):
 #   REMOTE_HOST     ssh host running the remote master+worker (required)
 #   MASTER_ADDR     master address the LOCAL worker connects to (default: $REMOTE_HOST:7777)
+#   MASTER_LISTEN   listen address for the remote master (default: 0.0.0.0:7777).
+#                   The daemon default is loopback-only (ADR-0003); running this
+#                   multi-host deploy script is the explicit opt-in.
 #   REMOTE_ORCH     orch binary path on the remote (default: ~/.local/bin/orch)
 #   ORCH_LOCAL_BIN  locally installed orch binary (default: ~/.local/bin/orch)
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REMOTE_HOST="${REMOTE_HOST:?set REMOTE_HOST to the ssh host of the remote master}"
 MASTER_ADDR="${MASTER_ADDR:-$REMOTE_HOST:7777}"
+MASTER_LISTEN="${MASTER_LISTEN:-0.0.0.0:7777}"
 REMOTE_ORCH="${REMOTE_ORCH:-~/.local/bin/orch}"
 ORCH_LOCAL_BIN="${ORCH_LOCAL_BIN:-$HOME/.local/bin/orch}"
 
@@ -57,7 +61,7 @@ ssh "$REMOTE_HOST" "
   $REMOTE_ORCH worker stop >/dev/null 2>&1 || true
   $REMOTE_ORCH master kill >/dev/null 2>&1 || true
   sleep 1
-  $REMOTE_ORCH master start
+  $REMOTE_ORCH master start --listen tcp://$MASTER_LISTEN
   sleep 2
   $REMOTE_ORCH worker start
 "

--- a/scripts/e2e-master-worker-client-remote-full.sh
+++ b/scripts/e2e-master-worker-client-remote-full.sh
@@ -31,7 +31,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-ssh "$REMOTE_HOST" "$ZEUS_ENV_PREFIX $ZEUS_ORCH_BIN master start" >/dev/null
+ssh "$REMOTE_HOST" "$ZEUS_ENV_PREFIX $ZEUS_ORCH_BIN master start --listen tcp://0.0.0.0:7777" >/dev/null
 ssh "$REMOTE_HOST" "$ZEUS_ENV_PREFIX $ZEUS_ORCH_BIN worker start" >/dev/null
 ssh "$REMOTE_HOST" "$ZEUS_ENV_PREFIX $ZEUS_ORCH_BIN master status"
 ssh "$REMOTE_HOST" "$ZEUS_ENV_PREFIX $ZEUS_ORCH_BIN worker status"


### PR DESCRIPTION
## Why

The daemon's TCP control socket is **unauthenticated**, yet it bound `0.0.0.0:7777` by default — including when an ordinary command auto-starts the daemon. A first-time user running the install one-liner exposed full daemon control (create/stop runs, full proto API) to their LAN. Flagged as the top pre-publication risk in the 2026-07-10 audit; decision: multi-host must be opt-in, not opt-out.

## What

- `DefaultTCPListenAddr` → `127.0.0.1:7777`. Multi-host = explicit `--listen tcp://0.0.0.0:7777` (or a specific trusted interface).
- Warning logged on any non-loopback bind, naming the exposure.
- opencode server `--hostname` → `127.0.0.1` (verified: every consumer — prompt injection, attach, models — dials `127.0.0.1` on the same host).
- `deploy-all.sh` (multi-host by definition) opts in via `MASTER_LISTEN` (default `0.0.0.0:7777`); remote e2e script opts in explicitly.
- **ADR-0003** + remote-usage.md server-setup section rewritten as opt-in + configuration.md / commands.md / help text updated.

## Zero-config single-host path verified unbroken

The ADR-0002 colocated worker registers to its local master via the explicit `--remote=` local path (worker_autostart.go:80) — no cross-host TCP involved. SSH-tunnel-only setups now work with the default (no flag).

## Migration (breaking for multi-host operators)

Add `--listen tcp://0.0.0.0:7777` (or an interface address) to the master start command once. Workers and clients dial out — unaffected. Our own zeus deploy goes through the updated `deploy-all.sh`.

## Tests

`TestDefaultTCPListenAddrIsLoopback` (regression guard), `TestIsLoopbackListenAddr` (incl. empty-host-binds-all case). Full daemon/cli/agent suites + `make lint` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)