### PR TITLE
fix: repair tmux no-server inventory handling

### DIFF
--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -3663,7 +3663,9 @@ func (s *SocketServer) handleProtoReadAgentPrompt(req *orchpb.ReadAgentPromptReq
 }
 
 func (s *SocketServer) handleProtoRepairState(req *orchpb.RepairStateRequest) *orchpb.Response {
-	result := &orchpb.RepairStateResponse{}
+	result := &orchpb.RepairStateResponse{
+		Details: []string{"session inventory scope: master host only"},
+	}
 
 	if err := CleanupStaleRegistrations(); err != nil {
 		result.Details = append(result.Details, fmt.Sprintf("registry cleanup error: %v", err))
@@ -3744,6 +3746,8 @@ type repairRunContext struct {
 	run         *model.Run
 	issueStatus model.IssueStatus
 	reaper      config.ReaperConfig
+	projectID   string
+	store       store.Store
 }
 
 func (s *SocketServer) findSessionRepairFindings(now time.Time) ([]sessionRepairFinding, error) {
@@ -3823,6 +3827,8 @@ func (s *SocketServer) classifySessionRepairFindings(sessions []string, now time
 				run:         run,
 				issueStatus: issueStatuses[run.IssueID],
 				reaper:      reaperCfg,
+				projectID:   repoCtx.RepoID,
+				store:       repoCtx.Store,
 			}
 		}
 	}
@@ -3856,11 +3862,17 @@ func (s *SocketServer) classifySessionRepairFindings(sessions []string, now time
 			}
 		}
 		if keptReason == "" {
-			exists, existsErr := worktreeDirectoryExists(run.WorktreePath)
+			worktreeResult, existsErr := s.runWorktreeOperation(
+				s.worktreeRequestContext(runCtx.projectID, runCtx.store),
+				run,
+				runWorktreeInspect,
+			)
 			switch {
 			case existsErr != nil:
 				keptReason = fmt.Sprintf("worktree check failed: %v", existsErr)
-			case !exists:
+			case worktreeResult == nil:
+				keptReason = "worktree check failed: inspect returned no result"
+			case !worktreeResult.Exists:
 				keptReason = fmt.Sprintf("worktree does not exist: %s", run.WorktreePath)
 			}
 		}

--- a/internal/daemon/reaper_test.go
+++ b/internal/daemon/reaper_test.go
@@ -6,10 +6,12 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/proboscis/orch/api/orchpb"
 	"github.com/proboscis/orch/internal/config"
 	"github.com/proboscis/orch/internal/model"
 	"github.com/proboscis/orch/internal/store"
