### PR TITLE
one-liner install points to the released runbook (release asset), not main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,7 @@ jobs:
     needs: [build-go]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -58,7 +59,12 @@ jobs:
           cd ..
       - uses: softprops/action-gh-release@v2
         with:
+          # The agent-install runbook ships with each release so the README
+          # one-liner (releases/latest/download/agent-install.md) always
+          # matches the released binary, never a moving main.
           files: |
-            orch-*
+            orch-darwin-*
+            orch-linux-*
             checksums.txt
+            docs/agent-install.md
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ orch runs AI coding agents non-interactively in the background, creating isolate
 Paste this into your coding agent (Claude Code, Codex, OpenCode, …):
 
 ```
-Fetch https://raw.githubusercontent.com/proboscis/orch/main/docs/agent-install.md and follow it exactly: install the orch binary, install the orch skill into this agent, then walk me through my first orch run interactively.
+Fetch https://github.com/proboscis/orch/releases/latest/download/agent-install.md and follow it exactly: install the orch binary, install the orch skill into this agent, then walk me through my first orch run interactively.
 ```
 
 The agent installs the binary, installs the [orch skill](./claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md)

--- a/claude-plugins/orch-toolset/README.md
+++ b/claude-plugins/orch-toolset/README.md
@@ -19,7 +19,7 @@ This skill provides Claude Code with comprehensive knowledge about using the **o
 Paste this into your coding agent (Claude Code, Codex, OpenCode, ...):
 
 ```
-Fetch https://raw.githubusercontent.com/proboscis/orch/main/docs/agent-install.md and follow it exactly: install the orch binary, install the orch skill into this agent, then walk me through my first orch run interactively.
+Fetch https://github.com/proboscis/orch/releases/latest/download/agent-install.md and follow it exactly: install the orch binary, install the orch skill into this agent, then walk me through my first orch run interactively.
 ```
 
 The [Agent Install Runbook](../../docs/agent-install.md) installs the orch


### PR DESCRIPTION
The one-line agent install in README (and the plugin README) now fetches `releases/latest/download/agent-install.md` instead of `raw/.../main/docs/agent-install.md`. Rationale: install.sh installs the latest release binary, but the runbook was read from main — after any docs-ahead-of-release commit the two could disagree (e.g. main describing worker autostart while the released binary lacked it). Shipping the runbook as a release asset makes the pair atomic, and the `latest/download` URL self-updates on every release with zero maintenance.

release.yaml: release job now checks out the repo and includes `docs/agent-install.md` in the release files; binary globs narrowed to `orch-darwin-*`/`orch-linux-*` so the checkout's `orch-monitor-tui` directory cannot match.

v1.6.1-beta gets the asset retroactively via `gh release upload` so the new URL works immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)