### PR TITLE
ADR-0005 T3a: send/attach auto-revive — reaped session の in-place 再 boot(R5 + L4' 法改定)

### DIFF
--- a/docs/adr/defadr_0005_run_session_lifecycle.hy
+++ b/docs/adr/defadr_0005_run_session_lifecycle.hy
@@ -40,7 +40,7 @@
      (rule R2 "daemon reaper reconciler: a self-throttled sibling pass in the daemon tick loop enumerates ALL runs (including terminal) per repo context and kills run-* sessions whose run is (a) terminal for > terminal grace (default 10min), (b) of a resolved issue and idle > resolved grace (default 1h), or (c) idle > TTL (default 7d, idle = run.UpdatedAt age). Policy keys live in a reaper: config section (pointer-merge, KnownFields)")
      (rule R3 "reap protocol, in order: persist a final pane capture (sidecar file under the run log dir + artifact event session_snapshot) → append note session_reaped (attrs: reason, session_name, generation) → KillSession. A failed kill is an error artifact and a retry on the next pass — never a warning-and-forget")
      (rule R4 "reap interlock: the reaper kills only sessions whose run has a recorded agent_session (or backend opencode) AND an existing worktree (no worktree_removed note); anything else is kept alive and REPORTED (repair output + reaper log). Unrevivable garbage is a human decision, not a default")
-     (rule R5 "revive is in-place and entered only via send/attach: on a reaped run, orch send / orch attach re-boot the same run — same run record, same session name, agent resumed natively (claude --resume <chain tip> / codex resume <id>) in the same worktree — then append note session_revived plus a new-generation agent_session artifact. Terminal runs re-enter via a user-sourced status event (CanTransitionStatus already permits user-sourced terminal exit). Preconditions are stored facts (LS5); a missing one fails fast naming the fact and pointing at restart-from --branch")
+     (rule R5 "revive is in-place and entered only via send/attach: on a reaped run, orch send / orch attach re-boot the same run — same run record, same session name, agent resumed natively (claude --resume <id> / codex ... resume <id>) in the same worktree — then the MASTER appends note session_revived plus the generation+1 agent_session artifact (worker does only the physical boot + codex identity re-resolution; ADR-0004). Measured physics (docs/design/revive-physics.md, 2026-07-13): the id is STABLE across generations — claude --resume appends to the same transcript and the CLI rejects --session-id alongside --resume (--fork-session is new-conversation semantics and is never used by revive); codex resume continues the existing rollout, re-verified by the R1 discovery arm. Terminal runs re-enter via the launch-plane milestone stageSessionRevived, whose commit carries source=user (the one user-sourced observation in the vocabulary — run-state-machine.md §13, L4 refinement). Preconditions are stored facts (LS5); a missing one fails fast naming the fact and pointing at restart-from --branch")
      (rule R6 "observers never boot: capture/capture-all/ps/show/wait/diff/events/query/debug perform no launch; capture on a reaped run serves the persisted session_snapshot with an explicit 'reaped at <ts>' notice. ps/show/debug surface the session state (live / reaped(revivable) / reaped(unrevivable))")
      (rule R7 "orch tick is removed — command, registration, docs, and the dead 'resume' event vocabulary; the unused proto ResumeRun RPC goes with it. No compat shim: agents are controlled via orch send (its own help already says so)")
      (rule R8 "clean appends a worktree_removed note event so unrevivability becomes a stored fact; delete kills the session (via the R3 protocol) before removing the run record; an empty Multiplexer field on a kill path is an error, not a skip")]
@@ -70,7 +70,19 @@
      (law kill-failures-are-loud
        :statement "a failed KillSession yields an error artifact and a retry on the next reaper pass; canceled/deleted is never recorded as achieved when the kill failed silently"
        :counterexamples
-         [(counterexample "socket.go:5126 warning-lognil-return: stop reports canceled, session lives on (observed pre-ADR behavior)")])]
+         [(counterexample "socket.go:5126 warning-lognil-return: stop reports canceled, session lives on (observed pre-ADR behavior)")])
+     (law revive-is-the-only-terminal-exit-observation
+       :statement "terminal views absorb every observation except the O8 stageSessionRevived milestone, whose single effect is a running commit carried with source=user; no daemon-sourced observation ever exits a terminal status (L4 refinement, run-state-machine.md §13)"
+       :counterexamples
+         [(counterexample "a daemon-sourced launch milestone (stageAgentStarted) on a done run re-enters running — the terminality law dissolves and every autonomous inference can resurrect finished runs")
+          (counterexample "revive commits running WITHOUT source=user — the store guard rejects the terminal exit, or worse, a future guard change lets daemon writes exit terminal states")]
+       :enforcement-note "internal/daemon/revive_test.go TestStepTerminalAbsorbsAllObservationsExceptReviveMilestone (matrix), store-side guard internal/store/file/file.go CanTransitionStatus on Attrs[source]")
+     (law conversation-identity-durable
+       :statement "the agent_session id is constant across generations: revive resumes the SAME conversation identity and increments only the generation; revive never uses --fork-session (fork = new conversation, not an incarnation)"
+       :counterexamples
+         [(counterexample "revive forks the claude conversation to obtain a fresh mintable id — the user believes the agent continues its conversation; the original conversation is silently abandoned as a dead branch")
+          (counterexample "revive records generation+1 with a GUESSED codex id instead of re-running the discovery arm — a wrong id makes the next reap destroy an unresumable session")]
+       :enforcement-note "internal/agent/claude_test.go / codex_test.go resume argv contracts; internal/daemon/revive_test.go identity fold assertions; measured physics docs/design/revive-physics.md")]
   :enforcement
     [(defsemgrep adr0005-no-warning-only-kill-failure
        :languages ["generic"]
@@ -83,5 +95,11 @@
        :message "ADR-0005 R7: orch tick was removed (its resume event had zero consumers); agents are controlled via orch send — do not reintroduce"
        :pattern "orch tick"
        :bad ["Use `orch tick --all` to resume waiting runs."]
-       :good ["Use `orch send <RUN_REF> <message>` to answer waiting runs."])]
+       :good ["Use `orch send <RUN_REF> <message>` to answer waiting runs."])
+     (defsemgrep adr0005-revive-never-forks
+       :languages ["generic"]
+       :message "ADR-0005 conversation-identity-durable: revive resumes the SAME conversation identity; --fork-session is new-conversation semantics (measured physics, docs/design/revive-physics.md) and must never appear on a resume/revive argv path"
+       :pattern "\"--fork-session\""
+       :bad ["args = append(args, \"--resume\", id, \"--fork-session\")"]
+       :good ["args = append(args, \"--resume\", id)"])]
   :plans ["docs/orch-2026-07-13-run-session-lifecycle-architecture-plan.md"])

--- a/docs/design/revive-physics.md
+++ b/docs/design/revive-physics.md
@@ -1,0 +1,47 @@
+# revive の実 CLI 物理(ADR-0005 R5 の校正記録)
+
+sessionhost 化前の orch が依存する、実物 claude / codex CLI の resume 物理の
+実測記録。`internal/agent/claude.go` / `codex.go` の resume argv と、revive の
+identity 意味論(同一 id・世代のみ増加)の根拠をここに凍結する。
+
+測定日 2026-07-13(claude はこの日の Claude Code、model haiku-4-5 で実測。
+codex は同日の doeff ADR-DOE-AGENTS-006 Phase 0 プローブ、codex 0.144.1)。
+
+## claude
+
+- **`--resume <id>` は同一 transcript に追記する(identity 不変)**。実測:
+  `--session-id <uuid1>` で鋳造したセッションに対し
+  `claude --print --resume <uuid1> "..."` を実行しても、transcript ファイルは
+  `<CLAUDE_CONFIG_DIR>/projects/<mangled cwd>/<uuid1>.jsonl` の 1 つのまま
+  (新ファイルは現れない)。2 ターン目の応答本文が 1 ターン目の内容を明示的に
+  参照しており、文脈継承もファイル内容(両ターンのメッセージが同一ファイルに
+  連続)で証明される。
+- **`--session-id` は `--resume` と併用できない**。実測エラー:
+  `--session-id can only be used with --continue or --resume if --fork-session
+  is also specified.`
+  → `--fork-session` は「親の文脈を継いだ**新しい会話**」(doeff Phase 0 で
+  実測: 親と別の新 UUID transcript が生まれる)であり、revive(同一会話の
+  継続)の意味論ではない。**revive では使わない**。
+- 含意: revive の claude argv は `claude ... --resume <AgentSessionID>`。
+  identity は起動前から確定している stored fact であり、発見腕は不要。
+
+## codex
+
+- **`resume <id>` は既存 rollout を継続する**(doeff Phase 0 実測: 前セッション
+  で覚えさせた語を resume 後に回答、既存 rollout ファイル継続)。usage は
+  `codex [OPTIONS] <COMMAND> [ARGS]` — root options が subcommand に先行する
+  ため、argv は `codex --yolo ... resume <id>` の形。
+- revive 後の identity は同一 id の見込みだが、orch は T1b の発見腕
+  (rollout 先頭行 `session_meta` の cwd-match)を boot 後に再実行して
+  観測で裏取りした id を generation+1 の agent_session artifact に記録する
+  (推測ではなく観測に基づく事実として)。
+
+## 意味論への帰結(ADR-0005 R5)
+
+- **conversation identity は世代を跨いで不変**: `agent_session` artifact の
+  id は revive で変わらず、generation だけが incarnation の通し番号として
+  +1 される。L-S3 ラッチは「reaped 世代 >= 現世代」で判定されるので、
+  generation+1 の記録がラッチを解消する。
+- doeff ADR-DOE-AGENTS-006 の存在論(会話 = 耐久エンティティ、session 行 =
+  incarnation)と同型。backend を doeff-sessionhost に差し替える将来の
+  メジャー版でも、この意味論はそのまま移行する。

--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -229,11 +229,11 @@ distinction the law tests themselves forced:
 | L1b fixed point (streams) | repeating one stream observation reaches a quiet fixed point after boundedly many steps (no oscillation) |
 | L2 order-independent convergence | {session gone ×3 + git evidence, PR merged/closed} in any interleaving converge to the same terminal status |
 | L3' grace | a never-alive run within `neverAliveVerdictGrace` never receives an `unknown`/`failed` verdict, on any observation sequence; after the grace, any plane concludes `unknown` on the standing evidence (revised from v1's pinned asymmetry by §7 D-C3) |
