### PR TITLE
fix(agent): veto Claude spinner line as busy - stop misreading working panes as waiting

### DIFF
--- a/internal/agent/busy_test.go
+++ b/internal/agent/busy_test.go
@@ -1,0 +1,75 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The Claude Code activity spinner renders no stable keyword ("Architecting…",
+// "Pondering…", …) and some UI variants show no "esc to interrupt" hint
+// anywhere on the pane, while the composer prompt patterns below it still
+// match. Without the spinner-line veto such a pane concludes waiting while
+// the agent is demonstrably mid-task (issue claude-run-state-detection,
+// re-confirmed live 2026-07-11).
+func TestClaudeSpinnerPaneIsNotWaiting(t *testing.T) {
+	pane, err := os.ReadFile(filepath.Join("testdata", "busy", "claude_spinner_xhigh.txt"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	output := string(pane)
+
+	if !strings.Contains(output, "… (") {
+		t.Fatal("fixture lost its spinner line; re-capture a real working pane")
+	}
+	if IsWaitingForInput(output) {
+		t.Fatal("working pane with active spinner must not read as waiting")
+	}
+	if kind := DetectGate(string(AgentClaude), output); kind != "" {
+		t.Fatalf("working pane must not read as a gate, got %q", kind)
+	}
+}
+
+// Control: the same pane without its spinner line is an idle composer and
+// must keep reading as waiting — the veto must not over-suppress.
+func TestClaudeIdlePaneStillWaiting(t *testing.T) {
+	pane, err := os.ReadFile(filepath.Join("testdata", "busy", "claude_spinner_xhigh.txt"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var kept []string
+	for _, line := range strings.Split(string(pane), "\n") {
+		if isSpinnerLine(strings.ToLower(line)) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	idle := strings.Join(kept, "\n")
+	if !IsWaitingForInput(idle) {
+		t.Fatal("idle composer pane (spinner removed) must still read as waiting")
+	}
+}
+
+func TestIsSpinnerLine(t *testing.T) {
+	cases := []struct {
+		line string
+		want bool
+	}{
+		// Real frames observed live (glyph rotates per frame).
+		{"· Architecting… (2m 54s · ↓ 7.8k tokens · thinking with xhigh effort)", true},
+		{"✽ Working… (52m)", true},
+		{"  ✻ Pondering… (3s)", true},
+		// Bullet or transcript lines must not match: no "… (" marker.
+		{"· plain bullet item", false},
+		{"✽ decorative glyph without duration", false},
+		// "… (" without a spinner glyph prefix is prose, not a spinner.
+		{"the run stalled… (see logs)", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isSpinnerLine(tc.line); got != tc.want {
+			t.Errorf("isSpinnerLine(%q) = %v, want %v", tc.line, got, tc.want)
+		}
+	}
+}

--- a/internal/agent/gates.go
+++ b/internal/agent/gates.go
@@ -69,9 +69,36 @@ var busyMarkers = []string{
 	"background terminal running",
 }
 
+// claudeSpinnerGlyphs are the animation frames of Claude Code's activity
+// spinner. The spinner line ("· Architecting… (2m 54s · ↓ 7.8k tokens)")
+// carries no stable keyword — the verb rotates freely and some UI variants
+// render no "esc to interrupt" hint anywhere on the pane — so the glyph
+// prefix plus the "… (" duration marker is the invariant. Real captured
+// fixture: testdata/busy/claude_spinner_xhigh.txt (2026-07-11 incident:
+// a working Fable run concluded waiting for 2+ ticks).
+var claudeSpinnerGlyphs = []string{"· ", "✢ ", "✳ ", "✶ ", "✻ ", "✽ "}
+
+func isSpinnerLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if !strings.Contains(trimmed, "… (") {
+		return false
+	}
+	for _, glyph := range claudeSpinnerGlyphs {
+		if strings.HasPrefix(trimmed, glyph) {
+			return true
+		}
+	}
+	return false
+}
+
 func hasBusyMarker(lowerLines string) bool {
 	for _, pattern := range busyMarkers {
 		if strings.Contains(lowerLines, pattern) {
+			return true
+		}
+	}
+	for _, line := range strings.Split(lowerLines, "\n") {
+		if isSpinnerLine(line) {
 			return true
 		}
 	}

--- a/internal/agent/testdata/busy/claude_spinner_xhigh.txt
+++ b/internal/agent/testdata/busy/claude_spinner_xhigh.txt
@@ -1,0 +1,24 @@
+
+❯ ultrathink Please read 'ORCH_PROMPT.md' in the current directory and follow
+  the instructions found there.
+
+⏺ まず ORCH_PROMPT.md を読みます。
+
+  Read 2 files, listed 1 directory, ran 1 shell command
+
+⏺ 次に watchlist 表、run-state-machine §7、既存ルールの構成、対象 struct
+  を確認します。
+
+  Searching for 5 patterns, reading 9 files, listing 2 directories, running 1
+  shell command…
+  ⎿  internal/model/event.go
+
+· Architecting… (2m 54s · ↓ 7.8k tokens · thinking with xhigh effort)
+
+────────────────────────────────────────────────────────────────────────────────
+❯ 
+────────────────────────────────────────────────────────────────────────────────
+   🦣 profile  Fable 5 XHI  ▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 8% 80000/1000000
+  $2.5999 │ ⏱ 2m44s(api 2m43s) │  │ Σ in:84062 out:149
+  5h:25.0% 7d:32.0% │ ⧉ 00000000-0000-0000-0000-000000000000
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents


### PR DESCRIPTION
## Symptom (re-confirmed live 2026-07-11)

A Fable xhigh run demonstrably mid-task (spinner `· Architecting… (2m 54s · ↓ 7.8k tokens · thinking with xhigh effort)` with active tool calls) concluded `waiting` within 2 monitor ticks. Issue: `claude-run-state-detection` (reopened with this evidence).

## Root cause

The Claude Code activity spinner rotates its verb ("Architecting…", "Pondering…", …) and its glyph (`· ✢ ✳ ✶ ✻ ✽`) per frame, and some UI variants render **no `esc to interrupt` hint anywhere on the pane**. None of the existing busy markers match, while the composer prompt patterns below the spinner (`shift+tab to cycle`, `❯`) do — so `IsWaitingForInput` returns true and the L10a streak confirms `waiting` on a working run.

## Fix

The frame-invariant signature is: line starts with a spinner glyph, and the same line contains the `… (` duration marker. Added as `isSpinnerLine` inside the shared busy veto `hasBusyMarker` (gates.go), so both readings are corrected at the single choke point:

- O4b prompt reading (`IsWaitingForInput`)
- O4e gate reading (`DetectGate`)

No transition-policy change; observation vocabulary only (`step.go` untouched).

## Fixture discipline (§9 contribution contract)

Real captured pane committed as `internal/agent/testdata/busy/claude_spinner_xhigh.txt` (identifiers sanitized, spinner/prompt lines byte-identical). Tests:

- `TestClaudeSpinnerPaneIsNotWaiting` — fixture must not read waiting nor gate
- `TestClaudeIdlePaneStillWaiting` — same pane minus spinner line must still read waiting (no over-suppression)
- `TestIsSpinnerLine` — frame variants + bullet/prose non-matches

## Validation

- `go test ./internal/agent ./internal/daemon -count=1` — pass
- `go build ./...` — pass
- `make lint` — pass

Tracking issue: `claude-run-state-detection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)