### PR TITLE
docs: state the agent-CLI login prerequisite explicitly

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,11 +8,20 @@ Before installing orch, ensure you have:
 
 1. **Go 1.25+** - For building orch from source (or use pre-built binaries)
 2. **tmux** or **zellij** - Terminal multiplexer for agent sessions
-3. **An LLM CLI** - At least one of:
+3. **An LLM CLI, logged in** - At least one of:
    - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`claude`)
    - [OpenCode](https://github.com/sst/opencode) (`opencode`)
    - [Codex](https://github.com/openai/codex) (`codex`)
    - [Gemini CLI](https://github.com/google/gemini-cli) (`gemini`)
+
+   Launch the CLI once and complete its login (e.g. `codex login`, or answer
+   `claude`'s first-run prompts) before your first orch run — orch starts the
+   CLI for you but never manages its credentials. A codex run launched with
+   missing credentials fails at launch and names the expected auth path; a
+   login screen that still appears is reported as `waiting` with reason
+   `gate_login`. To run multiple accounts of the same CLI (or pin an account
+   to specific machines), see the Profiles section of your agent's guide
+   ([Claude](./agents/claude.md#profiles), [Codex](./agents/codex.md#profiles)).
 4. **Git** - For worktree management. Your repository must have an `origin`
    remote — orch derives the project identity from its URL. (For a local
    sandbox the URL does not need to exist on GitHub; it is used as an


### PR DESCRIPTION
getting-started's Prerequisites instructed `gh auth login` but never said the agent CLI itself must be logged in before the first orch run — the one auth step orch cannot perform for the user (orch launches the CLI but never manages credentials).

Added to prerequisite 3:
- log in once before the first run (`codex login` / claude first-run prompts)
- what happens if you don't: the `agent_auth` launch preflight fails naming the expected auth path (PR #510); a login screen that still appears surfaces as `waiting(gate_login)` (§9)
- pointer to the Profiles sections (agents/claude.md, agents/codex.md) for multi-account / host-pinned setups

Found while answering "how is a user supposed to configure auth for orch" — docs covered the mechanism (Profiles) and the gh prerequisite, but not the base login requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)