### PR TITLE
Fix untargeted start run worker routing

### DIFF
--- a/docs/adr/ADR-0002-idempotent-worker-autostart.md
+++ b/docs/adr/ADR-0002-idempotent-worker-autostart.md
@@ -100,7 +100,8 @@ the pre-dispatch ensure. Default: enabled.
   normal local case. A systemd/nohup master with a minimal PATH may spawn a
   worker that cannot find agent CLIs; explicit `orch worker start` from a
   login shell remains the documented override, and the existing
-  `agent not available: <cli>` failure stays the observable symptom.
+  `agent not available: <cli> (worker <id>, host <host>)` failure stays the
+  observable symptom with the evaluating worker identified.
 - "worker not running" disappears as a user-visible error class on
   single-machine setups; docs and the embedded tutorial shrink accordingly.
 - The reconciler runs strictly inside the lease-failure path: zero cost when

--- a/docs/design/worker-lease.md
+++ b/docs/design/worker-lease.md
@@ -119,6 +119,7 @@ This is the correct mechanism/policy split and must be preserved by E2/E3:
 | LL3 completion finality | a completed lease never changes again (Completed is terminal; acks after completion are no-ops — currently unguarded, needs a check) |
 | LL4 restart amnesia is safe | master restart ⇒ all leases forgotten; every caller observes failure within its timeout; no run transition is *decided* by lease state alone (only via observations, §4) |
 | LL5 snapshot sufficiency | a worker executes any effect using only the lease payload (RunSnapshot); it never reads its local store for master-owned runs (PR #457's contract) |
+| LL6 start target confinement | every `start_run` resolves a `TargetWorkerID` before lease acquisition; empty/`local` targets resolve to the master's host worker, named targets resolve through `config.targets`, and neither may fall back to another worker |
 
 ## Next (E2/E3)
 

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -1447,14 +1447,15 @@ func (s *SocketServer) handleProtoStartRun(req *orchpb.StartRunRequest) *orchpb.
 		return errorResponse(err.Error())
 	}
 
