### PR TITLE
Fix PR cache fetch starvation

### DIFF
--- a/internal/pr/cache.go
+++ b/internal/pr/cache.go
@@ -47,8 +47,12 @@ type cacheEntry struct {
 }
 
 type cache struct {
-	LastFetch time.Time             `json:"last_fetch"`
-	Entries   map[string]cacheEntry `json:"entries"`
+	// LastFetch is a deprecated on-disk field retained during migration.
+	// Throttling must never use this file-wide timestamp: doing so lets one hot
+	// key starve every other key in the shared cache file.
+	LastFetch      time.Time             `json:"last_fetch,omitempty"`
+	LastFetchByKey map[string]time.Time  `json:"last_fetch_by_key,omitempty"`
+	Entries        map[string]cacheEntry `json:"entries"`
 }
 
 // PopulateRunInfo populates PR URLs and returns PR info for each run's branch.
@@ -59,6 +63,10 @@ func PopulateRunInfo(runs []*model.Run) InfoMap {
 // PopulateRunInfoWithClient populates PR URLs and returns PR info for each run's
 // branch using the provided GitHub client.
 func PopulateRunInfoWithClient(client github.Client, runs []*model.Run) InfoMap {
+	return populateRunInfoWithClient(client, runs, time.Now)
+}
+
+func populateRunInfoWithClient(client github.Client, runs []*model.Run, now func() time.Time) InfoMap {
 	prInfoMap := make(InfoMap)
 	if len(runs) == 0 {
 		return prInfoMap
@@ -87,12 +95,8 @@ func PopulateRunInfoWithClient(client github.Client, runs []*model.Run) InfoMap 
 		c.Entries = make(map[string]cacheEntry)
 	}
 
-	now := time.Now()
-	applyCachedInfo(runs, c, now, prInfoMap)
-
-	if time.Since(c.LastFetch) < cacheMinFetchInterval {
-		return prInfoMap
-	}
+	currentTime := now()
+	applyCachedInfo(runs, c, currentTime, prInfoMap)
 
 	dirty := false
 	fetches := 0
@@ -105,15 +109,12 @@ func PopulateRunInfoWithClient(client github.Client, runs []*model.Run) InfoMap 
 			continue
 		}
 
-		if entry, ok := c.Entries[r.Branch]; ok {
-			if isCacheEntryFresh(entry, now) {
-				info := infoFromCacheEntry(entry)
-				if info != nil {
-					r.PRUrl = info.URL
-					prInfoMap[r.Branch] = info
-				}
-				continue
+		if info, handled := cachedInfoForLookup(c, r.Branch, currentTime); handled {
+			if info != nil {
+				r.PRUrl = info.URL
+				prInfoMap[r.Branch] = info
 			}
+			continue
 		}
 
 		if fetches >= cacheMaxFetches {
@@ -121,12 +122,18 @@ func PopulateRunInfoWithClient(client github.Client, runs []*model.Run) InfoMap 
 		}
 
 		info, err := lookupInfo(client, repoRoot, r.Branch)
-		fetchTime := time.Now()
-		c.LastFetch = fetchTime
+		fetchTime := now()
+		recordFetch(&c, r.Branch, fetchTime)
 		fetches++
 		dirty = true
 
-		if err != nil || info == nil {
+		if err != nil {
+			// Keep the last known PR state. The per-key fetch timestamp will
+			// throttle an immediate retry, which can then return this stale
+			// entry instead of degrading the result to unknown.
+			continue
+		}
+		if info == nil {
 			c.Entries[r.Branch] = cacheEntry{CheckedAt: fetchTime}
 			continue
 		}
@@ -189,10 +196,14 @@ func isCacheEntryFresh(entry cacheEntry, now time.Time) bool {
 	}
 	// Entries persisted before the pr-attach law carry no head branch and
 	// cannot answer ownership checks — treat them as stale so they refetch.
-	if entry.URL != "" && entry.HeadRefName == "" {
+	if isPreLawCacheEntry(entry) {
 		return false
 	}
 	return now.Sub(entry.CheckedAt) < cacheEntryTTL(entry)
+}
+
+func isPreLawCacheEntry(entry cacheEntry) bool {
+	return entry.URL != "" && entry.HeadRefName == ""
 }
 
 func infoFromCacheEntry(entry cacheEntry) *Info {
@@ -224,11 +235,38 @@ func saveLookupCacheEntry(c *cache, key string, info *Info, checkedAt time.Time)
 	}
 }
 
-func shouldThrottleFetch(c cache, now time.Time) bool {
-	if c.LastFetch.IsZero() {
+func recordFetch(c *cache, key string, fetchedAt time.Time) {
+	if c.LastFetchByKey == nil {
+		c.LastFetchByKey = make(map[string]time.Time)
+	}
+	c.LastFetchByKey[key] = fetchedAt
+}
+
+func shouldThrottleFetch(c cache, key string, now time.Time) bool {
+	lastFetch := c.LastFetchByKey[key]
+	if lastFetch.IsZero() {
 		return false
 	}
-	return now.Sub(c.LastFetch) < cacheMinFetchInterval
+	return now.Sub(lastFetch) < cacheMinFetchInterval
+}
+
+func cachedInfoForLookup(c cache, key string, now time.Time) (*Info, bool) {
+	entry, cached := c.Entries[key]
+	if cached && isCacheEntryFresh(entry, now) {
+		return infoFromCacheEntry(entry), true
+	}
+	if !shouldThrottleFetch(c, key, now) {
+		return nil, false
+	}
+	// Pre-law entries cannot prove PR ownership and must be refetched even if
+	// a persisted per-key timestamp would otherwise throttle the lookup.
+	if cached && isPreLawCacheEntry(entry) {
+		return nil, false
+	}
+	// A throttled lookup still has information: preserve the last known PR
+	// state instead of degrading it to an unknown result. For a cached miss,
+	// info remains nil while handled distinguishes it from a fetchable miss.
+	return infoFromCacheEntry(entry), true
 }
 
 func urlCacheKey(prURL string) string {
@@ -330,17 +368,16 @@ func LookupInfoWithClient(client github.Client, repoRoot, branch string) (*Info,
 
 	c := loadCache(cachePath)
 	now := time.Now()
-	if entry, ok := c.Entries[branch]; ok && isCacheEntryFresh(entry, now) {
-		return infoFromCacheEntry(entry), nil
-	}
-	if shouldThrottleFetch(c, now) {
-		return nil, nil
+	if cachedInfo, handled := cachedInfoForLookup(c, branch, now); handled {
+		return cachedInfo, nil
 	}
 
 	info, err := lookupInfo(client, repoRoot, branch)
 	fetchTime := time.Now()
-	c.LastFetch = fetchTime
-	saveLookupCacheEntry(&c, branch, info, fetchTime)
+	recordFetch(&c, branch, fetchTime)
+	if err == nil {
+		saveLookupCacheEntry(&c, branch, info, fetchTime)
+	}
 	saveCache(cachePath, c)
 
 	if err != nil {
@@ -367,21 +404,23 @@ func LookupInfoByURL(prURL string) (*Info, error) {
 	if err != nil {
 		return lookupInfoByURL(ghClient, prURL)
 	}
+	return lookupInfoByURLWithCache(ghClient, cachePath, prURL, time.Now)
+}
 
+func lookupInfoByURLWithCache(client github.Client, cachePath, prURL string, now func() time.Time) (*Info, error) {
 	c := loadCache(cachePath)
 	cacheKey := urlCacheKey(prURL)
-	now := time.Now()
-	if entry, ok := c.Entries[cacheKey]; ok && isCacheEntryFresh(entry, now) {
-		return infoFromCacheEntry(entry), nil
-	}
-	if shouldThrottleFetch(c, now) {
-		return nil, nil
+	currentTime := now()
+	if cachedInfo, handled := cachedInfoForLookup(c, cacheKey, currentTime); handled {
+		return cachedInfo, nil
 	}
 
-	info, err := lookupInfoByURL(ghClient, prURL)
-	fetchTime := time.Now()
-	c.LastFetch = fetchTime
-	saveLookupCacheEntry(&c, cacheKey, info, fetchTime)
+	info, err := lookupInfoByURL(client, prURL)
+	fetchTime := now()
+	recordFetch(&c, cacheKey, fetchTime)
+	if err == nil {
+		saveLookupCacheEntry(&c, cacheKey, info, fetchTime)
+	}
 	saveCache(cachePath, c)
 
 	if err != nil {

--- a/internal/pr/cache_test.go
+++ b/internal/pr/cache_test.go
@@ -12,6 +12,7 @@ import (
 type fakeGitHubClient struct {
 	available bool
 	output    []byte
+	outputs   [][]byte
 	err       error
 
 	lastDir   string
@@ -23,17 +24,24 @@ func (f *fakeGitHubClient) IsAvailable() bool {
 	return f.available
 }
 
-func (f *fakeGitHubClient) Run(args ...string) ([]byte, error) {
+func (f *fakeGitHubClient) nextOutput() []byte {
+	callIndex := f.callCount
 	f.callCount++
+	if callIndex < len(f.outputs) {
+		return f.outputs[callIndex]
+	}
+	return f.output
+}
+
+func (f *fakeGitHubClient) Run(args ...string) ([]byte, error) {
 	f.lastArgs = append([]string(nil), args...)
-	return f.output, f.err
+	return f.nextOutput(), f.err
 }
 
 func (f *fakeGitHubClient) RunInDir(dir string, args ...string) ([]byte, error) {
-	f.callCount++
 	f.lastDir = dir
 	f.lastArgs = append([]string(nil), args...)
-	return f.output, f.err
+	return f.nextOutput(), f.err
 }
 
 func TestLookupInfoWithClient_UsesInjectedClient(t *testing.T) {
@@ -121,7 +129,7 @@ func TestPopulateRunInfo_RespectsMaxFetches(t *testing.T) {
 	}
 }
 
-func TestPopulateRunInfo_RespectsMinFetchInterval(t *testing.T) {
+func TestPopulateRunInfo_SameKeyCacheHitSkipsFetch(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 
 	client := &fakeGitHubClient{
@@ -137,13 +145,234 @@ func TestPopulateRunInfo_RespectsMinFetchInterval(t *testing.T) {
 	firstCallCount := client.callCount
 
 	runs2 := []*model.Run{
-		{IssueID: "test", RunID: "run-2", Branch: "branch-b"},
+		{IssueID: "test", RunID: "run-2", Branch: "branch-a"},
 	}
 	PopulateRunInfoWithClient(client, runs2)
 
 	if client.callCount != firstCallCount {
 		t.Fatalf("expected 0 additional API calls within cacheMinFetchInterval, got %d",
 			client.callCount-firstCallCount)
+	}
+}
+
+func TestShouldThrottleFetch_IsScopedPerKey(t *testing.T) {
+	now := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	c := cache{
+		// A recent legacy file-wide timestamp must not throttle any key.
+		LastFetch: now,
+		LastFetchByKey: map[string]time.Time{
+			"recent": now.Add(-cacheMinFetchInterval + time.Second),
+			"ready":  now.Add(-cacheMinFetchInterval),
+		},
+	}
+
+	if !shouldThrottleFetch(c, "recent", now) {
+		t.Fatal("same key must be throttled within cacheMinFetchInterval")
+	}
+	if shouldThrottleFetch(c, "ready", now) {
+		t.Fatal("same key must be fetchable at cacheMinFetchInterval")
+	}
+	if shouldThrottleFetch(c, "other", now) {
+		t.Fatal("one key's fetch must not throttle a different key")
+	}
+}
+
+func TestLookupInfoByURL_ExpiredKeysDoNotStarveEachOther(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	now := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	nowFunc := func() time.Time { return now }
+	cachePath, err := getCachePath(globalURLCacheScope)
+	if err != nil {
+		t.Fatalf("getCachePath: %v", err)
+	}
+
+	urls := []string{
+		"https://github.com/acme/repo/pull/101",
+		"https://github.com/acme/repo/pull/102",
+		"https://github.com/acme/repo/pull/103",
+	}
+	entries := make(map[string]cacheEntry, len(urls))
+	for i, prURL := range urls {
+		entries[urlCacheKey(prURL)] = cacheEntry{
+			URL:         prURL,
+			Number:      101 + i,
+			State:       "OPEN",
+			HeadRefName: fmt.Sprintf("feature/%d", 101+i),
+			CheckedAt:   now.Add(-cacheHitActiveTTL - time.Second),
+		}
+	}
+	saveCache(cachePath, cache{
+		// Under the old file-wide throttle, only the first key would fetch:
+		// its fetch moved LastFetch to now and blocked the remaining keys.
+		LastFetch: now.Add(-cacheMinFetchInterval),
+		Entries:   entries,
+	})
+
+	client := &fakeGitHubClient{
+		available: true,
+		outputs: [][]byte{
+			[]byte(`{"url":"https://github.com/acme/repo/pull/101","number":101,"state":"OPEN","headRefName":"feature/101"}`),
+			[]byte(`{"url":"https://github.com/acme/repo/pull/102","number":102,"state":"OPEN","headRefName":"feature/102"}`),
+			[]byte(`{"url":"https://github.com/acme/repo/pull/103","number":103,"state":"OPEN","headRefName":"feature/103"}`),
+		},
+	}
+	for _, prURL := range urls {
+		info, lookupErr := lookupInfoByURLWithCache(client, cachePath, prURL, nowFunc)
+		if lookupErr != nil {
+			t.Fatalf("lookupInfoByURLWithCache(%q): %v", prURL, lookupErr)
+		}
+		if info == nil {
+			t.Fatalf("lookupInfoByURLWithCache(%q) returned nil", prURL)
+		}
+		if info.URL != prURL {
+			t.Fatalf("lookupInfoByURLWithCache(%q) returned URL %q", prURL, info.URL)
+		}
+	}
+
+	if client.callCount != len(urls) {
+		t.Fatalf("expected every expired key to fetch once; got %d calls for %d keys", client.callCount, len(urls))
+	}
+	stored := loadCache(cachePath)
+	for _, prURL := range urls {
+		key := urlCacheKey(prURL)
+		if got := stored.LastFetchByKey[key]; !got.Equal(now) {
+			t.Errorf("LastFetchByKey[%q] = %v, want %v", key, got, now)
+		}
+	}
+}
+
+func TestPopulateRunInfo_ExpiredBranchesDoNotStarveEachOther(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	repoRoot, err := git.FindMainRepoRoot("")
+	if err != nil {
+		t.Skip("no git repo root available")
+	}
+	now := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	cachePath, err := getCachePath(repoRoot)
+	if err != nil {
+		t.Fatalf("getCachePath: %v", err)
+	}
+
+	branches := []string{"feature/301", "feature/302", "feature/303"}
+	entries := make(map[string]cacheEntry, len(branches))
+	runs := make([]*model.Run, len(branches))
+	for i, branch := range branches {
+		entries[branch] = cacheEntry{
+			URL:         fmt.Sprintf("https://github.com/acme/repo/pull/%d", 301+i),
+			Number:      301 + i,
+			State:       "OPEN",
+			HeadRefName: branch,
+			CheckedAt:   now.Add(-cacheHitActiveTTL - time.Second),
+		}
+		runs[i] = &model.Run{IssueID: "test", RunID: model.RunID(fmt.Sprintf("run-%d", i)), Branch: branch}
+	}
+	saveCache(cachePath, cache{
+		LastFetch: now.Add(-cacheMinFetchInterval),
+		Entries:   entries,
+	})
+
+	client := &fakeGitHubClient{
+		available: true,
+		outputs: [][]byte{
+			[]byte(`[{"url":"https://github.com/acme/repo/pull/301","number":301,"state":"OPEN","headRefName":"feature/301"}]`),
+			[]byte(`[{"url":"https://github.com/acme/repo/pull/302","number":302,"state":"OPEN","headRefName":"feature/302"}]`),
+			[]byte(`[{"url":"https://github.com/acme/repo/pull/303","number":303,"state":"OPEN","headRefName":"feature/303"}]`),
+		},
+	}
+	infoMap := populateRunInfoWithClient(client, runs, func() time.Time { return now })
+
+	if client.callCount != len(branches) {
+		t.Fatalf("expected every expired branch to fetch once; got %d calls for %d keys", client.callCount, len(branches))
+	}
+	for _, branch := range branches {
+		if infoMap[branch] == nil {
+			t.Errorf("missing refreshed info for branch %q", branch)
+		}
+	}
+}
+
+func TestLookupInfoByURL_ThrottleReturnsStaleEntry(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	now := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	cachePath, err := getCachePath(globalURLCacheScope)
+	if err != nil {
+		t.Fatalf("getCachePath: %v", err)
+	}
+	prURL := "https://github.com/acme/repo/pull/201"
+	key := urlCacheKey(prURL)
+	saveCache(cachePath, cache{
+		Entries: map[string]cacheEntry{
+			key: {
+				URL:         prURL,
+				Number:      201,
+				State:       "OPEN",
+				HeadRefName: "feature/201",
+				CheckedAt:   now.Add(-cacheHitActiveTTL - time.Second),
+			},
+		},
+	})
+
+	client := &fakeGitHubClient{available: true, err: fmt.Errorf("GitHub unavailable")}
+	info, err := lookupInfoByURLWithCache(client, cachePath, prURL, func() time.Time { return now })
+	if err == nil {
+		t.Fatal("first stale lookup must report the fetch error")
+	}
+	if info != nil {
+		t.Fatalf("failed fetch returned unexpected info: %#v", info)
+	}
+
+	// The failed attempt is now throttled for this key. It must retain and
+	// return the prior OPEN state rather than looking like a cache miss.
+	info, err = lookupInfoByURLWithCache(client, cachePath, prURL, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("lookupInfoByURLWithCache: %v", err)
+	}
+	if info == nil || info.State != "OPEN" || info.Number != 201 {
+		t.Fatalf("expected stale OPEN entry while throttled, got %#v", info)
+	}
+	if client.callCount != 1 {
+		t.Fatalf("throttled lookup made an additional API call; total = %d, want 1", client.callCount)
+	}
+}
+
+func TestLookupInfoByURL_PreLawEntryBypassesThrottle(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	now := time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC)
+	cachePath, err := getCachePath(globalURLCacheScope)
+	if err != nil {
+		t.Fatalf("getCachePath: %v", err)
+	}
+	prURL := "https://github.com/acme/repo/pull/401"
+	key := urlCacheKey(prURL)
+	saveCache(cachePath, cache{
+		LastFetchByKey: map[string]time.Time{key: now.Add(-time.Second)},
+		Entries: map[string]cacheEntry{
+			key: {
+				URL:       prURL,
+				Number:    401,
+				State:     "OPEN",
+				CheckedAt: now.Add(-time.Second),
+			},
+		},
+	})
+
+	client := &fakeGitHubClient{
+		available: true,
+		output:    []byte(`{"url":"https://github.com/acme/repo/pull/401","number":401,"state":"OPEN","headRefName":"feature/401"}`),
+	}
+	info, err := lookupInfoByURLWithCache(client, cachePath, prURL, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("lookupInfoByURLWithCache: %v", err)
+	}
+	if info == nil || info.HeadRefName != "feature/401" {
+		t.Fatalf("expected pre-law entry to be refetched with head branch, got %#v", info)
+	}
+	if client.callCount != 1 {
+		t.Fatalf("pre-law entry made %d API calls, want 1", client.callCount)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace the shared cache-file fetch gate with persisted per-key fetch timestamps for both URL and branch cache keys.
- Return the stale cached PR state when the same key is throttled, while preserving explicit errors on the failed refresh attempt.
- Keep pre-pr-attach-law entries uncacheable until HeadRefName is refetched.

## Acceptance criteria evidence

- Per-key throttling: TestShouldThrottleFetch_IsScopedPerKey passed and verifies the 30-second boundary plus independence between keys.
- Starvation regression (URL): TestLookupInfoByURL_ExpiredKeysDoNotStarveEachOther passed with three simultaneously expired URL keys; all three fetched in the same fixed-time window.
- Starvation regression (branch): TestPopulateRunInfo_ExpiredBranchesDoNotStarveEachOther passed with three simultaneously expired branch keys; all three fetched in the same fixed-time window.
- Throttled stale state: TestLookupInfoByURL_ThrottleReturnsStaleEntry passed; a failed refresh is reported once, then the throttled call returns the previous OPEN state without another API call.
- PR #509 behavior: TestLookupInfoByURL_PreLawEntryBypassesThrottle and TestPreLawCacheEntryIsStale passed, so entries without HeadRefName still refetch.
- Scope: only internal/pr/cache.go and internal/pr/cache_test.go changed; no daemon status writers, round-robin queue, or batch lookup were added.

## Verification

- go test -count=1 -v ./internal/pr -run acceptance-regression-selection — PASS (5/5)
- go test -race ./internal/pr — PASS
- go test ./... — PASS, including test/integration
- go build ./... — PASS
- make lint — PASS, 0 architecture findings on internal sources

Reference: pr-cache-fetch-starvation