### PR TITLE
Improve remote-master repo registration diagnostics

### DIFF
--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -144,7 +144,7 @@ the agent commit, push, and open a PR — the run then parks at `pr_open`.
 
 | Error | Fix |
 |-------|-----|
-| `project identity required` | repo has no `origin` remote, or you are outside the repo |
+| `project identity required` | repo has no `origin` remote, or you are outside the repo. With a remote master, `PROJECT_PATH` must exist on the daemon host; run `orch daemon repo register <path>` there with the daemon-local checkout path. |
 | `unknown project_id "…"` | run `orch daemon repo register "$(pwd)"` |
 | `no active worker on host "…"` | should not happen locally (workers auto-start); check `ORCH_WORKER_AUTOSTART`, or run `orch worker start` |
 | `agent not available: … (worker …, host …; probe "…"; PATH=…)` | the named worker cannot run that agent CLI — the probe and PATH in the error say why; fix PATH or log in on that host, then restart the worker from a login shell |

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -3327,6 +3327,17 @@ func (s *SocketServer) handleProtoRegisterRepo(req *orchpb.RegisterRepoRequest) 
 		if projectRoot == "" {
 			return errorResponse("repo URL required")
 		}
+		if _, err := os.Stat(projectRoot); os.IsNotExist(err) {
+			daemonHost, hostnameErr := currentDaemonHostname()
+			if hostnameErr != nil || strings.TrimSpace(daemonHost) == "" {
+				daemonHost = "unknown"
+			}
+			return errorResponse(fmt.Sprintf(
+				"path %q does not exist on daemon host %q; run 'orch daemon repo register <path>' from the daemon host",
+				projectRoot,
+				strings.TrimSpace(daemonHost),
+			))
+		}
 		repoID, err = s.repoIDForProjectRoot(projectRoot)
 		if err != nil {
 			return errorResponse(err.Error())

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -4068,6 +4068,49 @@ func TestRegisterRepoAPIRejectsPathWithoutRemote(t *testing.T) {
 	if !strings.Contains(resp.Error, "project identity required") {
 		t.Fatalf("expected project identity guidance, got: %s", resp.Error)
 	}
+	if !strings.Contains(resp.Error, "configure git remote origin") {
+		t.Fatalf("expected origin remote guidance, got: %s", resp.Error)
+	}
+	if strings.Contains(resp.Error, "does not exist on daemon host") {
+		t.Fatalf("existing path should not report a daemon-host path error: %s", resp.Error)
+	}
+}
+
+func TestRegisterRepoAPIRejectsPathMissingOnDaemonHost(t *testing.T) {
+	cleanup := setupXDGTestEnv(t)
+	defer cleanup()
+	setDaemonHostname(t, "remote-master")
+
+	logger := log.New(io.Discard, "", 0)
+	server := NewSocketServer(nil, logger)
+	if err := server.Start(); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	defer server.Stop()
+
+	missingPath := filepath.Join(t.TempDir(), "client-only-repo")
+	resp := sendProtoRequest(t, &orchpb.Request{
+		Request: &orchpb.Request_RegisterRepo{
+			RegisterRepo: &orchpb.RegisterRepoRequest{ProjectRoot: missingPath},
+		},
+	})
+
+	if resp.Ok {
+		t.Fatal("expected register repo to fail for path missing on daemon host")
+	}
+	for _, want := range []string{
+		missingPath,
+		"does not exist on daemon host",
+		"remote-master",
+		"from the daemon host",
+	} {
+		if !strings.Contains(resp.Error, want) {
+			t.Fatalf("expected error to contain %q, got: %s", want, resp.Error)
+		}
+	}
+	if strings.Contains(resp.Error, "configure git remote origin") {
+		t.Fatalf("missing daemon path should not report origin remote guidance: %s", resp.Error)
+	}
 }
 
 func TestDeriveRepoID(t *testing.T) {


### PR DESCRIPTION
## Summary

- detect a missing `PROJECT_PATH` on the daemon host before attempting git identity resolution
- report the path, daemon hostname, and the actionable daemon-host registration command
- preserve the existing origin-remote guidance for paths that do exist
- document the remote-master path requirement in `docs/agent-install.md`

## Root cause

Repo registration attempted to derive identity from the daemon-local filesystem without first distinguishing a path that was absent on the daemon host. The resulting git failure was converted into generic origin-remote guidance, even when the client checkout already had an origin.

## Acceptance criteria evidence

### Client-only path against a remote daemon

Command:

```console
/tmp/orch-repo-register-diag --remote=127.0.0.1:47771 daemon repo register /client-only/orch-sandbox
```

Observed result (exit 10):

```text
daemon error: path "/client-only/orch-sandbox" does not exist on daemon host "CA-20035844"; run 'orch daemon repo register <path>' from the daemon host
```

### Existing path without an origin remote

Command:

```console
/tmp/orch-repo-register-diag --remote=127.0.0.1:47771 daemon repo register /tmp/orch-repo-register-diag.fbmGkT/existing-no-origin
```

Observed result (exit 10):

```text
daemon error: project identity required for /tmp/orch-repo-register-diag.fbmGkT/existing-no-origin: set --project/ORCH_PROJECT to a repo ID or configure git remote origin
```

The focused API tests also assert that the two diagnoses never appear in the wrong case.

## Validation

- `go test ./internal/daemon -run 'TestRegisterRepoAPI(RejectsPathWithoutRemote|RejectsPathMissingOnDaemonHost)$' -count=1 -v`
- `go test ./internal/daemon -count=1`
- `go test ./... -count=1`
- `go build ./...`
- `make lint`
- `git diff --check`

Issue: `repo-register-remote-master-diagnostics`