### PR TITLE
feat: add ADR-0005 Stage 2 session reaper

### DIFF
--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -29,7 +29,7 @@ func newRepairCmd() *cobra.Command {
 This command will:
 - Restart the daemon if it's not running or unhealthy
 - Mark "running" runs with no tmux session as failed
-- Report orphaned sessions and worktrees`,
+- Report orphaned, terminal-but-alive, and unreapable-kept sessions`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRepair(opts)
 		},
@@ -95,7 +95,7 @@ func runRepair(opts *repairOptions) error {
 			problemsFixed += repairResult.ProblemsFixed
 		}
 		for _, detail := range repairResult.Details {
-			if strings.Contains(detail, "orphaned") {
+			if strings.Contains(detail, "session") {
 				fmt.Printf("  %s\n", detail)
 			}
 		}

--- a/internal/cli/repair_test.go
+++ b/internal/cli/repair_test.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRepairHelpDescribesImplementedSessionReporting(t *testing.T) {
+	help := newRepairCmd().Long
+	if strings.Contains(help, "worktrees") {
+		t.Fatalf("repair help still promises unimplemented worktree handling: %q", help)
+	}
+	for _, phrase := range []string{"orphaned", "terminal-but-alive", "unreapable-kept"} {
+		if !strings.Contains(help, phrase) {
+			t.Fatalf("repair help missing %q: %q", phrase, help)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,6 +149,42 @@ type GitHubConfig struct {
 	StatusLabels map[string]string `yaml:"status_labels,omitempty"` // Map GitHub labels to status (e.g., "status:resolved" -> "resolved")
 }
 
+const (
+	DefaultReaperTerminalGraceMinutes      = 10
+	DefaultReaperResolvedIssueGraceMinutes = 60
+	DefaultReaperIdleTTLHours              = 168
+)
+
+// ReaperConfig controls the daemon's ADR-0005 session lifecycle reconciler.
+// Zero grace/TTL values are valid and useful for deterministic incident replay;
+// negative values are rejected by Validate.
+type ReaperConfig struct {
+	TerminalGraceMinutes      int  `yaml:"terminal_grace_minutes"`
+	ResolvedIssueGraceMinutes int  `yaml:"resolved_issue_grace_minutes"`
+	IdleTTLHours              int  `yaml:"idle_ttl_hours"`
+	Enabled                   bool `yaml:"enabled"`
+}
+
+// DefaultReaperConfig returns the safe default lifecycle policy from ADR-0005
+// R2. It returns a value so callers cannot mutate shared defaults.
+func DefaultReaperConfig() ReaperConfig {
+	return ReaperConfig{
+		TerminalGraceMinutes:      DefaultReaperTerminalGraceMinutes,
+		ResolvedIssueGraceMinutes: DefaultReaperResolvedIssueGraceMinutes,
+		IdleTTLHours:              DefaultReaperIdleTTLHours,
+		Enabled:                   true,
+	}
+}
+
+// fileReaperConfig uses pointers so layered files merge per field and an
+// explicit `enabled: false` remains distinguishable from an omitted key.
+type fileReaperConfig struct {
+	TerminalGraceMinutes      *int  `yaml:"terminal_grace_minutes"`
+	ResolvedIssueGraceMinutes *int  `yaml:"resolved_issue_grace_minutes"`
+	IdleTTLHours              *int  `yaml:"idle_ttl_hours"`
+	Enabled                   *bool `yaml:"enabled"`
+}
+
 // IsConfigured returns true if GitHub backend has minimal required config.
 func (g *GitHubConfig) IsConfigured() bool {
 	return g.Owner != "" && g.Repo != ""
@@ -217,6 +253,7 @@ type Config struct {
 	Slack            SlackConfig      `yaml:"slack"`
 	Issues           IssuesConfig     `yaml:"issues"`
 	GitHub           GitHubConfig     `yaml:"github"`
+	Reaper           ReaperConfig     `yaml:"reaper"`
 	Targets          []TargetConfig   `yaml:"targets,omitempty"`
 
 	// Control agent settings used by orch agent and the Python orch-monitor.
@@ -230,38 +267,39 @@ type Config struct {
 }
 
 type fileConfig struct {
-	Vault               string           `yaml:"vault"`
-	VaultLegacy         string           `yaml:"Vault"`
-	DefaultVault        string           `yaml:"default_vault"`
-	Agent               string           `yaml:"agent"`
-	Model               string           `yaml:"model"`
-	ModelVariant        string           `yaml:"model_variant"`
-	WorktreeDir         string           `yaml:"worktree_dir"`
-	WorktreeDirLegacy   string           `yaml:"worktree_root"`
-	BaseBranch          string           `yaml:"base_branch"`
-	PRTargetBranch      string           `yaml:"pr_target_branch"`
-	LogLevel            string           `yaml:"log_level"`
-	PromptTemplate      string           `yaml:"prompt_template"`
-	Multiplexer         string           `yaml:"multiplexer"`
-	AgentMultiplexer    string           `yaml:"agent_multiplexer"`
-	NoPR                *bool            `yaml:"no_pr"`
-	PS                  PSConfig         `yaml:"ps"`
-	Monitor             MonitorConfig    `yaml:"monitor"`
-	Presets             []Preset         `yaml:"presets"`
-	OpenCodePresets     []OpenCodePreset `yaml:"opencode_presets"`
-	OpenCode            *OpenCodeConfig  `yaml:"opencode"`
-	Claude              *ClaudeConfig    `yaml:"claude"`
-	Codex               *CodexConfig     `yaml:"codex"`
-	Gemini              *GeminiConfig    `yaml:"gemini"`
-	DefaultPreset       string           `yaml:"default_preset"`
-	Slack               *SlackConfig     `yaml:"slack"`
-	Issues              *IssuesConfig    `yaml:"issues"`
-	GitHub              *GitHubConfig    `yaml:"github"`
-	Targets             []TargetConfig   `yaml:"targets"`
-	ControlAgent        string           `yaml:"control_agent"`
-	ControlModel        string           `yaml:"control_model"`
-	ControlModelVariant string           `yaml:"control_model_variant"`
-	DiffTool            string           `yaml:"diff_tool"`
+	Vault               string            `yaml:"vault"`
+	VaultLegacy         string            `yaml:"Vault"`
+	DefaultVault        string            `yaml:"default_vault"`
+	Agent               string            `yaml:"agent"`
+	Model               string            `yaml:"model"`
+	ModelVariant        string            `yaml:"model_variant"`
+	WorktreeDir         string            `yaml:"worktree_dir"`
+	WorktreeDirLegacy   string            `yaml:"worktree_root"`
+	BaseBranch          string            `yaml:"base_branch"`
+	PRTargetBranch      string            `yaml:"pr_target_branch"`
+	LogLevel            string            `yaml:"log_level"`
+	PromptTemplate      string            `yaml:"prompt_template"`
+	Multiplexer         string            `yaml:"multiplexer"`
+	AgentMultiplexer    string            `yaml:"agent_multiplexer"`
+	NoPR                *bool             `yaml:"no_pr"`
+	PS                  PSConfig          `yaml:"ps"`
+	Monitor             MonitorConfig     `yaml:"monitor"`
+	Presets             []Preset          `yaml:"presets"`
+	OpenCodePresets     []OpenCodePreset  `yaml:"opencode_presets"`
+	OpenCode            *OpenCodeConfig   `yaml:"opencode"`
+	Claude              *ClaudeConfig     `yaml:"claude"`
+	Codex               *CodexConfig      `yaml:"codex"`
+	Gemini              *GeminiConfig     `yaml:"gemini"`
+	DefaultPreset       string            `yaml:"default_preset"`
+	Slack               *SlackConfig      `yaml:"slack"`
+	Issues              *IssuesConfig     `yaml:"issues"`
+	GitHub              *GitHubConfig     `yaml:"github"`
+	Reaper              *fileReaperConfig `yaml:"reaper"`
+	Targets             []TargetConfig    `yaml:"targets"`
+	ControlAgent        string            `yaml:"control_agent"`
+	ControlModel        string            `yaml:"control_model"`
+	ControlModelVariant string            `yaml:"control_model_variant"`
+	DiffTool            string            `yaml:"diff_tool"`
 }
 
 // configFile is the name of the config file
@@ -273,7 +311,7 @@ const configFile = "config.yaml"
 // 3. Environment variables
 // 4. Global ~/.config/orch/config.yaml
 func Load() (*Config, error) {
-	cfg := &Config{}
+	cfg := &Config{Reaper: DefaultReaperConfig()}
 
 	// Load global config first (lowest precedence)
 	globalPath := globalConfigPath()
@@ -305,7 +343,7 @@ func Load() (*Config, error) {
 }
 
 func LoadFromProjectRoot(projectRoot string) (*Config, error) {
-	cfg := &Config{}
+	cfg := &Config{Reaper: DefaultReaperConfig()}
 
 	globalPath := globalConfigPath()
 	if globalPath != "" {
@@ -582,6 +620,20 @@ func loadFromFile(path string, cfg *Config) error {
 		}
 		if len(fileCfg.GitHub.StatusLabels) > 0 {
 			cfg.GitHub.StatusLabels = fileCfg.GitHub.StatusLabels
+		}
+	}
+	if fileCfg.Reaper != nil {
+		if fileCfg.Reaper.TerminalGraceMinutes != nil {
+			cfg.Reaper.TerminalGraceMinutes = *fileCfg.Reaper.TerminalGraceMinutes
+		}
+		if fileCfg.Reaper.ResolvedIssueGraceMinutes != nil {
+			cfg.Reaper.ResolvedIssueGraceMinutes = *fileCfg.Reaper.ResolvedIssueGraceMinutes
+		}
+		if fileCfg.Reaper.IdleTTLHours != nil {
+			cfg.Reaper.IdleTTLHours = *fileCfg.Reaper.IdleTTLHours
+		}
+		if fileCfg.Reaper.Enabled != nil {
+			cfg.Reaper.Enabled = *fileCfg.Reaper.Enabled
 		}
 	}
 	if fileCfg.ControlAgent != "" {
@@ -885,6 +937,15 @@ func (c *Config) Validate() error {
 	}
 	if c.AgentMultiplexer != "" && !validMultiplexers[c.AgentMultiplexer] {
 		errs = append(errs, fmt.Sprintf("agent_multiplexer must be one of %s (got %q)", joinAllowedKeys(validMultiplexers), c.AgentMultiplexer))
+	}
+	if c.Reaper.TerminalGraceMinutes < 0 {
+		errs = append(errs, "reaper.terminal_grace_minutes must be >= 0")
+	}
+	if c.Reaper.ResolvedIssueGraceMinutes < 0 {
+		errs = append(errs, "reaper.resolved_issue_grace_minutes must be >= 0")
+	}
+	if c.Reaper.IdleTTLHours < 0 {
+		errs = append(errs, "reaper.idle_ttl_hours must be >= 0")
 	}
 	for _, status := range c.Slack.NotifyOn {
 		if !validSlackNotifyStatuses[status] {

--- a/internal/config/reaper_test.go
+++ b/internal/config/reaper_test.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReaperConfigDefaultsApply(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	projectRoot := t.TempDir()
+
+	cfg, err := LoadFromProjectRoot(projectRoot)
+	if err != nil {
+		t.Fatalf("LoadFromProjectRoot() error = %v", err)
+	}
+	want := DefaultReaperConfig()
+	if cfg.Reaper != want {
+		t.Fatalf("Reaper = %#v, want defaults %#v", cfg.Reaper, want)
+	}
+}
+
+func TestReaperConfigParsesAndMergesPerField(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.yaml")
+	if err := os.WriteFile(basePath, []byte("reaper:\n  terminal_grace_minutes: 3\n  resolved_issue_grace_minutes: 4\n  idle_ttl_hours: 5\n"), 0o644); err != nil {
+		t.Fatalf("write base config: %v", err)
+	}
+	overridePath := filepath.Join(dir, "override.yaml")
+	if err := os.WriteFile(overridePath, []byte("reaper:\n  enabled: false\n  terminal_grace_minutes: 0\n"), 0o644); err != nil {
+		t.Fatalf("write override config: %v", err)
+	}
+
+	cfg := &Config{Reaper: DefaultReaperConfig()}
+	if err := loadFromFile(basePath, cfg); err != nil {
+		t.Fatalf("load base: %v", err)
+	}
+	if err := loadFromFile(overridePath, cfg); err != nil {
+		t.Fatalf("load override: %v", err)
+	}
+	if cfg.Reaper.Enabled {
+		t.Fatal("explicit enabled: false was not preserved")
+	}
+	if cfg.Reaper.TerminalGraceMinutes != 0 || cfg.Reaper.ResolvedIssueGraceMinutes != 4 || cfg.Reaper.IdleTTLHours != 5 {
+		t.Fatalf("per-field merge = %#v, want terminal=0 resolved=4 idle=5", cfg.Reaper)
+	}
+}
+
+func TestReaperConfigRejectsUnknownAndNegativeValues(t *testing.T) {
+	dir := t.TempDir()
+	unknownPath := filepath.Join(dir, "unknown.yaml")
+	if err := os.WriteFile(unknownPath, []byte("reaper:\n  terminal_grace_minute: 10\n"), 0o644); err != nil {
+		t.Fatalf("write unknown config: %v", err)
+	}
+	if err := loadFromFile(unknownPath, &Config{Reaper: DefaultReaperConfig()}); err == nil || !strings.Contains(err.Error(), "field terminal_grace_minute not found") {
+		t.Fatalf("unknown reaper key error = %v", err)
+	}
+
+	cfg := &Config{Reaper: DefaultReaperConfig()}
+	cfg.Reaper.IdleTTLHours = -1
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "reaper.idle_ttl_hours") {
+		t.Fatalf("negative TTL validation error = %v", err)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -45,6 +45,7 @@ type Daemon struct {
 
 	runStates     map[string]*RunState
 	lastFetchAt   map[string]time.Time
+	lastReapAt    map[string]time.Time
 	fetchInFlight map[string]bool
 	mu            sync.Mutex
 
@@ -111,6 +112,7 @@ func New(factory StoreFactory) *Daemon {
 		stopCh:        make(chan struct{}),
 		runStates:     make(map[string]*RunState),
 		lastFetchAt:   make(map[string]time.Time),
+		lastReapAt:    make(map[string]time.Time),
 		fetchInFlight: make(map[string]bool),
 		instanceNonce: generateMonitorID()[:12],
 	}
@@ -237,11 +239,13 @@ func (d *Daemon) Run() error {
 	defer ticker.Stop()
 
 	d.safeMonitorAll()
+	d.safeReapAll()
 
 	for {
 		select {
 		case <-ticker.C:
 			d.safeMonitorAll()
+			d.safeReapAll()
 			d.checkBinaryStaleness()
 		case sig := <-sigCh:
 			if sig == syscall.SIGHUP {

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -3719,20 +3719,26 @@ func (s *SocketServer) handleProtoRepairState(req *orchpb.RepairStateRequest) *o
 		}
 	}
 
-	// Repair orphaned sessions
-	orphaned := s.findOrphanedSessions()
-	if len(orphaned) > 0 {
-		result.ProblemsFound += int32(len(orphaned))
-		for _, sessionName := range orphaned {
-			result.Details = append(result.Details, fmt.Sprintf("orphaned session: %s", sessionName))
-			if !req.DryRun && req.Force {
-				mux := multiplexer.GetDefault()
-				if err := mux.KillSession(sessionName); err == nil {
-					result.ProblemsFixed++
-					result.Details = append(result.Details, fmt.Sprintf("killed orphaned session: %s", sessionName))
-				}
-			}
+	findings, findingsErr := s.findSessionRepairFindings(time.Now())
+	if findingsErr != nil {
+		result.ProblemsFound++
+		result.Details = append(result.Details, fmt.Sprintf("session inventory error: %v", findingsErr))
+	}
+	result.ProblemsFound += int32(len(findings))
+	for _, finding := range findings {
+		result.Details = append(result.Details, finding.detail())
+		// Status-aware findings are reports for the reaper/operator. Only truly
+		// orphaned sessions retain repair --force's existing destructive action.
+		if finding.Kind != sessionRepairOrphaned || req.DryRun || !req.Force {
+			continue
 		}
+		mux := multiplexer.GetDefault()
+		if err := mux.KillSession(finding.SessionName); err != nil {
+			result.Details = append(result.Details, fmt.Sprintf("failed to kill orphaned session %s: %v", finding.SessionName, err))
+			continue
+		}
+		result.ProblemsFixed++
+		result.Details = append(result.Details, fmt.Sprintf("killed orphaned session: %s", finding.SessionName))
 	}
 
 	return &orchpb.Response{
@@ -3743,43 +3749,171 @@ func (s *SocketServer) handleProtoRepairState(req *orchpb.RepairStateRequest) *o
 	}
 }
 
-func (s *SocketServer) findOrphanedSessions() []string {
+type sessionRepairKind string
+
+const (
+	sessionRepairOrphaned       sessionRepairKind = "orphaned"
+	sessionRepairTerminalAlive  sessionRepairKind = "terminal-but-alive"
+	sessionRepairUnreapableKept sessionRepairKind = "unreapable-kept"
+)
+
+type sessionRepairFinding struct {
+	Kind        sessionRepairKind
+	SessionName string
+	RunRef      string
+	Status      model.Status
+	Reason      string
+}
+
+func (f sessionRepairFinding) detail() string {
+	switch f.Kind {
+	case sessionRepairTerminalAlive:
+		return fmt.Sprintf("terminal-but-alive session: %s (run=%s status=%s)", f.SessionName, f.RunRef, f.Status)
+	case sessionRepairUnreapableKept:
+		return fmt.Sprintf("unreapable-kept session: %s (run=%s status=%s reason=%s)", f.SessionName, f.RunRef, f.Status, f.Reason)
+	default:
+		return fmt.Sprintf("orphaned session: %s", f.SessionName)
+	}
+}
+
+type repairRunContext struct {
+	run         *model.Run
+	issueStatus model.IssueStatus
+	reaper      config.ReaperConfig
+}
+
+func (s *SocketServer) findSessionRepairFindings(now time.Time) ([]sessionRepairFinding, error) {
 	mux := multiplexer.GetDefault()
 	sessions, err := mux.ListSessions()
-	if err != nil || len(sessions) == 0 {
-		return nil
+	if err != nil {
+		return nil, fmt.Errorf("list multiplexer sessions: %w", err)
+	}
+	if len(sessions) == 0 {
+		return nil, nil
+	}
+	return s.classifySessionRepairFindings(sessions, now)
+}
+
+func (s *SocketServer) classifySessionRepairFindings(sessions []string, now time.Time) ([]sessionRepairFinding, error) {
+	repoContexts := s.GetAllRepoContexts()
+	if len(repoContexts) == 0 {
+		return nil, fmt.Errorf("no registered repository stores; cannot classify %d live sessions", len(sessions))
 	}
 
-	stores := s.listStores()
-	if len(stores) == 0 {
-		return nil
-	}
-
-	expectedSessions := make(map[string]bool)
-	for _, st := range stores {
-		runs, err := st.ListRuns(&store.ListRunsFilter{})
-		if err != nil {
+	runsBySession := make(map[string]repairRunContext)
+	var inventoryErrs []error
+	for _, repoCtx := range repoContexts {
+		if repoCtx == nil || repoCtx.Store == nil {
 			continue
 		}
-		for _, run := range runs {
-			sessionName := run.SessionName
-			if sessionName == "" {
-				sessionName = model.GenerateSessionName(run.IssueID, run.RunID)
+		runs, err := repoCtx.Store.ListRuns(&store.ListRunsFilter{})
+		if err != nil {
+			inventoryErrs = append(inventoryErrs, fmt.Errorf("list runs for project %s: %w", repoCtx.RepoID, err))
+			continue
+		}
+
+		issueStatuses := make(map[model.IssueID]model.IssueStatus)
+		issues, err := repoCtx.Store.ListIssues()
+		if err != nil {
+			inventoryErrs = append(inventoryErrs, fmt.Errorf("list issues for project %s: %w", repoCtx.RepoID, err))
+		} else {
+			for _, issue := range issues {
+				if issue != nil {
+					issueStatuses[issue.ID] = issue.Status
+				}
 			}
-			expectedSessions[sessionName] = true
+		}
+
+		reaperCfg := config.DefaultReaperConfig()
+		if strings.TrimSpace(repoCtx.ProjectRoot) != "" {
+			cfg, err := config.LoadFromProjectRoot(repoCtx.ProjectRoot)
+			if err != nil {
+				inventoryErrs = append(inventoryErrs, fmt.Errorf("load reaper config for project %s: %w", repoCtx.RepoID, err))
+			} else {
+				reaperCfg = cfg.Reaper
+			}
+		}
+
+		for _, listedRun := range runs {
+			if listedRun == nil {
+				continue
+			}
+			// Repair classification needs event-ledger facts such as
+			// worktree_removed and a pending session_reaped retry. ListRuns is
+			// index-backed and intentionally omits Events, so classify only the
+			// authoritative run document.
+			run, err := repoCtx.Store.GetRun(listedRun.Ref())
+			if err != nil {
+				inventoryErrs = append(inventoryErrs, fmt.Errorf("load run %s for project %s: %w", listedRun.Ref().String(), repoCtx.RepoID, err))
+				continue
+			}
+			sessionName := model.GenerateSessionName(run.IssueID, run.RunID)
+			if run.SessionName != "" && run.SessionName != sessionName {
+				continue
+			}
+			if _, duplicate := runsBySession[sessionName]; duplicate {
+				inventoryErrs = append(inventoryErrs, fmt.Errorf("session %s maps to multiple runs", sessionName))
+				continue
+			}
+			runsBySession[sessionName] = repairRunContext{
+				run:         run,
+				issueStatus: issueStatuses[run.IssueID],
+				reaper:      reaperCfg,
+			}
 		}
 	}
 
-	var orphaned []string
+	var findings []sessionRepairFinding
 	for _, sess := range sessions {
-		if len(sess) > 4 && sess[:4] == "run-" {
-			if !expectedSessions[sess] {
-				orphaned = append(orphaned, sess)
+		if !strings.HasPrefix(sess, "run-") {
+			continue
+		}
+		runCtx, ok := runsBySession[sess]
+		if !ok {
+			findings = append(findings, sessionRepairFinding{Kind: sessionRepairOrphaned, SessionName: sess})
+			continue
+		}
+		run := runCtx.run
+		if run.Status.IsTerminal() {
+			findings = append(findings, sessionRepairFinding{
+				Kind: sessionRepairTerminalAlive, SessionName: sess, RunRef: run.Ref().String(), Status: run.Status,
+			})
+		}
+		if !runCtx.reaper.Enabled {
+			continue
+		}
+		if _, due := reapReasonForRun(run, runCtx.issueStatus, runCtx.reaper, now); !due {
+			continue
+		}
+		keptReason := reapInterlockProblem(run)
+		if keptReason == "" {
+			if routingErr := validateReaperMultiplexer(run); routingErr != nil {
+				keptReason = routingErr.Error()
 			}
+		}
+		if keptReason == "" {
+			exists, existsErr := worktreeDirectoryExists(run.WorktreePath)
+			switch {
+			case existsErr != nil:
+				keptReason = fmt.Sprintf("worktree check failed: %v", existsErr)
+			case !exists:
+				keptReason = fmt.Sprintf("worktree does not exist: %s", run.WorktreePath)
+			}
+		}
+		if keptReason != "" {
+			findings = append(findings, sessionRepairFinding{
+				Kind: sessionRepairUnreapableKept, SessionName: sess, RunRef: run.Ref().String(), Status: run.Status, Reason: keptReason,
+			})
 		}
 	}
 
-	return orphaned
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].SessionName == findings[j].SessionName {
+			return findings[i].Kind < findings[j].Kind
+		}
+		return findings[i].SessionName < findings[j].SessionName
+	})
+	return findings, errors.Join(inventoryErrs...)
 }
 
 func (s *SocketServer) handleProtoGetDaemonLog(req *orchpb.GetDaemonLogRequest) *orchpb.Response {

--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -1,0 +1,535 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/proboscis/orch/internal/agent"
+	"github.com/proboscis/orch/internal/config"
+	"github.com/proboscis/orch/internal/model"
+	"github.com/proboscis/orch/internal/multiplexer"
+	"github.com/proboscis/orch/internal/store"
+)
+
+const (
+	SessionReaperInterval = time.Minute
+	reaperSnapshotLines   = 2000
+)
+
+type reapReason string
+
+const (
+	reapReasonTerminalGrace reapReason = "terminal_grace"
+	reapReasonResolvedGrace reapReason = "resolved_grace"
+	reapReasonIdleTTL       reapReason = "idle_ttl"
+)
+
+type reaperSessionObservation struct {
+	Content        string
+	SessionAlive   bool
+	WorktreeExists bool
+}
+
+type sessionReaperDeps struct {
+	Observe func(run *model.Run, projectID, projectRoot string) (reaperSessionObservation, error)
+	Persist func(run *model.Run, content string, now time.Time) (string, error)
+	Kill    func(run *model.Run, projectID, projectRoot string) error
+}
+
+type reapRunOutcome struct {
+	Due        bool
+	Reaped     bool
+	Reason     reapReason
+	KeptReason string
+}
+
+type reaperMultiplexer interface {
+	HasSession(name string) bool
+	CapturePane(session string, lines int) (string, error)
+	KillSession(session string) error
+}
+
+func (d *Daemon) safeReapAll() {
+	defer func() {
+		if r := recover(); r != nil {
+			logAndRepanic(d.logger, "reapAll", r)
+		}
+	}()
+	d.reapAllAt(time.Now())
+}
+
+func (d *Daemon) reapAllAt(now time.Time) {
+	if d.socketServer == nil {
+		return
+	}
+
+	for _, repoCtx := range d.socketServer.GetAllRepoContexts() {
+		if repoCtx == nil || repoCtx.Store == nil {
+			continue
+		}
+		if !d.claimReaperPass(repoCtx.RepoID, now) {
+			continue
+		}
+
+		reaperCfg, err := d.reaperConfigForContext(repoCtx)
+		if err != nil {
+			d.logReaper("session reaper disabled for project %s: config load failed: %v", repoCtx.RepoID, err)
+			continue
+		}
+		if !reaperCfg.Enabled {
+			continue
+		}
+
+		runs, err := repoCtx.Store.ListRuns(&store.ListRunsFilter{})
+		if err != nil {
+			d.logReaper("session reaper failed to list all runs for project %s: %v", repoCtx.RepoID, err)
+			continue
+		}
+
+		issueStatuses := make(map[model.IssueID]model.IssueStatus)
+		issues, issueErr := repoCtx.Store.ListIssues()
+		if issueErr != nil {
+			d.logReaper("session reaper failed to list issues for project %s; resolved-issue policy unavailable this pass: %v", repoCtx.RepoID, issueErr)
+		} else {
+			for _, issue := range issues {
+				if issue != nil {
+					issueStatuses[issue.ID] = issue.Status
+				}
+			}
+		}
+
+		deps := sessionReaperDeps{
+			Observe: d.observeSessionForReap,
+			Persist: persistSessionSnapshot,
+			Kill:    d.killSessionForReap,
+		}
+		for _, listedRun := range runs {
+			if listedRun == nil {
+				continue
+			}
+			// ListRuns may be served by an index/projection that omits the run
+			// document path. Re-read the authoritative run before persisting a
+			// sidecar and before evaluating the newest event-log interlocks.
+			run, err := repoCtx.Store.GetRun(listedRun.Ref())
+			if err != nil {
+				d.logReaper("session reaper failed to load authoritative run %s: %v", listedRun.Ref().String(), err)
+				continue
+			}
+			outcome, err := reapRun(run, issueStatuses[run.IssueID], repoCtx.Store, repoCtx.RepoID, repoCtx.ProjectRoot, reaperCfg, now, deps)
+			if err != nil {
+				d.logReaper("session reaper failed for %s: %v", run.Ref().String(), err)
+				continue
+			}
+			if outcome.KeptReason != "" {
+				d.logReaper("session reaper kept %s (%s): %s", run.Ref().String(), outcome.Reason, outcome.KeptReason)
+			} else if outcome.Reaped {
+				d.logReaper("session reaper reaped %s (%s)", run.Ref().String(), outcome.Reason)
+			}
+		}
+	}
+}
+
+func (d *Daemon) claimReaperPass(repoID string, now time.Time) bool {
+	if strings.TrimSpace(repoID) == "" {
+		repoID = "default"
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.lastReapAt == nil {
+		d.lastReapAt = make(map[string]time.Time)
+	}
+	if last, ok := d.lastReapAt[repoID]; ok && now.Sub(last) < SessionReaperInterval {
+		return false
+	}
+	d.lastReapAt[repoID] = now
+	return true
+}
+
+func (d *Daemon) reaperConfigForContext(repoCtx *RepoContext) (config.ReaperConfig, error) {
+	if repoCtx != nil && strings.TrimSpace(repoCtx.ProjectRoot) != "" {
+		cfg, err := config.LoadFromProjectRoot(repoCtx.ProjectRoot)
+		if err != nil {
+			return config.ReaperConfig{}, err
+		}
+		return cfg.Reaper, nil
+	}
+	if d.config != nil {
+		return d.config.Reaper, nil
+	}
+	return config.DefaultReaperConfig(), nil
+}
+
+func (d *Daemon) logReaper(format string, args ...interface{}) {
+	if d.logger != nil {
+		d.logger.Printf(format, args...)
+	}
+}
+
+func reapRun(
+	run *model.Run,
+	issueStatus model.IssueStatus,
+	st store.Store,
+	projectID, projectRoot string,
+	reaperCfg config.ReaperConfig,
+	now time.Time,
+	deps sessionReaperDeps,
+) (reapRunOutcome, error) {
+	reason, due := reapReasonForRun(run, issueStatus, reaperCfg, now)
+	outcome := reapRunOutcome{Due: due, Reason: reason}
+	if !due {
+		return outcome, nil
+	}
+	if st == nil {
+		return outcome, fmt.Errorf("store required")
+	}
+	if deps.Observe == nil || deps.Persist == nil || deps.Kill == nil {
+		return outcome, fmt.Errorf("session reaper dependencies incomplete")
+	}
+
+	if keptReason := reapInterlockProblem(run); keptReason != "" {
+		outcome.KeptReason = keptReason
+		return outcome, nil
+	}
+	if err := validateReaperMultiplexer(run); err != nil {
+		return outcome, err
+	}
+
+	observation, err := deps.Observe(run, projectID, projectRoot)
+	if err != nil {
+		return outcome, err
+	}
+	if !observation.WorktreeExists {
+		outcome.KeptReason = fmt.Sprintf("worktree does not exist: %s", run.WorktreePath)
+		return outcome, nil
+	}
+	if !observation.SessionAlive {
+		return outcome, nil
+	}
+
+	snapshotPath, err := deps.Persist(run, observation.Content, now)
+	if err != nil {
+		return outcome, fmt.Errorf("persist final session snapshot: %w", err)
+	}
+	if err := st.AppendEvent(run.Ref(), model.NewArtifactEvent("session_snapshot", map[string]string{"path": snapshotPath})); err != nil {
+		return outcome, fmt.Errorf("record session_snapshot artifact: %w", err)
+	}
+
+	sessionName := model.GenerateSessionName(run.IssueID, run.RunID)
+	note := model.NewDaemonNoticeEvent("session_reaped", map[string]string{
+		"generation":   strconv.Itoa(run.AgentSessionGeneration),
+		"session_name": sessionName,
+		"reason":       string(reason),
+	})
+	if err := st.AppendEvent(run.Ref(), note); err != nil {
+		return outcome, fmt.Errorf("record session_reaped note: %w", err)
+	}
+
+	if err := deps.Kill(run, projectID, projectRoot); err != nil {
+		killErr := fmt.Errorf("kill session %s for %s: %w", sessionName, run.Ref().String(), err)
+		artifactErr := st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(killErr.Error()))
+		if artifactErr != nil {
+			return outcome, errors.Join(killErr, fmt.Errorf("record kill error artifact: %w", artifactErr))
+		}
+		return outcome, killErr
+	}
+
+	outcome.Reaped = true
+	return outcome, nil
+}
+
+func reapReasonForRun(run *model.Run, issueStatus model.IssueStatus, cfg config.ReaperConfig, now time.Time) (reapReason, bool) {
+	if run == nil {
+		return "", false
+	}
+	if reason, ok := pendingReapReason(run); ok {
+		return reason, true
+	}
+	if run.UpdatedAt.IsZero() {
+		return "", false
+	}
+	if terminalAt, terminal := terminalStatusTimestamp(run); terminal && !now.Before(terminalAt.Add(time.Duration(cfg.TerminalGraceMinutes)*time.Minute)) {
+		return reapReasonTerminalGrace, true
+	}
+	if issueStatus == model.IssueStatusResolved && !now.Before(run.UpdatedAt.Add(time.Duration(cfg.ResolvedIssueGraceMinutes)*time.Minute)) {
+		return reapReasonResolvedGrace, true
+	}
+	if !now.Before(run.UpdatedAt.Add(time.Duration(cfg.IdleTTLHours) * time.Hour)) {
+		return reapReasonIdleTTL, true
+	}
+	return "", false
+}
+
+func terminalStatusTimestamp(run *model.Run) (time.Time, bool) {
+	if run == nil || !run.Status.IsTerminal() {
+		return time.Time{}, false
+	}
+	for i := len(run.Events) - 1; i >= 0; i-- {
+		event := run.Events[i]
+		if event == nil || event.Type != model.EventTypeStatus {
+			continue
+		}
+		status, err := model.NormalizeStatus(event.Name)
+		if err == nil && status == run.Status {
+			return event.Timestamp, true
+		}
+	}
+	if !run.UpdatedAt.IsZero() {
+		return run.UpdatedAt, true
+	}
+	return time.Time{}, false
+}
+
+func pendingReapReason(run *model.Run) (reapReason, bool) {
+	if run == nil {
+		return "", false
+	}
+	for i := len(run.Events) - 1; i >= 0; i-- {
+		event := run.Events[i]
+		if event == nil || event.Type != model.EventTypeNote || event.Name != model.DaemonNoticeEventName || event.Attrs["kind"] != "session_reaped" {
+			continue
+		}
+		generation, err := strconv.Atoi(event.Attrs["generation"])
+		if err != nil || generation != run.AgentSessionGeneration {
+			continue
+		}
+		reason := reapReason(event.Attrs["reason"])
+		switch reason {
+		case reapReasonTerminalGrace, reapReasonResolvedGrace, reapReasonIdleTTL:
+			return reason, true
+		default:
+			return "", false
+		}
+	}
+	return "", false
+}
+
+func reapInterlockProblem(run *model.Run) string {
+	if run == nil {
+		return "run is nil"
+	}
+	expectedSession := model.GenerateSessionName(run.IssueID, run.RunID)
+	if run.SessionName != "" && run.SessionName != expectedSession {
+		return fmt.Sprintf("session name %q does not match exact run session %q", run.SessionName, expectedSession)
+	}
+	if strings.TrimSpace(run.AgentSessionID) == "" && run.Agent != string(agent.AgentOpenCode) {
+		return "agent_session identity is not recorded"
+	}
+	if run.Agent != string(agent.AgentOpenCode) && run.AgentSessionGeneration <= 0 {
+		return fmt.Sprintf("agent_session generation is not positive: %d", run.AgentSessionGeneration)
+	}
+	if run.Agent == string(agent.AgentOpenCode) && !run.Status.IsTerminal() {
+		return "non-terminal opencode reaping is outside ADR-0005 Stage 2 semantics"
+	}
+	if strings.TrimSpace(run.WorktreePath) == "" {
+		return "worktree path is not recorded"
+	}
+	if runHasWorktreeRemovedNote(run) {
+		return "worktree_removed note is recorded"
+	}
+	return ""
+}
+
+func runHasWorktreeRemovedNote(run *model.Run) bool {
+	if run == nil {
+		return false
+	}
+	for _, event := range run.Events {
+		if event == nil || event.Type != model.EventTypeNote {
+			continue
+		}
+		if event.Name == "worktree_removed" || (event.Name == model.DaemonNoticeEventName && event.Attrs["kind"] == "worktree_removed") {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *Daemon) observeSessionForReap(run *model.Run, projectID, projectRoot string) (reaperSessionObservation, error) {
+	if d.socketServer != nil && d.socketServer.runRequiresWorkerDelegation(run, "") {
+		return d.observeRemoteSessionForReap(run, projectID, projectRoot)
+	}
+	return observeLocalSessionForReap(run)
+}
+
+func observeLocalSessionForReap(run *model.Run) (reaperSessionObservation, error) {
+	observation := reaperSessionObservation{}
+	exists, err := worktreeDirectoryExists(run.WorktreePath)
+	if err != nil {
+		return observation, fmt.Errorf("check worktree %s: %w", run.WorktreePath, err)
+	}
+	observation.WorktreeExists = exists
+	if !exists {
+		return observation, nil
+	}
+
+	mux, err := reaperMultiplexerForRun(run)
+	if err != nil {
+		return observation, err
+	}
+	sessionName := model.GenerateSessionName(run.IssueID, run.RunID)
+	if !mux.HasSession(sessionName) {
+		return observation, nil
+	}
+	content, err := mux.CapturePane(sessionName, reaperSnapshotLines)
+	if err != nil {
+		return observation, fmt.Errorf("capture final pane snapshot from %s: %w", sessionName, err)
+	}
+	observation.Content = content
+	observation.SessionAlive = true
+	return observation, nil
+}
+
+func (d *Daemon) observeRemoteSessionForReap(run *model.Run, projectID, projectRoot string) (reaperSessionObservation, error) {
+	observation := reaperSessionObservation{}
+	if d.socketServer == nil {
+		return observation, fmt.Errorf("socket server unavailable for worker-hosted run %s", run.Ref().String())
+	}
+	target, err := resolveWorkerTargetForRunFields(run, projectRoot)
+	if err != nil {
+		return observation, err
+	}
+	payload := &WorkerEffectPayload{
+		CaptureSession: &CaptureSessionPayload{
+			Lines:          reaperSnapshotLines,
+			Target:         strings.TrimSpace(run.Target),
+			TargetHost:     target.Host,
+			TargetWorkerID: target.WorkerID,
+			RunSnapshot:    newRunSnapshot(run),
+			CheckWorktree:  true,
+		},
+	}
+	lease, err := d.socketServer.acquireWorkerLease(projectID, "capture_session", string(run.IssueID), string(run.RunID), payload)
+	if err != nil {
+		return observation, err
+	}
+	completed, err := d.socketServer.waitForWorkerLeaseCompletion(lease.LeaseID, remoteCaptureLeaseTimeout)
+	if err != nil {
+		return observation, err
+	}
+	result, err := decodeWorkerEffectResult(completed.ResultJSON)
+	if err != nil {
+		return observation, err
+	}
+	if result.CaptureResult == nil {
+		return observation, fmt.Errorf("worker lease completed without capture_result")
+	}
+	if !result.CaptureResult.WorktreeChecked {
+		return observation, fmt.Errorf("worker capture did not report the required worktree interlock")
+	}
+	observation.WorktreeExists = result.CaptureResult.WorktreeExists
+	if !observation.WorktreeExists || result.CaptureResult.Gone != nil {
+		return observation, nil
+	}
+	observation.Content = result.CaptureResult.Content
+	observation.SessionAlive = true
+	return observation, nil
+}
+
+func (d *Daemon) killSessionForReap(run *model.Run, projectID, projectRoot string) error {
+	if d.socketServer != nil && d.socketServer.runRequiresWorkerDelegation(run, "") {
+		return d.killRemoteSessionForReap(run, projectID, projectRoot)
+	}
+	return killLocalSessionForReap(run)
+}
+
+func killLocalSessionForReap(run *model.Run) error {
+	mux, err := reaperMultiplexerForRun(run)
+	if err != nil {
+		return err
+	}
+	sessionName := model.GenerateSessionName(run.IssueID, run.RunID)
+	if err := mux.KillSession(sessionName); err != nil {
+		return fmt.Errorf("multiplexer %s: %w", run.Multiplexer, err)
+	}
+	return nil
+}
+
+func (d *Daemon) killRemoteSessionForReap(run *model.Run, projectID, projectRoot string) error {
+	if d.socketServer == nil {
+		return fmt.Errorf("socket server unavailable for worker-hosted run %s", run.Ref().String())
+	}
+	target, err := resolveWorkerTargetForRunFields(run, projectRoot)
+	if err != nil {
+		return err
+	}
+	payload := &WorkerEffectPayload{
+		StopRun: &StopRunPayload{
+			ProjectRoot:    projectRoot,
+			Target:         strings.TrimSpace(run.Target),
+			TargetHost:     target.Host,
+			TargetWorkerID: target.WorkerID,
+			RunSnapshot:    newRunSnapshot(run),
+			ReapSession:    true,
+		},
+	}
+	_, err = d.socketServer.withWorkerLease(projectID, "stop_run", string(run.IssueID), string(run.RunID), payload)
+	return err
+}
+
+func reaperMultiplexerForRun(run *model.Run) (reaperMultiplexer, error) {
+	if err := validateReaperMultiplexer(run); err != nil {
+		return nil, err
+	}
+	muxType, _ := multiplexer.ParseType(strings.TrimSpace(run.Multiplexer))
+	mux, err := multiplexer.GetMultiplexer(muxType)
+	if err != nil {
+		return nil, fmt.Errorf("resolve multiplexer %q for run %s: %w", run.Multiplexer, run.Ref().String(), err)
+	}
+	if mux == nil {
+		return nil, fmt.Errorf("resolve multiplexer %q for run %s: no multiplexer returned", run.Multiplexer, run.Ref().String())
+	}
+	return mux, nil
+}
+
+func validateReaperMultiplexer(run *model.Run) error {
+	if run == nil {
+		return fmt.Errorf("run required")
+	}
+	raw := strings.TrimSpace(run.Multiplexer)
+	if raw == "" {
+		return fmt.Errorf("run %s has empty multiplexer; refusing session reap", run.Ref().String())
+	}
+	muxType, err := multiplexer.ParseType(raw)
+	if err != nil {
+		return fmt.Errorf("run %s has invalid multiplexer %q: %w", run.Ref().String(), raw, err)
+	}
+	if muxType == multiplexer.TypeAuto {
+		return fmt.Errorf("run %s has non-concrete multiplexer %q; refusing session reap", run.Ref().String(), raw)
+	}
+	return nil
+}
+
+func worktreeDirectoryExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return info.IsDir(), nil
+}
+
+func persistSessionSnapshot(run *model.Run, content string, now time.Time) (string, error) {
+	if run == nil {
+		return "", fmt.Errorf("run required")
+	}
+	if strings.TrimSpace(run.Path) == "" {
+		return "", fmt.Errorf("run %s has no run document path", run.Ref().String())
+	}
+	logDir := strings.TrimSuffix(run.Path, ".md") + ".log"
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return "", fmt.Errorf("create run log directory %s: %w", logDir, err)
+	}
+	name := fmt.Sprintf("session-snapshot-g%d-%d.txt", run.AgentSessionGeneration, now.UTC().UnixNano())
+	path := filepath.Join(logDir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return "", fmt.Errorf("write session snapshot %s: %w", path, err)
+	}
+	return path, nil
+}

--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -179,7 +179,11 @@ func reapRun(
 	now time.Time,
 	deps sessionReaperDeps,
 ) (reapRunOutcome, error) {
-	reason, due := reapReasonForRun(run, issueStatus, reaperCfg, now)
+	reason, pendingKill := pendingReapReason(run)
+	due := pendingKill
+	if !pendingKill {
+		reason, due = reapReasonForRun(run, issueStatus, reaperCfg, now)
+	}
 	outcome := reapRunOutcome{Due: due, Reason: reason}
 	if !due {
 		return outcome, nil
@@ -187,7 +191,7 @@ func reapRun(
 	if st == nil {
 		return outcome, fmt.Errorf("store required")
 	}
-	if deps.Observe == nil || deps.Persist == nil || deps.Kill == nil {
+	if deps.Kill == nil {
 		return outcome, fmt.Errorf("session reaper dependencies incomplete")
 	}
 
@@ -197,6 +201,16 @@ func reapRun(
 	}
 	if err := validateReaperMultiplexer(run); err != nil {
 		return outcome, err
+	}
+	if pendingKill {
+		if err := attemptReaperKill(run, st, projectID, projectRoot, deps.Kill); err != nil {
+			return outcome, err
+		}
+		outcome.Reaped = true
+		return outcome, nil
+	}
+	if deps.Observe == nil || deps.Persist == nil {
+		return outcome, fmt.Errorf("session reaper dependencies incomplete")
 	}
 
 	observation, err := deps.Observe(run, projectID, projectRoot)
@@ -229,17 +243,48 @@ func reapRun(
 		return outcome, fmt.Errorf("record session_reaped note: %w", err)
 	}
 
-	if err := deps.Kill(run, projectID, projectRoot); err != nil {
-		killErr := fmt.Errorf("kill session %s for %s: %w", sessionName, run.Ref().String(), err)
-		artifactErr := st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(killErr.Error()))
-		if artifactErr != nil {
-			return outcome, errors.Join(killErr, fmt.Errorf("record kill error artifact: %w", artifactErr))
-		}
-		return outcome, killErr
+	if err := attemptReaperKill(run, st, projectID, projectRoot, deps.Kill); err != nil {
+		return outcome, err
 	}
 
 	outcome.Reaped = true
 	return outcome, nil
+}
+
+func attemptReaperKill(
+	run *model.Run,
+	st store.Store,
+	projectID, projectRoot string,
+	kill func(run *model.Run, projectID, projectRoot string) error,
+) error {
+	sessionName := model.GenerateSessionName(run.IssueID, run.RunID)
+	if err := kill(run, projectID, projectRoot); err != nil {
+		killErr := fmt.Errorf("kill session %s for %s: %w", sessionName, run.Ref().String(), err)
+		// The returned error is logged on every pass. Keep only the first
+		// durable copy of a repeated failure so a broken multiplexer cannot
+		// grow the event ledger without bound once the reap note is pending.
+		if mostRecentErrorArtifactMessage(run) == killErr.Error() {
+			return killErr
+		}
+		if artifactErr := st.AppendEvent(run.Ref(), model.NewErrorArtifactEvent(killErr.Error())); artifactErr != nil {
+			return errors.Join(killErr, fmt.Errorf("record kill error artifact: %w", artifactErr))
+		}
+		return killErr
+	}
+	return nil
+}
+
+func mostRecentErrorArtifactMessage(run *model.Run) string {
+	if run == nil {
+		return ""
+	}
+	for i := len(run.Events) - 1; i >= 0; i-- {
+		event := run.Events[i]
+		if event != nil && event.Type == model.EventTypeArtifact && event.Name == "error" {
+			return event.Attrs["message"]
+		}
+	}
+	return ""
 }
 
 func reapReasonForRun(run *model.Run, issueStatus model.IssueStatus, cfg config.ReaperConfig, now time.Time) (reapReason, bool) {

--- a/internal/daemon/reaper_test.go
+++ b/internal/daemon/reaper_test.go
@@ -1,0 +1,426 @@
+package daemon
+
+import (
+	"errors"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/proboscis/orch/internal/config"
+	"github.com/proboscis/orch/internal/model"
+	"github.com/proboscis/orch/internal/store"
+	filestore "github.com/proboscis/orch/internal/store/file"
+)
+
+type recordingReaperStore struct {
+	store.Store
+	order *[]string
+}
+
+func (s *recordingReaperStore) AppendEvent(ref *model.RunRef, event *model.Event) error {
+	label := string(event.Type) + ":" + event.Name
+	if event.Type == model.EventTypeNote {
+		label += ":" + event.Attrs["kind"]
+	}
+	*s.order = append(*s.order, label)
+	return s.Store.AppendEvent(ref, event)
+}
+
+func createReaperTestRun(t *testing.T, status model.Status, updatedAt time.Time, withIdentity bool) (store.Store, *model.Run) {
+	t.Helper()
+	root := t.TempDir()
+	st, err := filestore.New(root)
+	if err != nil {
+		t.Fatalf("filestore.New() error = %v", err)
+	}
+	issueID := model.IssueID("reaper-issue")
+	if err := st.CreateIssue(&model.Issue{ID: issueID, Title: "Reaper issue", Status: model.IssueStatusOpen}); err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+	runID := model.RunID("20260713-120000")
+	if _, err := st.CreateRun(issueID, runID, map[string]string{"agent": "codex"}); err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	worktree := t.TempDir()
+	events := []*model.Event{
+		{Timestamp: updatedAt.Add(-3 * time.Second), Type: model.EventTypeArtifact, Name: "worktree", Attrs: map[string]string{"path": worktree}},
+		{Timestamp: updatedAt.Add(-2 * time.Second), Type: model.EventTypeArtifact, Name: "session", Attrs: map[string]string{"name": model.GenerateSessionName(issueID, runID), "multiplexer": "tmux"}},
+	}
+	if withIdentity {
+		events = append(events, &model.Event{Timestamp: updatedAt.Add(-time.Second), Type: model.EventTypeArtifact, Name: "agent_session", Attrs: map[string]string{"backend": "codex", "id": "rollout-test", "generation": "1"}})
+	}
+	events = append(events, &model.Event{Timestamp: updatedAt, Type: model.EventTypeStatus, Name: string(status), Attrs: map[string]string{"source": string(model.EventSourceDaemon)}})
+	for _, event := range events {
+		if err := st.AppendEvent(&model.RunRef{IssueID: issueID, RunID: runID}, event); err != nil {
+			t.Fatalf("AppendEvent(%s) error = %v", event.Name, err)
+		}
+	}
+	run, err := st.GetRun(&model.RunRef{IssueID: issueID, RunID: runID})
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	return st, run
+}
+
+func successfulReaperDeps(order *[]string, killed *bool) sessionReaperDeps {
+	return sessionReaperDeps{
+		Observe: func(*model.Run, string, string) (reaperSessionObservation, error) {
+			*order = append(*order, "capture")
+			return reaperSessionObservation{Content: "final pane output\n", SessionAlive: true, WorktreeExists: true}, nil
+		},
+		Persist: func(run *model.Run, content string, now time.Time) (string, error) {
+			*order = append(*order, "persist")
+			return persistSessionSnapshot(run, content, now)
+		},
+		Kill: func(*model.Run, string, string) error {
+			*order = append(*order, "kill")
+			*killed = true
+			return nil
+		},
+	}
+}
+
+func TestSessionReaperIncidentReplayPreservesTerminalStatusAndProtocolOrder(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	baseStore, run := createReaperTestRun(t, model.StatusDone, now.Add(-time.Hour), true)
+	var order []string
+	killed := false
+	recordingStore := &recordingReaperStore{Store: baseStore, order: &order}
+	cfg := config.DefaultReaperConfig()
+	cfg.TerminalGraceMinutes = 0
+
+	outcome, err := reapRun(run, model.IssueStatusOpen, recordingStore, "project", t.TempDir(), cfg, now, successfulReaperDeps(&order, &killed))
+	if err != nil {
+		t.Fatalf("reapRun() error = %v", err)
+	}
+	if !outcome.Reaped || outcome.Reason != reapReasonTerminalGrace || !killed {
+		t.Fatalf("outcome = %#v killed=%v", outcome, killed)
+	}
+	wantOrder := []string{"capture", "persist", "artifact:session_snapshot", "note:daemon_notice:session_reaped", "kill"}
+	if strings.Join(order, ",") != strings.Join(wantOrder, ",") {
+		t.Fatalf("protocol order = %v, want %v", order, wantOrder)
+	}
+
+	reloaded, err := baseStore.GetRun(run.Ref())
+	if err != nil {
+		t.Fatalf("GetRun() after reap error = %v", err)
+	}
+	if reloaded.Status != model.StatusDone {
+		t.Fatalf("status changed to %s, want done", reloaded.Status)
+	}
+	if !reloaded.SessionReaped() {
+		t.Fatal("session_reaped note did not latch the current generation")
+	}
+	var snapshotPath string
+	for _, event := range reloaded.Events {
+		if event.Type == model.EventTypeStatus && event.Name == string(model.StatusFailed) {
+			t.Fatalf("reaper manufactured failed verdict: %s", event.String())
+		}
+		if event.Type == model.EventTypeArtifact && event.Name == "session_snapshot" {
+			snapshotPath = event.Attrs["path"]
+		}
+		if event.Type == model.EventTypeNote && event.Attrs["kind"] == "session_reaped" {
+			if event.Attrs["generation"] != "1" || event.Attrs["reason"] != string(reapReasonTerminalGrace) || event.Attrs["session_name"] != model.GenerateSessionName(run.IssueID, run.RunID) {
+				t.Fatalf("session_reaped attrs = %#v", event.Attrs)
+			}
+		}
+	}
+	content, err := os.ReadFile(snapshotPath)
+	if err != nil {
+		t.Fatalf("read snapshot %q: %v", snapshotPath, err)
+	}
+	if string(content) != "final pane output\n" {
+		t.Fatalf("snapshot content = %q", content)
+	}
+}
+
+func TestSessionReaperIdleRunRequiresRecordedIdentity(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := config.DefaultReaperConfig()
+
+	t.Run("recorded identity is reaped", func(t *testing.T) {
+		st, run := createReaperTestRun(t, model.StatusWaiting, now.Add(-8*24*time.Hour), true)
+		var order []string
+		killed := false
+		outcome, err := reapRun(run, model.IssueStatusOpen, st, "project", t.TempDir(), cfg, now, successfulReaperDeps(&order, &killed))
+		if err != nil {
+			t.Fatalf("reapRun() error = %v", err)
+		}
+		if !outcome.Reaped || outcome.Reason != reapReasonIdleTTL || !killed {
+			t.Fatalf("outcome = %#v killed=%v", outcome, killed)
+		}
+	})
+
+	t.Run("missing identity is kept and reported", func(t *testing.T) {
+		st, run := createReaperTestRun(t, model.StatusWaiting, now.Add(-8*24*time.Hour), false)
+		observed := false
+		deps := sessionReaperDeps{
+			Observe: func(*model.Run, string, string) (reaperSessionObservation, error) {
+				observed = true
+				return reaperSessionObservation{}, nil
+			},
+			Persist: persistSessionSnapshot,
+			Kill:    func(*model.Run, string, string) error { return nil },
+		}
+		outcome, err := reapRun(run, model.IssueStatusOpen, st, "project", t.TempDir(), cfg, now, deps)
+		if err != nil {
+			t.Fatalf("reapRun() error = %v", err)
+		}
+		if outcome.KeptReason != "agent_session identity is not recorded" || observed {
+			t.Fatalf("outcome = %#v observed=%v", outcome, observed)
+		}
+	})
+}
+
+func TestSessionReaperResolvedIssueGrace(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	st, run := createReaperTestRun(t, model.StatusWaiting, now.Add(-2*time.Hour), true)
+	var order []string
+	killed := false
+	outcome, err := reapRun(run, model.IssueStatusResolved, st, "project", t.TempDir(), config.DefaultReaperConfig(), now, successfulReaperDeps(&order, &killed))
+	if err != nil {
+		t.Fatalf("reapRun() error = %v", err)
+	}
+	if !outcome.Reaped || outcome.Reason != reapReasonResolvedGrace || !killed {
+		t.Fatalf("outcome = %#v killed=%v", outcome, killed)
+	}
+}
+
+func TestSessionReaperKillFailureRecordsErrorAndRetriesNextPass(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	st, run := createReaperTestRun(t, model.StatusDone, now.Add(-time.Hour), true)
+	cfg := config.DefaultReaperConfig()
+	cfg.TerminalGraceMinutes = 0
+	killCalls := 0
+	deps := sessionReaperDeps{
+		Observe: func(*model.Run, string, string) (reaperSessionObservation, error) {
+			return reaperSessionObservation{Content: "retry snapshot", SessionAlive: true, WorktreeExists: true}, nil
+		},
+		Persist: persistSessionSnapshot,
+		Kill: func(*model.Run, string, string) error {
+			killCalls++
+			if killCalls == 1 {
+				return errors.New("injected mux failure")
+			}
+			return nil
+		},
+	}
+
+	if _, err := reapRun(run, model.IssueStatusOpen, st, "project", t.TempDir(), cfg, now, deps); err == nil || !strings.Contains(err.Error(), "injected mux failure") {
+		t.Fatalf("first reap error = %v", err)
+	}
+	retryRun, err := st.GetRun(run.Ref())
+	if err != nil {
+		t.Fatalf("GetRun() for retry error = %v", err)
+	}
+	if retryRun.UpdatedAt.Before(now) {
+		t.Fatalf("precondition: error artifact did not refresh UpdatedAt: %s", retryRun.UpdatedAt)
+	}
+	outcome, err := reapRun(retryRun, model.IssueStatusOpen, st, "project", t.TempDir(), cfg, now.Add(time.Minute), deps)
+	if err != nil {
+		t.Fatalf("retry reap error = %v", err)
+	}
+	if !outcome.Reaped || killCalls != 2 {
+		t.Fatalf("retry outcome = %#v killCalls=%d", outcome, killCalls)
+	}
+
+	reloaded, err := st.GetRun(run.Ref())
+	if err != nil {
+		t.Fatalf("GetRun() after retry error = %v", err)
+	}
+	foundError := false
+	for _, event := range reloaded.Events {
+		if event.Type == model.EventTypeArtifact && event.Name == "error" && strings.Contains(event.Attrs["message"], "injected mux failure") {
+			foundError = true
+		}
+	}
+	if !foundError {
+		t.Fatal("kill failure error artifact not found")
+	}
+}
+
+func TestSessionReaperEmptyMultiplexerIsError(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	st, run := createReaperTestRun(t, model.StatusDone, now.Add(-time.Hour), true)
+	run.Multiplexer = ""
+	observed := false
+	deps := sessionReaperDeps{
+		Observe: func(*model.Run, string, string) (reaperSessionObservation, error) {
+			observed = true
+			return reaperSessionObservation{}, nil
+		},
+		Persist: persistSessionSnapshot,
+		Kill:    func(*model.Run, string, string) error { return nil },
+	}
+	cfg := config.DefaultReaperConfig()
+	cfg.TerminalGraceMinutes = 0
+	if _, err := reapRun(run, model.IssueStatusOpen, st, "project", t.TempDir(), cfg, now, deps); err == nil || !strings.Contains(err.Error(), "empty multiplexer") {
+		t.Fatalf("empty multiplexer error = %v", err)
+	}
+	if observed {
+		t.Fatal("empty multiplexer reached observation path")
+	}
+}
+
+func TestWorkerReaperChecksWorktreeAndRejectsEmptyMultiplexer(t *testing.T) {
+	projectRoot := t.TempDir()
+	st, err := filestore.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("filestore.New() error = %v", err)
+	}
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+	server.SetWorkerIdentity("worker-reaper", "worker-host")
+	if _, err := server.registerRepoContext("worker-reaper-project", projectRoot, "", st); err != nil {
+		t.Fatalf("registerRepoContext() error = %v", err)
+	}
+
+	missingWorktree := filepath.Join(t.TempDir(), "missing")
+	captureLease := &WorkerLease{
+		LeaseID: "capture-reaper", WorkerID: "worker-reaper", ProjectID: "worker-reaper-project", Effect: "capture_session", IssueID: "worker-issue", RunID: "20260713-130000",
+		Payload: &WorkerEffectPayload{CaptureSession: &CaptureSessionPayload{
+			CheckWorktree: true,
+			RunSnapshot:   &RunSnapshot{IssueID: "worker-issue", RunID: "20260713-130000", Status: model.StatusDone, WorktreePath: missingWorktree, Multiplexer: "tmux"},
+		}},
+	}
+	result, err := server.executeLeaseEffect(captureLease)
+	if err != nil {
+		t.Fatalf("worktree interlock capture error = %v", err)
+	}
+	if result == nil || result.CaptureResult == nil || !result.CaptureResult.WorktreeChecked || result.CaptureResult.WorktreeExists {
+		t.Fatalf("capture result = %#v, want checked missing worktree", result)
+	}
+
+	stopLease := &WorkerLease{
+		LeaseID: "stop-reaper", WorkerID: "worker-reaper", ProjectID: "worker-reaper-project", Effect: "stop_run", IssueID: "worker-issue", RunID: "20260713-130000",
+		Payload: &WorkerEffectPayload{StopRun: &StopRunPayload{
+			ReapSession: true,
+			RunSnapshot: &RunSnapshot{IssueID: "worker-issue", RunID: "20260713-130000", Status: model.StatusDone, WorktreePath: projectRoot},
+		}},
+	}
+	if _, err := server.executeLeaseEffect(stopLease); err == nil || !strings.Contains(err.Error(), "empty multiplexer") {
+		t.Fatalf("worker empty multiplexer error = %v", err)
+	}
+}
+
+type countingListRunsStore struct {
+	store.Store
+	listCalls int
+}
+
+func (s *countingListRunsStore) ListRuns(filter *store.ListRunsFilter) ([]*model.Run, error) {
+	s.listCalls++
+	return s.Store.ListRuns(filter)
+}
+
+func TestSessionReaperEnabledFalseDisablesPass(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	projectRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".orch"), 0o755); err != nil {
+		t.Fatalf("mkdir .orch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, ".orch", "config.yaml"), []byte("reaper:\n  enabled: false\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	baseStore, err := filestore.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("filestore.New() error = %v", err)
+	}
+	counting := &countingListRunsStore{Store: baseStore}
+	server := NewSocketServer(func(string) (store.Store, error) { return counting, nil }, log.New(io.Discard, "", 0))
+	if _, err := server.registerRepoContext("reaper-disabled", projectRoot, "", counting); err != nil {
+		t.Fatalf("registerRepoContext() error = %v", err)
+	}
+	daemon := New(func(string) (store.Store, error) { return counting, nil })
+	daemon.socketServer = server
+	daemon.reapAllAt(time.Now())
+	if counting.listCalls != 0 {
+		t.Fatalf("disabled reaper listed runs %d times, want 0", counting.listCalls)
+	}
+}
+
+func createRepairFindingRun(t *testing.T, st store.Store, issueID model.IssueID, runID model.RunID, status model.Status, updatedAt time.Time, identity bool) *model.Run {
+	t.Helper()
+	if err := st.CreateIssue(&model.Issue{ID: issueID, Title: string(issueID), Status: model.IssueStatusOpen}); err != nil {
+		t.Fatalf("CreateIssue(%s) error = %v", issueID, err)
+	}
+	if _, err := st.CreateRun(issueID, runID, map[string]string{"agent": "codex"}); err != nil {
+		t.Fatalf("CreateRun(%s) error = %v", issueID, err)
+	}
+	worktree := t.TempDir()
+	events := []*model.Event{
+		{Timestamp: updatedAt.Add(-3 * time.Second), Type: model.EventTypeArtifact, Name: "worktree", Attrs: map[string]string{"path": worktree}},
+		{Timestamp: updatedAt.Add(-2 * time.Second), Type: model.EventTypeArtifact, Name: "session", Attrs: map[string]string{"name": model.GenerateSessionName(issueID, runID), "multiplexer": "tmux"}},
+	}
+	if identity {
+		events = append(events, &model.Event{Timestamp: updatedAt.Add(-time.Second), Type: model.EventTypeArtifact, Name: "agent_session", Attrs: map[string]string{"id": "recorded", "generation": "1"}})
+	}
+	events = append(events, &model.Event{Timestamp: updatedAt, Type: model.EventTypeStatus, Name: string(status), Attrs: map[string]string{"source": string(model.EventSourceDaemon)}})
+	ref := &model.RunRef{IssueID: issueID, RunID: runID}
+	for _, event := range events {
+		if err := st.AppendEvent(ref, event); err != nil {
+			t.Fatalf("AppendEvent(%s) error = %v", event.Name, err)
+		}
+	}
+	run, err := st.GetRun(ref)
+	if err != nil {
+		t.Fatalf("GetRun(%s) error = %v", ref.String(), err)
+	}
+	return run
+}
+
+func TestRepairReportsTerminalAliveAndUnreapableKeptSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	projectRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".orch"), 0o755); err != nil {
+		t.Fatalf("mkdir .orch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, ".orch", "config.yaml"), []byte("reaper:\n  terminal_grace_minutes: 0\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	st, err := filestore.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("filestore.New() error = %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	terminal := createRepairFindingRun(t, st, "repair-terminal", "20260713-120001", model.StatusDone, now.Add(-time.Hour), true)
+	unreapable := createRepairFindingRun(t, st, "repair-unreapable", "20260713-120002", model.StatusWaiting, now.Add(-8*24*time.Hour), false)
+
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+	if _, err := server.registerRepoContext("repair-project", projectRoot, "", st); err != nil {
+		t.Fatalf("registerRepoContext() error = %v", err)
+	}
+	orphan := "run-orphan-20260713-120003"
+	findings, err := server.classifySessionRepairFindings([]string{
+		model.GenerateSessionName(terminal.IssueID, terminal.RunID),
+		model.GenerateSessionName(unreapable.IssueID, unreapable.RunID),
+		orphan,
+		"orch-control-agent",
+		"orch-monitor-test",
+	}, now)
+	if err != nil {
+		t.Fatalf("classifySessionRepairFindings() error = %v", err)
+	}
+
+	want := map[sessionRepairKind]string{
+		sessionRepairTerminalAlive:  model.GenerateSessionName(terminal.IssueID, terminal.RunID),
+		sessionRepairUnreapableKept: model.GenerateSessionName(unreapable.IssueID, unreapable.RunID),
+		sessionRepairOrphaned:       orphan,
+	}
+	if len(findings) != len(want) {
+		t.Fatalf("findings = %#v, want one of each kind", findings)
+	}
+	for _, finding := range findings {
+		if want[finding.Kind] != finding.SessionName {
+			t.Fatalf("finding = %#v, want session %q for kind %s", finding, want[finding.Kind], finding.Kind)
+		}
+		if finding.Kind == sessionRepairUnreapableKept && !strings.Contains(finding.Reason, "identity is not recorded") {
+			t.Fatalf("unreapable reason = %q", finding.Reason)
+		}
+	}
+}

--- a/internal/daemon/reaper_test.go
+++ b/internal/daemon/reaper_test.go
@@ -195,15 +195,21 @@ func TestSessionReaperKillFailureRecordsErrorAndRetriesNextPass(t *testing.T) {
 	st, run := createReaperTestRun(t, model.StatusDone, now.Add(-time.Hour), true)
 	cfg := config.DefaultReaperConfig()
 	cfg.TerminalGraceMinutes = 0
+	observeCalls := 0
+	persistCalls := 0
 	killCalls := 0
 	deps := sessionReaperDeps{
 		Observe: func(*model.Run, string, string) (reaperSessionObservation, error) {
+			observeCalls++
 			return reaperSessionObservation{Content: "retry snapshot", SessionAlive: true, WorktreeExists: true}, nil
 		},
-		Persist: persistSessionSnapshot,
+		Persist: func(run *model.Run, content string, now time.Time) (string, error) {
+			persistCalls++
+			return persistSessionSnapshot(run, content, now)
+		},
 		Kill: func(*model.Run, string, string) error {
 			killCalls++
-			if killCalls == 1 {
+			if killCalls <= 2 {
 				return errors.New("injected mux failure")
 			}
 			return nil
@@ -220,26 +226,50 @@ func TestSessionReaperKillFailureRecordsErrorAndRetriesNextPass(t *testing.T) {
 	if retryRun.UpdatedAt.Before(now) {
 		t.Fatalf("precondition: error artifact did not refresh UpdatedAt: %s", retryRun.UpdatedAt)
 	}
-	outcome, err := reapRun(retryRun, model.IssueStatusOpen, st, "project", t.TempDir(), cfg, now.Add(time.Minute), deps)
-	if err != nil {
-		t.Fatalf("retry reap error = %v", err)
+	eventsAfterFirstFailure := len(retryRun.Events)
+	if _, err := reapRun(retryRun, model.IssueStatusOpen, st, "project", t.TempDir(), cfg, now.Add(time.Minute), deps); err == nil || !strings.Contains(err.Error(), "injected mux failure") {
+		t.Fatalf("second reap error = %v", err)
 	}
-	if !outcome.Reaped || killCalls != 2 {
-		t.Fatalf("retry outcome = %#v killCalls=%d", outcome, killCalls)
+
+	afterTwoFailures, err := st.GetRun(run.Ref())
+	if err != nil {
+		t.Fatalf("GetRun() after second failure error = %v", err)
+	}
+	if len(afterTwoFailures.Events) != eventsAfterFirstFailure {
+		t.Fatalf("second identical failure appended events: first=%d second=%d", eventsAfterFirstFailure, len(afterTwoFailures.Events))
+	}
+	var snapshotArtifacts, reapNotes, errorArtifacts int
+	for _, event := range afterTwoFailures.Events {
+		switch {
+		case event.Type == model.EventTypeArtifact && event.Name == "session_snapshot":
+			snapshotArtifacts++
+		case event.Type == model.EventTypeNote && event.Name == model.DaemonNoticeEventName && event.Attrs["kind"] == "session_reaped":
+			reapNotes++
+		case event.Type == model.EventTypeArtifact && event.Name == "error":
+			errorArtifacts++
+		}
+	}
+	if snapshotArtifacts != 1 || reapNotes != 1 || errorArtifacts != 1 {
+		t.Fatalf("bounded retry ledger: snapshots=%d reap_notes=%d errors=%d, want 1 each", snapshotArtifacts, reapNotes, errorArtifacts)
+	}
+	if observeCalls != 1 || persistCalls != 1 || killCalls != 2 {
+		t.Fatalf("retry calls: observe=%d persist=%d kill=%d, want 1,1,2", observeCalls, persistCalls, killCalls)
+	}
+
+	outcome, err := reapRun(afterTwoFailures, model.IssueStatusOpen, st, "project", t.TempDir(), cfg, now.Add(2*time.Minute), deps)
+	if err != nil {
+		t.Fatalf("successful retry reap error = %v", err)
+	}
+	if !outcome.Reaped || killCalls != 3 || observeCalls != 1 || persistCalls != 1 {
+		t.Fatalf("successful retry outcome=%#v observe=%d persist=%d kill=%d", outcome, observeCalls, persistCalls, killCalls)
 	}
 
 	reloaded, err := st.GetRun(run.Ref())
 	if err != nil {
-		t.Fatalf("GetRun() after retry error = %v", err)
+		t.Fatalf("GetRun() after successful retry error = %v", err)
 	}
-	foundError := false
-	for _, event := range reloaded.Events {
-		if event.Type == model.EventTypeArtifact && event.Name == "error" && strings.Contains(event.Attrs["message"], "injected mux failure") {
-			foundError = true
-		}
-	}
-	if !foundError {
-		t.Fatal("kill failure error artifact not found")
+	if len(reloaded.Events) != eventsAfterFirstFailure {
+		t.Fatalf("successful kill-only retry appended events: before=%d after=%d", eventsAfterFirstFailure, len(reloaded.Events))
 	}
 }
 

--- a/internal/daemon/worker_plane.go
+++ b/internal/daemon/worker_plane.go
@@ -86,6 +86,9 @@ type StopRunPayload struct {
 	TargetHost     string `json:"target_host,omitempty"`
 	TargetWorkerID string `json:"target_worker_id,omitempty"`
 	RunSnapshot    *RunSnapshot
+	// ReapSession selects ADR-0005's session-only kill. The worker must not
+	// append a status event; the master already recorded snapshot + reap note.
+	ReapSession bool `json:"reap_session,omitempty"`
 }
 
 type CaptureSessionPayload struct {
@@ -94,6 +97,9 @@ type CaptureSessionPayload struct {
 	TargetHost     string `json:"target_host,omitempty"`
 	TargetWorkerID string `json:"target_worker_id,omitempty"`
 	RunSnapshot    *RunSnapshot
+	// CheckWorktree asks the execution host to attest the ADR-0005 R4
+	// worktree interlock before any session is reaped.
+	CheckWorktree bool `json:"check_worktree,omitempty"`
 }
 
 type SendMessagePayload struct {
@@ -127,9 +133,11 @@ type GetDiffPayload struct {
 }
 
 type CaptureSessionResult struct {
-	Content       string `json:"content,omitempty"`
-	TimestampUnix int64  `json:"timestamp_unix,omitempty"`
-	Source        string `json:"source,omitempty"`
+	Content         string `json:"content,omitempty"`
+	TimestampUnix   int64  `json:"timestamp_unix,omitempty"`
+	Source          string `json:"source,omitempty"`
+	WorktreeChecked bool   `json:"worktree_checked,omitempty"`
+	WorktreeExists  bool   `json:"worktree_exists,omitempty"`
 	// ObserverID identifies the observing channel INSTANCE
 	// (worker:<id>:<nonce> / local:<nonce>), carried in the lease result
 	// rather than looked up from the registry: a lease answer may race a
@@ -800,6 +808,12 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 		if err != nil {
 			return nil, err
 		}
+		if lease.Payload != nil && lease.Payload.StopRun != nil && lease.Payload.StopRun.ReapSession {
+			if err := killLocalSessionForReap(run); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		}
 		if err := s.stopRunSession(run); err != nil {
 			return nil, err
 		}
@@ -817,6 +831,24 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 			lines = 100
 		}
 
+		worktreeChecked := lease.Payload.CaptureSession.CheckWorktree
+		worktreeExists := false
+		if worktreeChecked {
+			worktreeExists, err = worktreeDirectoryExists(run.WorktreePath)
+			if err != nil {
+				return nil, fmt.Errorf("check worktree %s: %w", run.WorktreePath, err)
+			}
+			if !worktreeExists {
+				return &WorkerEffectResult{
+					CaptureResult: &CaptureSessionResult{
+						TimestampUnix:   time.Now().Unix(),
+						ObserverID:      s.observerID(),
+						WorktreeChecked: true,
+					},
+				}, nil
+			}
+		}
+
 		var content string
 		var source string
 		if run.Agent == "opencode" {
@@ -832,9 +864,11 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 			if goneClass := classifyCaptureGone(run, err); goneClass != "" {
 				return &WorkerEffectResult{
 					CaptureResult: &CaptureSessionResult{
-						TimestampUnix: time.Now().Unix(),
-						ObserverID:    s.observerID(),
-						Gone:          &SessionGoneResult{Class: goneClass},
+						TimestampUnix:   time.Now().Unix(),
+						ObserverID:      s.observerID(),
+						Gone:            &SessionGoneResult{Class: goneClass},
+						WorktreeChecked: worktreeChecked,
+						WorktreeExists:  worktreeExists,
 					},
 				}, nil
 			}
@@ -843,10 +877,12 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 
 		return &WorkerEffectResult{
 			CaptureResult: &CaptureSessionResult{
-				Content:       content,
-				TimestampUnix: time.Now().Unix(),
-				Source:        source,
-				ObserverID:    s.observerID(),
+				Content:         content,
+				TimestampUnix:   time.Now().Unix(),
+				Source:          source,
+				ObserverID:      s.observerID(),
+				WorktreeChecked: worktreeChecked,
+				WorktreeExists:  worktreeExists,
 			},
 		}, nil
 	case "send_message":

--- a/scripts/e2e-session-reaper.sh
+++ b/scripts/e2e-session-reaper.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export ROOT="${ROOT:-$(mktemp -d /tmp/orch-session-reaper-e2e-XXXXXX)}"
+KEEP_ROOT="${KEEP_ROOT:-0}"
+ORCH_BIN="${ORCH_BIN:-}"
+
+tmux_cmd() {
+  env -u TMUX tmux "$@"
+}
+
+cleanup() {
+  set +e
+  if [ -n "${SESSION_NAME:-}" ]; then
+    tmux_cmd kill-session -t "$SESSION_NAME" >/dev/null 2>&1 || true
+  fi
+  tmux_cmd kill-session -t orch-control-reaper-e2e >/dev/null 2>&1 || true
+  tmux_cmd kill-session -t orch-monitor-reaper-e2e >/dev/null 2>&1 || true
+	if [ -n "${ORCH_BIN:-}" ] && [ -x "$ORCH_BIN" ]; then
+	  "$ORCH_BIN" worker stop --all >/dev/null 2>&1 || true
+    "$ORCH_BIN" master kill >/dev/null 2>&1 || true
+  fi
+  if [ "$KEEP_ROOT" != "1" ]; then
+    chmod -R u+w "$ROOT" >/dev/null 2>&1 || true
+    rm -rf "$ROOT"
+  fi
+}
+trap cleanup EXIT
+
+command -v tmux >/dev/null 2>&1 || { echo "tmux is required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; }
+
+echo "ROOT=$ROOT"
+mkdir -p "$ROOT"/{home,runtime,state,data,bin,repo/.orch,issues-store/issues,issues-store/runs,origin/example}
+
+export HOME="$ROOT/home"
+export XDG_RUNTIME_DIR="$ROOT/runtime"
+export XDG_STATE_HOME="$ROOT/state"
+export XDG_DATA_HOME="$ROOT/data"
+unset ORCH_PROJECT ORCH_REMOTE TMUX
+
+if [ -z "$ORCH_BIN" ]; then
+  go build -o "$ROOT/bin/orch" ./cmd/orch
+  ORCH_BIN="$ROOT/bin/orch"
+fi
+
+PROJECT="$(python3 - <<'PY'
+import os, pathlib
+print(pathlib.Path(os.path.realpath(os.path.join(os.environ["ROOT"], "repo"))))
+PY
+)"
+ISSUES="$(python3 - <<'PY'
+import os, pathlib
+print(pathlib.Path(os.path.realpath(os.path.join(os.environ["ROOT"], "issues-store"))))
+PY
+)"
+
+cat > "$PROJECT/.orch/config.yaml" <<EOF
+issues:
+  path: $ISSUES
+agent_multiplexer: tmux
+no_pr: true
+reaper:
+  enabled: true
+  terminal_grace_minutes: 0
+  resolved_issue_grace_minutes: 60
+  idle_ttl_hours: 168
+EOF
+
+cat > "$PROJECT/README.md" <<'EOF'
+# Session reaper E2E
+EOF
+
+cat > "$ROOT/bin/fake-agent.py" <<'EOF'
+import time
+
+print("Task completed successfully", flush=True)
+time.sleep(180)
+EOF
+
+git -C "$PROJECT" init >/dev/null
+git -C "$PROJECT" branch -M main
+git -C "$PROJECT" config user.email e2e@example.com
+git -C "$PROJECT" config user.name E2E
+git init --bare "$ROOT/origin/example/session-reaper.git" >/dev/null
+git -C "$ROOT/origin/example/session-reaper.git" symbolic-ref HEAD refs/heads/main
+REPO_URL="file://$ROOT/origin/example/session-reaper.git"
+PROJECT_ID="example-session-reaper"
+git -C "$PROJECT" remote add origin "$REPO_URL"
+git -C "$PROJECT" add .
+git -C "$PROJECT" commit -m init >/dev/null
+git -C "$PROJECT" push -u origin HEAD >/dev/null
+
+cd "$PROJECT"
+"$ORCH_BIN" master start --listen tcp://127.0.0.1:0 >/dev/null
+sleep 1
+"$ORCH_BIN" daemon repo register "$REPO_URL" >/dev/null
+"$ORCH_BIN" issue create reaper-e2e --title "Session reaper E2E" >/dev/null
+
+# These reserved families prove L2: the run-session reaper must not touch them.
+tmux_cmd new-session -d -s orch-control-reaper-e2e 'sleep 180'
+tmux_cmd new-session -d -s orch-monitor-reaper-e2e 'sleep 180'
+
+RUN_ID="$(date +%Y%m%d-%H%M%S)"
+RUN_JSON="$("$ORCH_BIN" --json --project "$PROJECT_ID" run reaper-e2e \
+  --run-id "$RUN_ID" \
+  --agent custom \
+  --agent-cmd "python3 -u $ROOT/bin/fake-agent.py" \
+  --multiplexer tmux)"
+printf '%s\n' "$RUN_JSON"
+printf '%s' "$RUN_JSON" | jq -e '.ok == true' >/dev/null
+SESSION_NAME="$(printf '%s' "$RUN_JSON" | jq -r '.session_name')"
+RUN_FILE="$ISSUES/runs/reaper-e2e/$RUN_ID.md"
+
+deadline=$((SECONDS + 30))
+while :; do
+  CAPTURE_OUT="$("$ORCH_BIN" --project "$PROJECT_ID" capture "reaper-e2e#$RUN_ID" --lines 50 2>/dev/null || true)"
+  if printf '%s' "$CAPTURE_OUT" | grep -F "Task completed successfully" >/dev/null; then
+    break
+  fi
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    printf '%s\n' "$CAPTURE_OUT" >&2
+    echo "fake run did not expose its completion marker" >&2
+    exit 1
+  fi
+  sleep 1
+done
+printf '%s\n' "$CAPTURE_OUT"
+
+# Replay the stored incident state while deliberately leaving the fake agent's
+# tmux session alive. Stop the daemon while installing the historical fixture,
+# then restart it so its FileStore baseline is established from that state;
+# production writes remain daemon-owned. The identity artifact is the same
+# durable fact R1 records for claude/codex.
+"$ORCH_BIN" master kill >/dev/null
+EVENT_TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf -- '- %s | status | done | source=daemon\n' "$EVENT_TS" >> "$RUN_FILE"
+printf -- '- %s | artifact | agent_session | backend=custom | generation=1 | id=fake-session-e2e\n' "$EVENT_TS" >> "$RUN_FILE"
+"$ORCH_BIN" master start --listen tcp://127.0.0.1:0 >/dev/null
+sleep 1
+"$ORCH_BIN" daemon repo register "$REPO_URL" >/dev/null
+SHOW_JSON="$("$ORCH_BIN" --json --project "$PROJECT_ID" show "reaper-e2e#$RUN_ID" --tail 200)"
+printf '%s' "$SHOW_JSON" | jq -e '.status == "done" and .agent_session_generation == 1' >/dev/null
+
+REPAIR_OUT="$("$ORCH_BIN" --project "$PROJECT_ID" repair --dry-run)"
+printf '%s\n' "$REPAIR_OUT"
+printf '%s' "$REPAIR_OUT" | grep -F "terminal-but-alive session: $SESSION_NAME" >/dev/null
+
+deadline=$((SECONDS + 80))
+while tmux_cmd has-session -t "$SESSION_NAME" >/dev/null 2>&1; do
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "session reaper did not kill $SESSION_NAME within one interval" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+SHOW_JSON="$("$ORCH_BIN" --json --project "$PROJECT_ID" show "reaper-e2e#$RUN_ID" --tail 200)"
+printf '%s\n' "$SHOW_JSON"
+printf '%s' "$SHOW_JSON" | jq -e '
+  .status == "done" and
+  ([.events[] | select(.type == "status" and .name == "failed")] | length) == 0 and
+  ([.events[] | select(.type == "artifact" and .name == "session_snapshot")] | length) >= 1 and
+  ([.events[] | select(.type == "note" and .name == "daemon_notice" and .attrs.kind == "session_reaped" and .attrs.generation == "1" and .attrs.reason == "terminal_grace")] | length) >= 1
+' >/dev/null
+
+SNAPSHOT_PATH="$(printf '%s' "$SHOW_JSON" | jq -r '[.events[] | select(.type == "artifact" and .name == "session_snapshot")][-1].attrs.path')"
+test -f "$SNAPSHOT_PATH"
+grep -F "Task completed successfully" "$SNAPSHOT_PATH" >/dev/null
+tmux_cmd has-session -t orch-control-reaper-e2e >/dev/null
+tmux_cmd has-session -t orch-monitor-reaper-e2e >/dev/null
+
+echo "SNAPSHOT_PATH=$SNAPSHOT_PATH"
+echo "SESSION_REAPER_E2E_OK"


### PR DESCRIPTION
## Summary

- add the ADR-0005 Stage 2 all-run daemon reaper with configurable terminal, resolved-issue, and idle policies
- enforce the R3/R4 protocol: exact run session + recorded identity + existing worktree, then snapshot artifact -> generation-scoped `session_reaped` note -> local or worker-lease kill
- record the first kill failure as an error artifact, then use the current-generation reap note as a kill-only retry latch without growing the ledger
- make `orch repair` report terminal-but-alive and unreapable-kept sessions without changing run status
- add an isolated fake-agent incident replay that prints and validates the resulting event log

The coupling-core boundary remains unchanged: this change adds no run-status writer, does not touch `step.go`, `commitRunStatus`, or `runCore`, and adds no `nosemgrep` exception.

Issue: `adr0005-s2-session-reaper`

## Verification

- `go build ./...`
- `go test ./...` (including `test/integration`, 138.994s on the review-fix rerun)
- `make lint` (96 internal Semgrep rules, 0 findings; TUI lint green)
- `uv run pytest docs/adr -q` (6 passed)
- `go test ./internal/config ./internal/daemon ./internal/cli -run 'Test(ReaperConfig|SessionReaper|WorkerReaper|Repair)' -count=1 -v`
- `go test ./internal/daemon -run 'TestSessionReaperKillFailureRecordsErrorAndRetriesNextPass|TestSessionReaperIncidentReplayPreservesTerminalStatusAndProtocolOrder' -count=1 -v`
  - two identical consecutive kill failures produce exactly one snapshot artifact, one `session_reaped` note, and one error artifact while Kill is attempted twice
- `env -u TMUX ORCH_BIN=/tmp/orch-reaper-e2e-bin ./scripts/e2e-session-reaper.sh`
  - final event log retained `status=done`
  - no `failed` status event
  - appended `artifact/session_snapshot`
  - appended `daemon_notice kind=session_reaped generation=1 reason=terminal_grace`
  - exact run session disappeared while `orch-control-*` and `orch-monitor*` sentinels remained alive
- canonical backend matrix with the authenticated Codex profile explicitly selected:
  - real Codex attach/capture/send produced `BACKEND_MATRIX_READY_CODEX`, `BACKEND_MATRIX_ACK_CODEX`, and `BACKEND_MATRIX_SMOKE_OK`

## Protocol

```text
all runs (including terminal)
          |
          v
policy due + R4 interlocks
          |
          v
first pass: capture -> persist sidecar -> snapshot artifact -> reaped note -> kill
                                                                         |
                                                                         +-- failure -> first error artifact

pending current generation: -----------------------------------------------> kill-only retry
```

## Follow-up notes

- Repair currently checks `run.WorktreePath` on the master, so `unreapable-kept` reasons may be wrong-host for worker-hosted runs. After #541 adds the execution-host `run_worktree` operation, repair should route this check through it; a `proto_handler.go` rebase against #541 is expected.
- `reapAllAt` intentionally calls `GetRun` for every indexed run on every pass. An index due-ness prefilter is unsafe because error artifacts refresh `UpdatedAt` and the current-generation pending reap note is not represented in the index.
