### PR TITLE
docs: beta scope = single machine; multi-host is the next milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Orchestrator for managing multiple LLM CLIs (Claude, Codex, Gemini, OpenCode) us
 
 orch runs AI coding agents non-interactively in the background, creating isolated git worktrees for each task. Check status with `orch ps`, interact when needed with `orch attach`.
 
+> **Beta scope: single machine.** The current beta covers running orch on one
+> machine (daemon, worker, and agents all local — zero process management
+> needed). Multi-host / cluster mode (remote masters, `ORCH_REMOTE`,
+> `--on <target>`) exists in the code but is the **next milestone**: not part
+> of the beta, not yet supported.
+
 ## Install via your AI agent (one line)
 
 Paste this into your coding agent (Claude Code, Codex, OpenCode, …):
@@ -54,7 +60,7 @@ orch attach my-task
 | **[Getting Started](./docs/getting-started.md)** | Install → First issue → First run → See it work |
 | **[Agent Install Runbook](./docs/agent-install.md)** | One-liner setup executed by your own AI agent (binary + skill + guided first run) |
 | **[ローカルクイックスタート (日本語)](./docs/local-quickstart.ja.md)** | 1 台のマシンで試す最短経路(クラスタ設定なし) |
-| **[Remote Usage](./docs/remote-usage.md)** | Run orch against a remote daemon over TCP |
+| **[Remote Usage](./docs/remote-usage.md)** | Multi-host mode — next milestone, out of beta scope |
 | **[Daily Workflow](./docs/daily-workflow.md)** | Morning routine, parallel runs, reviewing PRs |
 | **[orch-monitor TUI](./docs/orch-monitor.md)** | Visual dashboard for managing issues and runs |
 | **[Core Concepts](./docs/concepts.md)** | Issue, Run, Event, Status, Worktree explained |

--- a/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
+++ b/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
@@ -6,7 +6,7 @@ description: |
   restart-from, orch worker start/status/stop, orch attach/capture/send/exec, and remote execution
   via ORCH_REMOTE and target_host. Trigger terms: orch, orchestrator, worker, master, ORCH_REMOTE,
   target_host, run management, issue management, agent runs, worktree.
-version: 1.5.0
+version: 1.5.1
 ---
 
 # Orch Toolset
@@ -29,6 +29,10 @@ worktrees, and append-only run events.
 - **Worker**: a long-lived host-local executor process that registers to a master.
 - **Execution host**: the host where the run session actually lives. `orch ps` shows this in
   the `HOST` column, and JSON output exposes it as `target_host`.
+
+Beta scope note: multi-host / remote-master operation is the NEXT MILESTONE —
+out of scope for the current beta (beta = single machine, zero process
+management). The remote knowledge below is for maintainer/cluster use.
 
 Important remote rule:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Pick your path by what you are trying to do.
 | [Daily Workflow](./daily-workflow.md) | Morning routine, parallel runs, reviewing PRs |
 | [Core Concepts](./concepts.md) | Issue, Run, Event, Status, Worktree |
 | [Configuration](./configuration.md) | All config options with examples |
-| [Remote Usage](./remote-usage.md) | Run orch against a remote daemon over TCP |
+| [Remote Usage](./remote-usage.md) | Multi-host mode — next milestone, out of beta scope |
 | [Python orch-monitor TUI](./orch-monitor.md) | Visual dashboard for issues and runs |
 
 | Details | |

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -140,4 +140,5 @@ Tell the user:
 - deeper docs: [Getting Started](./getting-started.md),
   [ローカルクイックスタート (日本語)](./local-quickstart.ja.md),
   [Daily Workflow](./daily-workflow.md), and
-  [Remote Usage](./remote-usage.md) for multi-host clusters.
+  [Remote Usage](./remote-usage.md) is the next milestone (multi-host —
+  out of scope for the current beta).

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -211,7 +211,8 @@ Two long-lived processes cooperate to execute runs:
 
 On a single machine you run both locally and never notice the split. The same
 model scales to multiple hosts: workers on other machines register to one
-daemon (see [Remote Usage](./remote-usage.md)).
+daemon (see [Remote Usage](./remote-usage.md)) — multi-host is the next
+milestone and out of scope for the current beta.
 
 ### RUN_REF
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -310,7 +310,8 @@ orch resolve my-first-issue
 ## Next steps
 
 - Learn the [core concepts](./concepts.md) (Issue, Run, Event, etc.)
-- Set up [remote usage](./remote-usage.md) for server-based orchestration
+- [Remote usage](./remote-usage.md) (multi-host) is the next milestone — out
+  of scope for the current beta
 - Configure [different agents](./agents/claude.md)
 - Set up [backend integrations](./backends/file.md) (GitHub)
 - Explore all [CLI commands](./reference/commands.md)

--- a/docs/local-quickstart.ja.md
+++ b/docs/local-quickstart.ja.md
@@ -160,6 +160,6 @@ agent は commit → push → PR 作成まで行い、run は `pr_open` であ�
 ## 6. 今回あえて使わなかったもの
 
 `client.yaml`、`ORCH_REMOTE`、`config.targets`、`--on <target>`、SSH —
-これらはすべてマルチホスト(クラスタ)運用のための構成要素で、ローカル
-テストには不要です。クラスタ構成は [Remote Usage](./remote-usage.md) を
-参照してください。
+これらはすべてマルチホスト(クラスタ)運用のための構成要素です。
+**マルチホストは次のマイルストーンで、今回の beta の対象外**です。
+beta では単機構成だけを使ってください(将来の参考: [Remote Usage](./remote-usage.md))。

--- a/docs/remote-usage.md
+++ b/docs/remote-usage.md
@@ -1,5 +1,9 @@
 # Remote Usage with orch
 
+> **Next milestone — out of beta scope.** Multi-host mode works and is used in
+> development, but the current beta covers **single-machine use only**. Expect
+> rough edges here and no support until the multi-host milestone lands.
+
 This guide shows how to run orch against a remote daemon over TCP while keeping
 the same daily `orch` workflow from your local machine.
 

--- a/internal/cli/tutorial.go
+++ b/internal/cli/tutorial.go
@@ -296,8 +296,12 @@ The Development Loop:
 Run multiple issues in parallel - each gets its own git worktree!
 
 --------------------------------------------------------------------------------
-9. REMOTE MASTER (MULTI-HOST)
+9. REMOTE MASTER (MULTI-HOST) — NEXT MILESTONE, OUT OF BETA SCOPE
 --------------------------------------------------------------------------------
+
+Multi-host mode (a shared master with workers on several machines) exists in
+the code but is the NEXT MILESTONE: it is not part of the current beta and
+not yet supported. The beta covers single-machine use only. For the curious:
 
 Point every command at a shared master daemon via client.yaml
 (global: ~/.config/orch/client.yaml, or per-repo: .orch/client.yaml):


### PR DESCRIPTION
Per maintainer decision: the beta supports single-machine use only. Multi-host / remote-master mode remains in the code (it is exercised in development and is the next milestone) but is declared out of beta scope on every beta-facing surface: README scope callout, docs table annotations, a banner on remote-usage.md, concepts/getting-started notes, the agent-install runbook, the Japanese local quickstart, embedded `orch tutorial` section 9, and the bundled skill (v1.5.1).

No code behavior changes — `ORCH_REMOTE` / `--on` keep working for maintainer cluster use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)