### PR TITLE
ADR-0005 T2c: L-S3 reap absorption (step/monitor core)

### DIFF
--- a/docs/design/coupling-core-roadmap.md
+++ b/docs/design/coupling-core-roadmap.md
@@ -202,6 +202,8 @@ run-state-machine.md と同じ playbook を適用する。
 | 5 | client/daemon 境界(読み取り) | semgrep ~60 ルール✓ | `make lint` + CI | 完了 |
 | 6 | cancellation/stop 意味論(W7/W8, PR close terminal) | **disposition 決定済み**(run-state-machine.md §6): W7=ladder と統合、W8=v2 統合 | terminal guard + A1 凍結 | W7 統合済(D-B1); W8 は v2 |
 | 7 | エラー伝播 × append(fail-fast) | **修正済み (A2, 2026-06-12)** | `no-ignored-status-append` ルール | 完了 |
+| P-1 | 【未解決の構造問題】agent 状態の報告チャネルが存在せず、run status を画面・死活のプロキシ観測から推論している。§9 gate / §10 attestation / §11 pr-attach / §12 L-S3 は全て同一問題が生む補正条項 family(= 症状一覧) | 問題として記録(2026-07-13)。解決策は未決定 — 誰もこの構造を「選択」した事実はない | 各条項の property tests(症状の再発防止のみ。問題自体は塞げていない) | 解決には明示的な設計判断が必要(候補: agent 状態プロトコル)。条項 family が成長を続ける事実をこの表で可視化する |
+| P-2 | 【未解決の構造問題】session lifecycle に第一級の表現が無い。現状は agent_session artifact と session_reaped note の比較式(ADR-0005 L-S3 ラッチ)という影の状態機械 | 問題として記録(2026-07-13)。解決策は未決定 | L-S3 property tests(現行 2 イベント範囲のみ) | Stage 3(revive)が世代連鎖を本格化させる前に、session 世代台帳(明示的状態機械)への昇格を設計判断として検討するのが自然な時期 |
 
 進捗ログ:
 - 2026-06-12 Phase A 完了(PR #463): A1 ルール+46 サイト凍結 / A2 fail-fast 化 / A3 AGENTS.md routing。

--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -96,6 +96,7 @@ O1 PR merged                 branch or PRUrl set                   → done
 O1 PR closed                 〃                                    → canceled (+pr_closed artifact)
 O1 PR open/unknown           〃                                    遷移なし (URL発見時はartifact記録のみ)
 
+O3 session gone              reaped generation (§12 L-S3)          遷移なし (吸収 — カウント不進行、証拠要求なし)
 O3 session gone              count < 3                             遷移なし (カウント++)
 O3 session gone, count ≥ 3   → O5 git evidence を収集して判定:
    O5: PR(branch) found                                            → done/canceled/pr_open (outcomeに従う; URL未記録なら記録)
@@ -961,3 +962,45 @@ latch clearing, L-N1 once-only, L-N2 idle-only, L-N3 same-tick separation,
 2026-07-11 incident replay), `monitor_test.go` (refusal threading, note-event
 fold, failed-delivery retryability), `socket_test.go` (prompt branch
 discipline).