-| L4 terminality | from a terminal status, `step` emits no effect and no core change for any observation |
+| L4 terminality (refined 2026-07-13, §13) | from a terminal status, `step` emits no effect and no core change for any observation, EXCEPT the revive milestone (O8 `stageSessionRevived`) — the one user-sourced observation in the vocabulary (revive is entered only via the user verbs send/attach, ADR-0005 R5), whose single effect is a user-sourced `running` commit |
 | L5 verdict requires evidence | `obsSessionGone` never emits a status directly; it requests git evidence exactly when the dead-check threshold is reached |
 | L6 debounce | `waiting` via prompt requires ≥ `waitingPromptStreakThreshold` consecutive prompt observations; any busy capture resets the streak. Since §9 this is the `reading = prompt` special case of L10a |
 | L8 listener commit point | every committed W1 status transition fires exactly one status-change listener event after `AppendEvent` succeeds; duplicate-(status, reason) no-ops and failed appends fire none |
-| L9 launch failure reason | a launch-failure verdict (O8) always carries the machine-readable reason `launch_<step>`, preceded by an error artifact recording the bootstrap error; launch milestones on a terminal or already-reached status emit nothing |
+| L9 launch failure reason | a launch-failure verdict (O8) always carries the machine-readable reason `launch_<step>`, preceded by an error artifact recording the bootstrap error; launch milestones on a terminal or already-reached status emit nothing (sole exception: `stageSessionRevived`, L4 refinement / §13) |
 | L10a gate debounce (generalizes L6) | a `waiting` verdict with reason `gate_<kind>` requires ≥ `waitingPromptStreakThreshold` consecutive captures whose input-request reading is the same `gate:<kind>`; any busy capture or different reading resets the streak |
 | L10b reading precedence | busy veto > gate > {exited, completed, api-limited, failed} > prompt > output-changed; an unconfirmed gate reading masks every lower reading; each gate row's fixture locks its intended winner end-to-end |
 | L10c reason fidelity | the `waiting` reason always reflects the latest *confirmed* reading; a confirmed reading change re-appends under D-G1 and fires exactly one listener event (L8) |
@@ -1004,3 +1004,51 @@ mechanism and carries no policy. Property tests:
 `internal/daemon/step_reap_test.go` (absorption across agents × channels ×
 thresholds, revive dissolution, latch boundaries), fold tests:
 `internal/model/run_reap_test.go`.
