### PR TITLE
Docs: polish onboarding and CLI guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ orch daemon repo register "$(pwd)"   # map project identity -> this checkout
 orch issue create my-task --title "Add hello world function"
 
 # Run an agent
-orch run my-task
+orch run my-task --no-pr
 
 # Check status
 orch ps
@@ -49,6 +49,10 @@ orch ps
 # Interact when needed
 orch attach my-task
 ```
+
+`--no-pr` keeps this first exercise local when `origin` does not point to a
+real GitHub repository. Drop the flag once a real GitHub remote exists and
+`gh` is authenticated so the agent can push and open a pull request.
 
 **[Read the full Getting Started guide](./docs/getting-started.md)** —
 日本語版のローカル入門は **[ローカルクイックスタート](./docs/local-quickstart.ja.md)**。

--- a/docs/backends/file.md
+++ b/docs/backends/file.md
@@ -245,14 +245,13 @@ issues/runs/
 
 ## Migration from GitHub
 
-If you're moving from the GitHub backend to files:
-
-```bash
-# Export issues after selecting the GitHub issue backend in config (hypothetical command)
-orch issue export --output ./issues/
-
-# Or manually create issue files for each ticket
-```
+If you're moving from the GitHub backend to files, first configure the local
+backend and its `issues.path`. Then create one Markdown file for each ticket
+under `<issues.path>/issues/`, copying the issue title, status, and body into
+the frontmatter and Markdown format shown in [Issue File Format](#issue-file-format).
+When `issues.path` is omitted, use the default issues root shown in
+[Configuration](#configuration). Run `orch issue list` afterward to verify
+that orch detects every migrated issue.
 
 ## Troubleshooting
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -336,8 +336,9 @@ orch-monitor
 orch-monitor --new-control-agent
 ```
 
-Use bare `orch-monitor` for the first launch. The `--new` flag only restarts
-the layout while resuming an existing control agent session.
+Use bare `orch-monitor` for the first launch. `--new-control-agent` restarts
+both the layout and the control agent session. To restart only the layout and
+resume the saved control agent session, use `orch-monitor --new`.
 
 Features:
 - See all issues and runs at a glance

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -868,10 +868,11 @@ orch daemon status
 
 ### orch daemon repo register
 
-Register a repository URL for remote project identity mapping.
+Register a local Git checkout path for project identity mapping. The path must
+exist on the daemon host.
 
 ```bash
-orch daemon repo register REPO_URL
+orch daemon repo register "$(pwd)"
 ```
 
 ### orch daemon repo list

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -175,13 +175,6 @@ Events are typically created automatically by:
 - The monitoring daemon
 - Agent completion detection
 
-### Manual event (future)
-
-```bash
-# Planned but not yet implemented
-orch event append my-issue#20260120-163000 --type note --name comment --text "..."
-```
-
 ## Event Storage
 
 Events are stored as part of the run markdown file:

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -77,9 +77,14 @@ Mappings connect repo URL identities to daemon-managed project workspaces.`,
 
 func newDaemonRepoRegisterCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "register REPO_URL",
-		Short: "Register a repository URL for remote project identity",
-		Args:  cobra.ExactArgs(1),
+		Use:   "register PROJECT_PATH",
+		Short: "Register a local checkout path for project identity",
+		Long: `Register a local Git checkout path with the daemon.
+
+The daemon reads the checkout's origin remote to derive the project identity.
+PROJECT_PATH must exist on the daemon host.`,
+		Example: `  orch daemon repo register "$(pwd)"`,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDaemonRepoRegister(args[0])
 		},

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -92,16 +92,20 @@ func TestRunDaemonKillProjectFlagWarnsButIgnored(t *testing.T) {
 	}
 }
 
-func TestDaemonRepoRegisterCommandUsesRepoURLIdentity(t *testing.T) {
+func TestDaemonRepoRegisterCommandDocumentsProjectPath(t *testing.T) {
 	cmd := newDaemonRepoRegisterCmd()
 
-	if cmd.Use != "register REPO_URL" {
-		t.Fatalf("Use = %q, want %q", cmd.Use, "register REPO_URL")
+	if cmd.Use != "register PROJECT_PATH" {
+		t.Fatalf("Use = %q, want %q", cmd.Use, "register PROJECT_PATH")
 	}
-	if !strings.Contains(strings.ToLower(cmd.Short), "repository url") {
-		t.Fatalf("Short = %q, want repository URL guidance", cmd.Short)
+	helpText := strings.ToLower(strings.Join([]string{cmd.Short, cmd.Long, cmd.Example}, "\n"))
+	if !strings.Contains(helpText, "local checkout path") {
+		t.Fatalf("help text should describe a local checkout path, got %q", helpText)
 	}
-	if strings.Contains(strings.ToLower(cmd.Short), "project root") {
-		t.Fatalf("Short should not mention project root, got %q", cmd.Short)
+	if !strings.Contains(cmd.Example, `orch daemon repo register "$(pwd)"`) {
+		t.Fatalf("Example = %q, want a local checkout example", cmd.Example)
+	}
+	if strings.Contains(helpText, "repo_url") || strings.Contains(helpText, "repository url") {
+		t.Fatalf("help text should not describe the argument as a repository URL, got %q", helpText)
 	}
 }


### PR DESCRIPTION
## Summary

- Document `orch daemon repo register` as taking a daemon-host local `PROJECT_PATH`, including a working `$(pwd)` example, and align the command reference.
- Keep the README first run local with `--no-pr` and explain when to remove the flag.
- Replace the nonexistent file-backend export command with the real manual migration procedure and remove the unimplemented event command.
- Align the getting-started monitor restart guidance with the implemented flags.

## Acceptance evidence

- `go run ./cmd/orch daemon repo register --help` exits 0 and shows `orch daemon repo register PROJECT_PATH` plus the local checkout example.
- `git grep -n -- "orch run my-task --no-pr" README.md` finds the updated Quick Start command; the following paragraph explains GitHub remote and `gh` prerequisites.
- `git grep -n "hypothetical command"` and `git grep -n "orch event append"` both return no matches.
- `uv run --project orch-monitor-tui orch-monitor --help` exits 0 and reports `--new` as preserving the control-agent session and `--new-control-agent` as restarting it. Verified against the argparse definitions in `orch-monitor-tui/orch_monitor/__main__.py`.

## Verification

- `go build ./...`
- `go test ./... -count=1`
- `make lint`
- `go test ./internal/cli -run TestDaemonRepoRegisterCommandDocumentsProjectPath -count=1`
- `git diff --check`

## Tracking

- `docs-cli-polish-batch`