+
+## 12. Reaped sessions — gone-by-design absorption (ADR-0005 L-S3, decided 2026-07-13)
+
+Status: implemented (T2c). Lands BEFORE any reaper exists: with no
+`session_reaped` note in any log the arm is a no-op by construction, so the
+absorption law is in force before the first kill can happen (ordering
+required by ADR-0005 LS3 — reap may never go live without it).
+
+ADR-0005 (`docs/adr/defadr_0005_run_session_lifecycle.hy`) makes the daemon
+itself a session killer: a run's mux session may be intentionally destroyed
+(reap) while the run stays meaningful in every durable sense (agent
+transcript, worktree, event log). Without a law, the killer's own monitor
+reads the kill as death evidence — O3 gone streaks from an attested
+observer (§10) reach the evidence ladder and can manufacture a false
+`failed`. That is LS3's counterexample, and it is the §10 incident class
+inverted: there the observer was blind, here the observer is right but the
+disappearance is our own act.
+
+> **L-S3 (reap absorption).** A gone observation (O3) for a run whose
+> current agent-session generation is recorded as reaped advances no
+> dead-check streak, requests no evidence, and emits no verdict. The latch
+> is view-derived from the event log (D-C1: no core state):
+> `reaped := ReapedGeneration > 0 ∧ ReapedGeneration ≥ AgentSessionGeneration`,
+> where `AgentSessionGeneration` folds from the latest `agent_session`
+> artifact (ADR-0005 R1) and `ReapedGeneration` folds from the highest
+> `daemon_notice(kind=session_reaped)` generation (R3; the note is appended
+> BEFORE the kill, so the latch is fold-visible on every channel and
+> survives restarts). A revive dissolves the latch by recording a
+> higher-generation `agent_session` artifact (R5). The identity-less arm
+> (`AgentSessionGeneration = 0` with a reap note) absorbs too: R4 forbids
+> the reaper from producing it, but if it appears the safe direction is
+> delaying verdicts, never inventing them (L7' strength monotonicity).
+
+Mechanism/policy split (§5 D2): the shell additionally SKIPS O2/O3/O4
+gathering for reaped runs in `monitorRun` — observing a session we killed
+is wasted work — while the O1 PR-outcome fold keeps running: a reaped
+`pr_open` run still reaches `done` when its PR merges, and issue
+auto-resolve still fires. The step() arm is the law; the shell skip is
+mechanism and carries no policy. Property tests:
+`internal/daemon/step_reap_test.go` (absorption across agents × channels ×
+thresholds, revive dissolution, latch boundaries), fold tests:
+`internal/model/run_reap_test.go`.

--- a/internal/daemon/monitor.go
+++ b/internal/daemon/monitor.go
@@ -91,6 +91,18 @@ func (d *Daemon) monitorRun(run *model.Run, st store.Store, projectID, projectRo
 		}
 	}
 
+	// L-S3 (ADR-0005, run-state-machine.md §12): the run's current session
+	// generation was reaped by the daemon — there is no session to observe.
+	// Liveness and capture gathering are skipped as mechanism; the
+	// stepSessionGone absorption is the law beneath it (defense in depth for
+	// observations that slip through, e.g. a mid-tick reap). The O1
+	// PR-outcome fold above still runs: a reaped pr_open run must still
+	// reach done when its PR merges. Revive dissolves the latch with a
+	// higher-generation agent_session artifact (R5).
+	if run.SessionReaped() {
+		return nil
+	}
+
 	mgr := agent.GetManager(run)
 
 	// Runs executing on another host via the worker plane cannot be observed

--- a/internal/daemon/step.go
+++ b/internal/daemon/step.go
@@ -34,18 +34,28 @@ type runView struct {
 	StartedAt    time.Time
 	IssueID      model.IssueID
 	RunID        model.RunID
+	// AgentSessionGeneration is the run's current agent-native session
+	// generation (agent_session artifact fold, ADR-0005 R1; 0 = none
+	// recorded). ReapedGeneration is the highest generation recorded as
+	// reaped (session_reaped daemon_notice fold, R3). Both are view-derived
+	// from the event log (D-C1), never core state; together they encode the
+	// LS3 latch evaluated by sessionReaped().
+	AgentSessionGeneration int
+	ReapedGeneration       int
 }
 
 func runViewOf(run *model.Run) runView {
 	return runView{
-		Status:       run.Status,
-		StatusReason: run.StatusReason(),
-		Agent:        run.Agent,
-		Branch:       run.Branch,
-		PRUrl:        run.PRUrl,
-		StartedAt:    run.StartedAt,
-		IssueID:      run.IssueID,
-		RunID:        run.RunID,
+		Status:                 run.Status,
+		StatusReason:           run.StatusReason(),
+		Agent:                  run.Agent,
+		Branch:                 run.Branch,
+		PRUrl:                  run.PRUrl,
+		StartedAt:              run.StartedAt,
+		IssueID:                run.IssueID,
+		RunID:                  run.RunID,
+		AgentSessionGeneration: run.AgentSessionGeneration,
+		ReapedGeneration:       run.ReapedSessionGeneration(),
 	}
 }
 
