### PR TITLE
ADR-0005 §13.1: reap↔revive の per-run 直列化(L-S4)+ pending retry 再観測

### DIFF
--- a/docs/design/run-state-machine.md
+++ b/docs/design/run-state-machine.md
@@ -1052,3 +1052,21 @@ latch dissolution, user-sourced re-entry, each precondition's typed
 failure, pending-kill collision), the L4' matrix case in
 `TestStepTerminalAbsorbsAllObservationsExceptReviveMilestone`, and the
 adapter argv contracts in `internal/agent/{claude,codex}_test.go`.
+
+### §13.1 Reap↔revive serialization (added 2026-07-13, after a live race)
+
+Both master-side session-lifecycle actors — the reaper's kill (including its
+pending retry) and the revive boot — target the generation-INVARIANT session
+name. Observed live (revive-gate-live, 2026-07-13): a reaper pass that read
+its row before a concurrent revive landed killed the generation-4 session it
+had just booted, in the same second.
+
+Law (L-S4): a reap kill and a revive never interleave for the same run; each
+re-derives its decision from the authoritative run UNDER a shared per-run
+lock (`SocketServer.runLifecycleLocks`), so a kill decision can never outlive
+a generation change. The pending-kill retry additionally re-OBSERVES before
+killing: an absent session means the kill goal already holds (quiet no-op —
+idempotent kills otherwise turn the retry into an every-pass "reaped" log),
+and a live session under the lock is provably the decision row's own
+generation. Tests: `TestReaperPendingKillIsQuietWhenSessionAbsent`,
+`TestReviveReloadsRunUnderLifecycleLock` (internal/daemon).

--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -112,23 +112,31 @@ func (d *Daemon) reapAllAt(now time.Time) {
 			if listedRun == nil {
 				continue
 			}
-			// ListRuns may be served by an index/projection that omits the run
-			// document path. Re-read the authoritative run before persisting a
-			// sidecar and before evaluating the newest event-log interlocks.
-			run, err := repoCtx.Store.GetRun(listedRun.Ref())
+			// Serialize the whole decide-observe-kill against revive
+			// (run-state-machine.md §13): the kill targets the generation-
+			// invariant session name, so deciding from a row read outside
+			// the lock can destroy a session a concurrent revive just
+			// booted. The authoritative re-read below MUST happen inside
+			// the lock for the same reason (it also covers index-served
+			// ListRuns rows that omit the run document path and the newest
+			// event-log interlocks).
+			outcome, err := func() (reapRunOutcome, error) {
+				unlock := d.socketServer.lockRunLifecycle(listedRun.Ref().String())
+				defer unlock()
+				run, err := repoCtx.Store.GetRun(listedRun.Ref())
+				if err != nil {
+					return reapRunOutcome{}, fmt.Errorf("load authoritative run: %w", err)
+				}
+				return reapRun(run, issueStatuses[run.IssueID], repoCtx.Store, repoCtx.RepoID, repoCtx.ProjectRoot, reaperCfg, now, deps)
+			}()
 			if err != nil {
-				d.logReaper("session reaper failed to load authoritative run %s: %v", listedRun.Ref().String(), err)
-				continue
-			}
-			outcome, err := reapRun(run, issueStatuses[run.IssueID], repoCtx.Store, repoCtx.RepoID, repoCtx.ProjectRoot, reaperCfg, now, deps)
-			if err != nil {
-				d.logReaper("session reaper failed for %s: %v", run.Ref().String(), err)
+				d.logReaper("session reaper failed for %s: %v", listedRun.Ref().String(), err)
 				continue
 			}
 			if outcome.KeptReason != "" {
-				d.logReaper("session reaper kept %s (%s): %s", run.Ref().String(), outcome.Reason, outcome.KeptReason)
+				d.logReaper("session reaper kept %s (%s): %s", listedRun.Ref().String(), outcome.Reason, outcome.KeptReason)
 			} else if outcome.Reaped {
-				d.logReaper("session reaper reaped %s (%s)", run.Ref().String(), outcome.Reason)
+				d.logReaper("session reaper reaped %s (%s)", listedRun.Ref().String(), outcome.Reason)
 			}
 		}
 	}
