### PR TITLE
Expose worker agent availability diagnostics

### DIFF
--- a/docs/adr/ADR-0002-idempotent-worker-autostart.md
+++ b/docs/adr/ADR-0002-idempotent-worker-autostart.md
@@ -98,14 +98,32 @@ the pre-dispatch ensure. Default: enabled.
 - The auto-spawned worker inherits the master's (or client's) environment.
   A master auto-started from the user's shell carries the user's PATH — the
   normal local case. A systemd/nohup master with a minimal PATH may spawn a
-  worker that cannot find agent CLIs; explicit `orch worker start` from a
-  login shell remains the documented override, and the existing
-  `agent not available: <cli> (worker <id>, host <host>)` failure stays the
-  observable symptom with the evaluating worker identified.
+  worker that cannot find or execute agent CLIs. At worker startup, orch probes
+  every known adapter and logs a stable availability map plus the inherited
+  PATH. A failed run identifies the evaluating worker and reports the exact
+  probe command, exit status or lookup failure, and PATH, so the deciding
+  worker environment is immediately diagnosable. Explicit `orch worker start`
+  from an environment with the intended PATH remains the operator override.
 - "worker not running" disappears as a user-visible error class on
   single-machine setups; docs and the embedded tutorial shrink accordingly.
 - The reconciler runs strictly inside the lease-failure path: zero cost when
   workers are healthy, no background polling, no new periodic loop.
+
+### Environment normalization decision (2026-07-13)
+
+The worker does **not** synthesize a login-shell environment or rewrite PATH at
+spawn. It continues to inherit the environment of the process that launches
+it.
+
+Running a login shell is not a portable normalization rule: shell selection and
+startup-file semantics differ across platforms, startup files can have
+interactive side effects, and a service manager may intentionally constrain
+PATH. Rewriting the environment would also make the startup probe describe a
+different execution context from the one that launches agents. The invariant
+is therefore: **probe and agent launch observe the same inherited environment**.
+Operators configure PATH explicitly in their service/automation launcher, or
+restart the managed worker from the intended shell environment; orch exposes
+the mismatch rather than silently changing it.
 
 ## Alternatives considered
 

