### PR TITLE
docs: beta-audit fixes — license notice, auto-acked trust gates, LL6 routing, reference gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Orchestrator for managing multiple LLM CLIs (Claude, Codex, Gemini, OpenCode) us
 
 orch runs AI coding agents non-interactively in the background, creating isolated git worktrees for each task. Check status with `orch ps`, interact when needed with `orch attach`.
 
-> **Beta scope: single machine.** The current beta covers running orch on one
-> machine (daemon, worker, and agents all local — zero process management
-> needed). Multi-host / cluster mode (remote masters, `ORCH_REMOTE`,
-> `--on <target>`) exists in the code but is the **next milestone**: not part
-> of the beta, not yet supported.
+> **Beta support scope: single machine.** The current beta covers running orch
+> on one machine (daemon, worker, and agents all local — zero process
+> management needed). Multi-host / cluster mode (remote masters, `ORCH_REMOTE`,
+> `--on <target>`) works and is used in development, but it is **outside the
+> supported beta scope** until the multi-host milestone lands.
 
 ## Install via your AI agent (one line)
 
@@ -65,7 +65,7 @@ real GitHub repository. Drop the flag once a real GitHub remote exists and
 | **[Getting Started](./docs/getting-started.md)** | Install → First issue → First run → See it work |
 | **[Agent Install Runbook](./docs/agent-install.md)** | One-liner setup executed by your own AI agent (binary + skill + guided first run) |
 | **[ローカルクイックスタート (日本語)](./docs/local-quickstart.ja.md)** | 1 台のマシンで試す最短経路(クラスタ設定なし) |
-| **[Remote Usage](./docs/remote-usage.md)** | Multi-host mode — next milestone, out of beta scope |
+| **[Remote Usage](./docs/remote-usage.md)** | Multi-host mode — works, outside the supported beta scope |
 | **[Daily Workflow](./docs/daily-workflow.md)** | Morning routine, parallel runs, reviewing PRs |
 | **[orch-monitor TUI](./docs/orch-monitor.md)** | Visual dashboard for managing issues and runs |
 | **[Core Concepts](./docs/concepts.md)** | Issue, Run, Event, Status, Worktree explained |
