### PR TITLE
fix: unify wait run reference resolution

### DIFF
--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -661,6 +661,10 @@ func isAmbiguousRunLookupError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "ambiguous")
 }
 
+func ambiguousRunRefResponse(ref string) *orchpb.Response {
+	return errorResponse(fmt.Sprintf("ambiguous run ref: %s", strings.TrimSpace(ref)))
+}
+
 func parseWaitRunRef(ref string) (*model.RunRef, string, error) {
 	trimmed := strings.TrimSpace(ref)
 	if trimmed == "" {
@@ -674,8 +678,8 @@ func parseWaitRunRef(ref string) (*model.RunRef, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	if parsed == nil || parsed.RunID == "" {
-		return nil, "", fmt.Errorf("invalid run ref %q: use a short ID or ISSUE#RUN", trimmed)
+	if parsed == nil {
+		return nil, "", fmt.Errorf("invalid run ref %q", trimmed)
 	}
 
 	return parsed, "", nil
@@ -689,10 +693,13 @@ func (s *SocketServer) resolveWaitRunTarget(ctx *orchpb.RequestContext, ref stri
 
 	projectID := projectIDFromContext(ctx)
 	resolveInStore := func(st store.Store) (*model.Run, error) {
-		if shortID != "" {
-			return st.GetRunByShortID(model.ShortID(shortID))
+		issueID := ""
+		runID := ""
+		if runRef != nil {
+			issueID = string(runRef.IssueID)
+			runID = string(runRef.RunID)
 		}
-		return st.GetRun(runRef)
+		return resolveRunForMutation(st, issueID, runID, shortID)
 	}
 
 	if projectID != "" {
@@ -706,7 +713,7 @@ func (s *SocketServer) resolveWaitRunTarget(ctx *orchpb.RequestContext, ref stri
 				return nil, errorResponse(fmt.Sprintf("run not found: %s", strings.TrimSpace(ref)))
 			}
 			if isAmbiguousRunLookupError(err) {
-				return nil, errorResponse(fmt.Sprintf("ambiguous run ref: %s", strings.TrimSpace(ref)))
+				return nil, ambiguousRunRefResponse(ref)
 			}
 			return nil, errorResponse(s.storeOperationError(st, projectID, "run lookup", err))
 		}
@@ -721,7 +728,7 @@ func (s *SocketServer) resolveWaitRunTarget(ctx *orchpb.RequestContext, ref stri
 				continue
 			}
 			if isAmbiguousRunLookupError(err) {
-				return nil, errorResponse(fmt.Sprintf("ambiguous run ref: %s", strings.TrimSpace(ref)))
+				return nil, ambiguousRunRefResponse(ref)
 			}
 			return nil, errorResponse(s.storeOperationError(st, "", "run lookup", err))
 		}
@@ -729,7 +736,7 @@ func (s *SocketServer) resolveWaitRunTarget(ctx *orchpb.RequestContext, ref stri
 			continue
 		}
 		if resolved != nil {
-			return nil, errorResponse(fmt.Sprintf("ambiguous run ref: %s", strings.TrimSpace(ref)))
+			return nil, ambiguousRunRefResponse(ref)
 		}
 		resolved = &waitRunTarget{ref: strings.TrimSpace(ref), run: run, store: st}
 	}
@@ -1349,6 +1356,9 @@ func (s *SocketServer) handleProtoGetRun(req *orchpb.GetRunRequest) *orchpb.Resp
 
 		resolved, err := st.GetRun(ref)
 		if err != nil {
+			if isAmbiguousRunLookupError(err) {
+				return ambiguousRunRefResponse(ref.String())
+			}
 			return errorResponse("not_found")
 		}
 		run = resolved
@@ -2298,6 +2308,13 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 			run, err = st.GetRun(ref)
 		}
 		if err != nil {
+			if isAmbiguousRunLookupError(err) {
+				ref := req.ShortId
+				if ref == "" {
+					ref = (&model.RunRef{IssueID: model.IssueID(req.IssueId), RunID: model.RunID(req.RunId)}).String()
+				}
+				return ambiguousRunRefResponse(ref)
+			}
 			return errorResponse("not_found")
 		}
 		runStore = st
@@ -2314,7 +2331,7 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 						continue
 					}
 					if strings.Contains(strings.ToLower(err.Error()), "ambiguous") {
-						return errorResponse(fmt.Sprintf("ambiguous short id: %s", req.ShortId))
+						return ambiguousRunRefResponse(req.ShortId)
 					}
 					return errorResponse(s.storeOperationError(st, "", "short run lookup", err))
 				}
@@ -2334,7 +2351,7 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 			}
 			if run != nil {
 				if req.ShortId != "" {
-					return errorResponse(fmt.Sprintf("ambiguous short id: %s", req.ShortId))
+					return ambiguousRunRefResponse(req.ShortId)
 				}
 				return errorResponse(fmt.Sprintf("ambiguous run ref: %s#%s", req.IssueId, req.RunId))
 			}
