### PR TITLE
ADR-0005 revive: resumed REPL の ready 待ち(send-keys レース修正)

### DIFF
--- a/docs/design/revive-physics.md
+++ b/docs/design/revive-physics.md
@@ -45,3 +45,16 @@ codex は同日の doeff ADR-DOE-AGENTS-006 Phase 0 プローブ、codex 0.144.1
 - doeff ADR-DOE-AGENTS-006 の存在論(会話 = 耐久エンティティ、session 行 =
   incarnation)と同型。backend を doeff-sessionhost に差し替える将来の
   メジャー版でも、この意味論はそのまま移行する。
+
+## revive 後の send-keys レース(2026-07-13 実機ゲート検証での実測)
+
+- fresh launch は prompt を **argv** で渡すため REPL の入力受付を待つ必要が
+  ないが、revive の保留メッセージは boot 後に **send-keys** で配送される。
+  resume 中(数秒)の端末に打鍵されたキーは REPL の入力欄が存在する前に
+  素の端末へ流れて**失われる**。実測: 質問文が codex バナーの**上**に
+  生エコーとして表示され、入力としては受理されなかった(revive-gate-live
+  run dfb9f5、第2世代)。
+- 対策(実装済み): revive は resumed REPL が入力プロンプトを描画するまで
+  待って初めて完了とする。マーカー実測値: claude = `❯`、codex 0.144 = `›`。
+  タイムアウト時は半起動セッションを kill して(reaped・セッション無しの
+  一貫状態へ戻し)fail-clearly — 次の send が再試行できる。

--- a/internal/daemon/revive.go
+++ b/internal/daemon/revive.go
@@ -33,12 +33,33 @@ var reviveLeaseTimeout = 120 * time.Second
 // identity re-resolution (T1b arm, reused by revive with generation+1).
 var reviveResolveCodexSessionID = agent.ResolveCodexSessionIDWithRetry
 
+// reviveReadyTimeout bounds the post-boot wait for the resumed REPL to render
+// its input prompt. A fresh launch never needs this (the prompt travels as
+// argv), but a revive delivers the pending message via send-keys AFTERWARD —
+// keys typed while the agent is still booting are swallowed by the raw
+// terminal before the REPL exists (measured 2026-07-13, revive-physics.md:
+// the question was visible ABOVE the codex banner as raw echo, never received
+// as input). Variable for tests.
+var reviveReadyTimeout = 60 * time.Second
+
+// reviveReadyPattern is the per-agent REPL input marker to wait for before a
+// revive is considered complete. Measured on the real CLIs (revive-physics.md):
+// claude renders its input line with "❯", codex 0.144 with "›". These are
+// revive-local on purpose — Adapter.ReadyPattern() is the InjectionTmux launch
+// seam and claude/codex are InjectionArg there.
+var reviveReadyPattern = map[agent.AgentType]string{
+	agent.AgentClaude: "❯",
+	agent.AgentCodex:  "›",
+}
+
 // reviveMultiplexer is the slice of multiplexer.Multiplexer revive needs;
 // narrowed for tests.
 type reviveMultiplexer interface {
 	Type() multiplexer.Type
 	HasSession(name string) bool
 	NewSession(cfg *multiplexer.SessionConfig) error
+	WaitForReady(session, pattern string, timeout time.Duration) error
+	KillSession(session string) error
 }
 
 // getReviveMultiplexer is a test seam resolving the run's recorded