-	if strings.TrimSpace(opts.Target) != "" && strings.TrimSpace(opts.Target) != "local" {
-		target, targetErr := resolveTargetForProjectRoot(projectRoot, opts.Target)
-		if targetErr != nil {
-			return errorResponse(targetErr.Error())
-		}
-		opts.TargetHost = target.Host
-		opts.TargetWorkerID = target.WorkerID
+	// Resolve even the implicit local target before acquiring the lease. Leaving
+	// TargetWorkerID empty makes worker selection a preference with arbitrary
+	// fallback, so an untargeted run can otherwise execute on any registered host.
+	target, targetErr := resolveStartRunWorkerTarget(projectRoot, opts.Target)
+	if targetErr != nil {
+		return errorResponse(targetErr.Error())
 	}
+	opts.TargetHost = target.Host
+	opts.TargetWorkerID = target.WorkerID
 
 	// Resolve the issue on the MASTER (issue-store SSOT) and carry the snapshot in
 	// the worker payload. Fail fast here, before delegating, so a missing issue

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -3494,7 +3494,8 @@ func (s *SocketServer) handleStartRun(req SendRequest, encoder *json.Encoder) {
 		return
 	}
 
-	if !adapter.IsAvailable() {
+	isRemoteTarget := strings.TrimSpace(req.Target) != "" && strings.TrimSpace(req.Target) != "local"
+	if !isRemoteTarget && !adapter.IsAvailable() {
 		encoder.Encode(StartRunResponse{OK: false, Error: "agent not available: " + agentName})
 		return
 	}
@@ -3840,7 +3841,7 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 	}
 
 	if !isRemoteTarget && !adapter.IsAvailable() {
-		return nil, fmt.Errorf("agent not available: %s", agentName)
+		return nil, s.agentNotAvailableError(agentName)
 	}
 	if isRemoteTarget && adapter.PromptInjection() == agent.InjectionHTTP {
 		return nil, fmt.Errorf("agent %s with HTTP prompt injection is not supported with remote target %q", agentName, targetName)
@@ -4127,6 +4128,21 @@ func (s *SocketServer) processStartRunCore(st store.Store, projectRoot string, o
 	}, nil
 }
 
+func (s *SocketServer) agentNotAvailableError(agentName string) error {
+	workerID := strings.TrimSpace(s.currentWorkerID)
+	host := strings.TrimSpace(s.currentWorkerHost)
+	switch {
+	case workerID != "" && host != "":
+		return fmt.Errorf("agent not available: %s (worker %s, host %s)", agentName, workerID, host)
+	case workerID != "":
+		return fmt.Errorf("agent not available: %s (worker %s)", agentName, workerID)
+	case host != "":
+		return fmt.Errorf("agent not available: %s (host %s)", agentName, host)
+	default:
+		return fmt.Errorf("agent not available: %s", agentName)
+	}
+}
+
 func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string, opts *ContinueRunOptions) (*ContinueRunResult, error) {
 	cfg, err := loadConfigForProjectRoot(projectRoot)
 	if err != nil {
@@ -4340,7 +4356,7 @@ func (s *SocketServer) processContinueRunCore(st store.Store, projectRoot string
 	}
 
 	if !adapter.IsAvailable() {
-		return nil, fmt.Errorf("agent not available: %s", agentName)
+		return nil, s.agentNotAvailableError(agentName)
 	}
 
 	reqModel := strings.TrimSpace(opts.Model)

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -641,7 +641,7 @@ func TestWithWorkerLeaseExternalProcessSuccessResultPath(t *testing.T) {
 	}
 }
 
-func TestProtoStartRunUsesExternalWorkerResultJSON(t *testing.T) {
+func TestProtoStartRunUsesResolvedDefaultWorkerResultJSON(t *testing.T) {
 	cleanup := setupXDGTestEnv(t)
 	defer cleanup()
 
@@ -662,9 +662,9 @@ func TestProtoStartRunUsesExternalWorkerResultJSON(t *testing.T) {
 	client := NewProtoClientWithAddress("", "")
 	defer client.Close()
 
-	workerID := "external-helper-worker-start"
+	workerID := defaultWorkerID()
 	if _, err := client.RegisterWorker(workerID, "executor", "localhost", "external"); err != nil {
-		t.Fatalf("register external worker failed: %v", err)
+		t.Fatalf("register default worker failed: %v", err)
 	}
 	defer client.UnregisterWorker(workerID)
 
@@ -715,7 +715,7 @@ func TestProtoStartRunUsesExternalWorkerResultJSON(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatal("expected start_run lease assigned to external worker")
+		t.Fatal("expected start_run lease assigned to resolved default worker")
 	}
 }
 
@@ -5855,7 +5855,7 @@ func TestProtoStartRunFieldMapping(t *testing.T) {
 		// If it fails with "agent not available", that's expected in CI without claude installed.
 		// The key contract test is that Model is NOT in Message.
 		errMsg := resp.Error
-		if errMsg != "agent not available: claude" && errMsg != "no project root available" && !strings.Contains(errMsg, "no active workers available") {
+		if errMsg != "agent not available: claude" && errMsg != "no project root available" && !strings.Contains(errMsg, "no active worker on host") {
 			t.Fatalf("unexpected error: %s", errMsg)
 		}
 	}
@@ -6212,6 +6212,81 @@ func TestProcessStartRunCoreValidation(t *testing.T) {
 			t.Fatalf("expected to reach 'no project root available', got: %v", err)
 		}
 	})
+}
+
+func TestLegacyStartRunAvailabilityCheckUsesExecutionTarget(t *testing.T) {
+	projectRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".orch"), 0o755); err != nil {
+		t.Fatalf("mkdir .orch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, ".orch", "config.yaml"), []byte("agent: claude\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Chdir(projectRoot)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	issue := &model.Issue{ID: "availability-check", Title: "availability check"}
+	st := &mockStore{
+		runs:   make(map[string]*model.Run),
+		issues: map[string]*model.Issue{string(issue.ID): issue},
+	}
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	registerRepoContextForTest(t, server, "availability-project", projectRoot, st)
+
+	run := func(target string) StartRunResponse {
+		t.Helper()
+		var response bytes.Buffer
+		server.handleStartRun(SendRequest{
+			IssueID:   string(issue.ID),
+			RepoID:    "availability-project",
+			AgentType: "claude",
+			Target:    target,
+			DryRun:    true,
+		}, json.NewEncoder(&response))
+		var got StartRunResponse
+		if err := json.Unmarshal(response.Bytes(), &got); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		return got
+	}
+
+	if got := run("mac"); !got.OK {
+		t.Fatalf("remote-target dry run failed on master availability check: %s", got.Error)
+	}
+	if got := run("local"); got.OK || got.Error != "agent not available: claude" {
+		t.Fatalf("local-target response = %+v, want explicit unavailable error", got)
+	}
+}
+
+func TestProcessStartRunCoreAvailabilityErrorNamesEvaluatingWorker(t *testing.T) {
+	projectRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".orch"), 0o755); err != nil {
+		t.Fatalf("mkdir .orch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, ".orch", "config.yaml"), []byte("agent: claude\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	server.SetWorkerIdentity("host-zeus", "zeus")
+	issue := &model.Issue{ID: "availability-context", Title: "availability context"}
+	_, err := server.processStartRunCore(&mockStore{}, projectRoot, &StartRunOptions{
+		IssueID:        issue.ID,
+		IssueSnapshot:  issue,
+		Agent:          "claude",
+		TargetHost:     "zeus",
+		TargetWorkerID: "host-zeus",
+	})
+	if err == nil {
+		t.Fatal("processStartRunCore() error = nil, want unavailable agent error")
+	}
+	want := "agent not available: claude (worker host-zeus, host zeus)"
+	if err.Error() != want {
+		t.Fatalf("processStartRunCore() error = %q, want %q", err, want)
+	}
 }
 
 // TestMasterFailsFastOnMissingIssueBeforeDelegation verifies that the master

--- a/internal/daemon/target_resolution.go
+++ b/internal/daemon/target_resolution.go
@@ -13,6 +13,32 @@ type resolvedTarget struct {
 	WorkerID string
 }
 
+// resolveStartRunWorkerTarget resolves every start_run to an execution worker
+// before lease acquisition. An empty or "local" target means the master's
+// colocated worker; it must not remain unconstrained and fall back to an
+// arbitrary registered worker.
+func resolveStartRunWorkerTarget(projectRoot, targetName string) (*resolvedTarget, error) {
+	targetName = strings.TrimSpace(targetName)
+	if targetName != "" && targetName != "local" {
+		return resolveTargetForProjectRoot(projectRoot, targetName)
+	}
+
+	host, err := currentHostname()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve local start_run worker host: %w", err)
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return nil, fmt.Errorf("failed to resolve local start_run worker host: hostname is empty")
+	}
+
+	return &resolvedTarget{
+		Name:     targetName,
+		Host:     host,
+		WorkerID: HostWorkerID(host),
+	}, nil
+}
+
 func resolveTargetForProjectRoot(projectRoot, targetName string) (*resolvedTarget, error) {
 	targetName = strings.TrimSpace(targetName)
 	if targetName == "" || targetName == "local" {

--- a/internal/daemon/worker_plane_law_test.go
+++ b/internal/daemon/worker_plane_law_test.go
@@ -1,6 +1,6 @@
 package daemon
 
-// Law tests for the worker-lease core (LL1–LL5 drafted in
+// Law tests for the worker-lease core (LL1–LL6 drafted in
 // docs/design/worker-lease.md; Phase E2 of the coupling-core roadmap).
 // LL1 (liveness fail-fast) is covered by
 // TestWaitForWorkerLeaseCompletionFailsFastWhenWorkerLost; LL5 (snapshot
@@ -132,6 +132,40 @@ func TestLeaseLawRestartAmnesiaFailsFast(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("amnesia failure took %s, want immediate", elapsed)
+	}
+}
+
+// LL6 target confinement: an implicit local start resolves to the master's
+// host worker before lease acquisition and cannot fall back to another active
+// worker, regardless of registration/heartbeat order.
+func TestLeaseLawImplicitLocalStartIsConfinedToMasterWorker(t *testing.T) {
+	origHostname := currentHostname
+	currentHostname = func() (string, error) { return "master-host", nil }
+	t.Cleanup(func() { currentHostname = origHostname })
+
+	server := NewSocketServer(nil, log.New(io.Discard, "", 0))
+	if _, ttl := server.registerWorker("host-master-host", "external", "master-host", "external", []string{"start_run"}); ttl <= 0 {
+		t.Fatal("expected positive heartbeat ttl for master worker")
+	}
+	time.Sleep(time.Millisecond)
+	if _, ttl := server.registerWorker("host-agent-ready", "external", "agent-ready", "external", []string{"start_run"}); ttl <= 0 {
+		t.Fatal("expected positive heartbeat ttl for remote worker")
+	}
+
+	target, err := resolveStartRunWorkerTarget("", "")
+	if err != nil {
+		t.Fatalf("resolveStartRunWorkerTarget() error = %v", err)
+	}
+	payload := &WorkerEffectPayload{StartRun: &StartRunOptions{
+		TargetHost:     target.Host,
+		TargetWorkerID: target.WorkerID,
+	}}
+	lease, err := server.acquireWorkerLease("project-test", "start_run", "orch-ll6", "run-ll6", payload)
+	if err != nil {
+		t.Fatalf("acquireWorkerLease() error = %v", err)
+	}
+	if lease.WorkerID != "host-master-host" {
+		t.Fatalf("lease worker = %q, want resolved default worker %q", lease.WorkerID, "host-master-host")
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve every proto `start_run` to a concrete worker before lease acquisition, including empty/`local` targets
- pin untargeted starts to the master host worker instead of falling back to an arbitrary registered worker
- include evaluating worker and host in worker-side agent availability errors
- mirror the remote-target availability guard in the legacy start handler
- codify worker target confinement as worker-lease law LL6

## Acceptance criteria evidence

1. **Empty-target routing is deterministic.** `resolveStartRunWorkerTarget` resolves empty/`local` targets to the master hostname and `HostWorkerID`; `handleProtoStartRun` places both values in the lease payload before `withWorkerLease`. `TestLeaseLawImplicitLocalStartIsConfinedToMasterWorker` registers two workers with the non-target worker newer and proves the lease still goes to the resolved default worker.
2. **Availability failures identify the evaluator.** `processStartRunCore` and `processContinueRunCore` now report errors such as `agent not available: claude (worker host-zeus, host zeus)`. `TestProcessStartRunCoreAvailabilityErrorNamesEvaluatingWorker` verifies the exact error.
3. **Legacy remote guard is aligned.** `handleStartRun` skips the master-side `IsAvailable` check only for non-local targets. `TestLegacyStartRunAvailabilityCheckUsesExecutionTarget` proves remote proceeds while local still fails explicitly.
4. **No status-write-surface changes.** The change only touches target resolution, availability diagnostics, tests, and the worker-lease invariant/spec.

The legacy continue handler is local-only and does not resolve or dispatch remote targets; skipping its availability check would allow local worktree mutation for a remote run. The proto continue worker path retains the check and now includes worker/host context.

## Verification

- `go test ./internal/daemon -run "Test(LeaseLawImplicitLocalStartIsConfinedToMasterWorker|LegacyStartRunAvailabilityCheckUsesExecutionTarget|ProcessStartRunCoreAvailabilityErrorNamesEvaluatingWorker)$" -count=1 -v` — PASS
- `go build ./...` — PASS
- `go test ./...` — PASS, including `test/integration` in 137.425s
- `make lint` — PASS; full internal Semgrep scan reported 0 findings

Refs: start-run-availability-wrong-host