--- a/internal/agent/adapter.go
+++ b/internal/agent/adapter.go
@@ -170,8 +170,8 @@ type Adapter interface {
 	// ExtraEnv returns agent-specific environment variables to inject at launch.
 	ExtraEnv() []string
 
-	// IsAvailable checks if the agent CLI is available
-	IsAvailable() bool
+	// ProbeAvailability checks the agent CLI and retains the exact probe result.
+	ProbeAvailability() Availability
 
 	// PromptInjection returns how the prompt should be sent to the agent
 	// Default implementations should return InjectionArg

--- a/internal/agent/availability.go
+++ b/internal/agent/availability.go
@@ -1,0 +1,143 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+const availabilityProbeTimeout = 5 * time.Second
+
+// Availability is the complete result of checking one agent CLI in the
+// current process environment. It deliberately retains the probe and PATH:
+// workers inherit their launcher's environment, so both are required to make
+// an unavailable result actionable on the host that evaluated it.
+type Availability struct {
+	Agent     AgentType
+	Available bool
+	Probe     string
+	ExitCode  int
+	Failure   string
+	Path      string
+	Deferred  bool
+}
+
+// Diagnostic formats an availability result for a run failure. Unlike the
+// startup map, a per-run failure includes PATH inline so the error remains
+// self-contained as it crosses the worker/master protocol boundary.
+func (a Availability) Diagnostic() string {
+	return a.outcome() + "; PATH=" + displayPATH(a.Path)
+}
+
+func (a Availability) outcome() string {
+	switch {
+	case a.Deferred:
+		return fmt.Sprintf("probe %q deferred until launch", a.Probe)
+	case a.Available:
+		return fmt.Sprintf("probe %q succeeded", a.Probe)
+	case a.ExitCode >= 0:
+		return fmt.Sprintf("probe %q exited %d", a.Probe, a.ExitCode)
+	case a.Failure != "":
+		return fmt.Sprintf("probe %q failed: %s", a.Probe, a.Failure)
+	default:
+		return fmt.Sprintf("probe %q failed", a.Probe)
+	}
+}
+
+func displayPATH(path string) string {
+	if path == "" {
+		return "<empty>"
+	}
+	return path
+}
+
+func probeCommand(agentType AgentType, binary, displayCommand string, args ...string) Availability {
+	result := Availability{
+		Agent:    agentType,
+		Probe:    displayCommand,
+		ExitCode: -1,
+		Path:     os.Getenv("PATH"),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), availabilityProbeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, args...)
+	err := cmd.Run()
+	if err == nil {
+		result.Available = true
+		result.ExitCode = 0
+		return result
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		result.Failure = fmt.Sprintf("timed out after %s", availabilityProbeTimeout)
+		return result
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() >= 0 {
+		result.ExitCode = exitErr.ExitCode()
+		return result
+	}
+	result.Failure = err.Error()
+	return result
+}
+
+func unavailableProbe(agentType AgentType, probe, failure string) Availability {
+	return Availability{
+		Agent:    agentType,
+		Probe:    probe,
+		ExitCode: -1,
+		Failure:  failure,
+		Path:     os.Getenv("PATH"),
+	}
+}
+
+// KnownAgentTypes returns every adapter type in stable log order.
+func KnownAgentTypes() []AgentType {
+	return []AgentType{AgentClaude, AgentCodex, AgentGemini, AgentOpenCode, AgentCustom}
+}
+
+// ProbeKnownAdapters probes every known adapter once. Probes run concurrently
+// so one slow or broken CLI delays worker startup by at most the per-probe
+// timeout rather than the sum of all timeouts; result order remains stable.
+func ProbeKnownAdapters() []Availability {
+	types := KnownAgentTypes()
+	results := make([]Availability, len(types))
+	var wg sync.WaitGroup
+	for i, agentType := range types {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			adapter, err := GetAdapter(agentType)
+			if err != nil {
+				results[i] = unavailableProbe(agentType, string(agentType)+" adapter", err.Error())
+				return
+			}
+			results[i] = adapter.ProbeAvailability()
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+// FormatAvailabilityMap formats the one-time worker startup report. PATH is
+// emitted once because every probe runs in the same inherited environment.
+func FormatAvailabilityMap(results []Availability) string {
+	entries := make([]string, 0, len(results))
+	path := ""
+	for _, result := range results {
+		state := "unavailable"
+		if result.Available {
+			state = "available"
+		}
+		entries = append(entries, fmt.Sprintf("%s=%s (%s)", result.Agent, state, result.outcome()))
+		if path == "" {
+			path = result.Path
+		}
+	}
+	return "{" + strings.Join(entries, ", ") + "}; PATH=" + displayPATH(path)
+}

--- a/internal/agent/availability_test.go
+++ b/internal/agent/availability_test.go
@@ -1,0 +1,108 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAdapterAvailabilityFailureIncludesProbeExitAndPATH(t *testing.T) {
+	for _, agentType := range []AgentType{AgentClaude, AgentCodex, AgentGemini, AgentOpenCode} {
+		t.Run(string(agentType), func(t *testing.T) {
+			binDir := t.TempDir()
+			binPath := filepath.Join(binDir, string(agentType))
+			if err := os.WriteFile(binPath, []byte("#!/bin/sh\nexit 7\n"), 0755); err != nil {
+				t.Fatalf("write fake %s: %v", agentType, err)
+			}
+			t.Setenv("PATH", binDir)
+
+			adapter, err := GetAdapter(agentType)
+			if err != nil {
+				t.Fatalf("GetAdapter(%s): %v", agentType, err)
+			}
+			availability := adapter.ProbeAvailability()
+			if availability.Available {
+				t.Fatal("ProbeAvailability() reported an exiting probe as available")
+			}
+
+			diagnostic := availability.Diagnostic()
+			for _, want := range []string{fmt.Sprintf(`probe %q exited 7`, agentType+" --version"), "PATH=" + binDir} {
+				if !strings.Contains(diagnostic, want) {
+					t.Fatalf("Diagnostic() = %q, want substring %q", diagnostic, want)
+				}
+			}
+		})
+	}
+}
+
+func TestKnownAgentTypesIncludesEveryAdapter(t *testing.T) {
+	got := KnownAgentTypes()
+	want := []AgentType{AgentClaude, AgentCodex, AgentGemini, AgentOpenCode, AgentCustom}
+	if len(got) != len(want) {
+		t.Fatalf("KnownAgentTypes() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("KnownAgentTypes() = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestProbeKnownAdaptersProbesEachVersionedCLIOnce(t *testing.T) {
+	binDir := t.TempDir()
+	callDir := t.TempDir()
+	for _, agentType := range []AgentType{AgentClaude, AgentCodex, AgentGemini, AgentOpenCode} {
+		callPath := filepath.Join(callDir, string(agentType)+".calls")
+		script := fmt.Sprintf("#!/bin/sh\nprintf x >> %q\nexit 0\n", callPath)
+		if err := os.WriteFile(filepath.Join(binDir, string(agentType)), []byte(script), 0755); err != nil {
+			t.Fatalf("write fake %s: %v", agentType, err)
+		}
+	}
+	t.Setenv("PATH", binDir)
+
+	results := ProbeKnownAdapters()
+	if len(results) != len(KnownAgentTypes()) {
+		t.Fatalf("ProbeKnownAdapters() returned %d results, want %d", len(results), len(KnownAgentTypes()))
+	}
+	for _, result := range results {
+		if !result.Available {
+			t.Fatalf("ProbeKnownAdapters() result for %s = %+v, want available", result.Agent, result)
+		}
+		if result.Agent == AgentCustom {
+			if !result.Deferred {
+				t.Fatalf("custom availability = %+v, want deferred", result)
+			}
+			continue
+		}
+		calls, err := os.ReadFile(filepath.Join(callDir, string(result.Agent)+".calls"))
+		if err != nil {
+			t.Fatalf("read %s probe calls: %v", result.Agent, err)
+		}
+		if string(calls) != "x" {
+			t.Fatalf("%s probe calls = %q, want exactly one", result.Agent, calls)
+		}
+	}
+}
+
+func TestFormatAvailabilityMapIncludesOutcomesAndSinglePATH(t *testing.T) {
+	results := []Availability{
+		{Agent: AgentClaude, Available: false, Probe: "claude --version", ExitCode: 1, Path: "/usr/bin:/bin"},
+		{Agent: AgentCustom, Available: true, Probe: "custom command", Deferred: true, Path: "/usr/bin:/bin"},
+	}
+
+	got := FormatAvailabilityMap(results)
+	for _, want := range []string{
+		`claude=unavailable (probe "claude --version" exited 1)`,
+		`custom=available (probe "custom command" deferred until launch)`,
+		"PATH=/usr/bin:/bin",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("FormatAvailabilityMap() = %q, want substring %q", got, want)
+		}
+	}
+	if strings.Count(got, "PATH=") != 1 {
+		t.Fatalf("FormatAvailabilityMap() = %q, want PATH exactly once", got)
+	}
+}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"os/exec"
 	"strings"
 )
 
@@ -12,9 +11,8 @@ func (a *ClaudeAdapter) Type() AgentType {
 	return AgentClaude
 }
 
-func (a *ClaudeAdapter) IsAvailable() bool {
-	cmd := exec.Command("claude", "--version")
-	return cmd.Run() == nil
+func (a *ClaudeAdapter) ProbeAvailability() Availability {
+	return probeCommand(AgentClaude, "claude", "claude --version", "--version")
 }
 
 func (a *ClaudeAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 )
 
@@ -13,9 +12,8 @@ func (a *CodexAdapter) Type() AgentType {
 	return AgentCodex
 }
 
-func (a *CodexAdapter) IsAvailable() bool {
-	cmd := exec.Command("codex", "--version")
-	return cmd.Run() == nil
+func (a *CodexAdapter) ProbeAvailability() Availability {
+	return probeCommand(AgentCodex, "codex", "codex --version", "--version")
 }
 
 func (a *CodexAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {

--- a/internal/agent/custom.go
+++ b/internal/agent/custom.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"os"
 )
 
 // CustomAdapter handles custom agent commands
@@ -11,9 +12,18 @@ func (a *CustomAdapter) Type() AgentType {
 	return AgentCustom
 }
 
-func (a *CustomAdapter) IsAvailable() bool {
-	// Custom adapter is always "available" - the actual command check happens at runtime
-	return true
+func (a *CustomAdapter) ProbeAvailability() Availability {
+	// A custom command is part of each launch config, not the adapter, so it
+	// cannot be probed until launch. Preserve the existing availability
+	// contract while making that deferred check explicit in startup logs.
+	return Availability{
+		Agent:     AgentCustom,
+		Available: true,
+		Probe:     "custom command",
+		ExitCode:  -1,
+		Path:      os.Getenv("PATH"),
+		Deferred:  true,
+	}
 }
 
 func (a *CustomAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"os/exec"
 	"strings"
 )
 
@@ -12,9 +11,8 @@ func (a *GeminiAdapter) Type() AgentType {
 	return AgentGemini
 }
 
-func (a *GeminiAdapter) IsAvailable() bool {
-	cmd := exec.Command("gemini", "--version")
-	return cmd.Run() == nil
+func (a *GeminiAdapter) ProbeAvailability() Availability {
+	return probeCommand(AgentGemini, "gemini", "gemini --version", "--version")
 }
 
 func (a *GeminiAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -17,8 +17,12 @@ func (a *OpenCodeAdapter) Type() AgentType {
 	return AgentOpenCode
 }
 
-func (a *OpenCodeAdapter) IsAvailable() bool {
-	return findOpenCodeBinary() != ""
+func (a *OpenCodeAdapter) ProbeAvailability() Availability {
+	binary := findOpenCodeBinary()
+	if binary == "" {
+		return unavailableProbe(AgentOpenCode, "opencode --version", "executable not found in PATH or ~/.opencode/bin")
+	}
+	return probeCommand(AgentOpenCode, binary, "opencode --version", "--version")
 }
 
 func findOpenCodeBinary() string {

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -307,8 +307,9 @@ func createMultiplexerSession(orchDir, projectRoot string, agentType agent.Agent
 		return fmt.Errorf("failed to get adapter: %w", err)
 	}
 
-	if !adapter.IsAvailable() {
-		return fmt.Errorf("%s CLI is not available", agentType)
+	availability := adapter.ProbeAvailability()
+	if !availability.Available {
+		return fmt.Errorf("agent not available: %s (%s)", agentType, availability.Diagnostic())
 	}
 
 	issuesRoot, err := getIssuesRootForProjectIfConfigured(projectRoot)

--- a/internal/cli/master_worker.go
+++ b/internal/cli/master_worker.go
@@ -15,6 +15,7 @@ var requireDaemonForWorker = func() (worker.Client, error) {
 	return requireDaemon()
 }
 var runExternalWorkerLoop = worker.RunExternalLoop
+var logWorkerAgentAvailability = worker.LogAgentAvailability
 
 func newMasterCmd() *cobra.Command {
 	cmd := newDaemonCmd()
@@ -58,6 +59,7 @@ func newWorkerRunCmd() *cobra.Command {
 		Short: "Run long-lived orch-worker host loop",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			worker.ScrubInheritedMultiplexerEnv()
+			logWorkerAgentAvailability(workerID)
 
 			client, err := requireDaemonForWorker()
 			if err != nil {

--- a/internal/cli/master_worker_test.go
+++ b/internal/cli/master_worker_test.go
@@ -71,9 +71,11 @@ func TestWorkerRunCommandInvokesExternalLoop(t *testing.T) {
 
 	origRequire := requireDaemonForWorker
 	origRun := runExternalWorkerLoop
+	origLogAvailability := logWorkerAgentAvailability
 	t.Cleanup(func() {
 		requireDaemonForWorker = origRequire
 		runExternalWorkerLoop = origRun
+		logWorkerAgentAvailability = origLogAvailability
 	})
 
 	requireDaemonForWorker = func() (worker.Client, error) {
@@ -86,6 +88,13 @@ func TestWorkerRunCommandInvokesExternalLoop(t *testing.T) {
 	}
 
 	called := false
+	availabilityLogged := false
+	logWorkerAgentAvailability = func(workerID string) {
+		availabilityLogged = true
+		if workerID != "worker-1" {
+			t.Fatalf("availability worker id = %q, want worker-1", workerID)
+		}
+	}
 	var got worker.RunConfig
 	runExternalWorkerLoop = func(client worker.Client, cfg worker.RunConfig) error {
 		called = true
@@ -101,6 +110,9 @@ func TestWorkerRunCommandInvokesExternalLoop(t *testing.T) {
 
 	if !called {
 		t.Fatal("expected runExternalWorkerLoop to be called")
+	}
+	if !availabilityLogged {
+		t.Fatal("expected worker startup to log agent availability")
 	}
 	if got.WorkerID != "worker-1" || !got.Once || got.PollInterval != 300*time.Millisecond || got.HeartbeatInterval != 7*time.Second {
 		t.Fatalf("unexpected run config: %+v", got)

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -2469,8 +2469,9 @@ func (s *SocketServer) processControlAgentLaunchCore(st store.Store, params *Con
 		return nil, fmt.Errorf("failed to get adapter: %w", err)
 	}
 
-	if !adapter.IsAvailable() {
-		return nil, fmt.Errorf("%s CLI not available", agentName)
+	availability := adapter.ProbeAvailability()
+	if !availability.Available {
+		return nil, s.agentNotAvailableError(agentName, availability)
 	}
 
 	prompt := getControlPromptInstruction()
@@ -3495,9 +3496,12 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 	}
 
 	isRemoteTarget := strings.TrimSpace(req.Target) != "" && strings.TrimSpace(req.Target) != "local"
-	if !isRemoteTarget && !adapter.IsAvailable() {
-		encoder.Encode(StartRunResponse{OK: false, Error: "agent not available: " + agentName})
-		return
+	if !isRemoteTarget {
+		availability := adapter.ProbeAvailability()
+		if !availability.Available {
+			encoder.Encode(StartRunResponse{OK: false, Error: s.agentNotAvailableError(agentName, availability).Error()})
+			return
+		}
 	}
 
 	runID := model.RunID(req.RunID)
@@ -3840,8 +3844,11 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 		return nil, fmt.Errorf("failed to get adapter: %w", err)
 	}
 
-	if !isRemoteTarget && !adapter.IsAvailable() {
-		return nil, s.agentNotAvailableError(agentName)
+	if !isRemoteTarget {
+		availability := adapter.ProbeAvailability()
+		if !availability.Available {
+			return nil, s.agentNotAvailableError(agentName, availability)
+		}
 	}
 	if isRemoteTarget && adapter.PromptInjection() == agent.InjectionHTTP {
 		return nil, fmt.Errorf("agent %s with HTTP prompt injection is not supported with remote target %q", agentName, targetName)
@@ -4128,19 +4135,21 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 	}, nil
 }
 
-func (s *SocketServer) agentNotAvailableError(agentName string) error {
+func (s *SocketServer) agentNotAvailableError(agentName string, availability agent.Availability) error {
 	workerID := strings.TrimSpace(s.currentWorkerID)
 	host := strings.TrimSpace(s.currentWorkerHost)
-	switch {
-	case workerID != "" && host != "":
-		return fmt.Errorf("agent not available: %s (worker %s, host %s)", agentName, workerID, host)
-	case workerID != "":
-		return fmt.Errorf("agent not available: %s (worker %s)", agentName, workerID)
-	case host != "":
-		return fmt.Errorf("agent not available: %s (host %s)", agentName, host)
-	default:
-		return fmt.Errorf("agent not available: %s", agentName)
+	identity := make([]string, 0, 2)
+	if workerID != "" {
+		identity = append(identity, "worker "+workerID)
 	}
+	if host != "" {
+		identity = append(identity, "host "+host)
+	}
+	detail := availability.Diagnostic()
+	if len(identity) > 0 {
+		detail = strings.Join(identity, ", ") + "; " + detail
+	}
+	return fmt.Errorf("agent not available: %s (%s)", agentName, detail)
 }
 
 func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string, opts *ContinueRunOptions) (*ContinueRunResult, error) {
@@ -4355,8 +4364,9 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 		return nil, fmt.Errorf("failed to get adapter: %w", err)
 	}
 
-	if !adapter.IsAvailable() {
-		return nil, s.agentNotAvailableError(agentName)
+	availability := adapter.ProbeAvailability()
+	if !availability.Available {
+		return nil, s.agentNotAvailableError(agentName, availability)
 	}
 
 	reqModel := strings.TrimSpace(opts.Model)
@@ -4801,8 +4811,9 @@ func (s *SocketServer) handleContinueRun(req SendRequest, encoder *json.Encoder)
 		return
 	}
 
-	if !adapter.IsAvailable() {
-		encoder.Encode(ContinueRunResponse{OK: false, Error: "agent not available: " + agentName})
+	availability := adapter.ProbeAvailability()
+	if !availability.Available {
+		encoder.Encode(ContinueRunResponse{OK: false, Error: s.agentNotAvailableError(agentName, availability).Error()})
 		return
 	}
 

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -5855,7 +5855,7 @@ func TestProtoStartRunFieldMapping(t *testing.T) {
 		// If it fails with "agent not available", that's expected in CI without claude installed.
 		// The key contract test is that Model is NOT in Message.
 		errMsg := resp.Error
-		if errMsg != "agent not available: claude" && errMsg != "no project root available" && !strings.Contains(errMsg, "no active worker on host") {
+		if !strings.Contains(errMsg, "agent not available: claude") && errMsg != "no project root available" && !strings.Contains(errMsg, "no active worker on host") {
 			t.Fatalf("unexpected error: %s", errMsg)
 		}
 	}
@@ -6180,6 +6180,29 @@ func TestProcessStartRunCoreValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("unavailable agent error includes probe exit and PATH", func(t *testing.T) {
+		binDir := t.TempDir()
+		binPath := filepath.Join(binDir, "claude")
+		if err := os.WriteFile(binPath, []byte("#!/bin/sh\nexit 9\n"), 0755); err != nil {
+			t.Fatalf("write fake claude: %v", err)
+		}
+		t.Setenv("PATH", binDir)
+
+		opts := &StartRunOptions{
+			IssueID: "test-issue",
+			Agent:   "claude",
+		}
+		_, err := server.processStartRunCore(st, "", opts)
+		if err == nil {
+			t.Fatal("expected unavailable agent error")
+		}
+		for _, want := range []string{`agent not available: claude`, `probe "claude --version" exited 9`, "PATH=" + binDir} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("processStartRunCore() error = %q, want substring %q", err, want)
+			}
+		}
+	})
+
 	t.Run("uses payload issue snapshot without reading worker store", func(t *testing.T) {
 		// A worker pinned to a different host than the master has no issue store.
 		// The master carries the resolved issue in opts.IssueSnapshot; the worker
@@ -6223,7 +6246,8 @@ func TestLegacyStartRunAvailabilityCheckUsesExecutionTarget(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 	t.Chdir(projectRoot)
-	t.Setenv("PATH", t.TempDir())
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	issue := &model.Issue{ID: "availability-check", Title: "availability check"}
@@ -6254,7 +6278,8 @@ func TestLegacyStartRunAvailabilityCheckUsesExecutionTarget(t *testing.T) {
 	if got := run("mac"); !got.OK {
 		t.Fatalf("remote-target dry run failed on master availability check: %s", got.Error)
 	}
-	if got := run("local"); got.OK || got.Error != "agent not available: claude" {
+	wantLocal := fmt.Sprintf(`agent not available: claude (probe "claude --version" failed: exec: "claude": executable file not found in $PATH; PATH=%s)`, binDir)
+	if got := run("local"); got.OK || got.Error != wantLocal {
 		t.Fatalf("local-target response = %+v, want explicit unavailable error", got)
 	}
 }
@@ -6267,7 +6292,11 @@ func TestProcessStartRunCoreAvailabilityErrorNamesEvaluatingWorker(t *testing.T)
 	if err := os.WriteFile(filepath.Join(projectRoot, ".orch", "config.yaml"), []byte("agent: claude\n"), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	t.Setenv("PATH", t.TempDir())
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("#!/bin/sh\nexit 9\n"), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", binDir)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
@@ -6283,7 +6312,7 @@ func TestProcessStartRunCoreAvailabilityErrorNamesEvaluatingWorker(t *testing.T)
 	if err == nil {
 		t.Fatal("processStartRunCore() error = nil, want unavailable agent error")
 	}
-	want := "agent not available: claude (worker host-zeus, host zeus)"
+	want := fmt.Sprintf(`agent not available: claude (worker host-zeus, host zeus; probe "claude --version" exited 9; PATH=%s)`, binDir)
 	if err.Error() != want {
 		t.Fatalf("processStartRunCore() error = %q, want %q", err, want)
 	}

--- a/internal/worker/availability.go
+++ b/internal/worker/availability.go
@@ -1,0 +1,28 @@
+package worker
+
+import (
+	"log"
+	"os"
+
+	"github.com/proboscis/orch/internal/agent"
+	"github.com/proboscis/orch/internal/daemon"
+)
+
+// LogAgentAvailability probes every known adapter once at worker process
+// startup. This runs before master registration so a healthy-looking worker
+// never hides the agent capabilities of its inherited environment.
+func LogAgentAvailability(workerID string) {
+	host, _ := os.Hostname()
+	if host == "" {
+		host = "localhost"
+	}
+	if workerID == "" {
+		workerID = daemon.HostWorkerID(host)
+	}
+	logAgentAvailability(workerID, host, agent.ProbeKnownAdapters, log.Printf)
+}
+
+func logAgentAvailability(workerID, host string, probe func() []agent.Availability, logf func(string, ...any)) {
+	results := probe()
+	logf("orch-worker %s on %s: agent availability: %s", workerID, host, agent.FormatAvailabilityMap(results))
+}

--- a/internal/worker/availability_test.go
+++ b/internal/worker/availability_test.go
@@ -1,0 +1,40 @@
+package worker
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/proboscis/orch/internal/agent"
+)
+
+func TestLogAgentAvailabilityNamesWorkerHostAndEveryOutcome(t *testing.T) {
+	probeCalls := 0
+	probe := func() []agent.Availability {
+		probeCalls++
+		return []agent.Availability{
+			{Agent: agent.AgentClaude, Available: false, Probe: "claude --version", ExitCode: 1, Path: "/usr/bin:/bin"},
+			{Agent: agent.AgentCodex, Available: true, Probe: "codex --version", ExitCode: 0, Path: "/usr/bin:/bin"},
+		}
+	}
+	var logLine string
+	logf := func(format string, args ...any) {
+		logLine = fmt.Sprintf(format, args...)
+	}
+
+	logAgentAvailability("worker-1", "host-1", probe, logf)
+
+	if probeCalls != 1 {
+		t.Fatalf("availability probe calls = %d, want 1", probeCalls)
+	}
+	for _, want := range []string{
+		"orch-worker worker-1 on host-1: agent availability:",
+		`claude=unavailable (probe "claude --version" exited 1)`,
+		`codex=available (probe "codex --version" succeeded)`,
+		"PATH=/usr/bin:/bin",
+	} {
+		if !strings.Contains(logLine, want) {
+			t.Fatalf("startup log = %q, want substring %q", logLine, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- replace boolean-only adapter checks with probe results that preserve command, exit status or lookup failure, and inherited PATH
- compose PR #536 worker identity with probe detail under the historical `agent not available: <name>` prefix
- preserve the remote-target guard so master-side legacy handling never probes the wrong execution host
- probe every known adapter once at worker startup and log a stable host-scoped availability map
- document the decision to preserve the launcher environment instead of synthesizing a login-shell PATH

## Composed error contract

With worker identity:

```text
agent not available: claude (worker host-zeus, host zeus; probe "claude --version" exited 9; PATH=...)
```

Without worker identity:

```text
agent not available: claude (probe "claude --version" exited 9; PATH=...)
```

`TestProcessStartRunCoreAvailabilityErrorNamesEvaluatingWorker` exact-matches the first form. `TestLegacyStartRunAvailabilityCheckUsesExecutionTarget` exact-matches the identity-free form and verifies remote-target dry runs skip the master availability check.

## Acceptance evidence

1. Probe-rich failures for every adapter
   - `go test ./internal/agent -run "TestAdapterAvailabilityFailureIncludesProbeExitAndPATH|TestProbeKnownAdaptersProbesEachVersionedCLIOnce"`
   - verifies Claude, Codex, Gemini, and OpenCode retain the exact `<agent> --version` probe, exit code, and PATH; each startup probe executes exactly once; Custom is explicitly deferred to launch.

2. Startup availability map
   - `go test ./internal/worker -run TestLogAgentAvailabilityNamesWorkerHostAndEveryOutcome`
   - `go test ./internal/cli -run TestWorkerRunCommandInvokesExternalLoop`

3. Environment normalization decision
   - ADR-0002 records the rejection of login-shell PATH synthesis and the invariant that startup probes and agent launches observe the same inherited environment.

## Verification after rebasing onto PR #536

- `go build ./...`
- `go test ./internal/agent ./internal/daemon ./internal/worker ./internal/cli`
- `make lint`
- `git diff --check origin/main...HEAD`

All passed.

Issue: worker-env-agent-availability