@@ -161,6 +182,20 @@ func (s *SocketServer) revivePhysical(run *model.Run, projectRoot string) (*Revi
 		Env:         env,
 	}); err != nil {
 		return nil, fmt.Errorf("revive %s: failed to create session: %w", ref, err)
+	}
+
+	// The pending message is delivered via send-keys AFTER the revive, so the
+	// revive is complete only when the resumed REPL renders its input prompt —
+	// keys typed into a still-booting agent are lost (revive-physics.md). On
+	// timeout, kill the half-booted session so the run's observable state
+	// stays consistent (reaped, no session) and the next send can retry.
+	if pattern := reviveReadyPattern[agentType]; pattern != "" {
+		if err := mux.WaitForReady(sessionName, pattern, reviveReadyTimeout); err != nil {
+			if killErr := mux.KillSession(sessionName); killErr != nil {
+				return nil, fmt.Errorf("revive %s: resumed REPL never became ready (%v) AND cleanup kill failed: %w", ref, err, killErr)
+			}
+			return nil, fmt.Errorf("revive %s: resumed REPL never became ready within %s (session cleaned up; resend to retry): %w", ref, reviveReadyTimeout, err)
+		}
 	}
 
 	result := &ReviveRunResult{

--- a/internal/daemon/revive_test.go
+++ b/internal/daemon/revive_test.go
@@ -18,7 +18,10 @@ import (
 type mockReviveMux struct {
 	hasSession bool
 	newErr     error
+	readyErr   error
 	booted     []*multiplexer.SessionConfig
+	readyWaits []string // "session|pattern"
+	killed     []string
 }
 
 func (m *mockReviveMux) Type() multiplexer.Type { return multiplexer.TypeTmux }
@@ -26,6 +29,14 @@ func (m *mockReviveMux) HasSession(string) bool { return m.hasSession }
 func (m *mockReviveMux) NewSession(cfg *multiplexer.SessionConfig) error {
 	m.booted = append(m.booted, cfg)
 	return m.newErr
+}
+func (m *mockReviveMux) WaitForReady(session, pattern string, _ time.Duration) error {
+	m.readyWaits = append(m.readyWaits, session+"|"+pattern)
+	return m.readyErr
+}
+func (m *mockReviveMux) KillSession(session string) error {
+	m.killed = append(m.killed, session)
+	return nil
 }
 
 // createReapedTestRun builds a run whose CURRENT generation is recorded as
@@ -272,5 +283,47 @@ func TestStepTerminalAbsorbsAllObservationsExceptReviveMilestone(t *testing.T) {
 	_, effects := stepRun(view, runCore{}, runObservation{Kind: obsLaunchProgress, Launch: launchReached(stageSessionRevived)}, time.Now())
 	if len(effects) != 1 || effects[0].Kind != effectSetStatus || effects[0].Status != model.StatusRunning || effects[0].Source != model.EventSourceUser {
 		t.Fatalf("revive milestone on terminal view must yield exactly one user-sourced running commit, got %+v", effects)
+	}
+}
+
+func TestReviveWaitsForResumedREPLBeforeCompleting(t *testing.T) {
+	st, run := createReapedTestRun(t, "claude", true)
+	mux := &mockReviveMux{}
+	withMockReviveMux(t, mux)
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+
+	if _, err := server.reviveIfReaped(st, "project", t.TempDir(), run); err != nil {
+		t.Fatalf("reviveIfReaped() error = %v", err)
+	}
+	session := model.GenerateSessionName(run.IssueID, run.RunID)
+	if len(mux.readyWaits) != 1 || mux.readyWaits[0] != session+"|❯" {
+		t.Fatalf("revive must wait for the claude input prompt before completing, got %v", mux.readyWaits)
+	}
+}
+
+func TestReviveReadyTimeoutCleansUpHalfBootedSession(t *testing.T) {
+	st, run := createReapedTestRun(t, "codex", true)
+	mux := &mockReviveMux{readyErr: fmt.Errorf("pattern not found before timeout")}
+	withMockReviveMux(t, mux)
+	prevResolve := reviveResolveCodexSessionID
+	reviveResolveCodexSessionID = func(string, string, time.Duration) (string, error) { return "conv-8888", nil }
+	t.Cleanup(func() { reviveResolveCodexSessionID = prevResolve })
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+
+	_, err := server.reviveIfReaped(st, "project", t.TempDir(), run)
+	if err == nil || !strings.Contains(err.Error(), "never became ready") {
+		t.Fatalf("ready timeout must fail the revive, got %v", err)
+	}
+	session := model.GenerateSessionName(run.IssueID, run.RunID)
+	if len(mux.killed) != 1 || mux.killed[0] != session {
+		t.Fatalf("half-booted session must be cleaned up, killed=%v", mux.killed)
+	}
+	// The ledger must be untouched: the run stays reaped so the next send retries.
+	fresh, err := st.GetRun(run.Ref())
+	if err != nil {
+		t.Fatalf("GetRun() error = %v", err)
+	}
+	if !fresh.SessionReaped() || fresh.AgentSessionGeneration != 1 {
+		t.Fatalf("failed revive must leave the latch intact (gen=%d reaped=%v)", fresh.AgentSessionGeneration, fresh.SessionReaped())
 	}
 }


### PR DESCRIPTION
実機ゲート検証(revive-gate-live)で発見した T3a のギャップ修正。詳細は commit message と docs/design/revive-physics.md 追記を参照。検証: フルスイート+lint green、回帰テスト2本追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)