@@ -452,5 +454,89 @@ func TestRepairReportsTerminalAliveAndUnreapableKeptSessions(t *testing.T) {
 		if finding.Kind == sessionRepairUnreapableKept && !strings.Contains(finding.Reason, "identity is not recorded") {
 			t.Fatalf("unreapable reason = %q", finding.Reason)
 		}
+	}
+}
+
+func TestRepairUsesExecutionHostWorktreeObservation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	projectRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".orch"), 0o755); err != nil {
+		t.Fatalf("mkdir .orch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, ".orch", "config.yaml"), []byte("reaper:\n  idle_ttl_hours: 168\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	st, err := filestore.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("filestore.New() error = %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	run := createRepairFindingRun(t, st, "repair-remote", "20260713-120004", model.StatusWaiting, now.Add(-8*24*time.Hour), true)
+	const host = "mac-host"
+	workerID := HostWorkerID(host)
+	if err := st.AppendEvent(run.Ref(), &model.Event{
+		Timestamp: now.Add(-8*24*time.Hour - 4*time.Second),
+		Type:      model.EventTypeArtifact,
+		Name:      "target",
+		Attrs: map[string]string{
+			"name":      "mac",
+			"host":      host,
+			"worker_id": workerID,
+		},
+	}); err != nil {
+		t.Fatalf("AppendEvent(target) error = %v", err)
+	}
+	run, err = st.GetRun(run.Ref())
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+	if _, err := server.registerRepoContext("repair-project", projectRoot, "", st); err != nil {
+		t.Fatalf("registerRepoContext() error = %v", err)
+	}
+	if _, ttl := server.registerWorker(workerID, "executor", host, "external", []string{"run_worktree"}); ttl <= 0 {
+		t.Fatal("expected positive heartbeat ttl for worktree worker")
+	}
+
+	go func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			lease := server.leaseWorkForWorker(workerID)
+			if lease == nil {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			_ = server.acknowledgeWorkerLease(workerID, lease.LeaseID, false, "failed to stat "+run.WorktreePath+": permission denied", "")
+			return
+		}
+	}()
+
+	findings, err := server.classifySessionRepairFindings([]string{model.GenerateSessionName(run.IssueID, run.RunID)}, now)
+	if err != nil {
+		t.Fatalf("classifySessionRepairFindings() error = %v", err)
+	}
+	if len(findings) != 1 || findings[0].Kind != sessionRepairUnreapableKept {
+		t.Fatalf("findings = %#v, want one unreapable-kept finding", findings)
+	}
+	for _, want := range []string{"worktree check failed", "execution host " + host, run.WorktreePath, "permission denied"} {
+		if !strings.Contains(findings[0].Reason, want) {
+			t.Fatalf("finding reason = %q, want worker-derived %q", findings[0].Reason, want)
+		}
+	}
+}
+
+func TestRepairStateReportsMasterHostOnlySessionInventoryScope(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	server := NewSocketServer(func(string) (store.Store, error) { return nil, errors.New("unused") }, log.New(io.Discard, "", 0))
+
+	resp := server.handleProtoRepairState(&orchpb.RepairStateRequest{DryRun: true})
+	if !resp.Ok {
+		t.Fatalf("handleProtoRepairState() error = %s", resp.Error)
+	}
+	details := resp.GetRepairState().GetDetails()
+	if !slices.Contains(details, "session inventory scope: master host only") {
+		t.Fatalf("repair details = %q, want master-host-only scope", details)
 	}
 }

--- a/internal/multiplexer/tmux.go
+++ b/internal/multiplexer/tmux.go
@@ -1,6 +1,7 @@
 package multiplexer
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -160,22 +161,38 @@ func (t *TmuxMultiplexer) KillSession(session string) error {
 
 // ListSessions returns all tmux session names.
 func (t *TmuxMultiplexer) ListSessions() ([]string, error) {
-	output, err := t.output("list-sessions", "-F", "#{session_name}")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	_, _, err := t.executor.RunCommand(
+		context.Background(),
+		"tmux",
+		[]string{"list-sessions", "-F", "#{session_name}"},
+		tmuxControlOptions(t.executor, executor.RunOptions{Stdout: &stdout, Stderr: &stderr}),
+	)
 	if err != nil {
-		// tmux returns error if no sessions exist
-		if strings.Contains(err.Error(), "no server running") {
+		stderrText := strings.TrimSpace(stderr.String())
+		if tmuxServerIsAbsent(stderrText) {
 			return nil, nil
+		}
+		if stderrText != "" {
+			return nil, fmt.Errorf("%w: %s", err, stderrText)
 		}
 		return nil, err
 	}
 
 	var sessions []string
-	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
 		if line != "" {
 			sessions = append(sessions, line)
 		}
 	}
 	return sessions, nil
+}
+
+func tmuxServerIsAbsent(stderr string) bool {
+	stderr = strings.TrimSpace(stderr)
+	return strings.Contains(stderr, "no server running") ||
+		(strings.HasPrefix(stderr, "error connecting to ") && strings.HasSuffix(stderr, "(No such file or directory)"))
 }
 
 // ListWindows returns windows for a session.

--- a/internal/multiplexer/tmux_test.go
+++ b/internal/multiplexer/tmux_test.go
@@ -10,10 +10,13 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/proboscis/orch/internal/executor"
 )
 
 type fakeCall struct {
 	output   string
+	stderr   string
 	exitCode int
 }
 
@@ -42,6 +45,7 @@ func (f *fakeExecutor) Command(name string, args ...string) *exec.Cmd {
 		"--",
 		"__orch_multiplexer_helper__",
 		base64.StdEncoding.EncodeToString([]byte(call.output)),
+		base64.StdEncoding.EncodeToString([]byte(call.stderr)),
 		fmt.Sprintf("%d", call.exitCode),
 		name,
 	)
@@ -53,7 +57,7 @@ func (f *fakeExecutor) Command(name string, args ...string) *exec.Cmd {
 }
 
 func TestHelperProcess(t *testing.T) {
-	output, code, ok := helperProcessPayload()
+	output, stderr, code, ok := helperProcessPayload()
 	if !ok {
 		return
 	}
@@ -61,26 +65,33 @@ func TestHelperProcess(t *testing.T) {
 	if output != "" {
 		_, _ = fmt.Fprint(os.Stdout, output)
 	}
+	if stderr != "" {
+		_, _ = fmt.Fprint(os.Stderr, stderr)
+	}
 
 	os.Exit(code)
 }
 
-func helperProcessPayload() (string, int, bool) {
+func helperProcessPayload() (string, string, int, bool) {
 	for i, arg := range os.Args {
-		if arg != "--" || i+4 >= len(os.Args) || os.Args[i+1] != "__orch_multiplexer_helper__" {
+		if arg != "--" || i+5 >= len(os.Args) || os.Args[i+1] != "__orch_multiplexer_helper__" {
 			continue
 		}
 		outputBytes, err := base64.StdEncoding.DecodeString(os.Args[i+2])
 		if err != nil {
-			return "", 2, true
+			return "", "", 2, true
 		}
-		code, err := strconv.Atoi(os.Args[i+3])
+		stderrBytes, err := base64.StdEncoding.DecodeString(os.Args[i+3])
 		if err != nil {
-			return "", 2, true
+			return "", "", 2, true
 		}
-		return string(outputBytes), code, true
+		code, err := strconv.Atoi(os.Args[i+4])
+		if err != nil {
+			return "", "", 2, true
+		}
+		return string(outputBytes), string(stderrBytes), code, true
 	}
-	return "", 0, false
+	return "", "", 0, false
 }
 
 func TestTmuxMultiplexer_Type(t *testing.T) {
@@ -348,6 +359,43 @@ func TestTmuxMultiplexer_ListSessions(t *testing.T) {
 	call := exec.recorded[0]
 	if !equalArgs(call.args, []string{"list-sessions", "-F", "#{session_name}"}) {
 		t.Fatalf("list-sessions args = %v", call.args)
+	}
+}
+
+func TestTmuxMultiplexer_ListSessions_NoServerIsEmpty(t *testing.T) {
+	for _, stderr := range []string{
+		"no server running on /tmp/tmux-1000/default\n",
+		"error connecting to /tmp/tmux-1000/default (No such file or directory)\n",
+	} {
+		t.Run(strings.TrimSpace(stderr), func(t *testing.T) {
+			exec := &fakeExecutor{calls: []fakeCall{{stderr: stderr, exitCode: 1}}}
+			tm := NewTmuxMultiplexerWithExecutor(executor.NewCommandFuncExecutor(exec.Command))
+
+			sessions, err := tm.ListSessions()
+			if err != nil {
+				t.Fatalf("ListSessions() error = %v, want nil", err)
+			}
+			if len(sessions) != 0 {
+				t.Fatalf("ListSessions() = %v, want empty", sessions)
+			}
+		})
+	}
+}
+
+func TestTmuxMultiplexer_ListSessions_OtherExitOneIsError(t *testing.T) {
+	exec := &fakeExecutor{calls: []fakeCall{{
+		output:   "no server running is stdout, not the failure reason\n",
+		stderr:   "permission denied\n",
+		exitCode: 1,
+	}}}
+	tm := NewTmuxMultiplexerWithExecutor(executor.NewCommandFuncExecutor(exec.Command))
+
+	_, err := tm.ListSessions()
+	if err == nil {
+		t.Fatal("ListSessions() error = nil, want exit-1 failure")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("ListSessions() error = %q, want stderr cause", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- treat tmux's canonical no-server stderr responses as an empty session inventory while preserving every other exit-1 failure
- make `orch repair` explicitly report that session inventory is master-host-only
- route unreapable-kept worktree inspection through the existing `run_worktree` execution-host lease
- record `repair-worker-session-inventory-routing` (`318da626`) as the batched-per-host inventory and cleanup follow-up

## Root cause

`TmuxMultiplexer.ListSessions` checked `err.Error()` for "no server running", but the executor carries tmux's diagnostic in command stderr, so the normal no-server exit status 1 surfaced as a repair problem. Repair also listed the master process's multiplexer directly and classified worktree existence with a master-local stat even for worker-hosted runs.

The worker-lease law requires future list enrichment to be batched per host, so this PR labels the current inventory scope honestly and leaves full inventory/kill routing to the tracked follow-up instead of adding per-run lease fan-out.

## Acceptance evidence

1. No-server is empty; unrelated exit 1 remains an error:
   - `TestTmuxMultiplexer_ListSessions_NoServerIsEmpty`
   - `TestTmuxMultiplexer_ListSessions_OtherExitOneIsError`
   - the latter puts a misleading no-server phrase on stdout and verifies stderr still controls the classification
2. Inventory scope is explicit:
   - `TestRepairStateReportsMasterHostOnlySessionInventoryScope`
   - follow-up issue: `repair-worker-session-inventory-routing` (`318da626`), with a worker-only red counterexample and batched-per-host contract
3. Worker-hosted worktree reasons use the execution host:
   - `TestRepairUsesExecutionHostWorktreeObservation` keeps the path present on the master, returns a worker-side permission failure, and asserts the resulting reason includes `execution host mac-host`, the path, and the concrete cause
4. Required gates:
   - `go build ./...` — pass
   - `go test ./...` — pass
   - `make lint` — pass, zero architecture findings

No run status-event write surface was changed.

Issue: `repair-tmux-no-server-phantom-error`