@@ -3167,6 +3184,9 @@ func (s *SocketServer) handleProtoGetRunByShortID(req *orchpb.GetRunByShortIDReq
 
 		resolved, err := st.GetRunByShortID(model.ShortID(req.ShortId))
 		if err != nil {
+			if isAmbiguousRunLookupError(err) {
+				return ambiguousRunRefResponse(req.ShortId)
+			}
 			return errorResponse("not_found")
 		}
 		run = resolved
@@ -3178,7 +3198,7 @@ func (s *SocketServer) handleProtoGetRunByShortID(req *orchpb.GetRunByShortIDReq
 					continue
 				}
 				if strings.Contains(strings.ToLower(err.Error()), "ambiguous") {
-					return errorResponse(fmt.Sprintf("ambiguous short id: %s", req.ShortId))
+					return ambiguousRunRefResponse(req.ShortId)
 				}
 				return errorResponse(s.storeOperationError(st, "", "short run lookup", err))
 			}
@@ -3186,7 +3206,7 @@ func (s *SocketServer) handleProtoGetRunByShortID(req *orchpb.GetRunByShortIDReq
 				continue
 			}
 			if run != nil {
-				return errorResponse(fmt.Sprintf("ambiguous short id: %s", req.ShortId))
+				return ambiguousRunRefResponse(req.ShortId)
 			}
 			run = resolved
 		}

--- a/internal/daemon/proto_handler_test.go
+++ b/internal/daemon/proto_handler_test.go
@@ -240,6 +240,14 @@ type waitForRunsStatusStore struct {
 	calls int
 }
 
