### PR TITLE
feat(config): per-repo .orch/client.yaml overrides the global client config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,10 +15,12 @@ Settings are resolved in this order (highest priority first):
 ## Remote Configuration
 
 When using a remote daemon, configure the client target in
-`~/.config/orch/client.yaml`.
+`~/.config/orch/client.yaml` (global), or per repository in
+`.orch/client.yaml` (discovered by walking up from the current directory,
+like `.orch/config.yaml`).
 
 ```yaml
-# ~/.config/orch/client.yaml
+# ~/.config/orch/client.yaml or <repo>/.orch/client.yaml
 remote:
   default: primary
   hosts:
@@ -27,6 +29,15 @@ remote:
     cloud:
       addr: 10.0.0.5:7777
 ```
+
+Per-repo values win field-wise: a non-empty `remote.default` overrides the
+global one, and host aliases are merged with per-repo entries taking
+precedence. The full resolution order for the remote address is `--remote`
+flag > `ORCH_REMOTE` > per-repo `client.yaml` > global `client.yaml`.
+
+A committed `.orch/client.yaml` redirects every orch command run inside that
+checkout, so review it like code when cloning; for machine-specific values,
+keep the file untracked (gitignored) instead of committing it.
 
 You can then run remote commands without passing `--remote` each time:
 
@@ -52,13 +63,12 @@ orch --remote master-host:7777 daemon repo register https://github.com/your-org/
 orch --remote master-host:7777 daemon repo list
 ```
 
-Because the default exposes the TCP API on every network interface, limit
-access with a firewall or restart the daemon bound to a trusted interface. For
-example, use loopback when clients connect through an SSH tunnel:
+Opting into `0.0.0.0` exposes the TCP API on every network interface — limit
+access with a firewall, or keep the loopback default and let clients connect
+through an SSH tunnel instead:
 
 ```bash
-orch daemon kill
-orch daemon start --listen tcp://127.0.0.1:7777
+ssh -L 7777:127.0.0.1:7777 master-host   # then: orch --remote localhost:7777 ps
 ```
 
 In remote mode, orch resolves project identity from `--project`/`ORCH_PROJECT`

--- a/docs/remote-usage.md
+++ b/docs/remote-usage.md
@@ -88,8 +88,13 @@ orch ps
 
 ### Option C: persistent client config (recommended)
 
+Global (`~/.config/orch/client.yaml`) or per repository
+(`<repo>/.orch/client.yaml`, discovered by walking up from the current
+directory). Per-repo values override the global ones field-wise
+(`remote.default` when non-empty; host aliases merged, per-repo wins).
+
 ```yaml