+
+## 13. Revive — in-place re-boot of a reaped session (ADR-0005 R5, decided 2026-07-13)
+
+Entry is exactly the user verbs `{send, attach}` (R6): observation verbs
+never boot. The master decides revivability from STORED FACTS alone (LS5) —
+`agent_session` identity recorded, worktree recorded, no `worktree_removed`
+note, concrete multiplexer — and a missing fact fails fast NAMING the fact
+and pointing at `restart-from --branch`, never probing, never dropping the
+message into a silent fresh context.
+
+Planes and ownership (ADR-0004): the EXECUTION HOST does only the physical
+part — host-local checks (worktree present; session not already alive, which
+would mean a pending reap-kill retry to fail clearly against), native-resume
+boot in the same worktree under the same session name, and the codex
+identity re-resolution (the T1b arm re-run). The MASTER alone writes the
+ledger, in this order:
+
+1. `daemon_notice(kind=session_revived, generation=N+1)` — the narrative
+   marker the gatherer folds alongside `session_reaped` (§12);
+2. `agent_session` artifact `(id, generation=N+1)` — dissolves the L-S3
+   latch (§12); the id is UNCHANGED across generations (measured physics:
+   `docs/design/revive-physics.md` — claude `--resume <id>` appends to the
+   same transcript, and `--session-id` cannot be combined with `--resume`;
+   codex `resume <id>` continues the existing rollout). The generation is
+   the incarnation counter over a durable conversation identity;
+3. the status re-entry via the launch plane: O8 gains the milestone
+   `stageSessionRevived`, whose single effect is a `running` commit carried
+   with `source=user` (`model.AttrStatusSource` on the event; the store
+   append guard re-validates terminal-exit legality from the same
+   attribute). This is the L4 refinement: the revive milestone is the one
+   user-sourced observation, so it alone escapes terminal absorption —
+   `CanTransitionStatus` has permitted user-sourced terminal exits all
+   along; the launch plane now has the one sanctioned way to say it.
+
+After the milestone the monitor plane owns the run again: the dissolved
+latch makes session observations evidence once more, and a revived run that
+sits idle simply re-derives `waiting` through the ordinary O4 readings.
+
+Worker routing: worker-hosted runs revive through the `revive_run` lease
+effect (payload mirrors stop/capture; the result carries the re-resolved
+identity back for the master's ledger writes). Local runs run the same
+physical function in-process.
+
+Tests: `internal/daemon/revive_test.go` (native-resume argv, ledger order,
+latch dissolution, user-sourced re-entry, each precondition's typed
+failure, pending-kill collision), the L4' matrix case in
+`TestStepTerminalAbsorbsAllObservationsExceptReviveMilestone`, and the
+adapter argv contracts in `internal/agent/{claude,codex}_test.go`.

--- a/docs/orch-2026-07-13-run-session-lifecycle-architecture-plan.md
+++ b/docs/orch-2026-07-13-run-session-lifecycle-architecture-plan.md
@@ -1,6 +1,6 @@
 # orch run-session lifecycle — master plan (2026-07-13)
 
-Status: in progress — Stage 0 / Stage 1 / T2c merged(PR #531 / #532 / #533、2026-07-13)。残 = Stage 2(reaper)・Stage 3(revive)・Stage 4(観測面)。
+Status: in progress — Stage 0 / Stage 1 / T2c merged(PR #531 / #532 / #533)、Stage 2 merged(PR #542、隔離 e2e `scripts/e2e-session-reaper.sh` green・実機 deploy 済み 2026-07-13)。Stage 3: T3a はブランチ `adr0005-t3a-revive`(本 plan と同一 change set)、T3b/T3c は issue 委譲中。残 = T3a merge・T3b/T3c merge・Stage 4(観測面)。
 Basis: ADR-0005 (`docs/adr/defadr_0005_run_session_lifecycle.hy`)。
 2026-07-11 インシデント(terminal run のセッション 25 個が最大 5.5 日生存、
 CPU 4 コア焼却、`orch repair --force` で回収不能)の根本対策。
@@ -18,8 +18,9 @@ CPU 4 コア焼却、`orch repair --force` で回収不能)の根本対策。
 
 | 種別 | パス / 参照 |
 |------|------------|
-| 本 ADR(executable) | `docs/adr/defadr_0005_run_session_lifecycle.hy` |
-| 遷移コア spec | `docs/design/run-state-machine.md`(§2 O2/O3、§5 L4、§9.7/§11.5 note-ledger 先例) |
+| 本 ADR(executable) | `docs/adr/defadr_0005_run_session_lifecycle.hy`(R5 精緻化 + L4'/identity 法 + fork 禁止 defsemgrep は adr0005-t3a-revive で追記) |
+| 遷移コア spec | `docs/design/run-state-machine.md`(§2 O2/O3、§5 L4(2026-07-13 精密化)、§9.7/§11.5 note-ledger 先例、§12 L-S3、§13 revive) |
+| revive の実 CLI 物理(実測) | `docs/design/revive-physics.md`(claude --resume 同一 transcript 追記・--session-id 併用不可、codex resume rollout 継続。2026-07-13 実測) |
 | watchlist | `docs/design/coupling-core-roadmap.md`(WL#1/#2、B3 に cli/tick.go 言及) |
 | 先行 ADR | `docs/adr/ADR-0001..0003.md`、`docs/adr/defadr_0004_store_writes_through_daemon.hy` |
 | 接地調査(4 subagent、2026-07-12) | 本ファイル「Current state」表に転記済み(file:line) |
@@ -88,13 +89,13 @@ ADR-0005 (law LS1-LS6)
 | T1a | R1 | claude: launch で UUID 発番、`--session-id` 付与(agent/claude.go)+ `agent_session` artifact append(launch ladder、error-artifact 先例に倣う) | 起動後の run record に claude session id が無い(test: DeriveState fold) | LaunchConfig 拡張 + artifact append + fold(model/run.go、opencode_session 同型) | **done**(PR #532) |
 | T1b | R1 | codex: boot 後 `$CODEX_HOME/sessions/**/rollout-*.jsonl` 先頭行 `payload.cwd == worktree_path` で id 解決 → 同 artifact | codex run に識別子無し | boot 後 resolver(リトライ付き、見つからなければ error artifact = unreapable) | **done**(PR #532) |
 | T1c | R1 | model.Run/orchapi.Run/RunSnapshot/query DDL+loader+view に AgentSessionID 面出し | query で引けない | F4 の opencode_session 配線の複製 | **done**(PR #532、file store run index cache の拡張 + version bump 4→5 込み) |
-| T2a | R2 | reaper reconciler: daemon tick 兄弟パス + `reaper:` config(terminal_grace=10m, resolved_grace=1h, idle_ttl=168h)+ 全 status ListRuns + issue status 参照 | 2026-07-11 再現: terminal run のセッションが grace 後も生存 | 新パス(status 書込なし、note/artifact のみ) | todo |
-| T2b | R3/F11 | reap protocol: CapturePane→sidecar file + `session_snapshot` artifact → `session_reaped` note → KillSession。失敗= error artifact+retry | kill 前に note が無い/失敗が warning | 実装順序を test で固定 | todo |
+| T2a | R2 | reaper reconciler: daemon tick 兄弟パス + `reaper:` config(terminal_grace=10m, resolved_grace=1h, idle_ttl=168h)+ 全 status ListRuns + issue status 参照 | 2026-07-11 再現: terminal run のセッションが grace 後も生存 | 新パス(status 書込なし、note/artifact のみ) | **done**(PR #542、retry の unbounded-append 修正込み) |
+| T2b | R3/F11 | reap protocol: CapturePane→sidecar file + `session_snapshot` artifact → `session_reaped` note → KillSession。失敗= error artifact+retry | kill 前に note が無い/失敗が warning | 実装順序を test で固定 | **done**(PR #542、隔離 e2e green) |
 | T2c | LS3 | gatherer が session_reaped/revived note を fold→観測に注入、step() O3 腕が reap 済み世代の gone を吸収(dead-check 不進行)。**コア変更: frontier+human** | reap→3 gone→偽 failed | run-state-machine.md §改訂同梱 + step property test | **done**(PR #533、§12 L-S3) |
-| T2d | F3 | findOrphanedSessions を status-aware に(terminal run のセッション報告)+ repair help の worktree 虚偽記載修正 | 25 個が repair で報告されない | expected 集合に status 条件 | todo |
-| T3a | R5 | send/attach auto-revive: reaped 判定→前提検証(stored facts)→同名セッション再 boot(claude --resume chain-tip / codex resume)→ `session_revived` note + 新世代 agent_session → 送信続行。terminal は source=user status event で再入 | reaped run へ send がエラー/黙って新規文脈 | daemon 側 revive 経路(launch ladder 変種) | todo |
-| T3b | R8 | delete が kill(R3 経由)してから record 削除。clean が `worktree_removed` note 記録。restart-from(run 参照)の worktree 消失エラーに `--branch` 導線明記 | delete 後セッション残存 / clean 後 revive が黙って fresh | 各 handler 修正 | todo |
-| T3c | F6 | kill 失敗 fail-fast 化(socket.go:5126 warning 撲滅、Multiplexer 空=error)+ `adr0005-no-warning-only-kill-failure` semgrep live 化 | 既存 bad fixture | エラー伝播 + semgrep | todo |
+| T2d | F3 | findOrphanedSessions を status-aware に(terminal run のセッション報告)+ repair help の worktree 虚偽記載修正 | 25 個が repair で報告されない | expected 集合に status 条件 | **done**(PR #542)。残欠陥は issue `repair-tmux-no-server-phantom-error`(tmux no-server の幻エラー + inventory の master-host 限定)に切出し・委譲中 |
+| T3a | R5 | send/attach auto-revive: reaped 判定→前提検証(stored facts)→同名セッション再 boot(claude `--resume <id>` / codex `resume <id>`、id は世代を跨いで不変 — revive-physics.md 実測)→ master が `session_revived` note + 世代+1 agent_session → `stageSessionRevived`(source=user、L4' 例外)で再入 → 送信続行 | reaped run へ send がエラー/黙って新規文脈 | daemon 側 revive 経路(launch ladder 変種)+ `revive_run` lease | **implemented on branch `adr0005-t3a-revive`**(コード+テスト+spec §13+physics 記録+本 ADR 改訂、フルスイート green)。残: lint → PR → レビュー → merge |
+| T3b | R8 | delete が kill(R3 経由)してから record 削除。clean が `worktree_removed` note 記録(daemon_notice 形、master 書き)。restart-from(run 参照)の worktree 消失エラーに `--branch` 導線明記 | delete 後セッション残存 / clean 後 revive が黙って fresh | 各 handler 修正 | **dispatched**(issue `adr0005-s3-delete-clean-ledger`、run c604ca、codex) |
+| T3c | F6 | kill 失敗 fail-fast 化(socket.go:5126 warning 撲滅、Multiplexer 空=error)+ `adr0005-no-warning-only-kill-failure` semgrep live 化 | 既存 bad fixture | エラー伝播 + semgrep | **dispatched**(issue `adr0005-s3-kill-failfast`、run 1494a8、codex) |
 | T4a | R6 | ps/show/debug に session 状態列(live/reaped(revivable)/reaped(unrevivable))。capture は snapshot+reaped 通知を返す。wait は reaped=帰着扱い | reaped run が ALIVE - としか見えない | daemon 計算(client 側導出禁止の既存境界に従う) | todo |
 | T4b | R6 | query runs テーブルに agent_session_id / session_state 列 | SQL で引けない | schema.go+loader.go+view | todo |
 
@@ -122,8 +123,16 @@ ADR-0005 (law LS1-LS6)
 | worker-core | T1a/T1b/T2a/T2b/T3a 実装 | daemon/agent | frontier(orch run --agent claude fable xhigh 委譲可 — 決定は ADR で閉鎖済み) | 順次 | red→green |
 | reviewer | 各 PR の adversarial review(tripwire checklist) | read-only | codex(cx read-only) | 各 stage 後 | verdict |
 
-実装は orch 自身の issue/run で回す(dogfood)。コア面 T2c だけは
+実装は orch 自身の issue/run で回す(dogfood)。コア面 T2c と T3a は
 orch 委譲せず親セッション(frontier+human)で行う。
+
+Routing 実績(2026-07-13、model-routing の A/B 証跡): Stage 2(T2a/T2b/T2d、
+choice space 閉鎖済み verified issue)は codex(gpt-5.6)が実装し、frontier
+レビューで required 修正 1 件(kill-retry の unbounded ledger append —
+過去の 5,830 重複イベントと同類)を検出・修正させて merge。柵(status write
+surface / derived-state guard / tripwire)はすべて守られていた。結論: 柵の
+外の verified issue は sub-frontier 委譲で成立、ただし unbounded-growth 類の
+時間軸バグは frontier レビューが引き続き必須。
 
 ## Non-goals
 
@@ -139,7 +148,13 @@ orch 委譲せず親セッション(frontier+human)で行う。
 
 ## Immediate next action
 
-(2026-07-13 更新)Stage 0 / Stage 1 / T2c は merge 済み。次は Stage 2:
-issue `adr0005-s2-session-reaper`(verified issue、前提 PR #533 merge 済み)を
-orch run で dispatch。merge 後 Stage 3(T3a はコア隣接 = frontier + 人間、
-T3b/T3c は委譲)→ Stage 4。beta 配布は Stage 4 完了後。
+(2026-07-13 二度目の更新)Stage 0/1/2 + T2c merge 済み(reaper は実機配備・
+隔離 e2e green)。**今**: (1) ブランチ `adr0005-t3a-revive` を lint → PR →
+frontier+human レビュー → merge(T3a 本体 + spec §13 + revive-physics.md +
+本 ADR 改訂が同一 change set)。(2) 委譲中 run のレビュー・merge:
+T3b(c604ca)/ T3c(1494a8)/ repair-phantom(21169e)— tripwire checklist
+準拠、kill 経路と revive 前提条件の整合(T3b の worktree_removed 形 =
+daemon_notice)を重点確認。(3) 完了後 Stage 4(T4a/T4b)を verified issue 化
+して委譲 → merge → deploy-all → 完成 gate 5/7 の実機確認(reaped→send→
+revived→応答)→ beta 配布可能。cryptic の Fable 週次残量が細い間、orch run
+の claude レーンは ca-pro(要 zeus 側 config 追加)か codex を使う。

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -41,16 +42,21 @@ func (a *ClaudeAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 	// via the CLAUDE_CONFIG_DIR environment variable (LaunchConfig.Env), so
 	// cfg.Profile must never reach the command line.
 
-	// ADR-0005 R1: pin the agent-native session id at launch so the
-	// transcript is addressable for reap/revive. Resume reuses an existing
-	// session, so the two flags are mutually exclusive; resume wins.
-	if cfg.AgentSessionID != "" && !cfg.Resume {
+	// ADR-0005 R1/R5: at launch, pin the agent-native session id so the
+	// transcript is addressable for reap/revive (--session-id). On revive,
+	// resume that SAME id: `claude --resume <id>` appends to the existing
+	// transcript — identity is stable across generations, and the CLI
+	// rejects --session-id alongside --resume (it requires --fork-session,
+	// which is new-conversation semantics, not revive). Measured physics:
+	// docs/design/revive-physics.md.
+	if cfg.Resume {
+		id := strings.TrimSpace(cfg.AgentSessionID)
+		if id == "" {
+			return "", fmt.Errorf("claude resume requires the recorded agent session id (ADR-0005 LS5)")
+		}
+		args = append(args, "--resume", id)
+	} else if cfg.AgentSessionID != "" {
 		args = append(args, "--session-id", cfg.AgentSessionID)
-	}
-
-	// Add resume flag if applicable
-	if cfg.Resume && cfg.SessionName != "" {
-		args = append(args, "--resume", cfg.SessionName)
 	}
 
 	// Add prompt as positional argument (must be last, in double quotes)

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -23,10 +23,11 @@ func TestDoubleQuote(t *testing.T) {
 func TestClaudeLaunchCommand(t *testing.T) {
 	adapter := &ClaudeAdapter{}
 	cfg := &LaunchConfig{
-		Prompt:      "hello",
-		Profile:     "work", // display-only: claude has no --profile flag
-		Resume:      true,
-		SessionName: "session-1",
+		Prompt:         "hello",
+		Profile:        "work", // display-only: claude has no --profile flag
+		Resume:         true,
+		AgentSessionID: "11111111-1111-1111-1111-111111111111",
+		SessionName:    "session-1", // multiplexer session; must NOT reach --resume
 	}
 
 	cmd, err := adapter.LaunchCommand(cfg)
@@ -35,9 +36,22 @@ func TestClaudeLaunchCommand(t *testing.T) {
 	}
 	// The profile must NOT reach the command line — claude has no --profile
 	// flag and would refuse to start. Profile selection is CLAUDE_CONFIG_DIR.
-	want := "claude --dangerously-skip-permissions --resume session-1 \"hello\""
+	// Resume targets the AGENT-NATIVE id (ADR-0005 R5), never the
+	// multiplexer session name.
+	want := "claude --dangerously-skip-permissions --resume 11111111-1111-1111-1111-111111111111 \"hello\""
 	if cmd != want {
 		t.Fatalf("command = %q, want %q", cmd, want)
+	}
+}
+
+func TestClaudeLaunchCommandResumeWithoutIdentityFailsFast(t *testing.T) {
+	// ADR-0005 LS5: resume without a recorded agent-native id has no valid
+	// argv (claude --resume expects the session UUID, not a tmux name);
+	// building one silently would boot a fresh context.
+	adapter := &ClaudeAdapter{}
+	cfg := &LaunchConfig{Resume: true, SessionName: "session-1"}
+	if _, err := adapter.LaunchCommand(cfg); err == nil {
+		t.Fatal("resume without AgentSessionID must fail")
 	}
 }
 
@@ -60,14 +74,15 @@ func TestClaudeLaunchCommandAgentSessionID(t *testing.T) {
 	}
 }
 
-func TestClaudeLaunchCommandResumeExcludesAgentSessionID(t *testing.T) {
-	// --resume reuses an existing session; pinning a fresh --session-id at
-	// the same time would conflict, so resume wins and the mint is dropped.
+func TestClaudeLaunchCommandResumeExcludesSessionIDFlag(t *testing.T) {
+	// The claude CLI rejects --session-id alongside --resume (it requires
+	// --fork-session, which is new-conversation semantics). Resume therefore
+	// carries the id ONLY through --resume — measured physics recorded in
+	// docs/design/revive-physics.md.
 	adapter := &ClaudeAdapter{}
 	cfg := &LaunchConfig{
 		Prompt:         "hello",
 		Resume:         true,
-		SessionName:    "session-1",
 		AgentSessionID: "11111111-1111-1111-1111-111111111111",
 	}
 
@@ -75,7 +90,7 @@ func TestClaudeLaunchCommandResumeExcludesAgentSessionID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LaunchCommand error: %v", err)
 	}
-	want := "claude --dangerously-skip-permissions --resume session-1 \"hello\""
+	want := "claude --dangerously-skip-permissions --resume 11111111-1111-1111-1111-111111111111 \"hello\""
 	if cmd != want {
 		t.Fatalf("command = %q, want %q", cmd, want)
 	}

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -41,6 +41,19 @@ func (a *CodexAdapter) LaunchCommand(cfg *LaunchConfig) (string, error) {
 		args = append(args, "-c", fmt.Sprintf("model_reasoning_effort=%s", shellQuote(variant)))
 	}
 
+	// ADR-0005 R5: revive resumes the recorded agent-native session in place.
+	// Codex CLI usage is `codex [OPTIONS] <COMMAND> [ARGS]`, so the resume
+	// subcommand goes after the root options. Resuming appends to the
+	// existing rollout — the session id stays the durable conversation
+	// identity across generations (docs/design/revive-physics.md).
+	if cfg.Resume {
+		id := strings.TrimSpace(cfg.AgentSessionID)
+		if id == "" {
+			return "", fmt.Errorf("codex resume requires the recorded agent session id (ADR-0005 LS5)")
+		}
+		args = append(args, "resume", shellQuote(id))
+	}
+
 	// Add the prompt
 	if cfg.Prompt != "" {
 		// Escape the prompt for shell

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -105,3 +105,30 @@ func TestCodexModelName(t *testing.T) {
 		})
 	}
 }
+
+func TestCodexLaunchCommandResumeAppendsSubcommand(t *testing.T) {
+	// ADR-0005 R5: codex revive resumes the recorded rollout. Root options
+	// precede the subcommand (`codex [OPTIONS] <COMMAND> [ARGS]`), and the
+	// resume id is the agent-native identity, never the tmux session name.
+	adapter := &CodexAdapter{}
+	cfg := &LaunchConfig{
+		Resume:         true,
+		AgentSessionID: "019f5a57-6d94-78e0-8f88-2db9a64a5be6",
+		SessionName:    "run-x-y",
+	}
+	cmd, err := adapter.LaunchCommand(cfg)
+	if err != nil {
+		t.Fatalf("LaunchCommand error: %v", err)
+	}
+	want := "codex --yolo resume 019f5a57-6d94-78e0-8f88-2db9a64a5be6"
+	if cmd != want {
+		t.Fatalf("command = %q, want %q", cmd, want)
+	}
+}
+
+func TestCodexLaunchCommandResumeWithoutIdentityFailsFast(t *testing.T) {
+	adapter := &CodexAdapter{}
+	if _, err := adapter.LaunchCommand(&LaunchConfig{Resume: true}); err == nil {
+		t.Fatal("codex resume without AgentSessionID must fail")
+	}
+}

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -2240,6 +2240,7 @@ func (s *SocketServer) handleProtoGetControlAgentConfig(req *orchpb.GetControlAg
 
 func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest) *orchpb.Response {
 	var run *model.Run
+	var runStore store.Store
 	projectID := projectIDFromContext(req.Context)
 
 	if projectID != "" {
@@ -2258,6 +2259,7 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 		if err != nil {
 			return errorResponse("not_found")
 		}
+		runStore = st
 	} else {
 		for _, st := range s.listStores() {
 			var (
@@ -2296,11 +2298,28 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 				return errorResponse(fmt.Sprintf("ambiguous run ref: %s#%s", req.IssueId, req.RunId))
 			}
 			run = resolved
+			runStore = st
 		}
 		if run == nil {
 			return errorResponse("not_found")
 		}
 	}
+
+	// ADR-0005 R5: attach is a revive entry verb — a reaped session is
+	// re-booted in place before the client is handed its attach target, so
+	// attach never points at a session the daemon itself destroyed.
+	reviveProjectRoot := ""
+	if repo := s.repoContextForStore(runStore); repo != nil {
+		reviveProjectRoot = repo.ProjectRoot
+		if strings.TrimSpace(projectID) == "" {
+			projectID = repo.RepoID
+		}
+	}
+	revivedRun, reviveErr := s.reviveIfReaped(runStore, projectID, reviveProjectRoot, run)
+	if reviveErr != nil {
+		return errorResponse(reviveErr.Error())
+	}
+	run = revivedRun
 
 	attachInfo := &orchpb.GetAttachInfoResponse{
 		Command:           []string{"orch", "attach", fmt.Sprintf("%s#%s", run.IssueID, run.RunID)},
@@ -2484,6 +2503,16 @@ func (s *SocketServer) handleProtoSendMessage(req *orchpb.SendMessageRequest) *o
 	if errResp != nil {
 		return errResp
 	}
+
+	// ADR-0005 R5: send is a revive entry verb — a reaped session is re-booted
+	// in place before the message is delivered. A failed precondition (LS5)
+	// surfaces as an explicit error naming the missing fact; the message is
+	// never dropped into a silent fresh context.
+	revived, err := s.reviveIfReaped(runCtx.store, runCtx.projectID, runCtx.projectRoot, runCtx.run)
+	if err != nil {
+		return errorResponse(err.Error())
+	}
+	runCtx.run = revived
 
 	if s.runRequiresWorkerDelegation(runCtx.run, "") {
 		if strings.TrimSpace(runCtx.projectID) == "" {

--- a/internal/daemon/revive.go
+++ b/internal/daemon/revive.go
@@ -1,0 +1,300 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/proboscis/orch/internal/agent"
+	"github.com/proboscis/orch/internal/model"
+	"github.com/proboscis/orch/internal/multiplexer"
+	"github.com/proboscis/orch/internal/store"
+)
+
+// ADR-0005 R5: revive is in-place and entered only via send/attach. The
+// master decides revivability from STORED FACTS (LS5), the execution host
+// does the physical re-boot (native resume in the same worktree, same
+// session name), and the master alone writes the ledger: session_revived
+// note, the new-generation agent_session artifact (which dissolves the L-S3
+// latch), and the user-sourced status re-entry (stageSessionRevived, L4').
+//
+// Measured CLI physics (docs/design/revive-physics.md): claude --resume <id>
+// appends to the SAME transcript (identity stable; --session-id alongside
+// --resume is rejected by the CLI); codex resume <id> continues the existing
+// rollout. The conversation identity is durable across generations — the
+// generation counts incarnations.
+
+// reviveLeaseTimeout bounds the worker-side revive: session boot plus the
+// codex rollout re-resolution (codexAgentSessionResolveTimeout, 60s).
+var reviveLeaseTimeout = 120 * time.Second
+
+// reviveResolveCodexSessionID is a test seam over the post-boot codex
+// identity re-resolution (T1b arm, reused by revive with generation+1).
+var reviveResolveCodexSessionID = agent.ResolveCodexSessionIDWithRetry
+
+// reviveMultiplexer is the slice of multiplexer.Multiplexer revive needs;
+// narrowed for tests.
+type reviveMultiplexer interface {
+	Type() multiplexer.Type
+	HasSession(name string) bool
+	NewSession(cfg *multiplexer.SessionConfig) error
+}
+
+// getReviveMultiplexer is a test seam resolving the run's recorded
+// multiplexer. Production resolves the concrete type recorded on the run —
+// revive never guesses (same rule as the reaper).
+var getReviveMultiplexer = func(run *model.Run) (reviveMultiplexer, error) {
+	if err := validateReaperMultiplexer(run); err != nil {
+		return nil, err
+	}
+	muxType, _ := multiplexer.ParseType(strings.TrimSpace(run.Multiplexer))
+	mux, err := multiplexer.GetMultiplexer(muxType)
+	if err != nil {
+		return nil, fmt.Errorf("resolve multiplexer %q for run %s: %w", run.Multiplexer, run.Ref().String(), err)
+	}
+	if mux == nil {
+		return nil, fmt.Errorf("resolve multiplexer %q for run %s: no multiplexer returned", run.Multiplexer, run.Ref().String())
+	}
+	return mux, nil
+}
+
+// checkRevivePreconditions decides revivability from stored facts alone
+// (ADR-0005 LS5): agent kind, recorded identity, recorded worktree, no
+// worktree_removed note. A missing fact fails fast NAMING the fact and
+// pointing at restart-from --branch — never a probe, never a silent fresh
+// session. Filesystem/liveness checks belong to the execution host
+// (revivePhysical), not here.
+func checkRevivePreconditions(run *model.Run) error {
+	if run == nil {
+		return fmt.Errorf("run required")
+	}
+	ref := run.Ref().String()
+	switch run.Agent {
+	case string(agent.AgentClaude), string(agent.AgentCodex):
+	default:
+		return fmt.Errorf("revive is not defined for agent %q (run %s): only claude/codex sessions record a resumable identity — use `orch restart-from --branch` for a fresh session", run.Agent, ref)
+	}
+	if strings.TrimSpace(run.AgentSessionID) == "" {
+		return fmt.Errorf("revive precondition missing for %s: agent_session identity is not recorded — the session cannot be resumed; use `orch restart-from --branch` to continue on a fresh session", ref)
+	}
+	if strings.TrimSpace(run.WorktreePath) == "" {
+		return fmt.Errorf("revive precondition missing for %s: no worktree is recorded — use `orch restart-from --branch`", ref)
+	}
+	if runHasWorktreeRemovedNote(run) {
+		return fmt.Errorf("revive precondition missing for %s: the worktree was removed (worktree_removed note) — use `orch restart-from --branch` to recreate one", ref)
+	}
+	if err := validateReaperMultiplexer(run); err != nil {
+		return err
+	}
+	return nil
+}
+
+// revivePhysical performs the execution-host part of a revive: verify the
+// host-local facts (worktree present, session not already alive), build the
+// native resume command, boot the session, and re-resolve the codex identity
+// (claude identity is stable and pre-known). It writes NO ledger events —
+// the master owns the store of record (ADR-0004).
+func (s *SocketServer) revivePhysical(run *model.Run, projectRoot string) (*ReviveRunResult, error) {
+	if run == nil {
+		return nil, fmt.Errorf("run required")
+	}
+	ref := run.Ref().String()
+
+	exists, err := worktreeDirectoryExists(run.WorktreePath)
+	if err != nil {
+		return nil, fmt.Errorf("revive %s: check worktree %s: %w", ref, run.WorktreePath, err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("revive %s: worktree %s does not exist on execution host — use `orch restart-from --branch`", ref, run.WorktreePath)
+	}
+
+	mux, err := getReviveMultiplexer(run)
+	if err != nil {
+		return nil, err
+	}
+	sessionName := model.GenerateSessionName(run.IssueID, run.RunID)
+	if mux.HasSession(sessionName) {
+		// SessionReaped latch set but the session still exists = a reap kill
+		// failed and its retry is pending (LS6). Racing a boot against that
+		// kill would destroy the freshly revived session; fail clearly.
+		return nil, fmt.Errorf("revive %s: session %s is still alive with a pending reap-kill retry; resend after the reaper completes", ref, sessionName)
+	}
+
+	cfg, err := loadConfigForProjectRoot(projectRoot)
+	if err != nil {
+		return nil, fmt.Errorf("revive %s: failed to load config: %w", ref, err)
+	}
+	agentType := agent.AgentType(run.Agent)
+	adapter, err := agent.GetAdapter(agentType)
+	if err != nil {
+		return nil, fmt.Errorf("revive %s: %w", ref, err)
+	}
+
+	launchCfg := &agent.LaunchConfig{
+		Type:           agentType,
+		WorkDir:        run.WorktreePath,
+		IssueID:        string(run.IssueID),
+		RunID:          string(run.RunID),
+		RunPath:        run.Path,
+		Branch:         run.Branch,
+		SessionName:    sessionName,
+		Resume:         true,
+		AgentSessionID: run.AgentSessionID,
+		Model:          run.Model,
+		ModelVariant:   run.ModelVariant,
+		ExtraArgs:      cfg.GetExtraArgs(run.Agent),
+	}
+
+	// Re-resolve the run's recorded execution profile to its auth dir with
+	// the same authoritative decision point the launch paths use, so the
+	// revived agent authenticates as the same account.
+	switch agentType {
+	case agent.AgentCodex:
+		decision, err := resolveCodexProfile(cfg, run.Agent, run.Profile, "")
+		if err != nil {
+			return nil, fmt.Errorf("revive %s: %w", ref, err)
+		}
+		launchCfg.CodexHome = decision.AuthDir
+	case agent.AgentClaude:
+		decision, err := resolveClaudeProfile(cfg, run.Agent, run.Profile, "")
+		if err != nil {
+			return nil, fmt.Errorf("revive %s: %w", ref, err)
+		}
+		launchCfg.ClaudeConfigDir = decision.AuthDir
+	}
+
+	if err := agent.AuthPreflight(launchCfg); err != nil {
+		return nil, fmt.Errorf("revive %s: %w", ref, err)
+	}
+
+	agentCmd, err := adapter.LaunchCommand(launchCfg)
+	if err != nil {
+		return nil, fmt.Errorf("revive %s: build resume command: %w", ref, err)
+	}
+
+	env := launchCfg.Env()
+	env = append(env, adapter.ExtraEnv()...)
+	if err := mux.NewSession(&multiplexer.SessionConfig{
+		SessionName: sessionName,
+		WorkDir:     run.WorktreePath,
+		Command:     agentCmd,
+		Env:         env,
+	}); err != nil {
+		return nil, fmt.Errorf("revive %s: failed to create session: %w", ref, err)
+	}
+
+	result := &ReviveRunResult{
+		SessionName: sessionName,
+		Multiplexer: string(mux.Type()),
+		Generation:  run.AgentSessionGeneration + 1,
+	}
+	switch agentType {
+	case agent.AgentClaude:
+		// Measured physics: claude --resume appends to the same transcript;
+		// the identity is the stored fact, no discovery needed.
+		result.AgentSessionID = run.AgentSessionID
+	case agent.AgentCodex:
+		// Re-run the T1b discovery arm: resume continues the existing
+		// rollout, so the newest cwd-matching rollout re-yields the same id;
+		// resolving rather than assuming keeps the fact observation-backed.
+		id, err := reviveResolveCodexSessionID(launchCfg.CodexSessionsHome(), launchCfg.WorkDir, codexAgentSessionResolveTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("revive %s: session booted but codex identity re-resolution failed (run stays latched-unreapable until resolved): %w", ref, err)
+		}
+		result.AgentSessionID = id
+	}
+	return result, nil
+}
+
+// reviveRunForVerb is the master-side revive orchestration used by the entry
+// verbs send and attach (R6: observation verbs never boot). It checks the
+// stored-fact preconditions against the authoritative run, routes the
+// physical re-boot to the execution host (worker lease) or runs it locally,
+// and then writes the ledger on the master store: session_revived note →
+// agent_session generation+1 (dissolves the L-S3 latch) → user-sourced
+// status re-entry via the launch plane (stageSessionRevived).
+func (s *SocketServer) reviveRunForVerb(st store.Store, projectID, projectRoot string, run *model.Run) error {
+	if st == nil || run == nil {
+		return fmt.Errorf("store and run required")
+	}
+	if err := checkRevivePreconditions(run); err != nil {
+		return err
+	}
+
+	var result *ReviveRunResult
+	if s.runRequiresWorkerDelegation(run, "") {
+		if strings.TrimSpace(projectID) == "" {
+			return fmt.Errorf("no project context available to revive remote run %s#%s", run.IssueID, run.RunID)
+		}
+		target, err := resolveWorkerTargetForRunFields(run, projectRoot)
+		if err != nil {
+			return err
+		}
+		payload := &WorkerEffectPayload{
+			ReviveRun: &ReviveRunPayload{
+				Target:         strings.TrimSpace(run.Target),
+				TargetHost:     target.Host,
+				TargetWorkerID: target.WorkerID,
+				RunSnapshot:    newRunSnapshot(run),
+			},
+		}
+		lease, err := s.acquireWorkerLease(projectID, "revive_run", string(run.IssueID), string(run.RunID), payload)
+		if err != nil {
+			return err
+		}
+		completed, err := s.waitForWorkerLeaseCompletion(lease.LeaseID, reviveLeaseTimeout)
+		if err != nil {
+			return fmt.Errorf("revive on execution host %s for run %s#%s: %w", target.Host, run.IssueID, run.RunID, err)
+		}
+		effectResult, err := decodeWorkerEffectResult(completed.ResultJSON)
+		if err != nil {
+			return fmt.Errorf("decode revive result from execution host %s for run %s#%s: %w", target.Host, run.IssueID, run.RunID, err)
+		}
+		if effectResult.ReviveRunResult == nil {
+			return fmt.Errorf("revive on execution host %s for run %s#%s completed without revive_run_result", target.Host, run.IssueID, run.RunID)
+		}
+		result = effectResult.ReviveRunResult
+	} else {
+		local, err := s.revivePhysical(run, projectRoot)
+		if err != nil {
+			return err
+		}
+		result = local
+	}
+
+	// Ledger, on the master store only (ADR-0004). Order matters: the note
+	// is the narrative marker the gatherer folds (T2c), the agent_session
+	// artifact is what dissolves the L-S3 latch, and the status re-entry
+	// goes last so a run never counts as running before its latch state and
+	// lineage are durable.
+	note := model.NewDaemonNoticeEvent("session_revived", map[string]string{
+		"generation":   fmt.Sprintf("%d", result.Generation),
+		"session_name": result.SessionName,
+	})
+	if err := st.AppendEvent(run.Ref(), note); err != nil {
+		return fmt.Errorf("record session_revived note for %s#%s: %w", run.IssueID, run.RunID, err)
+	}
+	s.appendAgentSessionArtifact(st, run, run.Agent, result.AgentSessionID, result.Generation)
+	s.reportLaunchProgress(st, run, launchReached(stageSessionRevived))
+	s.logger.Printf("%s#%s: revived session %s (agent=%s generation=%d)", run.IssueID, run.RunID, result.SessionName, run.Agent, result.Generation)
+	return nil
+}
+
+// reviveIfReaped is the send/attach entry hook: a run whose CURRENT
+// generation is recorded as reaped gets revived in place before the verb
+// proceeds. Non-reaped runs pass through untouched. It re-reads the
+// authoritative run afterward so the caller continues against post-revive
+// state.
+func (s *SocketServer) reviveIfReaped(st store.Store, projectID, projectRoot string, run *model.Run) (*model.Run, error) {
+	if run == nil || !run.SessionReaped() {
+		return run, nil
+	}
+	if err := s.reviveRunForVerb(st, projectID, projectRoot, run); err != nil {
+		return run, err
+	}
+	fresh, err := st.GetRun(run.Ref())
+	if err != nil {
+		return run, fmt.Errorf("reload run %s#%s after revive: %w", run.IssueID, run.RunID, err)
+	}
+	return fresh, nil
+}

--- a/internal/daemon/revive_test.go
+++ b/internal/daemon/revive_test.go
@@ -1,0 +1,276 @@
+package daemon
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/proboscis/orch/internal/model"
+	"github.com/proboscis/orch/internal/multiplexer"
+	"github.com/proboscis/orch/internal/store"
+	filestore "github.com/proboscis/orch/internal/store/file"
+)
+
+// mockReviveMux records the session boot the revive physical path performs.
+type mockReviveMux struct {
+	hasSession bool
+	newErr     error
+	booted     []*multiplexer.SessionConfig
+}
+
+func (m *mockReviveMux) Type() multiplexer.Type { return multiplexer.TypeTmux }
+func (m *mockReviveMux) HasSession(string) bool { return m.hasSession }
+func (m *mockReviveMux) NewSession(cfg *multiplexer.SessionConfig) error {
+	m.booted = append(m.booted, cfg)
+	return m.newErr
+}
+
+// createReapedTestRun builds a run whose CURRENT generation is recorded as
+// reaped: terminal status, agent_session g1, session_reaped note g1. The
+// worktree is a real directory so the local physical preconditions hold.
+func createReapedTestRun(t *testing.T, agentName string, withIdentity bool) (store.Store, *model.Run) {
+	t.Helper()
+	root := t.TempDir()
+	st, err := filestore.New(root)
+	if err != nil {
+		t.Fatalf("filestore.New() error = %v", err)
+	}
+	issueID := model.IssueID("revive-issue")
+	if err := st.CreateIssue(&model.Issue{ID: issueID, Title: "Revive issue", Status: model.IssueStatusOpen}); err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+	runID := model.RunID("20260713-180000")
+	if _, err := st.CreateRun(issueID, runID, map[string]string{"agent": agentName}); err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	worktree := t.TempDir()
+	sessionName := model.GenerateSessionName(issueID, runID)
+	events := []*model.Event{
+		{Timestamp: now.Add(-5 * time.Second), Type: model.EventTypeArtifact, Name: "worktree", Attrs: map[string]string{"path": worktree}},
+		{Timestamp: now.Add(-4 * time.Second), Type: model.EventTypeArtifact, Name: "session", Attrs: map[string]string{"name": sessionName, "multiplexer": "tmux"}},
+	}
+	if withIdentity {
+		events = append(events, &model.Event{Timestamp: now.Add(-3 * time.Second), Type: model.EventTypeArtifact, Name: "agent_session", Attrs: map[string]string{"backend": agentName, "id": "conv-8888", "generation": "1"}})
+	}
+	events = append(events,
+		&model.Event{Timestamp: now.Add(-2 * time.Second), Type: model.EventTypeStatus, Name: string(model.StatusDone), Attrs: map[string]string{"source": string(model.EventSourceDaemon)}},
+		&model.Event{Timestamp: now.Add(-time.Second), Type: model.EventTypeNote, Name: model.DaemonNoticeEventName, Attrs: map[string]string{"kind": "session_reaped", "generation": "1", "session_name": sessionName, "reason": "terminal_grace"}},
+	)
+	for _, event := range events {
+		if err := st.AppendEvent(&model.RunRef{IssueID: issueID, RunID: runID}, event); err != nil {
+			t.Fatalf("AppendEvent(%s) error = %v", event.Name, err)
+		}
+	}
+	run, err := st.GetRun(&model.RunRef{IssueID: issueID, RunID: runID})
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if !run.SessionReaped() {
+		t.Fatalf("precondition: run must fold as reaped (gen=%d reaped=%v)", run.AgentSessionGeneration, run.SessionReaped())
+	}
+	return st, run
+}
+
+func withMockReviveMux(t *testing.T, mux *mockReviveMux) {
+	t.Helper()
+	prev := getReviveMultiplexer
+	getReviveMultiplexer = func(run *model.Run) (reviveMultiplexer, error) { return mux, nil }
+	t.Cleanup(func() { getReviveMultiplexer = prev })
+}
+
+func TestReviveBootsReapedClaudeSessionWithNativeResume(t *testing.T) {
+	st, run := createReapedTestRun(t, "claude", true)
+	mux := &mockReviveMux{}
+	withMockReviveMux(t, mux)
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+
+	fresh, err := server.reviveIfReaped(st, "project", t.TempDir(), run)
+	if err != nil {
+		t.Fatalf("reviveIfReaped() error = %v", err)
+	}
+
+	// (1) the physical boot resumed the SAME identity natively.
+	if len(mux.booted) != 1 {
+		t.Fatalf("expected exactly one session boot, got %d", len(mux.booted))
+	}
+	boot := mux.booted[0]
+	if boot.SessionName != model.GenerateSessionName(run.IssueID, run.RunID) {
+		t.Fatalf("revive must reuse the run session name, got %q", boot.SessionName)
+	}
+	if !strings.Contains(boot.Command, "--resume conv-8888") {
+		t.Fatalf("claude revive must resume the recorded identity, got %q", boot.Command)
+	}
+	if strings.Contains(boot.Command, "--session-id") {
+		t.Fatalf("claude revive must not mint a new session id (CLI rejects it with --resume), got %q", boot.Command)
+	}
+	if boot.WorkDir != run.WorktreePath {
+		t.Fatalf("revive must boot in the recorded worktree, got %q want %q", boot.WorkDir, run.WorktreePath)
+	}
+
+	// (2) the ledger: session_revived note + agent_session g2 + user-sourced
+	// status re-entry, and the L-S3 latch is dissolved.
+	if fresh.SessionReaped() {
+		t.Fatal("revive must dissolve the SessionReaped latch (agent_session generation+1)")
+	}
+	if fresh.AgentSessionID != "conv-8888" || fresh.AgentSessionGeneration != 2 {
+		t.Fatalf("revive identity fold = (%q, %d), want (conv-8888, 2)", fresh.AgentSessionID, fresh.AgentSessionGeneration)
+	}
+	if fresh.Status != model.StatusRunning {
+		t.Fatalf("revive must re-enter running, got %s", fresh.Status)
+	}
+	var revivedNote, userStatus bool
+	for _, e := range fresh.Events {
+		if e.Type == model.EventTypeNote && e.Name == model.DaemonNoticeEventName && e.Attrs["kind"] == "session_revived" && e.Attrs["generation"] == "2" {
+			revivedNote = true
+		}
+		if e.Type == model.EventTypeStatus && e.Name == string(model.StatusRunning) && e.Attrs[model.AttrStatusSource] == string(model.EventSourceUser) {
+			userStatus = true
+		}
+	}
+	if !revivedNote {
+		t.Fatal("session_revived note (generation 2) not recorded")
+	}
+	if !userStatus {
+		t.Fatal("terminal re-entry must be a user-sourced running status event")
+	}
+}
+
+func TestReviveCodexReResolvesIdentityPostBoot(t *testing.T) {
+	st, run := createReapedTestRun(t, "codex", true)
+	mux := &mockReviveMux{}
+	withMockReviveMux(t, mux)
+	prevResolve := reviveResolveCodexSessionID
+	reviveResolveCodexSessionID = func(sessionsHome, workDir string, timeout time.Duration) (string, error) {
+		return "conv-8888", nil
+	}
+	t.Cleanup(func() { reviveResolveCodexSessionID = prevResolve })
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+
+	fresh, err := server.reviveIfReaped(st, "project", t.TempDir(), run)
+	if err != nil {
+		t.Fatalf("reviveIfReaped() error = %v", err)
+	}
+	if len(mux.booted) != 1 {
+		t.Fatalf("expected exactly one session boot, got %d", len(mux.booted))
+	}
+	if !strings.Contains(mux.booted[0].Command, "resume conv-8888") {
+		t.Fatalf("codex revive must use the resume subcommand with the recorded id, got %q", mux.booted[0].Command)
+	}
+	if fresh.AgentSessionGeneration != 2 || fresh.SessionReaped() {
+		t.Fatalf("codex revive must record generation 2 and dissolve the latch (gen=%d reaped=%v)", fresh.AgentSessionGeneration, fresh.SessionReaped())
+	}
+}
+
+func TestReviveWithoutRecordedIdentityFailsNamingTheFact(t *testing.T) {
+	st, run := createReapedTestRun(t, "claude", false)
+	mux := &mockReviveMux{}
+	withMockReviveMux(t, mux)
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+
+	_, err := server.reviveIfReaped(st, "project", t.TempDir(), run)
+	if err == nil {
+		t.Fatal("revive without recorded identity must fail")
+	}
+	if !strings.Contains(err.Error(), "agent_session identity is not recorded") || !strings.Contains(err.Error(), "restart-from --branch") {
+		t.Fatalf("error must name the missing fact and point at restart-from --branch, got %v", err)
+	}
+	if len(mux.booted) != 0 {
+		t.Fatal("no session may be booted when a stored-fact precondition is missing")
+	}
+}
+
+func TestReviveWorktreeRemovedNoteFailsFast(t *testing.T) {
+	st, run := createReapedTestRun(t, "claude", true)
+	if err := st.AppendEvent(run.Ref(), model.NewDaemonNoticeEvent("worktree_removed", map[string]string{"path": run.WorktreePath})); err != nil {
+		t.Fatalf("AppendEvent(worktree_removed) error = %v", err)
+	}
+	run, err := st.GetRun(run.Ref())
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	mux := &mockReviveMux{}
+	withMockReviveMux(t, mux)
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+
+	_, err = server.reviveIfReaped(st, "project", t.TempDir(), run)
+	if err == nil || !strings.Contains(err.Error(), "worktree_removed") {
+		t.Fatalf("revive after worktree_removed must fail naming the fact, got %v", err)
+	}
+	if len(mux.booted) != 0 {
+		t.Fatal("no session may be booted after worktree_removed")
+	}
+}
+
+func TestRevivePendingReapKillRetryFailsClearly(t *testing.T) {
+	st, run := createReapedTestRun(t, "claude", true)
+	mux := &mockReviveMux{hasSession: true}
+	withMockReviveMux(t, mux)
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+
+	_, err := server.reviveIfReaped(st, "project", t.TempDir(), run)
+	if err == nil || !strings.Contains(err.Error(), "pending reap-kill retry") {
+		t.Fatalf("revive against a still-alive reaped session must fail clearly, got %v", err)
+	}
+	if len(mux.booted) != 0 {
+		t.Fatal("no session may be booted over a pending reap-kill")
+	}
+}
+
+func TestReviveNonReapedRunIsUntouched(t *testing.T) {
+	st, run := createReapedTestRun(t, "claude", true)
+	// Dissolve the latch first: a generation-2 identity means not reaped.
+	if err := st.AppendEvent(run.Ref(), model.NewArtifactEvent("agent_session", map[string]string{"backend": "claude", "id": "conv-8888", "generation": "2"})); err != nil {
+		t.Fatalf("AppendEvent(agent_session) error = %v", err)
+	}
+	run, err := st.GetRun(run.Ref())
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	mux := &mockReviveMux{}
+	withMockReviveMux(t, mux)
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+
+	fresh, err := server.reviveIfReaped(st, "project", t.TempDir(), run)
+	if err != nil {
+		t.Fatalf("reviveIfReaped() on non-reaped run error = %v", err)
+	}
+	if fresh != run {
+		t.Fatal("non-reaped run must pass through untouched")
+	}
+	if len(mux.booted) != 0 {
+		t.Fatal("non-reaped run must not boot anything")
+	}
+}
+
+// TestStepTerminalAbsorbsAllObservationsExceptReviveMilestone pins the L4'
+// refinement: terminal views absorb every observation EXCEPT the
+// user-sourced revive milestone, which alone re-enters running.
+func TestStepTerminalAbsorbsAllObservationsExceptReviveMilestone(t *testing.T) {
+	view := runView{IssueID: "i", RunID: "r", Status: model.StatusDone}
+
+	observations := []runObservation{
+		{Kind: obsSessionAlive},
+		{Kind: obsSessionGone},
+		{Kind: obsCaptured},
+		{Kind: obsPRState},
+		{Kind: obsGitEvidence},
+		{Kind: obsLaunchProgress, Launch: launchReached(stageRunCreated)},
+		{Kind: obsLaunchProgress, Launch: launchReached(stageLaunchReady)},
+		{Kind: obsLaunchProgress, Launch: launchReached(stageAgentStarted)},
+		{Kind: obsLaunchProgress, Launch: launchFailed("session", fmt.Errorf("boom"))},
+	}
+	for _, obs := range observations {
+		if _, effects := stepRun(view, runCore{}, obs, time.Now()); len(effects) != 0 {
+			t.Fatalf("terminal view must absorb %+v, got effects %+v", obs, effects)
+		}
+	}
+
+	_, effects := stepRun(view, runCore{}, runObservation{Kind: obsLaunchProgress, Launch: launchReached(stageSessionRevived)}, time.Now())
+	if len(effects) != 1 || effects[0].Kind != effectSetStatus || effects[0].Status != model.StatusRunning || effects[0].Source != model.EventSourceUser {
+		t.Fatalf("revive milestone on terminal view must yield exactly one user-sourced running commit, got %+v", effects)
+	}
+}

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -1947,7 +1947,7 @@ func (s *SocketServer) reportLaunchProgress(st store.Store, run *model.Run, sig 
 				s.logger.Printf("%s#%s: failed to record error artifact: %v", run.IssueID, run.RunID, err)
 			}
 		case effectSetStatus:
-			if _, _, err := commitRunStatus(st, run, e.Status, e.Reason, nil); err != nil {
+			if _, _, err := commitRunStatusFromSource(st, run, e.Status, e.Reason, e.Source, nil); err != nil {
 				s.logger.Printf("%s#%s: failed to record %s status: %v", run.IssueID, run.RunID, e.Status, err)
 			}
 		case effectLog:
@@ -2523,17 +2523,20 @@ func (s *SocketServer) processControlAgentLaunchCore(st store.Store, params *Con
 		}
 
 		if agentName == "claude" && !newSession {
+			// Resume carries the agent-native session id in AgentSessionID
+			// (the adapter's --resume argument); SessionName stays the
+			// multiplexer-session concern everywhere, control path included.
 			stored := s.getStoredControlSession(params.ProjectRoot)
 			if stored != "" {
 				launchCfg.Resume = true
-				launchCfg.SessionName = stored
+				launchCfg.AgentSessionID = stored
 				sessionID = stored
 				resumed = true
 			} else {
 				discovered := s.discoverClaudeSession(params.ProjectRoot)
 				if discovered != "" {
 					launchCfg.Resume = true
-					launchCfg.SessionName = discovered
+					launchCfg.AgentSessionID = discovered
 					sessionID = discovered
 					resumed = true
 					s.saveControlSession(params.ProjectRoot, discovered, "claude")

--- a/internal/daemon/status_commit.go
+++ b/internal/daemon/status_commit.go
@@ -23,9 +23,23 @@ import (
 // absorbed (same-status no-op, or illegal for the daemon source); the
 // caller must not publish or notify in that case.
 func commitRunStatus(st store.Store, run *model.Run, status model.Status, reason string, debugf func(format string, args ...interface{})) (model.Status, bool, error) {
-	ref := &model.RunRef{IssueID: run.IssueID, RunID: run.RunID}
+	return commitRunStatusFromSource(st, run, status, reason, model.EventSourceDaemon, debugf)
+}
 
-	// Check current status - daemon cannot overwrite terminal states
+// commitRunStatusFromSource is commitRunStatus with an explicit event
+// source. The only non-daemon source today is the revive ladder (ADR-0005
+// R5): terminal re-entry via send/attach is a user command, and the store's
+// append guard requires source=user for a terminal exit. The source travels
+// on the status event (model.AttrStatusSource) so the store re-validates the
+// same fact this function checked.
+func commitRunStatusFromSource(st store.Store, run *model.Run, status model.Status, reason string, source model.EventSource, debugf func(format string, args ...interface{})) (model.Status, bool, error) {
+	ref := &model.RunRef{IssueID: run.IssueID, RunID: run.RunID}
+	if source == "" {
+		source = model.EventSourceDaemon
+	}
+
+	// Check current status - the daemon source cannot overwrite terminal
+	// states; a user source may (CanTransitionStatus).
 	var fromStatus model.Status
 	if currentRun, err := st.GetRun(ref); err == nil && currentRun != nil {
 		fromStatus = currentRun.Status
@@ -39,15 +53,15 @@ func commitRunStatus(st store.Store, run *model.Run, status model.Status, reason
 		if fromStatus == status && currentRun.StatusReason() == reason {
 			return fromStatus, false, nil
 		}
-		if !model.CanTransitionStatus(currentRun.Status, status, model.EventSourceDaemon) {
+		if !model.CanTransitionStatus(currentRun.Status, status, source) {
 			if debugf != nil {
-				debugf("%s#%s: daemon cannot transition from %s to %s", run.IssueID, run.RunID, currentRun.Status, status)
+				debugf("%s#%s: %s source cannot transition from %s to %s", run.IssueID, run.RunID, source, currentRun.Status, status)
 			}
 			return fromStatus, false, nil
 		}
 	}
 
-	event := model.NewStatusEventWithReason(status, reason) // nosemgrep: run-status-write-surface
+	event := model.NewStatusEventWithReasonAndSource(status, reason, source) // nosemgrep: run-status-write-surface
 	if err := st.AppendEvent(ref, event); err != nil {
 		return fromStatus, false, err
 	}

--- a/internal/daemon/step.go
+++ b/internal/daemon/step.go
@@ -208,6 +208,14 @@ const (
 	// stageAgentStarted: the session exists and the initial prompt was
 	// handed to the agent.
 	stageAgentStarted
+	// stageSessionRevived: a reaped session was re-booted in place with the
+	// agent's native resume (ADR-0005 R5, entered only via send/attach).
+	// Its status commit carries source=user — revive is a user command, and
+	// terminal re-entry is legal exactly for the user source (F12 /
+	// CanTransitionStatus). After this milestone the monitor plane owns the
+	// run again; the dissolved L-S3 latch (higher-generation agent_session)
+	// makes its session observations evidence once more.
+	stageSessionRevived
 )
 
 // launchSignal is one O8 observation: either a milestone reached or a
@@ -328,6 +336,11 @@ type runEffect struct {
 	Output   string       // effectSetStatus listener payload context
 	Msg      string       // effectLog / effectDebugLog
 	Reason   string       // effectSetStatus: machine-readable verdict reason (model.AttrStatusReason)
+	// Source marks the EventSource of an effectSetStatus commit; empty means
+	// daemon. The only non-daemon producer is the revive milestone (L4'
+	// refinement, ADR-0005 R5) — user-sourced because revive is entered only
+	// via the user verbs send/attach, and terminal exit requires that source.
+	Source model.EventSource
 }
 
 func logEffect(format string, args ...interface{}) runEffect {
@@ -365,7 +378,15 @@ func stepRun(view runView, core runCore, obs runObservation, now time.Time) (run
 	// no observation may produce effects on them. Shells and updateStatus
 	// also guard this — encoding it here makes it a law of the pure core
 	// (step_test.go L4) instead of a property of call-site discipline.
+	//
+	// L4 refinement (ADR-0005 R5): the ONE user-sourced observation in the
+	// vocabulary is the revive milestone — send/attach re-booting a reaped
+	// session is a user command, and terminal re-entry is legal exactly for
+	// the user source. Every other observation stays absorbed.
 	if view.Status.IsTerminal() {
+		if obs.Kind == obsLaunchProgress && !obs.Launch.Failed && obs.Launch.Stage == stageSessionRevived {
+			return stepLaunchProgress(view, core, obs)
+		}
 		return core, nil
 	}
 
@@ -429,6 +450,7 @@ func stepLaunchProgress(view runView, core runCore, obs runObservation) (runCore
 	}
 
 	var target model.Status
+	source := model.EventSourceDaemon
 	switch sig.Stage {
 	case stageRunCreated:
 		target = model.StatusQueued
@@ -436,13 +458,18 @@ func stepLaunchProgress(view runView, core runCore, obs runObservation) (runCore
 		target = model.StatusBooting
 	case stageWorkspaceOnly, stageAgentStarted:
 		target = model.StatusRunning
+	case stageSessionRevived:
+		// ADR-0005 R5: revive is user-entered (send/attach); the user source
+		// is what legalizes the terminal exit (L4' / CanTransitionStatus).
+		target = model.StatusRunning
+		source = model.EventSourceUser
 	default:
 		return core, nil
 	}
 	if target == view.Status {
 		return core, nil
 	}
-	return core, []runEffect{setStatusEffect(target)}
+	return core, []runEffect{{Kind: effectSetStatus, Status: target, Source: source}}
 }
 
 // launchFailureReason is the machine-readable reason family for launch

--- a/internal/daemon/worker_plane.go
+++ b/internal/daemon/worker_plane.go
@@ -73,6 +73,7 @@ type WorkerEffectPayload struct {
 	GetBranchState    *GetBranchStatePayload
 	GetDiff           *GetDiffPayload
 	RunWorktree       *RunWorktreePayload
+	ReviveRun         *ReviveRunPayload
 	StartRunResult    *StartRunResult
 	ContinueRunResult *ContinueRunResult
 	CaptureResult     *CaptureSessionResult
@@ -136,6 +137,18 @@ type GetDiffPayload struct {
 
 type RunWorktreePayload struct {
 	Operation      string `json:"operation"`
+	Target         string `json:"target,omitempty"`
+	TargetHost     string `json:"target_host,omitempty"`
+	TargetWorkerID string `json:"target_worker_id,omitempty"`
+	RunSnapshot    *RunSnapshot
+}
+
+// ReviveRunPayload asks the execution host to re-boot a reaped run's session
+// in place with the agent's native resume (ADR-0005 R5). The worker performs
+// ONLY the physical boot and identity re-resolution; every ledger write
+// (session_revived note, agent_session generation, status re-entry) belongs
+// to the master (ADR-0004).
+type ReviveRunPayload struct {
 	Target         string `json:"target,omitempty"`
 	TargetHost     string `json:"target_host,omitempty"`
 	TargetWorkerID string `json:"target_worker_id,omitempty"`
@@ -207,11 +220,21 @@ type WorkerEffectResult struct {
 	BranchStateResult *GetBranchStateResult `json:"branch_state_result,omitempty"`
 	DiffResult        *GetDiffResult        `json:"diff_result,omitempty"`
 	RunWorktreeResult *RunWorktreeResult    `json:"run_worktree_result,omitempty"`
+	ReviveRunResult   *ReviveRunResult      `json:"revive_run_result,omitempty"`
+}
+
+// ReviveRunResult carries the execution host's physical revive outcome back
+// to the master, which alone writes the ledger facts derived from it.
+type ReviveRunResult struct {
+	AgentSessionID string `json:"agent_session_id"`
+	Generation     int    `json:"generation"`
+	SessionName    string `json:"session_name"`
+	Multiplexer    string `json:"multiplexer,omitempty"`
 }
 
 func normalizeCapabilities(caps []string) []string {
 	if len(caps) == 0 {
-		return []string{"capture_session", "continue_run", "get_branch_state", "get_diff", "get_diff_stats", "run_worktree", "send_message", "start_run", "stop_run"}
+		return []string{"capture_session", "continue_run", "get_branch_state", "get_diff", "get_diff_stats", "revive_run", "run_worktree", "send_message", "start_run", "stop_run"}
 	}
 	set := make(map[string]struct{}, len(caps))
 	norm := make([]string, 0, len(caps))
@@ -601,6 +624,18 @@ func preferredWorkerPreferenceForPayload(payload *WorkerEffectPayload) (string, 
 		}
 		return defaultWorkerID(), "", false
 	}
+	if payload.ReviveRun != nil {
+		if workerID := strings.TrimSpace(payload.ReviveRun.TargetWorkerID); workerID != "" {
+			return workerID, strings.TrimSpace(payload.ReviveRun.TargetHost), true
+		}
+		if host := strings.TrimSpace(payload.ReviveRun.TargetHost); host != "" {
+			return HostWorkerID(host), host, true
+		}
+		if target := strings.TrimSpace(payload.ReviveRun.Target); target != "" && target != "local" {
+			return target, strings.TrimSpace(payload.ReviveRun.TargetHost), true
+		}
+		return defaultWorkerID(), "", false
+	}
 	if payload.StopRun != nil {
 		if workerID := strings.TrimSpace(payload.StopRun.TargetWorkerID); workerID != "" {
 			return workerID, strings.TrimSpace(payload.StopRun.TargetHost), true
@@ -675,7 +710,8 @@ func marshalWorkerEffectResult(result *WorkerEffectResult) string {
 		result.DiffStatsResult == nil &&
 		result.BranchStateResult == nil &&
 		result.DiffResult == nil &&
-		result.RunWorktreeResult == nil {
+		result.RunWorktreeResult == nil &&
+		result.ReviveRunResult == nil {
 		return ""
 	}
 
@@ -785,6 +821,10 @@ func runFromLeaseSnapshot(lease *WorkerLease) (*model.Run, error) {
 	case "run_worktree":
 		if lease.Payload.RunWorktree != nil {
 			snapshot = lease.Payload.RunWorktree.RunSnapshot
+		}
+	case "revive_run":
+		if lease.Payload.ReviveRun != nil {
+			snapshot = lease.Payload.ReviveRun.RunSnapshot
 		}
 	}
 
@@ -995,6 +1035,19 @@ func (s *SocketServer) executeLeaseEffect(lease *WorkerLease) (*WorkerEffectResu
 			return nil, err
 		}
 		return &WorkerEffectResult{RunWorktreeResult: result}, nil
+	case "revive_run":
+		if lease.Payload == nil || lease.Payload.ReviveRun == nil {
+			return nil, fmt.Errorf("revive_run payload missing")
+		}
+		run, err := runFromLeaseSnapshot(lease)
+		if err != nil {
+			return nil, err
+		}
+		result, err := s.revivePhysical(run, repoCtx.ProjectRoot)
+		if err != nil {
+			return nil, err
+		}
+		return &WorkerEffectResult{ReviveRunResult: result}, nil
 	default:
 		return nil, fmt.Errorf("unsupported worker lease effect: %s", lease.Effect)
 	}

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -249,6 +249,13 @@ func NewStatusEvent(status Status) *Event {
 	return NewEvent(EventTypeStatus, string(status), nil)
 }
 
+// AttrStatusSource is the event attribute carrying the EventSource of a
+// status transition. The store's append guard reads it to decide terminal-
+// exit legality (CanTransitionStatus); an absent attribute means daemon.
+// Today the only writer of a non-daemon source is the revive ladder
+// (ADR-0005 R5): terminal re-entry via send/attach is a user command.
+const AttrStatusSource = "source"
+
 // AttrStatusReason is the event attribute carrying the machine-readable
 // reason for a status verdict. The status vocabulary itself is a closed set;
 // discrimination of *why* a verdict was reached travels as payload, the way
@@ -305,6 +312,22 @@ func NewStatusEventWithReason(status Status, reason string) *Event {
 		return NewStatusEvent(status)
 	}
 	return NewEvent(EventTypeStatus, string(status), map[string]string{AttrStatusReason: reason})
+}
+
+// NewStatusEventWithReasonAndSource is NewStatusEventWithReason with an
+// explicit event source recorded on the event (AttrStatusSource). The store
+// append guard validates terminal-exit legality from that attribute; a
+// daemon source degrades to the attribute-less form so existing events stay
+// byte-identical.
+func NewStatusEventWithReasonAndSource(status Status, reason string, source EventSource) *Event {
+	if source == "" || source == EventSourceDaemon {
+		return NewStatusEventWithReason(status, reason)
+	}
+	attrs := map[string]string{AttrStatusSource: string(source)}
+	if reason != "" {
+		attrs[AttrStatusReason] = reason
+	}
+	return NewEvent(EventTypeStatus, string(status), attrs)
 }
 
 // NewPhaseEvent creates a phase change event

--- a/internal/worker/loop.go
+++ b/internal/worker/loop.go
@@ -214,7 +214,7 @@ func RunExternalLoop(client Client, cfg RunConfig) (err error) {
 // error otherwise; the caller decides between reconnecting and exiting.
 func runWorkerSession(client Client, cfg RunConfig, workerID, host string, executor leaseExecutor, runtimeState *managedRuntimeStateWriter, sigCh <-chan os.Signal, resuming bool, registered *bool) error {
 	if capClient, ok := client.(capabilityRegisterClient); ok {
-		if _, err := capClient.RegisterWorkerWithCapabilities(workerID, "executor", host, "external", []string{"capture_session", "continue_run", "get_branch_state", "get_diff", "get_diff_stats", "run_worktree", "send_message", "start_run", "stop_run"}); err != nil {
+		if _, err := capClient.RegisterWorkerWithCapabilities(workerID, "executor", host, "external", []string{"capture_session", "continue_run", "get_branch_state", "get_diff", "get_diff_stats", "revive_run", "run_worktree", "send_message", "start_run", "stop_run"}); err != nil {
 			return classifyRegisterError(err)
 		}
 	} else if _, err := client.RegisterWorker(workerID, "executor", host, "external"); err != nil {


### PR DESCRIPTION
## 概要
ADR-0005 Stage 3 のコア面(T3a)。reaped run への `orch send` / `orch attach` が、同一 run・同一セッション名・同一 worktree で agent をネイティブ resume し、会話を継続する。**コア変更(step.go の L4 精密化 + status commit の source 軸)を含むため、law/spec/ADR 改訂を同一 change set で同梱**(AGENTS.md routing rule)。

## 設計の要点
- **L4'**: terminal 吸収の唯一の例外 = O8 `stageSessionRevived`(語彙中唯一の user-sourced 観測。revive の入口は user 動詞 send/attach のみ = R6)。効果は `source=user` の running commit ちょうど1つ。store の append guard が `Attrs[source]` から terminal-exit 合法性を再検証(F12 と整合、CanTransitionStatus 無変更)。
- **実測物理**(`docs/design/revive-physics.md` に凍結): claude `--resume <id>` は同一 transcript に追記(identity 不変・文脈継承をファイル内容で証明)、`--session-id` 併用は CLI が拒否(`--fork-session` は新会話意味論 → revive では不使用、defsemgrep で静的禁止)。codex `resume <id>` は rollout 継続、boot 後に T1b 発見腕で id を観測裏取り。**conversation identity は世代を跨いで不変、generation が incarnation 通番** — doeff ADR-DOE-AGENTS-006 の存在論と同型(将来の backend 差し替えにそのまま移行)。
- **plane 分離**(ADR-0004): worker は物理のみ(`revive_run` lease: 前提の host 検査・boot・codex id 再解決)。ledger は master のみ: `session_revived` note → `agent_session` 世代+1(L-S3 ラッチ解消)→ user-sourced 再入。
- **前提は stored facts**(LS5): identity 未記録 / worktree_removed / worktree 消失は事実名 + `restart-from --branch` 導線付きで fail-fast。pending reap-kill との衝突も fail-clearly。
- **adapter の tick 遺物撲滅**: 旧 `--resume <tmuxセッション名>`(claude が解釈できない形)を廃し、resume は AgentSessionID 必須に。control-agent 経路も新契約へ。

## 変更ファイル
step.go(L4' + stage + effect Source)/ status_commit.go(source 軸)/ revive.go(新規)/ worker_plane.go + worker/loop.go(revive_run lease)/ proto_handler.go(send/attach hook)/ agent/claude.go + codex.go / model/event.go(AttrStatusSource)/ spec §13 + L4/L9 / ADR-0005 defadr(R5 精緻化 + 法2本 + defsemgrep)/ revive-physics.md(新規)/ master plan 更新 / テスト(revive_test.go 新規 7本 + L4' matrix + adapter 契約)

## 検証
- `go build ./...` / `ORCH_SAFE_CLI_TEST=1 go test -p 1 ./...` 全 green
- `make lint` green(status write surface に新 writer なし — commit 構築点は 1 箇所のまま)
- `uv run pytest docs/adr -q` **7 passed**(+1 = 新 defsemgrep `adr0005-revive-never-forks` の fixture 証明)
- 完成 gate 5(実 agent での reaped→send→revived→応答 e2e)は merge + deploy 後に実機確認予定(gate 7 と併せて)

🤖 Generated with [Claude Code](https://claude.com/claude-code)