@@ -148,4 +148,6 @@ See [GitHub Releases](https://github.com/proboscis/orch/releases) for binaries.
 
 ## License
 
-MIT
+License: TBD. During the beta, orch is provided for **evaluation purposes
+only** — no license is granted yet, and redistribution is not permitted.
+A license will be chosen before general availability.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Pick your path by what you are trying to do.
 | [Daily Workflow](./daily-workflow.md) | Morning routine, parallel runs, reviewing PRs |
 | [Core Concepts](./concepts.md) | Issue, Run, Event, Status, Worktree |
 | [Configuration](./configuration.md) | All config options with examples |
-| [Remote Usage](./remote-usage.md) | Multi-host mode — next milestone, out of beta scope |
+| [Remote Usage](./remote-usage.md) | Multi-host mode — works, outside the supported beta scope |
 | [Python orch-monitor TUI](./orch-monitor.md) | Visual dashboard for issues and runs |
 
 | Details | |

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -120,13 +120,13 @@ orch ps                               # booting -> running -> waiting
 orch capture hello-world              # read the agent's screen
 ```
 
-**Expect a trust prompt on the first run**: the agent CLI asks
-"Do you trust the contents of this directory?" and the run parks at
-`waiting`. Show the user the captured screen, then answer it:
-
-```bash
-orch send hello-world ""              # empty message = press Enter (accept default)
-```
+**Trust prompts are handled automatically**: on the first run the agent CLI
+may ask "Do you trust the contents of this directory?" — the daemon detects
+this gate and acknowledges it itself, once per run (recorded as a `gate_ack`
+event). You do NOT need to answer it. Only **login gates** park the run: if
+`orch ps` shows `waiting` with reason `gate_login`, the agent CLI is not
+logged in — show the user the captured screen and have THEM log in via
+`orch attach` (credentials belong to humans, never type them yourself).
 
 Wait for the turn to finish and show the user the result:
 
@@ -146,8 +146,9 @@ the agent commit, push, and open a PR — the run then parks at `pr_open`.
 |-------|-----|
 | `project identity required` | repo has no `origin` remote, or you are outside the repo |
 | `unknown project_id "…"` | run `orch daemon repo register "$(pwd)"` |
-| `no active workers available` | should not happen locally (workers auto-start); check `ORCH_WORKER_AUTOSTART`, or run `orch worker start` |
-| `store_error` on issue commands | a malformed issue file; frontmatter `status` must be open/closed/resolved |
+| `no active worker on host "…"` | should not happen locally (workers auto-start); check `ORCH_WORKER_AUTOSTART`, or run `orch worker start` |
+| `agent not available: … (worker …, host …; probe "…"; PATH=…)` | the named worker cannot run that agent CLI — the probe and PATH in the error say why; fix PATH or log in on that host, then restart the worker from a login shell |
+| `store … failed for project "…"` on issue commands | a malformed issue file (the error names it); frontmatter `status` must be open/closed/resolved |
 
 ## Step 5 — Wrap up
 
@@ -158,5 +159,5 @@ Tell the user:
 - deeper docs: [Getting Started](./getting-started.md),
   [ローカルクイックスタート (日本語)](./local-quickstart.ja.md),
   [Daily Workflow](./daily-workflow.md), and
-  [Remote Usage](./remote-usage.md) is the next milestone (multi-host —
-  out of scope for the current beta).
+  [Remote Usage](./remote-usage.md) (multi-host — works, but outside the
+  supported beta scope).

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -211,8 +211,10 @@ Two long-lived processes cooperate to execute runs:
 
 On a single machine you run both locally and never notice the split. The same
 model scales to multiple hosts: workers on other machines register to one
-daemon (see [Remote Usage](./remote-usage.md)) — multi-host is the next
-milestone and out of scope for the current beta.
+daemon (see [Remote Usage](./remote-usage.md)) — multi-host works, but is
+outside the supported scope of the current beta. A run without `--on` always
+executes on the master's own host worker; other hosts must be targeted
+explicitly.
 
 ### RUN_REF
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,6 +133,24 @@ agent_multiplexer: tmux
 
 # `multiplexer` is a deprecated compatibility key. Use `agent_multiplexer`.
 
+# Default model / reasoning-effort variant for runs (per-agent defaults below
+# take precedence; --model / --model-variant flags override everything)
+model: claude-opus-4-5
+model_variant: max
+
+# Skip PR creation by default (equivalent to always passing --no-pr)
+no_pr: false
+
+# Default preset name from `presets:` applied when `orch run` has no
+# agent/model flags
+default_preset: main
+
+# CLI log level: debug, info, warn, error
+log_level: info
+
+# External diff tool for `orch diff --tool` (e.g. "cursor --diff")
+diff_tool: "cursor --diff"
+
 # =============================================================================
 # EXECUTION TARGETS
 # =============================================================================
@@ -176,16 +194,43 @@ claude:
   prompt_template: |
     ultrathink Please read 'ORCH_PROMPT.md' in the current directory.
     {{issue}}
+  # Extra CLI args appended to every launch / control-agent launch
+  extra_args: ["--dangerously-skip-permissions"]
+  control_extra_args: []
+  # Multi-account profiles: each maps to a CLAUDE_CONFIG_DIR and may be
+  # pinned to targets (see .orch/config.example.yaml for a full example)
+  default_profile: personal
+  profiles:
+    personal:
+      config_dir: ~/.claude-personal
+      target: mac              # optional: default target for this profile
+      allowed_targets: [mac]   # optional: hosts this profile may run on
+    work:
+      config_dir: ~/.claude-work
 
 # Codex configuration
 codex:
+  default_model: gpt-5.2-codex   # default model for codex runs
+  default_variant: high          # default reasoning effort
   prompt_template: |
     Think step by step. Follow best practices.
     {{issue}}
+  extra_args: []
+  control_extra_args: []
+  # Multi-account profiles: each maps to a CODEX_HOME directory
+  default_profile: personal
+  profiles:
+    personal:
+      codex_home: ~/.codex
+    company:
+      codex_home: ~/.codex-profiles/company
+      allowed_targets: [mac]
 
 # Gemini configuration
 gemini:
   prompt_template: "{{issue}}"
+  extra_args: []
+  control_extra_args: []
 
 # =============================================================================
 # PROMPT TEMPLATES
@@ -204,6 +249,13 @@ github:
   owner: your-org
   repo: your-repo
   poll_interval: 300  # seconds between polling for updates
+  # Only sync issues carrying this label (also: ORCH_GITHUB_LABEL_FILTER)
+  label_filter: orch
+  # Map GitHub labels to orch issue statuses (label -> status); when set,
+  # resolving an issue applies the matching label
+  status_labels:
+    "status:open": open
+    "status:resolved": resolved
 
 # =============================================================================
 # NOTIFICATIONS
@@ -219,10 +271,14 @@ slack:
   # bot_token: xoxb-your-bot-token
   # channel: "#orch-notifications"
   
-  # Events that trigger notifications
+  # Events that trigger notifications.
+  # Valid: waiting, blocked, rate_limited, blocked_api, done, failed.
+  # When omitted, defaults to: waiting, blocked, rate_limited, blocked_api.
   notify_on:
     - waiting
     - rate_limited
+    # - blocked
+    # - blocked_api
     # - done
     # - failed
 
@@ -287,6 +343,11 @@ presets:
   - name: codex-high
     backend: codex
     model: o3
+  - name: claude-work
+    backend: claude
+    model: claude-opus-4-5
+    variant: max
+    profile: work   # claude/codex profile name (see profiles above)
 ```
 
 ## Environment Variables

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -234,17 +234,22 @@ This will:
 
 The command returns immediately - the agent runs in the background.
 
-### First run: expect a trust prompt
+### First run: trust prompts are answered automatically
 
 On a fresh machine or directory, agent CLIs show a one-time interactive gate
-(e.g. "Do you trust the contents of this directory?") and the run parks at
-`waiting`. This is the normal interaction loop, not a failure:
+(e.g. "Do you trust the contents of this directory?"). The daemon detects
+trust gates and acknowledges them itself, once per run — dispatching a run
+into a worktree IS the operator's trust decision, so nothing parks. You may
+briefly see `waiting` with reason `gate_trust` before it clears; the
+acknowledgement is recorded as a `gate_ack` event on the run.
+
+**Login gates are different**: if the agent CLI is not logged in, the run
+parks at `waiting` with reason `gate_login` and stays there — credentials
+belong to humans. Handle it directly:
 
 ```bash
 orch capture my-first-issue   # see what the agent is asking
-orch send my-first-issue ""   # empty message = press Enter (accept the default)
-# or take over the terminal directly:
-orch attach my-first-issue    # answer, then detach (see below)
+orch attach my-first-issue    # log in interactively, then detach (see below)
 ```
 
 ## Check status
@@ -322,8 +327,8 @@ orch resolve my-first-issue
 ## Next steps
 
 - Learn the [core concepts](./concepts.md) (Issue, Run, Event, etc.)
-- [Remote usage](./remote-usage.md) (multi-host) is the next milestone — out
-  of scope for the current beta
+- [Remote usage](./remote-usage.md) (multi-host) — works, but outside the
+  supported beta scope
 - Configure [different agents](./agents/claude.md)
 - Set up [backend integrations](./backends/file.md) (GitHub)
 - Explore all [CLI commands](./reference/commands.md)

--- a/docs/local-quickstart.ja.md
+++ b/docs/local-quickstart.ja.md
@@ -113,17 +113,20 @@ orch ps                      # booting → running → waiting と遷移する
 orch capture hello-world     # agent のターミナル画面のスナップショット
 ```
 
-### 初回 run では agent が trust 確認を出す
+### 初回 run の trust 確認は daemon が自動応答する
 
 まっさらなマシン/ディレクトリでは、agent CLI が初回に対話ゲート
-(「Do you trust the contents of this directory?」など)を表示し、run は
-`waiting` で停止します。これは故障ではなく、orch の対話ループそのものです:
+(「Do you trust the contents of this directory?」など)を表示しますが、
+**trust ゲートは daemon が検知して run ごとに1回だけ自動で Enter を送り**、
+run は自動的に続行します(`gate_ack` イベントとして記録)。手動対応は不要です。
+
+**ログインゲートだけは例外**です: agent CLI が未ログインだと run は
+`waiting`(reason `gate_login`)で停止したままになります。認証情報は人間の
+ものなので、直接対応してください:
 
 ```bash
 orch capture hello-world     # 何を聞かれているか確認する
-orch send hello-world ""     # 空メッセージ = Enter 送信(デフォルト選択を受理)
-# あるいはターミナルを直接操作する:
-orch attach hello-world      # 対話後、Ctrl+B D でデタッチ
+orch attach hello-world      # ログインを済ませ、Ctrl+B D でデタッチ
 ```
 
 ### 完了を待って結果を確認する
@@ -132,8 +135,8 @@ orch attach hello-world      # 対話後、Ctrl+B D でデタッチ
 orch wait hello-world --timeout 600
 ```
 
-`waiting` は「agent の入力欄が空いている」ことを意味します — trust ゲート
-通過後の `waiting` は通常「agent がそのターンを終えた」合図です。
+`waiting` は「agent の入力欄が空いている」ことを意味します — 通常は
+「agent がそのターンを終えた」合図です。
 **結論を出す前に必ず `orch capture` で agent の報告を読んでください。**
 成果物は隔離された worktree にあります(パスは `orch ps` /
 `orch show hello-world` で表示されます):

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -523,10 +523,15 @@ orch issue show ISSUE_ID [flags]
 
 ### orch issue edit
 
-Edit an issue.
+Edit an issue. Without flags, opens the body in `$EDITOR` (the edit is applied
+through the daemon — never edit store files directly, ADR-0004).
 
 ```bash
 orch issue edit ISSUE_ID [flags]
+
+# Non-interactive body edits (for scripts and agents):
+orch issue edit my-issue --body "replacement body"
+printf '\n## Update\nnew findings\n' | orch issue edit my-issue --append-body -
 ```
 
 #### Flags
@@ -534,6 +539,8 @@ orch issue edit ISSUE_ID [flags]
 | Flag | Description |
 |------|-------------|
 | `-t, --title <title>` | Update title directly without opening editor |
+| `-b, --body <text\|->` | Replace the body with text, or `-` to read from stdin |
+| `--append-body <text\|->` | Append text to the body, or `-` to read from stdin (mutually exclusive with `--body`) |
 
 ### orch issue close
 
@@ -891,7 +898,7 @@ orch worker run [flags]
 
 ### orch worker start
 
-Start a managed orch-worker host process. Usually automatic since v1.5
+Start a managed orch-worker host process. Usually automatic
 (ADR-0002): the master auto-starts its colocated worker on demand, and run
 dispatch to a remote master auto-starts the local worker for it. Manual start
 remains for other hosts and for `ORCH_WORKER_AUTOSTART=0`.

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -51,7 +51,8 @@ Status events may carry a machine-readable `reason` attribute
 | `agent_exited` | `unknown` | Agent process exited without a verdict, shell prompt showing |
 | `observer_unverified` | `unknown` | Dead-check threshold reached via an observation channel that never saw this run alive |
 | `launch_<step>` | `failed` | Launch failed at the named bootstrap step |
-| `gate_<kind>` | `waiting` | Run is stopped at an interactive gate (e.g. `gate_login`, `gate_trust`) |
+| `gate_<kind>` | `waiting` | Run is stopped at an interactive gate (e.g. `gate_login`, `gate_trust`; trust gates are auto-acknowledged by the daemon once per run) |
+| `pr_branch_mismatch` | `waiting` | Agent opened a PR from a branch other than the run's assigned branch; the PR was not attached to the run |
 
 ### artifact
 
@@ -107,7 +108,7 @@ Examples:
 
 ### note
 
-Human-added notes or comments.
+Human-added notes or comments, plus daemon-authored notices.
 
 ```
 - <ts> | note | <title> | text="..."
@@ -116,6 +117,16 @@ Human-added notes or comments.
 Example:
 ```
 - 2026-01-20T17:00:00+09:00 | note | manual_fix | text="Fixed import manually"
+```
+
+The daemon records its own one-time interventions as `daemon_notice` note
+events. Current kinds: `gate_ack` (the daemon auto-acknowledged a trust gate
+by sending Enter) and `pr_branch_mismatch` (the daemon sent the agent a
+corrective message about a PR opened from the wrong branch). These serve as
+the once-only ledger — a notice is never re-sent for the same cause.
+
+```
+- <ts> | note | daemon_notice | kind=gate_ack gate=trust
 ```
 
 ## Event Flow Example

--- a/docs/reference/statuses.md
+++ b/docs/reference/statuses.md
@@ -167,7 +167,8 @@ status event. `orch ps` renders it inline, e.g. `unknown(never_alive)` or
 |--------|---------|---------|
 | `unknown` | `never_alive`, `session_lost`, `agent_exited`, `observer_unverified` | Why observability was lost: agent never seen alive (boot grace expired), backend lost the session, agent exited to shell, or the dead-check fired via an observer that never saw this run alive |
 | `failed` | `launch_<step>` | Launch failed at the named bootstrap step |
-| `waiting` | `gate_<kind>` | Stopped at an interactive gate (e.g. `gate_login`, `gate_trust`) |
+| `waiting` | `gate_<kind>` | Stopped at an interactive gate (e.g. `gate_login`, `gate_trust`; trust gates are auto-acknowledged by the daemon once per run) |
+| `waiting` | `pr_branch_mismatch` | Agent opened a PR from a branch other than the run's assigned branch; the work sits in a PR the daemon refused to attach (the daemon also sends the agent a one-time corrective notice) |
 
 See [Event Reference](./events.md) for the full reason vocabulary.
 

--- a/docs/remote-usage.md
+++ b/docs/remote-usage.md
@@ -1,8 +1,9 @@
 # Remote Usage with orch
 
-> **Next milestone — out of beta scope.** Multi-host mode works and is used in
-> development, but the current beta covers **single-machine use only**. Expect
-> rough edges here and no support until the multi-host milestone lands.
+> **Works, but outside the supported beta scope.** Multi-host mode works and
+> is used in development daily; everything below is accurate. The current
+> beta's *support* scope is single-machine use only — multi-host issues are
+> welcome as reports but are not covered until the multi-host milestone lands.
 
 This guide shows how to run orch against a remote daemon over TCP while keeping
 the same daily `orch` workflow from your local machine.
@@ -132,9 +133,13 @@ orch --remote master-host:7777 --project yourorg-yourrepo capture my-issue
 
 - `--project` / `ORCH_PROJECT` provides project identity scope.
 - Remote commands depend on daemon-side repo registration (`daemon repo register`).
+- An untargeted `orch run` (no `--on`) always executes on the **master's own
+  host worker** — never on an arbitrary registered worker (worker-lease law
+  LL6). To execute on your client host (or any other host), name it
+  explicitly with `--on <target>` using a target from `.orch/config.yaml`.
 - Before `orch run` dispatches to a remote master, the client idempotently
-  starts its local managed worker and registers it to that master. The client
-  host can therefore execute untargeted runs from that master.
+  starts its local managed worker and registers it to that master, so an
+  explicitly targeted run can land on the client host without manual setup.
 - Set `ORCH_WORKER_AUTOSTART=0` on the client to disable that pre-dispatch
   worker start. The same setting on the master disables automatic startup of
   its colocated worker; workers must then be started manually with


### PR DESCRIPTION
Docs audit against the v1.7.0-beta implementation (implementation = source of truth; 3 parallel audit passes over CLI reference, configuration, and behavior claims + direct review of README/agent-install).

## Fixes (verified stale)
- **README license**: replace false "MIT" grant with an explicit evaluation-only notice (no LICENSE by decision)
- **Trust gates**: getting-started / agent-install / local-quickstart.ja no longer instruct a manual `orch send ""` — the daemon auto-acknowledges trust gates once per run (L-G1, `gate_ack`); login gates documented as the human-only exception
- **remote-usage**: untargeted runs pin to the master's host worker (LL6) — fixed the wrong claim that the client host may execute untargeted runs; banner self-contradiction resolved
- **Scope wording** unified to "works, but outside the supported beta scope" (boundary kept, per decision)
- **statuses/events**: add `pr_branch_mismatch` reason + `daemon_notice` note events
- **commands**: `orch issue edit --body/--append-body` (ADR-0004 path); drop "since v1.5"
- **agent-install troubleshooting**: retire eliminated `store_error`, host-scoped worker error, new availability error shape
- **configuration**: document 9 groups of implemented-but-missing keys (profiles surface, diff_tool, extra_args, codex defaults, github label_filter/status_labels with correct label→status direction, slack notify_on full set, presets[].profile)

All added config keys were re-verified against `internal/config/config.go` yaml tags; the `status_labels` direction was corrected against `internal/github/backend.go:SetStatus`.

Docs-only change. After merge: replace the `agent-install.md` asset on the v1.7.0-beta release so the README one-liner serves the corrected runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)