@@ -471,7 +481,28 @@ func stepPRState(view runView, core runCore, obs runObservation) (runCore, []run
 	return core, effects
 }
 
+// sessionReaped evaluates the LS3 latch (ADR-0005, run-state-machine.md §12)
+// on the view: the run's current session generation is recorded as reaped, so
+// its absence is the daemon's own doing, not evidence about the work. A
+// revive dissolves the latch by recording a higher-generation agent_session
+// artifact. The zero-identity arm (ReapedGeneration > 0, AgentSessionGeneration
+// == 0) absorbs too — the safe direction is delaying verdicts (L7').
+func sessionReaped(view runView) bool {
+	return view.ReapedGeneration > 0 && view.ReapedGeneration >= view.AgentSessionGeneration
+}
+
 func stepSessionGone(view runView, core runCore, obs runObservation) (runCore, []runEffect) {
+	// L-S3 reap absorption (ADR-0005 LS3, §12): a gone observation for a
+	// session generation the daemon itself reaped is EXPECTED. It advances
+	// no dead-check streak, requests no evidence, and emits no verdict —
+	// otherwise the reaper's own monitor would manufacture false failed
+	// verdicts from attested gone streaks (LS3's counterexample). The core
+	// is returned untouched so the streak state is exactly as if the
+	// observation had not happened.
+	if sessionReaped(view) {
+		return core, []runEffect{debugEffect("%s#%s: session gone but generation %d is reaped (L-S3), absorbing", view.IssueID, view.RunID, view.ReapedGeneration)}
+	}
+
 	// L11a streak continuity: a dead-check streak is evidence only within a
 	// single observer generation. A gone observation from a different
 	// observer restarts the streak at 1 and re-owns it.

--- a/internal/daemon/step_reap_test.go
+++ b/internal/daemon/step_reap_test.go
@@ -1,0 +1,115 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/proboscis/orch/internal/model"
+)
+
+// reapTestView builds a view whose current session generation is recorded as
+// reaped (the LS3 latch): agent_session generation == session_reaped
+// generation.
+func reapTestView(status model.Status, agent string, startedAt time.Time, agentGen, reapedGen int) runView {
+	view := stepTestView(status, agent, startedAt)
+	view.AgentSessionGeneration = agentGen
+	view.ReapedGeneration = reapedGen
+	return view
+}
+
+// L-S3 (ADR-0005 LS3, run-state-machine.md §12): gone observations on a
+// reaped session generation advance no dead-check streak, request no
+// evidence, and emit no verdict — for any agent, any non-terminal status,
+// local and remote channels, attested or not, repeated past every threshold.
+func TestStepLawReapAbsorption(t *testing.T) {
+	now := time.Now()
+	for _, agent := range stepTestAgents {
+		for _, remote := range []bool{false, true} {
+			view := reapTestView(model.StatusWaiting, agent, now.Add(-time.Hour), 1, 1)
+			// Attested observer: the exact channel that would otherwise be
+			// allowed to reach a failed verdict (L11b) — the strongest case.
+			core := runCore{WasAlive: true, AliveObserver: "obs-a"}
+			obs := runObservation{Kind: obsSessionGone, Remote: remote, Observer: "obs-a", GoneClass: "session_absent"}
+
+			for i := 0; i < deadChecksBeforeFailed*2; i++ {
+				var effects []runEffect
+				core, effects = stepRun(view, core, obs, now)
+				if core.DeadCheckCount != 0 {
+					t.Fatalf("agent=%s remote=%v: dead-check streak advanced to %d on a reaped generation", agent, remote, core.DeadCheckCount)
+				}
+				if effectsContain(effects, effectGatherGitEvidence) {
+					t.Fatalf("agent=%s remote=%v: evidence requested for a reaped generation", agent, remote)
+				}
+				if status, ok := statusEffectOf(effects); ok {
+					t.Fatalf("agent=%s remote=%v: verdict %q emitted for a reaped generation", agent, remote, status)
+				}
+			}
+		}
+	}
+}
+
+// A revive records a higher-generation agent_session artifact (ADR-0005 R5),
+// dissolving the LS3 latch: gone observations resume normal dead-check
+// accumulation and reach the evidence request at the threshold.
+func TestStepLawReviveDissolvesReapLatch(t *testing.T) {
+	now := time.Now()
+	view := reapTestView(model.StatusRunning, "claude", now.Add(-time.Hour), 2, 1)
+	core := runCore{WasAlive: true, AliveObserver: "obs-a"}
+	obs := runObservation{Kind: obsSessionGone, Remote: false, Observer: "obs-a", GoneClass: "session_absent"}
+
+	sawEvidenceRequest := false
+	for i := 0; i < deadChecksBeforeFailed; i++ {
+		var effects []runEffect
+		core, effects = stepRun(view, core, obs, now)
+		if effectsContain(effects, effectGatherGitEvidence) {
+			sawEvidenceRequest = true
+		}
+	}
+	if core.DeadCheckCount != deadChecksBeforeFailed {
+		t.Fatalf("revived run's dead-check streak = %d, want %d (latch must dissolve)", core.DeadCheckCount, deadChecksBeforeFailed)
+	}
+	if !sawEvidenceRequest {
+		t.Fatalf("revived run never reached the evidence request after %d gone checks", deadChecksBeforeFailed)
+	}
+}
+
+// Defensive arm: a reap note with no recorded agent_session identity
+// (AgentSessionGeneration == 0) still absorbs. The reaper is forbidden from
+// producing this state (R4 kills only identity-recorded runs), but if it
+// appears the safe direction is delaying verdicts, never inventing them (L7'
+// strength monotonicity).
+func TestStepLawReapAbsorptionWithoutIdentity(t *testing.T) {
+	now := time.Now()
+	view := reapTestView(model.StatusRunning, "codex", now.Add(-time.Hour), 0, 1)
+	core := runCore{WasAlive: true, AliveObserver: "obs-a"}
+	obs := runObservation{Kind: obsSessionGone, Remote: false, Observer: "obs-a", GoneClass: "session_absent"}
+
+	for i := 0; i < deadChecksBeforeFailed+1; i++ {
+		var effects []runEffect
+		core, effects = stepRun(view, core, obs, now)
+		if core.DeadCheckCount != 0 || effectsContain(effects, effectGatherGitEvidence) {
+			t.Fatalf("identity-less reaped run was not absorbed (count=%d)", core.DeadCheckCount)
+		}
+	}
+}
+
+// The latch itself: boundary semantics of sessionReaped.
+func TestSessionReapedLatchBoundaries(t *testing.T) {
+	cases := []struct {
+		agentGen, reapedGen int
+		want                bool
+	}{
+		{0, 0, false},  // no identity, no reap
+		{1, 0, false},  // live identity, never reaped
+		{1, 1, true},   // current generation reaped
+		{2, 1, false},  // revived past the reap
+		{1, 2, true},   // reap note ahead (reaper raced a fold) — absorb
+		{0, 1, true},   // defensive arm
+	}
+	for _, c := range cases {
+		view := runView{AgentSessionGeneration: c.agentGen, ReapedGeneration: c.reapedGen}
+		if got := sessionReaped(view); got != c.want {
+			t.Errorf("sessionReaped(agent=%d, reaped=%d) = %v, want %v", c.agentGen, c.reapedGen, got, c.want)
+		}
+	}
+}

