### PR TITLE
Propagate daemon error causes

### DIFF
--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -150,9 +150,15 @@ func runAttachWithDeps(refStr string, opts *attachOptions, deps *attachDeps) err
 	if cfg != nil {
 		muxSetting = cfg.AgentMultiplexer
 	}
-	muxType, _ := deps.parseMuxType(muxSetting)
+	muxType, err := deps.parseMuxType(muxSetting)
+	if err != nil {
+		return fmt.Errorf("invalid agent_multiplexer %q: %w", muxSetting, err)
+	}
 	if info.Multiplexer != "" {
-		muxType, _ = deps.parseMuxType(string(info.Multiplexer))
+		muxType, err = deps.parseMuxType(string(info.Multiplexer))
+		if err != nil {
+			return fmt.Errorf("invalid multiplexer %q for run %s#%s: %w", info.Multiplexer, info.IssueID, info.RunID, err)
+		}
 	}
 
 	var mux attachSessionMux

--- a/internal/cli/attach_test.go
+++ b/internal/cli/attach_test.go
@@ -195,6 +195,49 @@ func TestRunAttachWithDeps_NoMultiplexerExits(t *testing.T) {
 	}
 }
 
+func TestRunAttachWithDeps_InvalidConfiguredMultiplexerFails(t *testing.T) {
+	api := &mockAttachAPI{
+		cfg: &orchapi.Config{AgentMultiplexer: "screen"},
+		info: &orchapi.AttachInfo{
+			IssueID:       "orch-4",
+			RunID:         "20260101-040405",
+			Agent:         "claude",
+			SessionExists: true,
+		},
+	}
+	deps, _, exitCodes := newAttachDepsForTest(api)
+
+	err := runAttachWithDeps("orch-4#20260101-040405", &attachOptions{}, deps)
+	if err == nil || !strings.Contains(err.Error(), "invalid agent_multiplexer") || !strings.Contains(err.Error(), "screen") {
+		t.Fatalf("runAttachWithDeps() error = %v, want invalid agent_multiplexer with configured value", err)
+	}
+	if len(*exitCodes) != 0 {
+		t.Fatalf("exit codes = %v, want none", *exitCodes)
+	}
+}
+
+func TestRunAttachWithDeps_InvalidRunMultiplexerFails(t *testing.T) {
+	api := &mockAttachAPI{
+		cfg: &orchapi.Config{AgentMultiplexer: "tmux"},
+		info: &orchapi.AttachInfo{
+			IssueID:       "orch-4",
+			RunID:         "20260101-040406",
+			Agent:         "claude",
+			SessionExists: true,
+			Multiplexer:   orchapi.Multiplexer("screen"),
+		},
+	}
+	deps, _, exitCodes := newAttachDepsForTest(api)
+
+	err := runAttachWithDeps("orch-4#20260101-040406", &attachOptions{}, deps)
+	if err == nil || !strings.Contains(err.Error(), "invalid multiplexer") || !strings.Contains(err.Error(), "screen") {
+		t.Fatalf("runAttachWithDeps() error = %v, want invalid run multiplexer with stored value", err)
+	}
+	if len(*exitCodes) != 0 {
+		t.Fatalf("exit codes = %v, want none", *exitCodes)
+	}
+}
+
 func TestAttachOpenCodeFromInfoWithExecutor_NoServerOrSession(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	code, err := attachOpenCodeFromInfoWithExecutor(&orchapi.AttachInfo{

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -582,6 +582,19 @@ func (s *SocketServer) repoContextForStore(st store.Store) *RepoContext {
 	return nil
 }
 
+func (s *SocketServer) storeOperationError(st store.Store, projectID, operation string, err error) string {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		if repo := s.repoContextForStore(st); repo != nil {
+			projectID = strings.TrimSpace(repo.RepoID)
+		}
+	}
+	if projectID == "" {
+		projectID = "<unknown>"
+	}
+	return fmt.Sprintf("store %s failed for project %q: %v", operation, projectID, err)
+}
+
 func (s *SocketServer) resolveProtoRun(ctx *orchpb.RequestContext, issueID, runID string) (*resolvedProtoRun, *orchpb.Response) {
 	ref := &model.RunRef{IssueID: model.IssueID(issueID), RunID: model.RunID(runID)}
 	projectID := projectIDFromContext(ctx)
@@ -615,13 +628,13 @@ func (s *SocketServer) resolveProtoRun(ctx *orchpb.RequestContext, issueID, runI
 			if isStoreNotFoundError(err) {
 				continue
 			}
-			return nil, errorResponse("store_error")
+			return nil, errorResponse(s.storeOperationError(st, "", "run lookup", err))
 		}
 		if run == nil {
 			continue
 		}
 		if resolved != nil {
-			return nil, errorResponse("ambiguous_run_ref")
+			return nil, errorResponse(fmt.Sprintf("ambiguous run ref: %s#%s", issueID, runID))
 		}
 		repo := s.repoContextForStore(st)
 		projectID := ""
@@ -699,7 +712,7 @@ func (s *SocketServer) resolveWaitRunTarget(ctx *orchpb.RequestContext, ref stri
 			if isAmbiguousRunLookupError(err) {
 				return nil, errorResponse(fmt.Sprintf("ambiguous run ref: %s", strings.TrimSpace(ref)))
 			}
-			return nil, errorResponse("store_error")
+			return nil, errorResponse(s.storeOperationError(st, projectID, "run lookup", err))
 		}
 		return &waitRunTarget{ref: strings.TrimSpace(ref), run: run, store: st}, nil
 	}
@@ -714,7 +727,7 @@ func (s *SocketServer) resolveWaitRunTarget(ctx *orchpb.RequestContext, ref stri
 			if isAmbiguousRunLookupError(err) {
 				return nil, errorResponse(fmt.Sprintf("ambiguous run ref: %s", strings.TrimSpace(ref)))
 			}
-			return nil, errorResponse("store_error")
+			return nil, errorResponse(s.storeOperationError(st, "", "run lookup", err))
 		}
 		if run == nil {
 			continue
@@ -881,7 +894,7 @@ func (s *SocketServer) handleProtoListRuns(req *orchpb.ListRunsRequest) *orchpb.
 		if err != nil {
 			storeDuration := time.Since(storeStart)
 			s.maybeLogListRunsTiming(req, 0, storeDuration, 0, time.Since(requestStart), err)
-			return errorResponse("store_error")
+			return errorResponse(s.storeOperationError(st, projectID, "list runs", err))
 		}
 		for _, run := range runs {
 			entries = append(entries, runStoreEntry{run: run, store: st})
@@ -892,7 +905,7 @@ func (s *SocketServer) handleProtoListRuns(req *orchpb.ListRunsRequest) *orchpb.
 			if err != nil {
 				storeDuration := time.Since(storeStart)
 				s.maybeLogListRunsTiming(req, 0, storeDuration, 0, time.Since(requestStart), err)
-				return errorResponse("store_error")
+				return errorResponse(s.storeOperationError(st, "", "list runs", err))
 			}
 			for _, run := range runs {
 				entries = append(entries, runStoreEntry{run: run, store: st})
@@ -1109,10 +1122,13 @@ func (s *SocketServer) applyRunLiveness(runs []*model.Run, protoRuns []*orchpb.R
 	}
 }
 
-func enrichRunProto(pr *orchpb.Run, run *model.Run, runner git.Runner) {
+func enrichRunProto(pr *orchpb.Run, run *model.Run, runner git.Runner) error {
 	if run.WorktreePath != "" && run.Branch != "" {
 		pr.BranchState = computeBranchState(run.WorktreePath, run.Branch, "main", runner)
-		stats := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
+		stats, err := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
+		if err != nil {
+			return err
+		}
 		if stats.Additions > 0 || stats.Deletions > 0 || stats.FilesChanged > 0 {
 			pr.DiffStats = &orchpb.DiffStats{
 				Additions:    int32(stats.Additions),
@@ -1124,6 +1140,16 @@ func enrichRunProto(pr *orchpb.Run, run *model.Run, runner git.Runner) {
 	}
 	pr.ElapsedDisplay = formatElapsedTime(run.StartedAt, run.UpdatedAt, run.Status)
 	populateRunDisplayFields(pr)
+	return nil
+}
+
+func (s *SocketServer) enrichRunProtoForResponse(pr *orchpb.Run, run *model.Run) error {
+	if s.runRequiresWorkerDelegation(run, "") {
+		pr.ElapsedDisplay = formatElapsedTime(run.StartedAt, run.UpdatedAt, run.Status)
+		populateRunDisplayFields(pr)
+		return nil
+	}
+	return enrichRunProto(pr, run, s.gitRunner)
 }
 
 func enrichRunsParallel(runs []*model.Run, protoRuns []*orchpb.Run) ([]*orchpb.Run, error) {
@@ -1272,7 +1298,7 @@ func (s *SocketServer) handleProtoWaitForRuns(req *orchpb.WaitForRunsRequest) *o
 				if isStoreNotFoundError(err) {
 					return errorResponse(fmt.Sprintf("run not found: %s", target.ref))
 				}
-				return errorResponse("store_error")
+				return errorResponse(s.storeOperationError(target.store, "", "run refresh", err))
 			}
 			if current == nil {
 				return errorResponse(fmt.Sprintf("run not found: %s", target.ref))
@@ -1331,13 +1357,13 @@ func (s *SocketServer) handleProtoGetRun(req *orchpb.GetRunRequest) *orchpb.Resp
 				if isStoreNotFoundError(err) {
 					continue
 				}
-				return errorResponse("store_error")
+				return errorResponse(s.storeOperationError(st, "", "run lookup", err))
 			}
 			if resolved == nil {
 				continue
 			}
 			if run != nil {
-				return errorResponse("ambiguous_run_ref")
+				return errorResponse(fmt.Sprintf("ambiguous run ref: %s#%s", req.IssueId, req.RunId))
 			}
 			run = resolved
 		}
@@ -1355,7 +1381,9 @@ func (s *SocketServer) handleProtoGetRun(req *orchpb.GetRunRequest) *orchpb.Resp
 	if err != nil {
 		return errorResponse(err.Error())
 	}
-	enrichRunProto(pr, run, s.gitRunner)
+	if err := s.enrichRunProtoForResponse(pr, run); err != nil {
+		return errorResponse(err.Error())
+	}
 	s.applyRunLiveness([]*model.Run{run}, []*orchpb.Run{pr})
 
 	return &orchpb.Response{
@@ -1923,14 +1951,14 @@ func (s *SocketServer) handleProtoListIssues(req *orchpb.ListIssuesRequest) *orc
 
 		list, err := st.ListIssues()
 		if err != nil {
-			return errorResponse("store_error")
+			return errorResponse(s.storeOperationError(st, projectID, "list issues", err))
 		}
 		issues = append(issues, list...)
 	} else {
 		for _, st := range s.listStores() {
 			list, err := st.ListIssues()
 			if err != nil {
-				return errorResponse("store_error")
+				return errorResponse(s.storeOperationError(st, "", "list issues", err))
 			}
 			issues = append(issues, list...)
 		}
@@ -2071,7 +2099,7 @@ func (s *SocketServer) handleProtoGetIssue(req *orchpb.GetIssueRequest) *orchpb.
 				if isStoreNotFoundError(err) {
 					continue
 				}
-				return errorResponse("store_error")
+				return errorResponse(s.storeOperationError(st, "", "issue lookup", err))
 			}
 			if resolved == nil {
 				continue
@@ -2264,9 +2292,9 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 						continue
 					}
 					if strings.Contains(strings.ToLower(err.Error()), "ambiguous") {
-						return errorResponse("ambiguous_short_id")
+						return errorResponse(fmt.Sprintf("ambiguous short id: %s", req.ShortId))
 					}
-					return errorResponse("store_error")
+					return errorResponse(s.storeOperationError(st, "", "short run lookup", err))
 				}
 			} else {
 				ref := &model.RunRef{IssueID: model.IssueID(req.IssueId), RunID: model.RunID(req.RunId)}
@@ -2275,7 +2303,7 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 					if isStoreNotFoundError(err) {
 						continue
 					}
-					return errorResponse("store_error")
+					return errorResponse(s.storeOperationError(st, "", "run lookup", err))
 				}
 			}
 
@@ -2284,9 +2312,9 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 			}
 			if run != nil {
 				if req.ShortId != "" {
-					return errorResponse("ambiguous_short_id")
+					return errorResponse(fmt.Sprintf("ambiguous short id: %s", req.ShortId))
 				}
-				return errorResponse("ambiguous_run_ref")
+				return errorResponse(fmt.Sprintf("ambiguous run ref: %s#%s", req.IssueId, req.RunId))
 			}
 			run = resolved
 		}
@@ -2335,9 +2363,15 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 			}
 		}
 	} else if attachInfo.TargetHost == "" {
-		muxType, _ := multiplexer.ParseType(run.Multiplexer)
-		mux, _ := multiplexer.GetMultiplexer(muxType)
-		if mux != nil && !mux.HasSession(sessionName) {
+		muxType, err := multiplexer.ParseType(run.Multiplexer)
+		if err != nil {
+			return errorResponse(fmt.Sprintf("invalid multiplexer type %q for run %s#%s: %v", run.Multiplexer, run.IssueID, run.RunID, err))
+		}
+		mux, err := multiplexer.GetMultiplexer(muxType)
+		if err != nil {
+			return errorResponse(fmt.Sprintf("multiplexer %q unavailable for run %s#%s: %v", muxType, run.IssueID, run.RunID, err))
+		}
+		if !mux.HasSession(sessionName) {
 			return &orchpb.Response{
 				Ok:    false,
 				Error: "session_not_found",
@@ -2570,7 +2604,10 @@ func (s *SocketServer) handleProtoGetDiffStats(req *orchpb.GetDiffStatsRequest) 
 		}
 	}
 
-	stats := git.GetDiffStats(runCtx.run.WorktreePath, runCtx.run.Branch, "main")
+	stats, err := git.GetDiffStats(runCtx.run.WorktreePath, runCtx.run.Branch, "main")
+	if err != nil {
+		return errorResponse(err.Error())
+	}
 
 	return &orchpb.Response{
 		Ok: true,
@@ -3076,15 +3113,15 @@ func (s *SocketServer) handleProtoGetRunByShortID(req *orchpb.GetRunByShortIDReq
 					continue
 				}
 				if strings.Contains(strings.ToLower(err.Error()), "ambiguous") {
-					return errorResponse("ambiguous_short_id")
+					return errorResponse(fmt.Sprintf("ambiguous short id: %s", req.ShortId))
 				}
-				return errorResponse("store_error")
+				return errorResponse(s.storeOperationError(st, "", "short run lookup", err))
 			}
 			if resolved == nil {
 				continue
 			}
 			if run != nil {
-				return errorResponse("ambiguous_short_id")
+				return errorResponse(fmt.Sprintf("ambiguous short id: %s", req.ShortId))
 			}
 			run = resolved
 		}
@@ -3097,7 +3134,9 @@ func (s *SocketServer) handleProtoGetRunByShortID(req *orchpb.GetRunByShortIDReq
 	if err != nil {
 		return errorResponse(err.Error())
 	}
-	enrichRunProto(pr, run, s.gitRunner)
+	if err := s.enrichRunProtoForResponse(pr, run); err != nil {
+		return errorResponse(err.Error())
+	}
 
 	protoEvents := make([]*orchpb.Event, len(run.Events))
 	for i, e := range run.Events {
@@ -3587,9 +3626,9 @@ func (s *SocketServer) handleProtoReadAgentPrompt(req *orchpb.ReadAgentPromptReq
 						continue
 					}
 					if strings.Contains(strings.ToLower(err.Error()), "ambiguous") {
-						return errorResponse("ambiguous_short_id")
+						return errorResponse(fmt.Sprintf("ambiguous short id: %s", req.ShortId))
 					}
-					return errorResponse(fmt.Sprintf("run lookup failed: %v", err))
+					return errorResponse(s.storeOperationError(candidateStore, "", "short run lookup", err))
 				}
 			} else {
 				ref := &model.RunRef{IssueID: model.IssueID(req.IssueId), RunID: model.RunID(req.RunId)}
@@ -3607,9 +3646,9 @@ func (s *SocketServer) handleProtoReadAgentPrompt(req *orchpb.ReadAgentPromptReq
 			}
 			if run != nil {
 				if req.ShortId != "" {
-					return errorResponse("ambiguous_short_id")
+					return errorResponse(fmt.Sprintf("ambiguous short id: %s", req.ShortId))
 				}
-				return errorResponse("ambiguous_run_ref")
+				return errorResponse(fmt.Sprintf("ambiguous run ref: %s#%s", req.IssueId, req.RunId))
 			}
 			run = resolved
 			st = candidateStore

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -3101,6 +3101,7 @@ func (s *SocketServer) handleListRuns(req SendRequest, encoder *json.Encoder) {
 
 	// If --all flag is set, aggregate runs from all repos
 	var runs []*model.Run
+	var selectedStore store.Store
 	if req.All {
 		runs, err = s.listAllRepoRuns(req)
 	} else {
@@ -3109,6 +3110,7 @@ func (s *SocketServer) handleListRuns(req SendRequest, encoder *json.Encoder) {
 			encoder.Encode(ListRunsResponse{OK: false, Error: "no store available"})
 			return
 		}
+		selectedStore = st
 		filter := &store.ListRunsFilter{
 			IssueID:    model.IssueID(req.IssueID),
 			Agent:      req.Agent,
@@ -3129,7 +3131,11 @@ func (s *SocketServer) handleListRuns(req SendRequest, encoder *json.Encoder) {
 
 	if err != nil {
 		s.logger.Printf("error listing runs: %v", err)
-		encoder.Encode(ListRunsResponse{OK: false, Error: "store_error"})
+		errorMessage := err.Error()
+		if selectedStore != nil {
+			errorMessage = s.storeOperationError(selectedStore, req.RepoID, "list runs", err)
+		}
+		encoder.Encode(ListRunsResponse{OK: false, Error: errorMessage})
 		return
 	}
 
@@ -3151,7 +3157,12 @@ func (s *SocketServer) handleListRuns(req SendRequest, encoder *json.Encoder) {
 
 	summaries := make([]*RunSummary, len(paginatedRuns))
 	for i, run := range paginatedRuns {
-		summaries[i] = RunToSummaryWithAlive(run, computeAlive)
+		summary, err := RunToSummaryWithAlive(run, computeAlive)
+		if err != nil {
+			encoder.Encode(ListRunsResponse{OK: false, Error: err.Error()})
+			return
+		}
+		summaries[i] = summary
 	}
 
 	var nextCursor *string
@@ -3195,7 +3206,7 @@ func (s *SocketServer) listAllRepoRuns(req SendRequest) ([]*model.Run, error) {
 		}
 		runs, err := st.ListRuns(filter)
 		if err != nil {
-			return nil, err
+			return nil, errors.New(s.storeOperationError(st, "", "list runs", err))
 		}
 		allRuns = append(allRuns, runs...)
 	}
@@ -3226,6 +3237,7 @@ func (s *SocketServer) handleListIssues(req SendRequest, encoder *json.Encoder) 
 	}
 
 	var issues []*model.Issue
+	var selectedStore store.Store
 	if s.githubBackend != nil {
 		issues, err = s.githubBackend.ListFromCache()
 	} else {
@@ -3234,11 +3246,16 @@ func (s *SocketServer) handleListIssues(req SendRequest, encoder *json.Encoder) 
 			encoder.Encode(ListIssuesResponse{OK: false, Error: "no store available"})
 			return
 		}
+		selectedStore = st
 		issues, err = st.ListIssues()
 	}
 	if err != nil {
 		s.logger.Printf("error listing issues: %v", err)
-		encoder.Encode(ListIssuesResponse{OK: false, Error: "store_error"})
+		errorMessage := fmt.Sprintf("github issue cache list failed: %v", err)
+		if selectedStore != nil {
+			errorMessage = s.storeOperationError(selectedStore, req.RepoID, "list issues", err)
+		}
+		encoder.Encode(ListIssuesResponse{OK: false, Error: errorMessage})
 		return
 	}
 
@@ -3369,10 +3386,13 @@ func (s *SocketServer) handleGetRun(req SendRequest, encoder *json.Encoder) {
 		return manager.IsAlive(r)
 	}
 
-	encoder.Encode(GetRunResponse{
-		OK:  true,
-		Run: RunToFullWithAlive(run, computeAlive),
-	})
+	full, err := RunToFullWithAlive(run, computeAlive)
+	if err != nil {
+		encoder.Encode(GetRunResponse{OK: false, Error: err.Error()})
+		return
+	}
+
+	encoder.Encode(GetRunResponse{OK: true, Run: full})
 }
 
 func (s *SocketServer) handleGetIssue(req SendRequest, encoder *json.Encoder) {
@@ -5000,7 +5020,7 @@ func (s *SocketServer) handleStopRun(req SendRequest, encoder *json.Encoder) {
 		})
 		if err != nil {
 			s.logger.Printf("error listing runs for %s: %v", req.IssueID, err)
-			encoder.Encode(StopRunResponse{OK: false, Error: "store_error"})
+			encoder.Encode(StopRunResponse{OK: false, Error: s.storeOperationError(st, req.RepoID, "list runs", err)})
 			return
 		}
 		for _, run := range runs {
@@ -5135,7 +5155,7 @@ func (s *SocketServer) handleResolveIssue(req SendRequest, encoder *json.Encoder
 		runs, err := st.ListRuns(&store.ListRunsFilter{IssueID: model.IssueID(req.IssueID)})
 		if err != nil {
 			s.logger.Printf("error listing runs for %s: %v", req.IssueID, err)
-			encoder.Encode(ResolveIssueResponse{OK: false, Error: "store_error"})
+			encoder.Encode(ResolveIssueResponse{OK: false, Error: s.storeOperationError(st, req.RepoID, "list runs", err)})
 			return
 		}
 
@@ -5155,7 +5175,7 @@ func (s *SocketServer) handleResolveIssue(req SendRequest, encoder *json.Encoder
 
 	if err := st.SetIssueStatus(model.IssueID(req.IssueID), model.IssueStatusResolved); err != nil {
 		s.logger.Printf("error resolving issue %s: %v", req.IssueID, err)
-		encoder.Encode(ResolveIssueResponse{OK: false, Error: "store_error"})
+		encoder.Encode(ResolveIssueResponse{OK: false, Error: s.storeOperationError(st, req.RepoID, "set issue status", err)})
 		return
 	}
 
@@ -5440,10 +5460,13 @@ func (s *SocketServer) handleGetRunByShortID(req SendRequest, encoder *json.Enco
 		return
 	}
 
-	encoder.Encode(GetRunResponse{
-		OK:  true,
-		Run: RunToFull(run),
-	})
+	full, err := RunToFull(run)
+	if err != nil {
+		encoder.Encode(GetRunResponse{OK: false, Error: err.Error()})
+		return
+	}
+
+	encoder.Encode(GetRunResponse{OK: true, Run: full})
 }
 
 func (s *SocketServer) handleRegisterMonitor(req SendRequest, encoder *json.Encoder) {

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -87,6 +88,15 @@ func TestExternalWorkerHelperProcess(t *testing.T) {
 type mockStore struct {
 	runs   map[string]*model.Run
 	issues map[string]*model.Issue
+}
+
+type listRunsErrorStore struct {
+	*mockStore
+	err error
+}
+
+func (s *listRunsErrorStore) ListRuns(*store.ListRunsFilter) ([]*model.Run, error) {
+	return nil, s.err
 }
 
 func (m *mockStore) ResolveIssue(issueID model.IssueID) (*model.Issue, error) {
@@ -2211,6 +2221,7 @@ func TestListRunsPaginationContract(t *testing.T) {
 }
 
 func TestGetRunAPI(t *testing.T) {
+	worktreePath := initGitRepoWithCommit(t)
 	st := &mockStore{
 		runs: map[string]*model.Run{
 			"orch-001#20250117-010000": {
@@ -2220,8 +2231,8 @@ func TestGetRunAPI(t *testing.T) {
 				Agent:             "opencode",
 				Model:             "anthropic/claude-sonnet-4",
 				ModelVariant:      "high",
-				Branch:            "orch-001-feature",
-				WorktreePath:      "/repo/worktrees/orch-001",
+				Branch:            "main",
+				WorktreePath:      worktreePath,
 				ServerPort:        8080,
 				OpenCodeSessionID: "sess_xxx",
 				Path:              "/vault/runs/orch-001/20250117-010000.md",
@@ -3726,6 +3737,29 @@ func TestListRunsWithRequestContextProjectID(t *testing.T) {
 	}
 }
 
+func TestListRunsStoreFailureIncludesProjectAndCause(t *testing.T) {
+	cause := errors.New("corrupt run index")
+	st := &listRunsErrorStore{
+		mockStore: &mockStore{runs: map[string]*model.Run{}, issues: map[string]*model.Issue{}},
+		err:       cause,
+	}
+	server := newTestServer(t, st)
+
+	resp := server.handleProtoListRuns(&orchpb.ListRunsRequest{
+		Context: &orchpb.RequestContext{ProjectId: testProjectID},
+	})
+
+	if resp.Ok {
+		t.Fatalf("handleProtoListRuns() Ok = true, want false")
+	}
+	if !strings.Contains(resp.Error, testProjectID) || !strings.Contains(resp.Error, cause.Error()) {
+		t.Fatalf("handleProtoListRuns() error = %q, want project ID and underlying cause", resp.Error)
+	}
+	if resp.Error == "store_error" {
+		t.Fatal("handleProtoListRuns() returned opaque store_error token")
+	}
+}
+
 func TestListRunsWithoutProjectContextAggregatesAcrossStores(t *testing.T) {
 	cleanup := setupXDGTestEnv(t)
 	defer cleanup()
@@ -3898,6 +3932,36 @@ func TestListIssuesUnknownProjectContextReturnsProjectScopedError(t *testing.T) 
 	expected := "no store available for project_id \"missing-project\" (register daemon project mapping)"
 	if resp.Error != expected {
 		t.Fatalf("expected %q, got %q", expected, resp.Error)
+	}
+}
+
+func TestRunLookupWithoutProjectContextReturnsSpacedAmbiguousMessages(t *testing.T) {
+	runA := &model.Run{IssueID: "ambiguous-issue", RunID: "ambiguous-run"}
+	runB := &model.Run{IssueID: "ambiguous-issue", RunID: "ambiguous-run"}
+	stA := &mockStore{runs: map[string]*model.Run{runA.Ref().String(): runA}, issues: map[string]*model.Issue{}}
+	stB := &mockStore{runs: map[string]*model.Run{runB.Ref().String(): runB}, issues: map[string]*model.Issue{}}
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	registerRepoContextForTest(t, server, "project-a", "/srv/repos/a", stA)
+	registerRepoContextForTest(t, server, "project-b", "/srv/repos/b", stB)
+
+	fullResp := server.handleProtoGetRun(&orchpb.GetRunRequest{
+		IssueId: string(runA.IssueID),
+		RunId:   string(runA.RunID),
+		Context: &orchpb.RequestContext{},
+	})
+	fullMessage := fmt.Sprintf("ambiguous run ref: %s#%s", runA.IssueID, runA.RunID)
+	if fullResp.Ok || fullResp.Error != fullMessage {
+		t.Fatalf("full-ref response: ok=%v error=%q, want %q", fullResp.Ok, fullResp.Error, fullMessage)
+	}
+
+	shortID := string(runA.ShortID())
+	shortResp := server.handleProtoGetRunByShortID(&orchpb.GetRunByShortIDRequest{
+		ShortId: shortID,
+		Context: &orchpb.RequestContext{},
+	})
+	shortMessage := fmt.Sprintf("ambiguous short id: %s", shortID)
+	if shortResp.Ok || shortResp.Error != shortMessage {
+		t.Fatalf("short-ref response: ok=%v error=%q, want %q", shortResp.Ok, shortResp.Error, shortMessage)
 	}
 }
 
@@ -4111,6 +4175,62 @@ func TestGetAttachInfoWithoutProjectContextAggregatesAcrossStores(t *testing.T) 
 	}
 	if attachResp.IssueId != "attach-issue" || attachResp.RunId != "attach-run" {
 		t.Fatalf("unexpected attach payload: issue=%q run=%q", attachResp.IssueId, attachResp.RunId)
+	}
+}
+
+func TestGetAttachInfoInvalidMultiplexerReturnsExplicitError(t *testing.T) {
+	st := &mockStore{
+		runs: map[string]*model.Run{
+			"attach-issue#attach-run": {
+				IssueID:     "attach-issue",
+				RunID:       "attach-run",
+				Agent:       "claude",
+				Multiplexer: "screen",
+			},
+		},
+		issues: map[string]*model.Issue{},
+	}
+	server := newTestServer(t, st)
+
+	resp := server.handleProtoGetAttachInfo(&orchpb.GetAttachInfoRequest{
+		IssueId: "attach-issue",
+		RunId:   "attach-run",
+		Context: &orchpb.RequestContext{ProjectId: testProjectID},
+	})
+
+	if resp.Ok {
+		t.Fatal("handleProtoGetAttachInfo() Ok = true, want false")
+	}
+	if !strings.Contains(resp.Error, "screen") || !strings.Contains(resp.Error, "unknown multiplexer type") {
+		t.Fatalf("handleProtoGetAttachInfo() error = %q, want multiplexer type and cause", resp.Error)
+	}
+}
+
+func TestGetAttachInfoUnavailableMultiplexerReturnsExplicitError(t *testing.T) {
+	st := &mockStore{
+		runs: map[string]*model.Run{
+			"attach-issue#attach-run": {
+				IssueID:     "attach-issue",
+				RunID:       "attach-run",
+				Agent:       "claude",
+				Multiplexer: "auto",
+			},
+		},
+		issues: map[string]*model.Issue{},
+	}
+	server := newTestServer(t, st)
+
+	resp := server.handleProtoGetAttachInfo(&orchpb.GetAttachInfoRequest{
+		IssueId: "attach-issue",
+		RunId:   "attach-run",
+		Context: &orchpb.RequestContext{ProjectId: testProjectID},
+	})
+
+	if resp.Ok {
+		t.Fatal("handleProtoGetAttachInfo() Ok = true, want false")
+	}
+	if !strings.Contains(resp.Error, `multiplexer "auto" unavailable`) || !strings.Contains(resp.Error, "unknown multiplexer type: auto") {
+		t.Fatalf("handleProtoGetAttachInfo() error = %q, want unavailable multiplexer type and cause", resp.Error)
 	}
 }
 
@@ -4688,9 +4808,10 @@ func TestRemoteGitRequestsUseWorkerLease(t *testing.T) {
 	}
 }
 
-func TestGetDiffStatsWithoutProjectContextAggregatesAcrossStores(t *testing.T) {
+func TestGetDiffStatsGitFailureReturnsExplicitError(t *testing.T) {
 	cleanup := setupXDGTestEnv(t)
 	defer cleanup()
+	nonGitWorktree := t.TempDir()
 
 	stA := &mockStore{runs: map[string]*model.Run{}, issues: map[string]*model.Issue{}}
 	stB := &mockStore{
@@ -4700,7 +4821,7 @@ func TestGetDiffStatsWithoutProjectContextAggregatesAcrossStores(t *testing.T) {
 				RunID:        "diffstats-run",
 				Status:       model.StatusRunning,
 				UpdatedAt:    time.Now(),
-				WorktreePath: "/tmp/diffstats-missing",
+				WorktreePath: nonGitWorktree,
 				Branch:       "feature/diffstats",
 			},
 		},
@@ -4729,12 +4850,11 @@ func TestGetDiffStatsWithoutProjectContextAggregatesAcrossStores(t *testing.T) {
 		},
 	})
 
-	if !resp.Ok {
-		t.Fatalf("expected ok response, got error: %s", resp.Error)
+	if resp.Ok {
+		t.Fatal("expected git failure response, got ok=true")
 	}
-	statsResp := resp.GetGetDiffStats()
-	if statsResp == nil || statsResp.DiffStats == nil {
-		t.Fatal("expected GetDiffStats response payload")
+	if !strings.Contains(resp.Error, nonGitWorktree) || !strings.Contains(strings.ToLower(resp.Error), "not a git repository") {
+		t.Fatalf("error = %q, want worktree path and underlying git/filesystem cause", resp.Error)
 	}
 }
 

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -379,8 +379,11 @@ func computeWorktreeExists(path string) bool {
 }
 
 // RunToSummary converts a model.Run to a RunSummary
-func RunToSummary(run *model.Run) *RunSummary {
-	diffStats := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
+func RunToSummary(run *model.Run) (*RunSummary, error) {
+	diffStats, err := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
+	if err != nil {
+		return nil, err
+	}
 
 	elapsedSeconds, elapsedDisplay := computeElapsed(run)
 	branchState := computeBranchStateString(run)
@@ -424,21 +427,24 @@ func RunToSummary(run *model.Run) *RunSummary {
 		StartedAt:      formatTime(run.StartedAt),
 		UpdatedAt:      formatTime(run.UpdatedAt),
 		URI:            FileURI(run.Path),
-	}
+	}, nil
 }
 
 // RunToSummaryWithAlive converts a model.Run to a RunSummary with alive status computed.
 // This function requires the agent package and should be called when alive status is needed.
-func RunToSummaryWithAlive(run *model.Run, computeAlive func(*model.Run) bool) *RunSummary {
-	summary := RunToSummary(run)
+func RunToSummaryWithAlive(run *model.Run, computeAlive func(*model.Run) bool) (*RunSummary, error) {
+	summary, err := RunToSummary(run)
+	if err != nil {
+		return nil, err
+	}
 	if computeAlive != nil {
 		summary.Alive = computeAlive(run)
 		summary.AliveKnown = true
 	}
-	return summary
+	return summary, nil
 }
 
-func RunToFull(run *model.Run) *RunFull {
+func RunToFull(run *model.Run) (*RunFull, error) {
 	events := make([]*EventJSON, len(run.Events))
 	for i, e := range run.Events {
 		events[i] = &EventJSON{
@@ -449,7 +455,10 @@ func RunToFull(run *model.Run) *RunFull {
 		}
 	}
 
-	diffStats := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
+	diffStats, err := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
+	if err != nil {
+		return nil, err
+	}
 	elapsedSeconds, elapsedDisplay := computeElapsed(run)
 	branchState := computeBranchStateString(run)
 	prNumber, prState := lookupPRInfo(run)
@@ -494,17 +503,20 @@ func RunToFull(run *model.Run) *RunFull {
 		UpdatedAt:      formatTime(run.UpdatedAt),
 		URI:            FileURI(run.Path),
 		Events:         events,
-	}
+	}, nil
 }
 
 // RunToFullWithAlive converts a model.Run to a RunFull with alive status computed.
-func RunToFullWithAlive(run *model.Run, computeAlive func(*model.Run) bool) *RunFull {
-	full := RunToFull(run)
+func RunToFullWithAlive(run *model.Run, computeAlive func(*model.Run) bool) (*RunFull, error) {
+	full, err := RunToFull(run)
+	if err != nil {
+		return nil, err
+	}
 	if computeAlive != nil {
 		full.Alive = computeAlive(run)
 		full.AliveKnown = true
 	}
-	return full
+	return full, nil
 }
 
 // IssueToSummary converts a model.Issue to an IssueSummary

--- a/internal/daemon/types_test.go
+++ b/internal/daemon/types_test.go
@@ -192,6 +192,7 @@ func TestSummaryToRunRejectsUnknownStatus(t *testing.T) {
 }
 
 func TestRunToSummaryRoundTrip(t *testing.T) {
+	worktreePath := initGitRepoWithCommit(t)
 	original := &model.Run{
 		IssueID:      "issue-roundtrip",
 		RunID:        "run-roundtrip-123",
@@ -200,14 +201,17 @@ func TestRunToSummaryRoundTrip(t *testing.T) {
 		Agent:        "opencode",
 		Profile:      "company",
 		Model:        "gpt-4",
-		Branch:       "fix/bug-123",
-		WorktreePath: "/home/user/worktrees/fix-bug",
+		Branch:       "main",
+		WorktreePath: worktreePath,
 		SessionName:  "orch-roundtrip",
 		Multiplexer:  "tmux",
 		PRUrl:        "",
 	}
 
-	summary := RunToSummary(original)
+	summary, err := RunToSummary(original)
+	if err != nil {
+		t.Fatalf("RunToSummary() error = %v", err)
+	}
 	roundTripped, err := SummaryToRun(summary)
 	if err != nil {
 		t.Fatalf("SummaryToRun() error = %v", err)

--- a/internal/daemon/worker_plane.go
+++ b/internal/daemon/worker_plane.go
@@ -872,7 +872,10 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 		if err != nil {
 			return nil, err
 		}
-		stats := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
+		stats, err := git.GetDiffStats(run.WorktreePath, run.Branch, "main")
+		if err != nil {
+			return nil, err
+		}
 		return &WorkerEffectResult{
 			DiffStatsResult: &GetDiffStatsResult{
 				Additions:    stats.Additions,

--- a/internal/daemon/worker_plane_test.go
+++ b/internal/daemon/worker_plane_test.go
@@ -253,6 +253,39 @@ func TestExecuteLeaseEffectStopRunUsesSnapshotWithEmptyWorkerRunStore(t *testing
 	}
 }
 
+func TestExecuteLeaseEffectGetDiffStatsPropagatesGitFailure(t *testing.T) {
+	missingWorktree := filepath.Join(t.TempDir(), "missing-worktree")
+	st := &mockStore{runs: map[string]*model.Run{}, issues: map[string]*model.Issue{}}
+	server := newTestServer(t, st)
+	lease := &WorkerLease{
+		LeaseID:   "lease-diff-stats-failure",
+		WorkerID:  "worker-local",
+		ProjectID: testProjectID,
+		Effect:    "get_diff_stats",
+		IssueID:   "issue-diff",
+		RunID:     "run-diff",
+		Payload: &WorkerEffectPayload{
+			GetDiffStats: &GetDiffStatsPayload{
+				RunSnapshot: &RunSnapshot{
+					IssueID:      "issue-diff",
+					RunID:        "run-diff",
+					Status:       model.StatusRunning,
+					Branch:       "feature/diff",
+					WorktreePath: missingWorktree,
+				},
+			},
+		},
+	}
+
+	result, err := server.executeLeaseEffect(lease)
+	if err == nil {
+		t.Fatalf("executeLeaseEffect() result = %#v, error = nil; want explicit git failure", result)
+	}
+	if !strings.Contains(err.Error(), missingWorktree) || !strings.Contains(err.Error(), "no such file") {
+		t.Fatalf("executeLeaseEffect() error = %q, want worktree path and underlying cause", err)
+	}
+}
+
 // TestProcessStartRunCoreUsesSnapshotWithEmptyWorkerIssueStore is the authoritative
 // regression for the cross-machine worker bug: a worker pinned to a different host
 // than the master has an EMPTY issue store. The master (issue-store SSOT) resolves a

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -17,15 +18,16 @@ type DiffStats struct {
 
 // GetDiffStats calculates the diff stats for a worktree compared to its base branch.
 // It returns the total additions and deletions across all files.
-// If the calculation fails, it returns zero stats (non-fatal).
-func GetDiffStats(worktreePath, branch, baseBranch string) DiffStats {
+// Missing run metadata produces empty stats; filesystem and git failures are
+// returned so callers cannot mistake unavailable evidence for a clean tree.
+func GetDiffStats(worktreePath, branch, baseBranch string) (DiffStats, error) {
 	if worktreePath == "" || branch == "" {
-		return DiffStats{}
+		return DiffStats{}, nil
 	}
 
 	// Check if worktree exists
-	if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
-		return DiffStats{}
+	if _, err := os.Stat(worktreePath); err != nil {
+		return DiffStats{}, fmt.Errorf("get diff stats for worktree %q: stat failed: %w", worktreePath, err)
 	}
 
 	if baseBranch == "" {
@@ -37,50 +39,79 @@ func GetDiffStats(worktreePath, branch, baseBranch string) DiffStats {
 	remoteBranchRef := RemoteBranchRef(remote, base)
 
 	// Try with remote ref first (three-dot syntax for merge-base comparison)
-	stats := getDiffStatsInternal(worktreePath, remoteBranchRef, branch)
+	stats, remoteErr := getDiffStatsInternal(worktreePath, remoteBranchRef, branch)
 	if stats.Additions > 0 || stats.Deletions > 0 {
-		return stats
+		return stats, nil
 	}
 
 	// Fallback: try with local base branch
-	stats = getDiffStatsInternal(worktreePath, base, branch)
+	stats, localErr := getDiffStatsInternal(worktreePath, base, branch)
 	if stats.Additions > 0 || stats.Deletions > 0 {
-		return stats
+		return stats, nil
+	}
+	if remoteErr != nil && localErr != nil {
+		return DiffStats{}, fmt.Errorf(
+			"get diff stats for worktree %q: remote comparison failed: %v; local comparison failed: %v",
+			worktreePath,
+			remoteErr,
+			localErr,
+		)
 	}
 
 	// Final fallback: diff against HEAD (uncommitted changes)
-	return getUncommittedDiffStats(worktreePath)
+	stats, err := getUncommittedDiffStats(worktreePath)
+	if err != nil {
+		return DiffStats{}, fmt.Errorf("get diff stats for worktree %q: %w", worktreePath, err)
+	}
+	return stats, nil
 }
 
 // getDiffStatsInternal runs git diff --numstat and parses the output.
-func getDiffStatsInternal(worktreePath, from, to string) DiffStats {
+func getDiffStatsInternal(worktreePath, from, to string) (DiffStats, error) {
 	// Use three-dot syntax for merge-base comparison
 	diffRange := from + "..." + to
 	cmd := exec.Command("git", "-C", worktreePath, "diff", "--numstat", diffRange)
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		// Try two-dot syntax as fallback
+		threeDotErr := commandError(err, output)
 		diffRange = from + ".." + to
 		cmd = exec.Command("git", "-C", worktreePath, "diff", "--numstat", diffRange)
-		output, err = cmd.Output()
+		output, err = cmd.CombinedOutput()
 		if err != nil {
-			return DiffStats{}
+			return DiffStats{}, fmt.Errorf(
+				"git diff %q failed with three-dot (%v) and two-dot (%v)",
+				from+" to "+to,
+				threeDotErr,
+				commandError(err, output),
+			)
 		}
 	}
 
-	return parseDiffNumstat(string(output))
+	return parseDiffNumstat(string(output)), nil
 }
 
 // getUncommittedDiffStats gets stats for uncommitted changes in the worktree.
-func getUncommittedDiffStats(worktreePath string) DiffStats {
+func getUncommittedDiffStats(worktreePath string) (DiffStats, error) {
 	// Get both staged and unstaged changes
 	cmd := exec.Command("git", "-C", worktreePath, "diff", "--numstat", "HEAD")
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return DiffStats{}
+		return DiffStats{}, fmt.Errorf("git diff against HEAD failed: %v", commandError(err, output))
 	}
 
-	return parseDiffNumstat(string(output))
+	return parseDiffNumstat(string(output)), nil
+}
+
+func commandError(err error, output []byte) error {
+	detail := strings.TrimSpace(string(output))
+	if detail == "" {
+		return err
+	}
+	if newline := strings.IndexByte(detail, '\n'); newline >= 0 {
+		detail = detail[:newline]
+	}
+	return fmt.Errorf("%w: %s", err, detail)
 }
 
 func parseDiffNumstat(output string) DiffStats {
@@ -122,15 +153,19 @@ func GetDiffStatsForRuns(runs []struct {
 	WorktreePath string
 	Branch       string
 	BaseBranch   string
-}) map[string]DiffStats {
+}) (map[string]DiffStats, error) {
 	results := make(map[string]DiffStats)
 
 	for _, run := range runs {
 		if run.WorktreePath == "" {
 			continue
 		}
-		results[run.WorktreePath] = GetDiffStats(run.WorktreePath, run.Branch, run.BaseBranch)
+		stats, err := GetDiffStats(run.WorktreePath, run.Branch, run.BaseBranch)
+		if err != nil {
+			return nil, err
+		}
+		results[run.WorktreePath] = stats
 	}
 
-	return results
+	return results, nil
 }

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -91,21 +92,31 @@ func TestParseDiffNumstat(t *testing.T) {
 }
 
 func TestGetDiffStats_EmptyInputs(t *testing.T) {
-	stats := GetDiffStats("", "", "")
+	stats, err := GetDiffStats("", "", "")
+	if err != nil {
+		t.Fatalf("GetDiffStats() error = %v, want nil", err)
+	}
 	if stats.Additions != 0 || stats.Deletions != 0 {
 		t.Errorf("Expected zero stats for empty inputs, got +%d -%d", stats.Additions, stats.Deletions)
 	}
 
-	stats = GetDiffStats("/some/path", "", "main")
+	stats, err = GetDiffStats("/some/path", "", "main")
+	if err != nil {
+		t.Fatalf("GetDiffStats() error = %v, want nil", err)
+	}
 	if stats.Additions != 0 || stats.Deletions != 0 {
 		t.Errorf("Expected zero stats for empty branch, got +%d -%d", stats.Additions, stats.Deletions)
 	}
 }
 
 func TestGetDiffStats_NonexistentPath(t *testing.T) {
-	stats := GetDiffStats("/nonexistent/path/that/does/not/exist", "feature", "main")
-	if stats.Additions != 0 || stats.Deletions != 0 {
-		t.Errorf("Expected zero stats for nonexistent path, got +%d -%d", stats.Additions, stats.Deletions)
+	path := "/nonexistent/path/that/does/not/exist"
+	_, err := GetDiffStats(path, "feature", "main")
+	if err == nil {
+		t.Fatal("GetDiffStats() error = nil, want explicit filesystem error")
+	}
+	if !strings.Contains(err.Error(), path) || !strings.Contains(err.Error(), "no such file") {
+		t.Fatalf("GetDiffStats() error = %q, want worktree path and underlying cause", err)
 	}
 }
 
@@ -147,7 +158,10 @@ func TestGetDiffStats_RealRepo(t *testing.T) {
 	runGit("add", ".")
 	runGit("commit", "-m", "add new file")
 
-	stats := getDiffStatsInternal(tmpDir, "main", "feature")
+	stats, err := getDiffStatsInternal(tmpDir, "main", "feature")
+	if err != nil {
+		t.Fatalf("getDiffStatsInternal() error = %v", err)
+	}
 	t.Logf("Got stats: +%d -%d", stats.Additions, stats.Deletions)
 
 	if stats.Additions != 3 {

--- a/internal/orchapi/daemon_client.go
+++ b/internal/orchapi/daemon_client.go
@@ -183,7 +183,7 @@ func (c *DaemonClient) ResolveRun(ctx context.Context, ref RunRef) (*Run, error)
 			if isNotFoundError(err) {
 				return nil, RunNotFound(string(ref.ShortID))
 			}
-			return nil, err
+			return nil, mapAmbiguousRefError(err)
 		}
 		return runFromDaemonFull(resp.Run), nil
 	}
@@ -194,7 +194,7 @@ func (c *DaemonClient) ResolveRun(ctx context.Context, ref RunRef) (*Run, error)
 			if isNotFoundError(err) {
 				return nil, RunNotFound(ref.String())
 			}
-			return nil, err
+			return nil, mapAmbiguousRefError(err)
 		}
 		return runFromDaemonFull(resp.Run), nil
 	}
@@ -208,7 +208,7 @@ func (c *DaemonClient) ResolveRun(ctx context.Context, ref RunRef) (*Run, error)
 	}
 	resp, err := c.proto.GetRun(runs.Runs[0].IssueID, runs.Runs[0].RunID)
 	if err != nil {
-		return nil, err
+		return nil, mapAmbiguousRefError(err)
 	}
 	return runFromDaemonFull(resp.Run), nil
 }
@@ -219,7 +219,7 @@ func (c *DaemonClient) GetRun(ctx context.Context, issueID model.IssueID, runID 
 		if isNotFoundError(err) {
 			return nil, RunNotFound(string(issueID) + "#" + string(runID))
 		}
-		return nil, err
+		return nil, mapAmbiguousRefError(err)
 	}
 	return runFromDaemonFull(resp.Run), nil
 }
@@ -351,10 +351,7 @@ func (c *DaemonClient) WaitForRuns(ctx context.Context, refs []string, timeoutSe
 		if isTimeoutError(err) {
 			return nil, fmt.Errorf("timed out waiting for runs: %w", ErrTimeout)
 		}
-		if isAmbiguousRefError(err) {
-			return nil, ErrAmbiguousRef
-		}
-		return nil, err
+		return nil, mapAmbiguousRefError(err)
 	}
 
 	status, err := NormalizeRunStatus(resp.Status)
@@ -376,7 +373,7 @@ func (c *DaemonClient) GetAttachInfo(ctx context.Context, ref RunRef) (*AttachIn
 		if isNotFoundError(err) {
 			return nil, RunNotFound(ref.String())
 		}
-		return nil, err
+		return nil, mapAmbiguousRefError(err)
 	}
 	if !resp.OK {
 		if resp.Error == "session_not_found" || resp.Error == "no sessions" {
@@ -564,7 +561,17 @@ func isAmbiguousRefError(err error) bool {
 		return false
 	}
 	s := strings.ToLower(err.Error())
-	return strings.Contains(s, "ambiguous short id") || strings.Contains(s, "ambiguous run ref")
+	return strings.Contains(s, "ambiguous short id") ||
+		strings.Contains(s, "ambiguous run ref") ||
+		strings.Contains(s, "ambiguous_short_id") ||
+		strings.Contains(s, "ambiguous_run_ref")
+}
+
+func mapAmbiguousRefError(err error) error {
+	if isAmbiguousRefError(err) {
+		return ErrAmbiguousRef
+	}
+	return err
 }
 
 func issueFromDaemon(iss *daemon.IssueFull) *Issue {

--- a/internal/orchapi/daemon_client_test.go
+++ b/internal/orchapi/daemon_client_test.go
@@ -1,0 +1,25 @@
+package orchapi
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestMapAmbiguousRefErrorSupportsCurrentAndHistoricDaemonMessages(t *testing.T) {
+	tests := []string{
+		"ambiguous run ref: orch-123#run-1",
+		"ambiguous short id: abc123",
+		"ambiguous_run_ref",
+		"ambiguous_short_id",
+	}
+
+	for _, message := range tests {
+		t.Run(message, func(t *testing.T) {
+			err := fmt.Errorf("daemon error: %s", message)
+			if got := mapAmbiguousRefError(err); !errors.Is(got, ErrAmbiguousRef) {
+				t.Fatalf("mapAmbiguousRefError(%q) = %v, want ErrAmbiguousRef", err, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

- daemon の store エラー応答から opaque な `store_error` を除去し、操作・project ID・根本原因を返すようにしました。
- 曖昧な run 参照は参照値付きの空白区切りメッセージへ統一し、client は旧 daemon の underscore 形式も `ErrAmbiguousRef` へ変換します。
- `git.GetDiffStats` を `(DiffStats, error)` に変更し、proto handler・worker lease・旧 socket 応答まで git 失敗を伝播します。
- CLI attach と daemon GetAttachInfo で multiplexer の parse/取得エラーを握り潰さないようにしました。

## 受入条件の証拠

- `git grep -n 'errorResponse("store_error")' -- .` → 0 hits
- `TestListRunsStoreFailureIncludesProjectAndCause` → PASS（project ID と underlying error を確認）
- `TestRunLookupWithoutProjectContextReturnsSpacedAmbiguousMessages` → PASS
- `TestMapAmbiguousRefErrorSupportsCurrentAndHistoricDaemonMessages` → PASS（空白区切り・underscore の4形式）
- `TestGetDiffStatsGitFailureReturnsExplicitError` → PASS（handler が `Ok:false`、worktree path と git cause を返却）
- `TestExecuteLeaseEffectGetDiffStatsPropagatesGitFailure` → PASS
- `TestRunAttachWithDeps_InvalidConfiguredMultiplexerFails` / `TestRunAttachWithDeps_InvalidRunMultiplexerFails` → PASS
- `TestGetAttachInfoInvalidMultiplexerReturnsExplicitError` / `TestGetAttachInfoUnavailableMultiplexerReturnsExplicitError` → PASS

## 全体検証

- `go build ./...` → PASS
- `go test ./... -count=1` → PASS
- `make lint` → PASS（architecture findings 0）
- `git diff --check` → PASS

status event writer、`step()` / monitor transition、launch ladder、`nosemgrep` annotation は変更していません。

Issue: `daemon-error-cause-propagation`