-# ~/.config/orch/client.yaml
+# ~/.config/orch/client.yaml or <repo>/.orch/client.yaml
 remote:
   default: primary
   hosts:

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -45,6 +45,10 @@ func setIsolatedXDG(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", filepath.Join(base, "data"))
 	t.Setenv("ORCH_REMOTE", "")
 	t.Setenv("ORCH_PROJECT", "")
+	// cwd is a config input too (.orch/config.yaml and .orch/client.yaml are
+	// discovered by walking up) — without this, tests inherit whatever repo
+	// the developer runs them from.
+	t.Chdir(base)
 }
 
 func TestRunDaemonStatusWithoutProjectRoot(t *testing.T) {

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,18 +36,91 @@ func ClientConfigPath() string {
 	return filepath.Join(home, ".config", "orch", clientConfigFile)
 }
 
-// LoadClient loads optional client config from ~/.config/orch/client.yaml.
-// Missing file is not an error.
+// LoadClient loads optional client config. Two locations are consulted:
+// a per-repo .orch/client.yaml discovered by walking up from the current
+// directory, and the global ~/.config/orch/client.yaml. Per-repo values win
+// field-wise: a non-empty remote.default overrides the global one, and host
+// aliases are merged with per-repo entries taking precedence. Missing files
+// are not an error.
 func LoadClient() (*ClientConfig, error) {
-	path := ClientConfigPath()
-	if path == "" {
-		return &ClientConfig{}, nil
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = ""
+	}
+	return loadClientFrom(cwd)
+}
+
+func loadClientFrom(startDir string) (*ClientConfig, error) {
+	merged := &ClientConfig{}
+	global, err := loadClientFile(ClientConfigPath())
+	if err != nil {
+		return nil, err
+	}
+	if global != nil {
+		merged = global
 	}
 
+	repoPath := findRepoClientConfig(startDir)
+	if repoPath == "" {
+		return merged, nil
+	}
+	repo, err := loadClientFile(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	if repo == nil {
+		return merged, nil
+	}
+
+	if d := strings.TrimSpace(repo.Remote.Default); d != "" {
+		merged.Remote.Default = d
+	}
+	if len(repo.Remote.Hosts) > 0 {
+		if merged.Remote.Hosts == nil {
+			merged.Remote.Hosts = make(map[string]ClientRemoteHost, len(repo.Remote.Hosts))
+		}
+		for name, host := range repo.Remote.Hosts {
+			merged.Remote.Hosts[name] = host
+		}
+	}
+	return merged, nil
+}
+
+// findRepoClientConfig walks up from startDir looking for .orch/client.yaml,
+// mirroring the project-config discovery of .orch/config.yaml. The repo does
+// not need a .orch/config.yaml for its client.yaml to apply.
+func findRepoClientConfig(startDir string) string {
+	if startDir == "" {
+		return ""
+	}
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return ""
+	}
+	for {
+		candidate := filepath.Join(dir, ".orch", clientConfigFile)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// loadClientFile reads and validates one client config file. A missing (or
+// empty) file yields (nil, nil); a present-but-invalid file is an error that
+// names the offending path.
+func loadClientFile(path string) (*ClientConfig, error) {
+	if path == "" {
+		return nil, nil
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &ClientConfig{}, nil
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -54,6 +129,9 @@ func LoadClient() (*ClientConfig, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 	if err := dec.Decode(&cfg); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("invalid client config schema in %s: %w", path, err)
 	}
 

--- a/internal/config/client_test.go
+++ b/internal/config/client_test.go
@@ -3,12 +3,36 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-func TestLoadClientMissingFile(t *testing.T) {
-	home := t.TempDir()
+// writeClientFile writes a client.yaml at dir/rel, creating parents.
+func writeClientFile(t *testing.T, dir, rel, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// hermetic pins HOME and the working directory to temp dirs so LoadClient's
+// cwd walk can never escape into the developer's real repo or global config.
+func hermetic(t *testing.T) (home, work string) {
+	t.Helper()
+	home = t.TempDir()
+	work = t.TempDir()
 	t.Setenv("HOME", home)
+	t.Chdir(work)
+	return home, work
+}
+
+func TestLoadClientMissingFile(t *testing.T) {
+	hermetic(t)
 
 	cfg, err := LoadClient()
 	if err != nil {
@@ -20,15 +44,9 @@ func TestLoadClientMissingFile(t *testing.T) {
 }
 
 func TestLoadClientAndResolveRemote(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home, _ := hermetic(t)
 
-	cfgDir := filepath.Join(home, ".config", "orch")
-	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
-		t.Fatalf("mkdir client config dir: %v", err)
-	}
-
-	content := []byte(`remote:
+	writeClientFile(t, home, ".config/orch/client.yaml", `remote:
   default: remotebox
   hosts:
     remotebox:
@@ -36,9 +54,6 @@ func TestLoadClientAndResolveRemote(t *testing.T) {
     cloud:
       addr: 10.0.0.5:7777
 `)
-	if err := os.WriteFile(filepath.Join(cfgDir, "client.yaml"), content, 0o644); err != nil {
-		t.Fatalf("write client config: %v", err)
-	}
 
 	cfg, err := LoadClient()
 	if err != nil {
@@ -57,25 +72,137 @@ func TestLoadClientAndResolveRemote(t *testing.T) {
 }
 
 func TestLoadClientRejectsHostWithoutAddr(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home, _ := hermetic(t)
 
-	cfgDir := filepath.Join(home, ".config", "orch")
-	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
-		t.Fatalf("mkdir client config dir: %v", err)
-	}
-
-	content := []byte(`remote:
+	writeClientFile(t, home, ".config/orch/client.yaml", `remote:
   hosts:
     remotebox:
       addr: ""
 `)
-	if err := os.WriteFile(filepath.Join(cfgDir, "client.yaml"), content, 0o644); err != nil {
-		t.Fatalf("write client config: %v", err)
-	}
 
 	_, err := LoadClient()
 	if err == nil {
 		t.Fatal("expected invalid client config error")
+	}
+}
+
+func TestLoadClientPerRepoOverridesGlobal(t *testing.T) {
+	home, work := hermetic(t)
+
+	writeClientFile(t, home, ".config/orch/client.yaml", `remote:
+  default: remotebox
+  hosts:
+    remotebox:
+      addr: remotebox:7777
+    cloud:
+      addr: 10.0.0.5:7777
+`)
+	writeClientFile(t, work, ".orch/client.yaml", `remote:
+  default: repobox
+  hosts:
+    repobox:
+      addr: repobox:7777
+    cloud:
+      addr: 10.9.9.9:7777
+`)
+
+	// The per-repo file must be discovered from a nested working directory.
+	nested := filepath.Join(work, "internal", "deep")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	t.Chdir(nested)
+
+	cfg, err := LoadClient()
+	if err != nil {
+		t.Fatalf("LoadClient error: %v", err)
+	}
+
+	if cfg.Remote.Default != "repobox" {
+		t.Fatalf("Remote.Default = %q, want repobox (per-repo wins)", cfg.Remote.Default)
+	}
+	if got := cfg.ResolveRemote("repobox"); got != "repobox:7777" {
+		t.Fatalf("ResolveRemote(repobox) = %q, want repobox:7777", got)
+	}
+	if got := cfg.ResolveRemote("cloud"); got != "10.9.9.9:7777" {
+		t.Fatalf("ResolveRemote(cloud) = %q, want per-repo override 10.9.9.9:7777", got)
+	}
+	if got := cfg.ResolveRemote("remotebox"); got != "remotebox:7777" {
+		t.Fatalf("ResolveRemote(remotebox) = %q, want global alias preserved", got)
+	}
+}
+
+func TestLoadClientRepoOnlyWithoutGlobal(t *testing.T) {
+	_, work := hermetic(t)
+
+	writeClientFile(t, work, ".orch/client.yaml", `remote:
+  default: repobox:7777
+`)
+
+	cfg, err := LoadClient()
+	if err != nil {
+		t.Fatalf("LoadClient error: %v", err)
+	}
+	if cfg.Remote.Default != "repobox:7777" {
+		t.Fatalf("Remote.Default = %q, want repobox:7777", cfg.Remote.Default)
+	}
+}
+
+func TestLoadClientRepoEmptyDefaultInheritsGlobal(t *testing.T) {
+	home, work := hermetic(t)
+
+	writeClientFile(t, home, ".config/orch/client.yaml", `remote:
+  default: remotebox:7777
+`)
+	writeClientFile(t, work, ".orch/client.yaml", `remote:
+  hosts:
+    extra:
+      addr: extra:7777
+`)
+
+	cfg, err := LoadClient()
+	if err != nil {
+		t.Fatalf("LoadClient error: %v", err)
+	}
+	if cfg.Remote.Default != "remotebox:7777" {
+		t.Fatalf("Remote.Default = %q, want global default inherited", cfg.Remote.Default)
+	}
+	if got := cfg.ResolveRemote("extra"); got != "extra:7777" {
+		t.Fatalf("ResolveRemote(extra) = %q, want extra:7777", got)
+	}
+}
+
+func TestLoadClientInvalidRepoFileNamesPath(t *testing.T) {
+	_, work := hermetic(t)
+
+	repoPath := writeClientFile(t, work, ".orch/client.yaml", `remote:
+  hosts:
+    broken:
+      addr: ""
+`)
+
+	_, err := LoadClient()
+	if err == nil {
+		t.Fatal("expected invalid client config error")
+	}
+	if !strings.Contains(err.Error(), repoPath) {
+		t.Fatalf("error %q does not name the offending file %q", err.Error(), repoPath)
+	}
+}
+
+func TestLoadClientEmptyRepoFileIsIgnored(t *testing.T) {
+	home, work := hermetic(t)
+
+	writeClientFile(t, home, ".config/orch/client.yaml", `remote:
+  default: remotebox:7777
+`)
+	writeClientFile(t, work, ".orch/client.yaml", "")
+
+	cfg, err := LoadClient()
+	if err != nil {
+		t.Fatalf("LoadClient error: %v", err)
+	}
+	if cfg.Remote.Default != "remotebox:7777" {
+		t.Fatalf("Remote.Default = %q, want global default (empty repo file ignored)", cfg.Remote.Default)
 	}
 }


### PR DESCRIPTION
## The drift

Three sources claimed a per-repo `.orch/client.yaml` works — the built-in `orch tutorial` (internal/cli/tutorial.go), the orch-toolset skill (SKILL.md, reference.md) — and this repo itself carries such a file. But `config.LoadClient` only ever read the global `~/.config/orch/client.yaml`: a repo-local file was silently dead. (Found while auditing "which files configure orch, and are they documented consistently".)

## Fix: implement the documented behavior

- `.orch/client.yaml` discovered by walking up from the current directory (same discovery as `.orch/config.yaml`; no `.orch/config.yaml` required)
- merged over the global file **field-wise**: non-empty `remote.default` overrides; host aliases merged with per-repo winning per key
- full remote resolution order: `--remote` flag > `ORCH_REMOTE` > per-repo `client.yaml` > global `client.yaml`
- invalid files error naming the offending path (fail fast); empty file = empty config, not a schema error

## Test hermeticity fix included

`setIsolatedXDG` now also `t.Chdir`s: cwd is a config input (config.yaml, and now client.yaml, walk up from it), so CLI tests inheriting the developer's repo cwd were never actually isolated — two of them failed against this feature by picking up the orch repo's own client.yaml. New config tests pin HOME and cwd to temp dirs.

## Docs

- configuration.md / remote-usage.md: document both locations + precedence, and note that a committed `.orch/client.yaml` redirects every command in that checkout (review like code; keep machine-specific values untracked)
- configuration.md: fixed a stale pre-ADR-0003 paragraph that still claimed the TCP API binds all interfaces by default (loopback is the default since #511)

## Validation

- `go build ./...` — pass
- `ORCH_SAFE_CLI_TEST=1 go test ./... -count=1` — 18/18 packages pass
- `make lint` — pass

New tests: per-repo overrides global (nested cwd discovery, alias merge/override), repo-only without global, empty repo default inherits global, invalid repo file names its path, empty repo file ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)