@@ -202,15 +210,28 @@ func reapRun(
 	if err := validateReaperMultiplexer(run); err != nil {
 		return outcome, err
 	}
+	if deps.Observe == nil || deps.Persist == nil {
+		return outcome, fmt.Errorf("session reaper dependencies incomplete")
+	}
 	if pendingKill {
+		// The retry arm re-OBSERVES before killing: with idempotent kills a
+		// blind retry would log "reaped" every pass forever on an absent
+		// session, and — worse — a stale pending decision could destroy a
+		// session a newer generation just booted (the per-run lifecycle lock
+		// closes that race; the observation keeps the retry quiet once the
+		// kill goal already holds).
+		observation, err := deps.Observe(run, projectID, projectRoot)
+		if err != nil {
+			return outcome, err
+		}
+		if !observation.SessionAlive {
+			return outcome, nil
+		}
 		if err := attemptReaperKill(run, st, projectID, projectRoot, deps.Kill); err != nil {
 			return outcome, err
 		}
 		outcome.Reaped = true
 		return outcome, nil
-	}
-	if deps.Observe == nil || deps.Persist == nil {
-		return outcome, fmt.Errorf("session reaper dependencies incomplete")
 	}
 
 	observation, err := deps.Observe(run, projectID, projectRoot)

--- a/internal/daemon/reaper_test.go
+++ b/internal/daemon/reaper_test.go
@@ -254,15 +254,19 @@ func TestSessionReaperKillFailureRecordsErrorAndRetriesNextPass(t *testing.T) {
 	if snapshotArtifacts != 1 || reapNotes != 1 || errorArtifacts != 1 {
 		t.Fatalf("bounded retry ledger: snapshots=%d reap_notes=%d errors=%d, want 1 each", snapshotArtifacts, reapNotes, errorArtifacts)
 	}
-	if observeCalls != 1 || persistCalls != 1 || killCalls != 2 {
-		t.Fatalf("retry calls: observe=%d persist=%d kill=%d, want 1,1,2", observeCalls, persistCalls, killCalls)
+	// The retry arm re-OBSERVES before each kill attempt (§13.1: quiet no-op
+	// once the session is gone; the per-run lock makes a live observation
+	// provably the decision row's own generation) — but it never re-persists
+	// or re-appends, so the ledger stays bounded.
+	if observeCalls != 2 || persistCalls != 1 || killCalls != 2 {
+		t.Fatalf("retry calls: observe=%d persist=%d kill=%d, want 2,1,2", observeCalls, persistCalls, killCalls)
 	}
 
 	outcome, err := reapRun(afterTwoFailures, model.IssueStatusOpen, st, "project", t.TempDir(), cfg, now.Add(2*time.Minute), deps)
 	if err != nil {
 		t.Fatalf("successful retry reap error = %v", err)
 	}
-	if !outcome.Reaped || killCalls != 3 || observeCalls != 1 || persistCalls != 1 {
+	if !outcome.Reaped || killCalls != 3 || observeCalls != 3 || persistCalls != 1 {
 		t.Fatalf("successful retry outcome=%#v observe=%d persist=%d kill=%d", outcome, observeCalls, persistCalls, killCalls)
 	}
 

--- a/internal/daemon/revive.go
+++ b/internal/daemon/revive.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/proboscis/orch/internal/agent"
@@ -232,6 +233,21 @@ func (s *SocketServer) reviveRunForVerb(st store.Store, projectID, projectRoot s
 	if st == nil || run == nil {
 		return fmt.Errorf("store and run required")
 	}
+
+	// Serialize against the reaper's kill (run-state-machine.md §13): both
+	// actors target the generation-invariant session name, so they must
+	// re-derive their decision under the same per-run lock. Re-read the
+	// authoritative run inside the lock — the caller's row may be stale.
+	unlock := s.lockRunLifecycle(run.Ref().String())
+	defer unlock()
+	if fresh, err := st.GetRun(run.Ref()); err == nil && fresh != nil {
+		run = fresh
+	}
+	if !run.SessionReaped() {
+		// A concurrent revive won the lock first; the session exists again.
+		return nil
+	}
+
 	if err := checkRevivePreconditions(run); err != nil {
 		return err
 	}
@@ -293,6 +309,15 @@ func (s *SocketServer) reviveRunForVerb(st store.Store, projectID, projectRoot s
 	s.reportLaunchProgress(st, run, launchReached(stageSessionRevived))
 	s.logger.Printf("%s#%s: revived session %s (agent=%s generation=%d)", run.IssueID, run.RunID, result.SessionName, run.Agent, result.Generation)
 	return nil
+}
+
+// lockRunLifecycle acquires the per-run session-lifecycle lock shared by the
+// reaper's kill path and the revive boot; the returned func releases it.
+func (s *SocketServer) lockRunLifecycle(ref string) func() {
+	muIface, _ := s.runLifecycleLocks.LoadOrStore(ref, &sync.Mutex{})
+	mu := muIface.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
 }
 
 // reviveIfReaped is the send/attach entry hook: a run whose CURRENT

--- a/internal/daemon/revive_test.go
+++ b/internal/daemon/revive_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/proboscis/orch/internal/config"
 	"github.com/proboscis/orch/internal/model"
 	"github.com/proboscis/orch/internal/multiplexer"
 	"github.com/proboscis/orch/internal/store"
@@ -325,5 +326,45 @@ func TestReviveReadyTimeoutCleansUpHalfBootedSession(t *testing.T) {
 	}
 	if !fresh.SessionReaped() || fresh.AgentSessionGeneration != 1 {
 		t.Fatalf("failed revive must leave the latch intact (gen=%d reaped=%v)", fresh.AgentSessionGeneration, fresh.SessionReaped())
+	}
+}
+
+func TestReaperPendingKillIsQuietWhenSessionAbsent(t *testing.T) {
+	st, run := createReapedTestRun(t, "codex", true)
+	killCalls := 0
+	deps := sessionReaperDeps{
+		Observe: func(*model.Run, string, string) (reaperSessionObservation, error) {
+			return reaperSessionObservation{WorktreeExists: true, SessionAlive: false}, nil
+		},
+		Persist: persistSessionSnapshot,
+		Kill:    func(*model.Run, string, string) error { killCalls++; return nil },
+	}
+	outcome, err := reapRun(run, model.IssueStatusOpen, st, "project", t.TempDir(), config.DefaultReaperConfig(), time.Now(), deps)
+	if err != nil {
+		t.Fatalf("reapRun() error = %v", err)
+	}
+	if !outcome.Due || outcome.Reaped || killCalls != 0 {
+		t.Fatalf("pending retry on an absent session must be a quiet no-op (due=%v reaped=%v kills=%d)", outcome.Due, outcome.Reaped, killCalls)
+	}
+}
+
+func TestReviveReloadsRunUnderLifecycleLock(t *testing.T) {
+	// The caller hands revive a STALE row that still folds as reaped; the
+	// authoritative store already has the generation-2 identity (a concurrent
+	// revive won). Under the lock the fresh row must win: no second boot.
+	st, run := createReapedTestRun(t, "claude", true)
+	stale := run
+	if err := st.AppendEvent(run.Ref(), model.NewArtifactEvent("agent_session", map[string]string{"backend": "claude", "id": "conv-8888", "generation": "2"})); err != nil {
+		t.Fatalf("AppendEvent() error = %v", err)
+	}
+	mux := &mockReviveMux{}
+	withMockReviveMux(t, mux)
+	server := NewSocketServer(func(string) (store.Store, error) { return st, nil }, log.New(io.Discard, "", 0))
+
+	if err := server.reviveRunForVerb(st, "project", t.TempDir(), stale); err != nil {
+		t.Fatalf("reviveRunForVerb() on stale row error = %v", err)
+	}
+	if len(mux.booted) != 0 {
+		t.Fatal("revive must re-read under the lock and skip the boot when the latch is already dissolved")
 	}
 }

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -309,6 +309,15 @@ type SocketServer struct {
 	gitRunner     git.Runner
 	procManager   ProcessManager
 
+	// runLifecycleLocks serializes the two master-side actors that create or
+	// destroy a run's session — the reaper's kill (including its pending
+	// retry) and the revive boot (run-state-machine.md §13). Both act on the
+	// generation-invariant session NAME, so an unserialized reaper working
+	// from a stale row can destroy a session a concurrent revive just booted
+	// (observed live 2026-07-13: revive g4 and a pending-g3 reap in the same
+	// second). Keyed by run ref string; entries are tiny and never collected.
+	runLifecycleLocks sync.Map
+
 	managedServerStore *managedServerStore
 
 	repos                map[string]*RepoContext


### PR DESCRIPTION
実機ゲート検証で観測した live race の根治。詳細は commit message / spec §13.1 参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)