+type ambiguousShortIDStore struct {
+	*mockStore
+}
+
+func (s *ambiguousShortIDStore) GetRunByShortID(model.ShortID) (*model.Run, error) {
+	return nil, fmt.Errorf("ambiguous short ID")
+}
+
 type resolveRunTestStore struct {
 	mockStore
 	appendErr          error
@@ -1554,6 +1562,81 @@ func TestHandleProtoWaitForRunsReturnsImmediatelyForShortID(t *testing.T) {
 	}
 	if waitResp.PrUrl != run.PRUrl {
 		t.Fatalf("pr_url = %q, want %q", waitResp.PrUrl, run.PRUrl)
+	}
+}
+
+func TestHandleProtoWaitForRunsReturnsImmediatelyForIssueID(t *testing.T) {
+	run := &model.Run{
+		IssueID: "issue-latest",
+		RunID:   "20260101-010101",
+		Status:  model.StatusPROpen,
+		PRUrl:   "https://example.test/pr/456",
+	}
+	st := &resolveRunTestStore{
+		mockStore: mockStore{
+			runs: map[string]*model.Run{
+				run.Ref().String(): run,
+			},
+		},
+		latestRun: run,
+	}
+	server, ctx := newResolveRunHandlerTestServer(t, st)
+
+	resp := server.handleProtoWaitForRuns(&orchpb.WaitForRunsRequest{
+		RunRefs: []string{string(run.IssueID)},
+		Context: ctx,
+	})
+	if !resp.Ok {
+		t.Fatalf("handleProtoWaitForRuns() error = %s", resp.Error)
+	}
+
+	waitResp := resp.GetWaitForRuns()
+	if waitResp == nil {
+		t.Fatal("expected WaitForRuns response payload")
+	}
+	if waitResp.RunId != string(run.ShortID()) {
+		t.Fatalf("run_id = %q, want %q", waitResp.RunId, run.ShortID())
+	}
+	if waitResp.Status != string(model.StatusPROpen) {
+		t.Fatalf("status = %q, want %q", waitResp.Status, model.StatusPROpen)
+	}
+	if waitResp.Issue != string(run.IssueID) {
+		t.Fatalf("issue = %q, want %q", waitResp.Issue, run.IssueID)
+	}
+	if waitResp.PrUrl != run.PRUrl {
+		t.Fatalf("pr_url = %q, want %q", waitResp.PrUrl, run.PRUrl)
+	}
+}
+
+func TestRunControlHandlersReturnTheSameAmbiguousRefError(t *testing.T) {
+	st := &ambiguousShortIDStore{mockStore: &mockStore{}}
+	server := NewSocketServer(nil, nil)
+	registerRepoContextForTest(t, server, "project-ambiguous-run", t.TempDir(), st)
+	ctx := &orchpb.RequestContext{ProjectId: "project-ambiguous-run"}
+	const shortID = "ab"
+	const want = "ambiguous run ref: ab"
+
+	responses := map[string]*orchpb.Response{
+		"wait": server.handleProtoWaitForRuns(&orchpb.WaitForRunsRequest{
+			RunRefs: []string{shortID},
+			Context: ctx,
+		}),
+		"capture lookup": server.handleProtoGetRunByShortID(&orchpb.GetRunByShortIDRequest{
+			ShortId: shortID,
+			Context: ctx,
+		}),
+		"attach": server.handleProtoGetAttachInfo(&orchpb.GetAttachInfoRequest{
+			ShortId: shortID,
+			Context: ctx,
+		}),
+	}
+
+	for name, resp := range responses {
+		t.Run(name, func(t *testing.T) {
+			if resp.Ok || resp.Error != want {
+				t.Fatalf("response: ok=%v error=%q, want %q", resp.Ok, resp.Error, want)
+			}
+		})
 	}
 }
 

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -4479,7 +4479,7 @@ func TestRunLookupWithoutProjectContextReturnsSpacedAmbiguousMessages(t *testing
 		ShortId: shortID,
 		Context: &orchpb.RequestContext{},
 	})
-	shortMessage := fmt.Sprintf("ambiguous short id: %s", shortID)
+	shortMessage := fmt.Sprintf("ambiguous run ref: %s", shortID)
 	if shortResp.Ok || shortResp.Error != shortMessage {
 		t.Fatalf("short-ref response: ok=%v error=%q, want %q", shortResp.Ok, shortResp.Error, shortMessage)
 	}

--- a/scripts/e2e-run-control-local.sh
+++ b/scripts/e2e-run-control-local.sh
@@ -95,7 +95,7 @@ git -C "$PROJECT" push -u origin HEAD >/dev/null
 
 cd "$PROJECT"
 
-"$ORCH_BIN" master start >/dev/null
+"$ORCH_BIN" master start --listen 127.0.0.1:0 >/dev/null
 sleep 1
 "$ORCH_BIN" worker start >/dev/null
 sleep 1
@@ -117,11 +117,16 @@ RUN_OUT="$("$ORCH_BIN" --project "$PROJECT_ID" run "$ISSUE_ID" \
 printf '%s\n' "$RUN_OUT"
 printf '%s' "$RUN_OUT" | jq -e '.ok == true' >/dev/null
 
-CAPTURE_CMD="\"$ORCH_BIN\" --project \"$PROJECT_ID\" capture \"$ISSUE_ID#$RUN_ID\" --lines 50"
+PS_OUT="$("$ORCH_BIN" --project "$PROJECT_ID" ps --issue "$ISSUE_ID" --json)"
+printf '%s\n' "$PS_OUT"
+printf '%s' "$PS_OUT" | jq -e --arg issue "$ISSUE_ID" \
+  'any(.items[]; .issue_id == $issue)' >/dev/null
+
+CAPTURE_CMD="\"$ORCH_BIN\" --project \"$PROJECT_ID\" capture \"$ISSUE_ID\" --lines 50"
 FIRST_CAPTURE="$(capture_until_contains "$CAPTURE_CMD" "READY")"
 printf '%s\n' "$FIRST_CAPTURE"
 
