### PR TITLE
feat(daemon): auto-acknowledge trust gates once per run (L-G1)

### DIFF
--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -236,6 +236,7 @@ distinction the law tests themselves forced:
 | L10a gate debounce (generalizes L6) | a `waiting` verdict with reason `gate_<kind>` requires ≥ `waitingPromptStreakThreshold` consecutive captures whose input-request reading is the same `gate:<kind>`; any busy capture or different reading resets the streak |
 | L10b reading precedence | busy veto > gate > {exited, completed, api-limited, failed} > prompt > output-changed; an unconfirmed gate reading masks every lower reading; each gate row's fixture locks its intended winner end-to-end |
 | L10c reason fidelity | the `waiting` reason always reflects the latest *confirmed* reading; a confirmed reading change re-appends under D-G1 and fires exactly one listener event (L8) |
+| L-G1 gate auto-ack (§9.7) | a confirmed AutoAck-gate reading is acknowledged by the daemon exactly once per (run, gate kind) via a bare Enter on the send path; the `gate_ack` note event is the fold-visible ledger; a reappearing gate waits for a human; login gates are never AutoAck |
 | L11a streak continuity | `DeadCheckCount` accumulates only while the observation's ObserverID equals `DeadCheckObserver`; a gone observation from a different observer restarts the streak at 1 (and re-owns it) |
 | L11b attestation | the no-evidence fallback death verdicts (`failed`; opencode's `unknown(session_lost)`) require `DeadCheckObserver == AliveObserver ≠ ""` — the channel pronouncing death must be the channel that last saw this run alive. Evidence-ladder verdicts are channel-independent and unaffected |
 | L11c unverified fallback | the same standing evidence from an unattested channel concludes at most `unknown(observer_unverified)`; never `failed`. Recovery is automatic: any successful capture re-attests the channel |
@@ -619,6 +620,7 @@ specific row proves noisy in practice.
 | L10a gate debounce (generalizes L6) | a `waiting` verdict with reason `gate_<kind>` requires ≥ `waitingPromptStreakThreshold` consecutive captures whose input-request reading is the same `gate:<kind>`; any busy capture or different reading resets the streak. L6 is the `reading = prompt` special case |
 | L10b reading precedence | busy veto > gate > {exited, completed, api-limited, failed} > prompt > output-changed. A curated conjunctive row outranks the loose generic heuristics; each row's fixture locks its intended winner. (This deliberately lets a future `gate_credit` row override `IsAPILimited` on account-credit dialogs — a credit dialog needs a human, not a rate-limit wait) |
 | L10c reason fidelity | the `waiting` reason always reflects the latest *confirmed* reading; a confirmed reading change re-appends under D-G1 and fires exactly one listener event (L8) |
+| L-G1 gate auto-ack (§9.7) | a confirmed AutoAck-gate reading is acknowledged by the daemon exactly once per (run, gate kind) via a bare Enter on the send path; the `gate_ack` note event is the fold-visible ledger; a reappearing gate waits for a human; login gates are never AutoAck |
 
 Counterexamples (must become fixtures/property tests at implementation):
 
@@ -650,6 +652,35 @@ Implemented as designed, frontier + human in-session: `agentSignal.Gate`,
 (`step_gate_test.go`), §2/§3/§4/§5 fold-in. All three fixture screens
 (codex login, codex trust, claude trust) were captured from real tmux panes
 before the pattern rows were written, as required.
+
+### 9.7 Gate auto-acknowledgement (L-G1, decided 2026-07-12)
+
+Incident: a codex trust dialog parked a dispatched run and an operator had
+to send Enter by hand. Detection (§9.1–9.5) had made the gate visible in
+under a minute — but visibility of a question whose answer is already known
+is still toil. Dispatching a run into a daemon-created worktree IS the
+operator's trust decision; asking the operator to repeat it is ceremony.
+
+> **L-G1 (gate auto-ack).** A confirmed AutoAck-gate reading (same L10a
+> streak that gates the `waiting(gate_<kind>)` verdict) is acknowledged by
+> the daemon exactly once per (run, gate kind): a bare Enter through the
+> send path, accepting the gate's preselected default. The ledger for
+> "acknowledged" is the `daemon_notice` note event (`kind=gate_ack`,
+> `attrs.gate=<kind>`), folded back by the gatherer — so the guarantee
+> survives restarts, and a gate that REAPPEARS after its one ack stays
+> `waiting(gate_<kind>)` for a human: acknowledgement loops are
+> structurally impossible. Which gates are AutoAck is declared on the gate
+> rule table itself (`gateRule.AutoAck` — trust: yes); **login gates are
+> never AutoAck** — credentials belong to humans, and the gates meta-test
+> enforces the exclusion mechanically.
+
+The `waiting(gate_<kind>)` verdict still fires on the ack tick, so the
+event log keeps an honest trail: `waiting(gate_trust)` → gate_ack note →
+`running` (the send path's feedback-resume, identical to a user
+`orch send run ""`). Rejected alternative: pre-seeding trust into the
+agent CLI's own config files before launch — it depends on third-party
+config formats that drift across versions and break silently; the ack
+path stays inside orch's own machinery and works for any mux agent.
 
 ## 10. Observation-channel health — death verdicts require attestation (designed 2026-07-07)
 

--- a/internal/agent/gates.go
+++ b/internal/agent/gates.go
@@ -34,10 +34,15 @@ const (
 
 // gateRule declares one gate screen: the gate is detected when ALL substrings
 // co-occur (lowercased) within the last gateWindowLines lines of the pane and
-// no busy marker is visible.
+// no busy marker is visible. AutoAck marks gates the daemon may acknowledge
+// itself, once per run, by sending Enter (run-state-machine.md §9.6 L-G1):
+// trust dialogs qualify because dispatching a run into a worktree IS the
+// operator's trust decision. Login gates must NEVER be AutoAck — credentials
+// belong to humans (TestGateRuleTable enforces this mechanically).
 type gateRule struct {
-	Kind string
-	All  []string
+	Kind    string
+	All     []string
+	AutoAck bool
 }
 
 // gateWindowLines matches the IsWaitingForInput window so gate and prompt
@@ -53,11 +58,13 @@ var gateRules = map[string][]gateRule{
 		// the ChatGPT sign-in menu.
 		{Kind: GateLogin, All: []string{"sign in with chatgpt", "press enter to continue"}},
 		// testdata/gates/codex_trust.txt — codex in an untrusted directory.
-		{Kind: GateTrust, All: []string{"do you trust the contents of this directory", "press enter to continue"}},
+		// Enter accepts the default "Yes, continue".
+		{Kind: GateTrust, All: []string{"do you trust the contents of this directory", "press enter to continue"}, AutoAck: true},
 	},
 	string(AgentClaude): {
 		// testdata/gates/claude_trust.txt — claude code folder-trust dialog.
-		{Kind: GateTrust, All: []string{"is this a project you created or one you trust", "yes, i trust this folder"}},
+		// Enter accepts the default "Yes, I trust this folder".
+		{Kind: GateTrust, All: []string{"is this a project you created or one you trust", "yes, i trust this folder"}, AutoAck: true},
 	},
 }
 
@@ -100,6 +107,21 @@ func hasBusyMarker(lowerLines string) bool {
 	for _, line := range strings.Split(lowerLines, "\n") {
 		if isSpinnerLine(line) {
 			return true
+		}
+	}
+	return false
+}
+
+// GateAutoAck reports whether the given gate kind is declared auto-
+// acknowledgeable for the agent (§9.6 L-G1). It consults the same rule
+// table as DetectGate so policy and detection cannot drift apart.
+func GateAutoAck(agentName, kind string) bool {
+	if kind == "" {
+		return false
+	}
+	for _, rule := range gateRules[agentName] {
+		if rule.Kind == kind {
+			return rule.AutoAck
 		}
 	}
 	return false

--- a/internal/agent/gates_test.go
+++ b/internal/agent/gates_test.go
@@ -31,6 +31,9 @@ func TestGateRuleTable(t *testing.T) {
 				if len(rule.All) < 2 {
 					t.Fatalf("rule %s/%s has %d substrings; the false-positive budget requires >= 2 conjunctive substrings", agentName, rule.Kind, len(rule.All))
 				}
+				if rule.Kind == GateLogin && rule.AutoAck {
+					t.Fatalf("rule %s/%s: login gates must NEVER be AutoAck — credentials belong to humans (L-G1)", agentName, rule.Kind)
+				}
 				for _, sub := range rule.All {
 					if sub != strings.ToLower(sub) {
 						t.Fatalf("rule %s/%s substring %q is not lowercase; matching lowercases the pane first", agentName, rule.Kind, sub)

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -152,6 +152,9 @@ func (d *Daemon) processRunOutput(run *model.Run, st store.Store, state *RunStat
 		Output: output,
 		Signal: signal,
 	}
+	if signal.Gate != "" {
+		obs.GateAckSent = runHasGateAck(run, signal.Gate)
+	}
 	// PR-URL detection is a scrape over arbitrary pane text: anything the
 	// agent prints (git log, gh output, prompt context) can contain a PR
 	// URL that belongs to a different run. Verify ownership here, impurely,
@@ -200,6 +203,20 @@ func (d *Daemon) classifyScrapedPRURL(run *model.Run, url string) (bool, string)
 	return true, info.HeadRefName
 }
 
+// runHasGateAck reports whether the run's event log already records a daemon
+// gate acknowledgement for the given gate kind (L-G1 once-only fold).
+func runHasGateAck(run *model.Run, gateKind string) bool {
+	for _, e := range run.Events {
+		if e == nil || e.Type != model.EventTypeNote || e.Name != model.DaemonNoticeEventName {
+			continue
+		}
+		if e.Attrs["kind"] == "gate_ack" && e.Attrs["gate"] == gateKind {
+			return true
+		}
+	}
+	return false
+}
+
 // runHasDaemonNotice reports whether the run's event log already records a
 // delivered daemon notice of the given kind for the given URL (L-N1). The
 // note event is the store of record for the once-only guarantee; no counter
@@ -225,13 +242,15 @@ func gatherAgentSignal(run *model.Run, mgr agent.AgentManager, output string) ag
 		status := mgr.GetStatus(run, output, &agent.RunState{}, false, false)
 		return agentSignal{Resolved: true, Status: status}
 	}
+	gate := mgr.DetectGate(output)
 	return agentSignal{
 		Exited:        agent.IsAgentExited(output),
 		Completed:     agent.IsCompleted(output),
 		APILimited:    agent.IsAPILimited(output),
 		Failed:        agent.IsFailed(output),
 		PromptShowing: mgr.DetectPrompt(output),
-		Gate:          mgr.DetectGate(output),
+		Gate:          gate,
+		GateAutoAck:   agent.GateAutoAck(run.Agent, gate),
 	}
 }
 
@@ -305,11 +324,16 @@ func (d *Daemon) applyRunEffects(run *model.Run, st store.Store, oldCore, core r
 // failed send must stay retryable, while a failed record after a successful
 // send merely risks one duplicate notice (logged loudly below).
 func (d *Daemon) sendAgentNotice(run *model.Run, st store.Store, projectID, projectRoot string, e runEffect) error {
-	message := fmt.Sprintf(
-		"[orch] Your PR %s was opened from branch %q, but this run's branch is %q. "+
-			"orch tracks a PR only when its head branch equals the run branch (pr-attach law), so that PR is currently untracked. "+
-			"Please push your work to the run branch (git push origin HEAD:%s) and open the PR from it (close the mismatched one).",
-		e.PRURL, e.PRHead, run.Branch, run.Branch)
+	// Gate acknowledgement (L-G1): the "message" is a bare Enter — an empty
+	// send accepts the gate's default answer (trust dialogs preselect Yes).
+	message := ""
+	if e.GateKind == "" {
+		message = fmt.Sprintf(
+			"[orch] Your PR %s was opened from branch %q, but this run's branch is %q. "+
+				"orch tracks a PR only when its head branch equals the run branch (pr-attach law), so that PR is currently untracked. "+
+				"Please push your work to the run branch (git push origin HEAD:%s) and open the PR from it (close the mismatched one).",
+			e.PRURL, e.PRHead, run.Branch, run.Branch)
+	}
 
 	s := d.socketServer
 	if s == nil {
@@ -333,11 +357,16 @@ func (d *Daemon) sendAgentNotice(run *model.Run, st store.Store, projectID, proj
 		}
 	}
 
-	notice := model.NewDaemonNoticeEvent(model.StatusReasonPRBranchMismatch, map[string]string{
-		"url":        e.PRURL,
-		"head":       e.PRHead,
-		"run_branch": run.Branch,
-	})
+	var notice *model.Event
+	if e.GateKind != "" {
+		notice = model.NewDaemonNoticeEvent("gate_ack", map[string]string{"gate": e.GateKind})
+	} else {
+		notice = model.NewDaemonNoticeEvent(model.StatusReasonPRBranchMismatch, map[string]string{
+			"url":        e.PRURL,
+			"head":       e.PRHead,
+			"run_branch": run.Branch,
+		})
+	}
 	if err := st.AppendEvent(run.Ref(), notice); err != nil {
 		// The agent HAS the message; only the once-only bookkeeping failed.
 		// The next idle capture may deliver a duplicate — visible and
@@ -345,7 +374,11 @@ func (d *Daemon) sendAgentNotice(run *model.Run, st store.Store, projectID, proj
 		d.logger.Printf("%s#%s: notice delivered but note event append failed (duplicate possible): %v", run.IssueID, run.RunID, err)
 		return nil
 	}
-	d.logger.Printf("%s#%s: daemon notice delivered: PR %s head %q does not match run branch %q", run.IssueID, run.RunID, e.PRURL, e.PRHead, run.Branch)
+	if e.GateKind != "" {
+		d.logger.Printf("%s#%s: gate %q auto-acknowledged (L-G1: once per run; a recurring gate waits for a human)", run.IssueID, run.RunID, e.GateKind)
+	} else {
+		d.logger.Printf("%s#%s: daemon notice delivered: PR %s head %q does not match run branch %q", run.IssueID, run.RunID, e.PRURL, e.PRHead, run.Branch)
+	}
 	return nil
 }
 

--- a/internal/daemon/step.go
+++ b/internal/daemon/step.go
@@ -156,8 +156,12 @@ type agentSignal struct {
 	PromptShowing bool
 	// Gate is the interactive-gate kind detected on this capture ("" =
 	// none), produced by AgentManager.DetectGate (O4e). The busy-marker veto
-	// is applied gather-side, identically to PromptShowing.
-	Gate string
+	// is applied gather-side, identically to PromptShowing. GateAutoAck
+	// mirrors the gate table's AutoAck declaration for this kind (§9.6):
+	// policy metadata gathered alongside the reading so stepRun never
+	// consults the table itself.
+	Gate        string
+	GateAutoAck bool
 }
 
 // gitEvidence is the raw fact set for a dead-session verdict, gathered by
@@ -260,6 +264,10 @@ type runObservation struct {
 	RefusedPRURL        string
 	RefusedPRHead       string
 	RefusedPRNoticeSent bool
+	// GateAckSent reports whether the run's event log already records a
+	// daemon gate acknowledgement for the CURRENTLY detected gate kind
+	// (L-G1 once-only fold; gatherer-derived like RefusedPRNoticeSent).
+	GateAckSent bool
 
 	// obsGitEvidence
 	Evidence gitEvidence
@@ -302,13 +310,14 @@ const (
 )
 
 type runEffect struct {
-	Kind   effectKind
-	Status model.Status // effectSetStatus
-	PRURL  string       // effectRecordPR / effectRecordPRClosed / effectSendAgentNotice
-	PRHead string       // effectSendAgentNotice: verified head of the refused PR
-	Output string       // effectSetStatus listener payload context
-	Msg    string       // effectLog / effectDebugLog
-	Reason string       // effectSetStatus: machine-readable verdict reason (model.AttrStatusReason)
+	Kind     effectKind
+	Status   model.Status // effectSetStatus
+	PRURL    string       // effectRecordPR / effectRecordPRClosed / effectSendAgentNotice
+	PRHead   string       // effectSendAgentNotice: verified head of the refused PR
+	GateKind string       // effectSendAgentNotice: gate to acknowledge (L-G1); "" = PR-mismatch notice
+	Output   string       // effectSetStatus listener payload context
+	Msg      string       // effectLog / effectDebugLog
+	Reason   string       // effectSetStatus: machine-readable verdict reason (model.AttrStatusReason)
 }
 
 func logEffect(format string, args ...interface{}) runEffect {
@@ -725,6 +734,22 @@ func stepCaptured(view runView, core runCore, obs runObservation, now time.Time)
 			logEffect("%s#%s: status change %s -> %s", view.IssueID, view.RunID, view.Status, statusWithReason(newStatus, reason)),
 			runEffect{Kind: effectSetStatus, Status: newStatus, Output: obs.Output, Reason: reason},
 		)
+	}
+
+	// Gate auto-ack (L-G1, §9.6): a confirmed AutoAck-gate reading is
+	// acknowledged by the daemon exactly once per (run, gate kind) — the
+	// gate_ack note event is the fold-visible ledger. The waiting(gate_)
+	// verdict above still fires on the same tick, so the event log keeps an
+	// honest trail (waiting(gate_trust) -> ack -> running via the send
+	// path's feedback-resume). A gate that REAPPEARS after its one ack
+	// stays waiting(gate_<kind>) for a human: ack loops are structurally
+	// impossible. Non-AutoAck gates (login) never reach this block.
+	if obs.Signal.Gate != "" && obs.Signal.GateAutoAck && !obs.GateAckSent &&
+		confirmedReading == "gate:"+obs.Signal.Gate {
+		effects = append(effects, runEffect{
+			Kind:     effectSendAgentNotice,
+			GateKind: obs.Signal.Gate,
+		})
 	}
 
 	// Daemon notice for the refused PR (L-N1..L-N3): at most one notice per

--- a/internal/daemon/step_gate_test.go
+++ b/internal/daemon/step_gate_test.go
@@ -251,3 +251,74 @@ func TestGateFixturePrecedence(t *testing.T) {
 		})
 	}
 }
+
+// L-G1 (§9.6): a confirmed AutoAck-gate reading is acknowledged by the daemon
+// exactly once per (run, gate kind); login gates are never acknowledged; a
+// gate that reappears after its one ack waits for a human.
+func TestStepLawGateAutoAck(t *testing.T) {
+	now := time.Now()
+	view := stepTestView(model.StatusRunning, "codex", now.Add(-time.Hour))
+
+	trust := runObservation{
+		Kind:   obsCaptured,
+		Output: "do you trust the contents of this directory\npress enter to continue",
+		Signal: agentSignal{Gate: "trust", GateAutoAck: true},
+	}
+
+	// Tick 1: unconfirmed — no verdict, no ack (the same L10a streak gates both).
+	core := runCore{WasAlive: true}
+	var effects []runEffect
+	core, effects = stepRun(view, core, trust, now)
+	for _, e := range effects {
+		if e.Kind == effectSendAgentNotice {
+			t.Fatal("ack before the gate reading confirms (L-G1/L10a violation)")
+		}
+	}
+
+	// Tick 2: confirmed — waiting(gate_trust) AND exactly one ack effect.
+	core, effects = stepRun(view, core, trust, now)
+	if status, reason, ok := statusReasonEffectOf(effects); !ok || status != model.StatusWaiting || reason != "gate_trust" {
+		t.Fatalf("confirmed trust gate = (%v %q %t), want waiting(gate_trust)", status, reason, ok)
+	}
+	acks := 0
+	for _, e := range effects {
+		if e.Kind == effectSendAgentNotice {
+			acks++
+			if e.GateKind != "trust" {
+				t.Fatalf("ack effect GateKind = %q, want trust", e.GateKind)
+			}
+		}
+	}
+	if acks != 1 {
+		t.Fatalf("confirmed AutoAck gate must emit exactly one ack effect, got %d", acks)
+	}
+
+	// After the gate_ack note event folds in, the reappearing gate stays
+	// waiting for a human — no second ack, ever (loop-impossibility).
+	acked := trust
+	acked.GateAckSent = true
+	core, effects = stepRun(view, core, acked, now)
+	for _, e := range effects {
+		if e.Kind == effectSendAgentNotice {
+			t.Fatal("second ack for the same (run, gate kind) (L-G1 violation)")
+		}
+	}
+
+	// Login gates: never acknowledged, regardless of confirmation.
+	login := runObservation{
+		Kind:   obsCaptured,
+		Output: "sign in with chatgpt\npress enter to continue",
+		Signal: agentSignal{Gate: "login", GateAutoAck: false},
+	}
+	core = runCore{WasAlive: true}
+	core, _ = stepRun(view, core, login, now)
+	core, effects = stepRun(view, core, login, now)
+	for _, e := range effects {
+		if e.Kind == effectSendAgentNotice {
+			t.Fatal("login gate acknowledged — credentials belong to humans (L-G1 violation)")
+		}
+	}
+	if status, reason, ok := statusReasonEffectOf(effects); !ok || status != model.StatusWaiting || reason != "gate_login" {
+		t.Fatalf("login gate must still conclude waiting(gate_login), got (%v %q %t)", status, reason, ok)
+	}
+}


### PR DESCRIPTION
## Incident (2026-07-12)

A codex trust dialog parked a dispatched run; the operator manually ran `orch send <run> ""`. §9 detection had made the gate visible within a minute — but a question whose answer is already known is toil: **dispatching a run into a daemon-created worktree IS the operator's trust decision.**

## L-G1 (spec §9.7 ships in this changeset)

```
確定した AutoAck gate 読み(L10a streak 共用)
  → waiting(gate_<kind>) verdict(従来どおり・痕跡)
  → 同 tick で ack effect: 素の Enter を send 経路で送信(既定の Yes を受諾)
台帳 = gate_ack note event(fold 可視・restart 耐性)
再出現した gate → 人間行き(ack ループ構造的に不可能)
gate_login は AutoAck 対象外 — meta-test で機械強制
```

- AutoAck は gate rule テーブル上の宣言(`gateRule.AutoAck`): codex trust / claude trust = yes、login = no
- 配送は #526 の L-N 機構を再利用(local `processSendMessageForRun` / worker `send_message` lease、feedback-resume で running 復帰)— **新規 status writer ゼロ、新規 nosemgrep ゼロ**
- 却下代替案を spec に記録: agent CLI の config への trust 事前書き込み(サードパーティ形式のドリフトで無言破損)

## Tests

- `TestStepLawGateAutoAck`: 未確定 tick は ack しない / 確定 tick で verdict+ack が正確に1回 / ack 済み再出現は人間行き / **login は確定しても絶対に ack しない**
- gates meta-test: `GateLogin && AutoAck` の rule はコンパイル時に fail
- full suite 18/18 pass, `make lint` / `make adr` green

Routing: coupling-core change (step.go/gates table) — frontier in-session + law revision same changeset; human review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)