### PR TITLE
docs: issue body is the worker's only context — teach the full-brief flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ mkdir -p .orch && printf 'agent: claude\nbase_branch: main\n' > .orch/config.yam
 orch daemon repo register "$(pwd)"   # map project identity -> this checkout
 # (daemon and worker start automatically on demand — no manual process management)
 
-# Create an issue
-orch issue create my-task --title "Add hello world function"
+# Create an issue — the body is the worker agent's ONLY context, so write a
+# complete brief (goal, constraints, acceptance criteria) in your editor:
+orch issue create my-task --title "Add hello world function" --edit
 
 # Run an agent
 orch run my-task --no-pr

--- a/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
+++ b/claude-plugins/orch-toolset/skills/orch-toolset/SKILL.md
@@ -6,7 +6,7 @@ description: |
   restart-from, orch worker start/status/stop, orch attach/capture/send/exec, and remote execution
   via ORCH_REMOTE and target_host. Trigger terms: orch, orchestrator, worker, master, ORCH_REMOTE,
   target_host, run management, issue management, agent runs, worktree.
-version: 1.5.1
+version: 1.5.2
 ---
 
 # Orch Toolset
@@ -438,6 +438,11 @@ Recommended triage order:
 
 ## Workflow Tips
 
+- **The issue body is the worker agent's ONLY context.** Write it as a complete
+  brief — goal, constraints, acceptance criteria, verification — never a
+  one-line `--body`. Humans author bodies in their editor
+  (`orch issue create <id> --title "..." --edit` / `orch issue edit <id>`);
+  agents author them via heredoc.
 - When issue bodies span multiple lines, prefer `orch issue create ... <<'EOF'` over a long escaped
   `--body` string.
 - Use `orch send` to answer `waiting` runs.

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -92,9 +92,27 @@ Then walk through this sequence, explaining each step:
 orch daemon repo register "$(pwd)"   # maps project identity -> this checkout
 # (daemon and worker auto-start on demand; `orch worker status` shows them)
 
-# 2. Describe a task and launch an agent on it
-orch issue create hello-world --title "Add a hello world script" \
-  --body "Create hello.py at the repo root that prints Hello, World!"
+# 2. Describe a task. THE ISSUE BODY IS THE WORKER AGENT'S ONLY CONTEXT —
+#    write it as a complete brief (goal, constraints, acceptance criteria,
+#    how to verify). Never cram it into a one-line --body. As the agent,
+#    author it with a heredoc; tell the user that when THEY write issues by
+#    hand, `orch issue create <id> --title "..." --edit` (or
+#    `orch issue edit <id>` later) opens their $EDITOR instead.
+orch issue create hello-world --title "Add a hello world script" <<'EOF'
+## Goal
+Create hello.py at the repository root that prints exactly "Hello, World!".
+
+## Constraints
+- Python 3, standard library only, a few lines.
+- Do not create or modify anything else.
+
+## Acceptance criteria
+- `python3 hello.py` outputs `Hello, World!` and exits 0.
+
+## Verification
+Run `python3 hello.py` and show the output in your final report.
+EOF
+
 orch run hello-world --no-pr          # drop --no-pr when the repo really exists on GitHub
 
 # 3. Observe

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -162,7 +162,10 @@ EOF
 ## Create your first issue
 
 Create issues through the CLI so orch validates them and writes them to the
-configured issue store:
+configured issue store. **The issue body is the worker agent's only context**
+— write a complete brief (goal, constraints, acceptance criteria, how to
+verify), never a one-line description. Heredoc works well when an agent or
+script authors the issue:
 
 ```bash
 orch issue create my-first-issue --title "Add a hello world function" <<'EOF'

--- a/docs/local-quickstart.ja.md
+++ b/docs/local-quickstart.ja.md
@@ -89,10 +89,17 @@ orch のコマンドはカレントディレクトリからプロジェクトを
 ```bash
 cd ~/orch-sandbox
 
-# 1. タスクを issue として記述する
+# 1. タスクを issue として記述する。issue 本文は worker agent が読む
+#    唯一のコンテキスト — 目的・制約・受け入れ条件・検証方法まで書いた
+#    「完全なブリーフ」にする(1 行の説明で済ませない)。
+#    手で書くなら --edit で $EDITOR を開くのが楽:
+#      orch issue create hello-world --title "..." --edit
+#    エージェントやスクリプトが書くなら heredoc で:
 orch issue create hello-world --title "Add a hello world script" << 'EOF'
 Create hello.py at the repository root that prints "Hello, World!" when run
 with python3. Keep it to a few lines. Do not create anything else.