-SEND_OUT="$("$ORCH_BIN" --json --project "$PROJECT_ID" send "$ISSUE_ID#$RUN_ID" <<EOF
+SEND_OUT="$("$ORCH_BIN" --json --project "$PROJECT_ID" send "$ISSUE_ID" <<EOF
 $MESSAGE_LINE_1
 $MESSAGE_LINE_2
 EOF
@@ -133,9 +138,20 @@ SECOND_CAPTURE="$(capture_until_contains "$CAPTURE_CMD" "ECHO:$MESSAGE_LINE_2")"
 printf '%s\n' "$SECOND_CAPTURE"
 printf '%s\n' "$SECOND_CAPTURE" | grep -F "ECHO:$MESSAGE_LINE_1" >/dev/null
 
-attach_expect_live "$ORCH_BIN" --project "$PROJECT_ID" attach "$ISSUE_ID#$RUN_ID"
+attach_expect_live "$ORCH_BIN" --project "$PROJECT_ID" attach "$ISSUE_ID"
 
-"$ORCH_BIN" --project "$PROJECT_ID" send "$ISSUE_ID#$RUN_ID" quit >/dev/null || true
-"$ORCH_BIN" --project "$PROJECT_ID" stop "$ISSUE_ID#$RUN_ID" --force >/dev/null
+(
+  sleep 1
+  "$ORCH_BIN" --project "$PROJECT_ID" stop "$ISSUE_ID" --force
+) &
+STOP_PID=$!
+
+WAIT_OUT="$("$ORCH_BIN" --project "$PROJECT_ID" wait "$ISSUE_ID" --timeout 60)"
+wait "$STOP_PID"
+printf '%s\n' "$WAIT_OUT"
+printf '%s' "$WAIT_OUT" | jq -e --arg issue "$ISSUE_ID" \
+  '.issue == $issue and .status == "canceled"' >/dev/null
+
+"$ORCH_BIN" --project "$PROJECT_ID" resolve "$ISSUE_ID" --force
 
 echo "RUN_CONTROL_LOCAL_E2E_OK"


### PR DESCRIPTION
## Summary

- allow `orch wait ISSUE_ID` to resolve the issue's latest run, matching `capture`, `send`, `show`, and other run-control verbs
- route wait lookups through the shared daemon run resolver
- preserve ambiguity instead of collapsing ambiguous short IDs to `not_found` in capture/attach lookup paths
- extend the canonical local run-control E2E to exercise issue-name-only ps/capture/send/attach/wait/stop/resolve

## Acceptance evidence

- **Bare issue name waits for the latest run:** `TestHandleProtoWaitForRunsReturnsImmediatelyForIssueID` reproduces the v1.8.0-beta error before the fix and passes after it.
- **All run-control ref forms use consistent ambiguity errors:** `TestRunControlHandlersReturnTheSameAmbiguousRefError` verifies wait, capture lookup, and attach all return `ambiguous run ref: ab`.
- **agent-install-style command works unchanged:** the isolated E2E ran `wait run-control-local --timeout 60` and returned:

  ```json
  {"run_id":"6fbaa1","status":"canceled","issue":"run-control-local","pr_url":""}
  ```

- **Issue-name-only sandbox lifecycle:** `scripts/e2e-run-control-local.sh` completed create -> run -> ps -> capture -> send/attach -> wait -> stop -> resolve with:

  ```text
  stopped: run-control-local#20260714-223157-local-control
  resolved: run-control-local
  RUN_CONTROL_LOCAL_E2E_OK
  ```

## Verification

- `go test ./internal/daemon ./internal/cli ./internal/orchapi -count=1`
- `go test -p 1 ./... -count=1` (controlled PATH excludes optional live agent CLIs; includes `test/integration`, 101.348s)
- `go build ./...`
- `make lint`
- `bash -n scripts/e2e-run-control-local.sh`
- `env -u TMUX ORCH_BIN=/tmp/orch-wait-ref-e2e-final bash scripts/e2e-run-control-local.sh`

Refs: wait-ref-inconsistent-with-capture