--- a/internal/model/run.go
+++ b/internal/model/run.go
@@ -161,6 +161,38 @@ func (r *Run) StatusReason() string {
 	return ""
 }
 
+// ReapedSessionGeneration returns the highest agent-session generation this
+// run's event log records as reaped (daemon_notice kind=session_reaped,
+// ADR-0005 R3), 0 when none. The reaper appends the note BEFORE killing the
+// session, so "gone because the daemon killed it" is always fold-derivable
+// on every channel and survives restarts (D-C1: view-derived, no core state).
+func (r *Run) ReapedSessionGeneration() int {
+	gen := 0
+	for _, e := range r.Events {
+		if e.Type != EventTypeNote || e.Name != DaemonNoticeEventName {
+			continue
+		}
+		if e.Attrs["kind"] != "session_reaped" {
+			continue
+		}
+		if g, err := strconv.Atoi(e.Attrs["generation"]); err == nil && g > gen {
+			gen = g
+		}
+	}
+	return gen
+}
+
+// SessionReaped reports whether the run's CURRENT agent-session generation is
+// recorded as reaped (ADR-0005 LS3): the daemon itself destroyed the session,
+// so its absence is expected, not evidence. A revive dissolves the latch by
+// recording a higher-generation agent_session artifact (R5). The zero
+// AgentSessionGeneration arm is defensive: a reap note with no recorded
+// identity still absorbs — the safe direction is delaying verdicts (L7').
+func (r *Run) SessionReaped() bool {
+	g := r.ReapedSessionGeneration()
+	return g > 0 && g >= r.AgentSessionGeneration
+}
+
 // GetPhase derives phase from events (last phase event wins).
 func (r *Run) GetPhase() Phase {
 	for i := len(r.Events) - 1; i >= 0; i-- {

--- a/internal/model/run_reap_test.go
+++ b/internal/model/run_reap_test.go
@@ -1,0 +1,50 @@
+package model
+
+import "testing"
+
+// ReapedSessionGeneration folds the highest session_reaped daemon_notice
+// generation from the event log (ADR-0005 R3); malformed or foreign notes
+// contribute nothing.
+func TestReapedSessionGeneration(t *testing.T) {
+	reapNote := func(gen string) *Event {
+		return NewDaemonNoticeEvent("session_reaped", map[string]string{"generation": gen})
+	}
+
+	cases := []struct {
+		name   string
+		events []*Event
+		want   int
+	}{
+		{"no events", nil, 0},
+		{"unrelated note", []*Event{NewDaemonNoticeEvent("gate_ack", map[string]string{"gate": "trust"})}, 0},
+		{"single reap", []*Event{reapNote("1")}, 1},
+		{"reap chain keeps max", []*Event{reapNote("1"), reapNote("2")}, 2},
+		{"malformed generation ignored", []*Event{reapNote("banana"), reapNote("1")}, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := &Run{}
+			r.Events = append(r.Events, c.events...)
+			if got := r.ReapedSessionGeneration(); got != c.want {
+				t.Fatalf("ReapedSessionGeneration() = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+// SessionReaped is the LS3 latch over the two folds.
+func TestSessionReaped(t *testing.T) {
+	r := &Run{}
+	if r.SessionReaped() {
+		t.Fatal("fresh run must not read as reaped")
+	}
+	r.Events = append(r.Events, NewDaemonNoticeEvent("session_reaped", map[string]string{"generation": "1"}))
+	r.AgentSessionGeneration = 1
+	if !r.SessionReaped() {
+		t.Fatal("current generation reaped must latch")
+	}
+	r.AgentSessionGeneration = 2 // revive recorded a new generation
+	if r.SessionReaped() {
+		t.Fatal("revive must dissolve the latch")
+	}
+}


### PR DESCRIPTION
## What
The Stage-2 precondition core change: `stepSessionGone` absorbs gone observations for a run whose current agent-session generation is recorded as reaped (`session_reaped` daemon_notice fold ≥ `agent_session` fold) — no dead-check accumulation, no evidence request, no verdict. `monitorRun` additionally skips O2/O3/O4 gathering for reaped runs (mechanism), while the O1 PR-outcome fold keeps running (a reaped `pr_open` run still folds merged → done).

## Why this lands before the reaper
Without L-S3, the reaper's own kills feed attested O3 gone streaks into the evidence ladder and manufacture false `failed` verdicts (ADR-0005 LS3 counterexample). With no `session_reaped` note in any log this change is a no-op by construction — so the law is in force before the first kill can ever happen.

## Law/spec shipped in the same change set (core routing rule)
- `docs/design/run-state-machine.md` §12 (L-S3) + §3 matrix row
- Property tests: `internal/daemon/step_reap_test.go` (absorption across agents × channels × thresholds, revive dissolution, latch boundaries)
- Fold tests: `internal/model/run_reap_test.go`

## Verification
`go build ./...` ✓ / `go test ./...` exit 0 ✓ / `make lint` ✓ / new law tests pass ✓

Core surfaces touched: `step.go`, `monitor.go` (frontier + human lane per AGENTS.md routing — human review requested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)