+
+Acceptance: `python3 hello.py` prints exactly "Hello, World!" and exits 0.
 EOF
 
 # (create の出力に 8 桁の hex ID が表示されます。7 桁以上の一意な hex prefix は

--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -54,17 +54,21 @@ func newIssueCreateCmd() *cobra.Command {
 
 For local backend, ISSUE_ID is required.
 For GitHub backend, ISSUE_ID is optional (GitHub assigns the number).
-Provide the issue body with --body, or omit it and redirect stdin via a
-pipe/heredoc for multi-line input.
+
+The issue body is the worker agent's ONLY context — write a complete brief
+(goal, constraints, acceptance criteria, how to verify), not a one-liner.
+Write it in $EDITOR with --edit, or pipe it via stdin (heredoc) when an
+agent or script authors the issue; --body suits short bodies only.
 
 Examples:
-  orch issue create fix-login-bug --title "Fix login timeout"
-  orch issue create plc-123 --title "Add dark mode" --body "Users want dark mode support"
+  orch issue create my-issue --title "Add dark mode" --edit   # opens $EDITOR
   orch issue create my-issue --title "Add dark mode" <<'EOF'
-  Users want dark mode support.
-  Include settings persistence.
+  ## Goal
+  Users want dark mode support, persisted in settings.
+  ## Acceptance criteria
+  ...
   EOF
-  orch issue create my-issue --edit  # Opens in $EDITOR
+  orch issue create fix-login-bug --title "Fix login timeout"
   orch issue create --title "GitHub issue"  # GitHub backend only`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/issue_test.go
+++ b/internal/cli/issue_test.go
@@ -13,11 +13,17 @@ import (
 func TestNewIssueCreateCmdLongDescriptionGuidance(t *testing.T) {
 	cmd := newIssueCreateCmd()
 
-	if !strings.Contains(cmd.Long, "pipe/heredoc") {
+	if !strings.Contains(cmd.Long, "stdin (heredoc)") {
 		t.Fatalf("expected issue create help to mention stdin usage")
 	}
 	if !strings.Contains(cmd.Long, "<<'EOF'") {
 		t.Fatalf("expected issue create help to include heredoc example")
+	}
+	if !strings.Contains(cmd.Long, "ONLY context") {
+		t.Fatalf("expected issue create help to teach that the body is the worker's only context")
+	}
+	if !strings.Contains(cmd.Long, "--edit") {
+		t.Fatalf("expected issue create help to lead humans to $EDITOR via --edit")
 	}
 }
 

--- a/internal/cli/tutorial.go
+++ b/internal/cli/tutorial.go
@@ -103,9 +103,18 @@ Use 'orch models' to list available models (requires opencode server).
 3. FIRST RUN
 --------------------------------------------------------------------------------
 
-Create an issue:
+Create an issue. THE ISSUE BODY IS THE WORKER AGENT'S ONLY CONTEXT — write a
+complete brief (goal, constraints, acceptance criteria, how to verify), never
+a one-line description. Writing by hand? Use your editor:
 
-    orch issue create my-001 --title "My first task" --body "Description here"
+    orch issue create my-001 --title "My first task" --edit
+
+Scripts and agents pipe the body via heredoc instead:
+
+    orch issue create my-001 --title "My first task" <<'EOF'
+    ## Goal
+    ...full brief: constraints, acceptance criteria, verification...
+    EOF
 
 Every issue also gets a derived hex ID (shown by 'orch issue list'); any
 unique prefix of 7+ chars works wherever an issue is named — 'orch run

--- a/vscode-orch/src/orch/client.ts
+++ b/vscode-orch/src/orch/client.ts
@@ -1,0 +1,270 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as vscode from 'vscode';
+import { OrchConfig } from '../config';
+
+const execFileAsync = promisify(execFile);
+
+export interface IssueInfo {
+  id: string;
+  title: string;
+  summary?: string;
+  status: string;
+  path: string;
+  runs?: RunSummary[];
+}
+
+export interface RunSummary {
+  run_id: string;
+  status: string;
+}
+
+export interface RunInfo {
+  issue_id: string;
+  issue_status?: string;
+  run_id: string;
+  short_id: string;
+  agent?: string;
+  status: string;
+  updated_at: string;
+  updated_ago: string;
+  started_at: string;
+  pr_url?: string;
+  branch?: string;
+  worktree_path?: string;
+  tmux_session?: string;
+}
+
+export interface RunResult {
+  issue_id: string;
+  run_id: string;
+  status: string;
+  branch?: string;
+  worktree_path?: string;
+  tmux_session?: string;
+}
+
+interface IssuesResponse {
+  ok: boolean;
+  issues: IssueInfo[];
+}
+
+interface RunsResponse {
+  ok: boolean;
+  items: RunInfo[];
+}
+
+interface CommandResult {
+  ok: boolean;
+  issue_id: string;
+  run_id: string;
+  status: string;
+  branch?: string;
+  worktree_path?: string;
+  tmux_session?: string;
+  error?: string;
+}
+
+export class OrchClient {
+  private issuesCache?: { items: IssueInfo[]; fetchedAt: number };
+  private runsCache?: { items: RunInfo[]; fetchedAt: number };
+  private issuesInFlight?: Promise<IssueInfo[]>;
+  private runsInFlight?: Promise<RunInfo[]>;
+
+  constructor(private readonly config: OrchConfig) {}
+
+  invalidateIssues(): void {
+    this.issuesCache = undefined;
+  }
+
+  invalidateRuns(): void {
+    this.runsCache = undefined;
+  }
+
+  async listIssues(includeResolved: boolean): Promise<IssueInfo[]> {
+    const cache = this.issuesCache;
+    if (cache && this.isCacheFresh(cache.fetchedAt)) {
+      return filterIssues(cache.items, includeResolved);
+    }
+
+    if (this.issuesInFlight) {
+      const items = await this.issuesInFlight;
+      return filterIssues(items, includeResolved);
+    }
+
+    this.issuesInFlight = this.fetchIssues();
+    try {
+      const items = await this.issuesInFlight;
+      return filterIssues(items, includeResolved);
+    } finally {
+      this.issuesInFlight = undefined;
+    }
+  }
+
+  async listRuns(statusFilter: string[]): Promise<RunInfo[]> {
+    const cache = this.runsCache;
+    if (cache && this.isCacheFresh(cache.fetchedAt)) {
+      return filterRuns(cache.items, statusFilter);
+    }
+
+    if (this.runsInFlight) {
+      const items = await this.runsInFlight;
+      return filterRuns(items, statusFilter);
+    }
+
+    this.runsInFlight = this.fetchRuns();
+    try {
+      const items = await this.runsInFlight;
+      return filterRuns(items, statusFilter);
+    } finally {
+      this.runsInFlight = undefined;
+    }
+  }
+
+  async startRun(issueId: string, agent: string): Promise<RunResult> {
+    const result = await this.execOrchJson<CommandResult>([
+      'run',
+      issueId,
+      '--agent',
+      agent
+    ]);
+    if (!result.ok) {
+      throw new Error(result.error || 'Failed to start run');
+    }
+    return result;
+  }
+
+  async continueRun(issueId: string, branch: string, agent: string): Promise<RunResult> {
+    const result = await this.execOrchJson<CommandResult>([
+      'continue',
+      '--branch',
+      branch,
+      '--issue',
+      issueId,
+      '--agent',
+      agent
+    ]);
+    if (!result.ok) {
+      throw new Error(result.error || 'Failed to continue run');
+    }
+    return result;
+  }
+
+  async stopRun(runRef: string): Promise<void> {
+    await this.execOrch(['stop', runRef]);
+  }
+
+  async resolveRun(runRef: string): Promise<void> {
+    await this.execOrch(['resolve', runRef]);
+  }
+
+  async listBranches(issueId: string): Promise<string[]> {
+    const workspaceRoot = this.config.getWorkspaceRoot();
+    if (!workspaceRoot) {
+      return [];
+    }
+
+    const refPath = `refs/heads/issue/${issueId}/`;
+    try {
+      const { stdout } = await execFileAsync('git', ['for-each-ref', '--format=%(refname:short)', refPath], {
+        cwd: workspaceRoot
+      });
+      return stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+    } catch (error) {
+      console.warn('orch: failed to list branches', error);
+      return [];
+    }
+  }
+
+  private async fetchIssues(): Promise<IssueInfo[]> {
+    const data = await this.execOrchJson<IssuesResponse>(['issue', 'list']);
+    if (!data.ok) {
+      throw new Error('Failed to list issues');
+    }
+    this.issuesCache = { items: data.issues || [], fetchedAt: Date.now() };
+    return this.issuesCache.items;
+  }
+
+  private async fetchRuns(): Promise<RunInfo[]> {
+    const data = await this.execOrchJson<RunsResponse>(['ps']);
+    if (!data.ok) {
+      throw new Error('Failed to list runs');
+    }
+    this.runsCache = { items: data.items || [], fetchedAt: Date.now() };
+    return this.runsCache.items;
+  }
+
+  private isCacheFresh(fetchedAt: number): boolean {
+    const ttl = Math.max(1000, this.config.getRefreshIntervalMs());
+    return Date.now() - fetchedAt < ttl;
+  }
+
+  private async execOrch(args: string[]): Promise<void> {
+    const scopeArgs = this.buildProjectScopeArgs();
+    const workspaceRoot = this.config.getWorkspaceRoot();
+    try {
+      await execFileAsync('orch', [...scopeArgs, ...args], {
+        cwd: workspaceRoot
+      });
+    } catch (error) {
+      const message = formatExecError(error, 'orch');
+      vscode.window.showErrorMessage(message);
+      throw error;
+    }
+  }
+
+  private async execOrchJson<T>(args: string[]): Promise<T> {
+    const scopeArgs = this.buildProjectScopeArgs();
+    const workspaceRoot = this.config.getWorkspaceRoot();
+    const commandArgs = ['--json', ...scopeArgs, ...args];
+    try {
+      const { stdout } = await execFileAsync('orch', commandArgs, {
+        cwd: workspaceRoot
+      });
+      return JSON.parse(stdout) as T;
+    } catch (error) {
+      const message = formatExecError(error, 'orch');
+      vscode.window.showErrorMessage(message);
+      throw error;
+    }
+  }
+
+  private buildProjectScopeArgs(): string[] {
+    const projectRoot = this.config.getWorkspaceRoot();
+    if (projectRoot) {
+      return ['--project-root', projectRoot];
+    }
+    return [];
+  }
+}
+
+function filterIssues(items: IssueInfo[], includeResolved: boolean): IssueInfo[] {
+  if (includeResolved) {
+    return items;
+  }
+  return items.filter((issue) => issue.status === 'open');
+}
+
+function filterRuns(items: RunInfo[], statusFilter: string[]): RunInfo[] {
+  if (statusFilter.length === 0) {
+    return items;
+  }
+  const allowed = new Set(statusFilter);
+  return items.filter((run) => allowed.has(run.status));
+}
+
+function formatExecError(error: unknown, toolName: string): string {
+  if (!error || typeof error !== 'object') {
+    return `Failed to run ${toolName}`;
+  }
+
+  const err = error as { message?: string; stderr?: string };
+  const message = err.stderr || err.message;
+  if (message) {
+    return message.toString().trim();
+  }
+  return `Failed to run ${toolName}`;
+}


### PR DESCRIPTION
Per maintainer decision: the issue body is the worker agent's ONLY context, so every teaching surface now demands a complete brief (goal, constraints, acceptance criteria, verification) and steers authors away from one-line `--body`:

- **Humans** author bodies in $EDITOR: `orch issue create <id> --title "..." --edit` / `orch issue edit <id>`.
- **Agents & scripts** pipe the brief via heredoc (`<<'EOF'`) — confirmed working stdin path.

Updated: agent-install runbook Step 4 (the guided first run now demonstrates a sectioned brief authored by the agent, and tells the user about the $EDITOR flow), embedded `orch tutorial`, `issue create --help` examples (help-guidance test updated to pin the new policy), README quick start, getting-started, Japanese quickstart, bundled skill v1.5.2.

`go test ./internal/...` 17/17 ok. Will tag v1.6.2-beta after merge so the release-bundled runbook (the README one-liner target) carries this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)