### PR TITLE
Preserve daemon listen mode across upgrade restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -269,7 +269,8 @@ restart_daemon_after_upgrade() {
     if "${INSTALL_DIR}/orch" daemon-restart; then
         success "Restarted orch daemon"
     else
-        warn "Could not restart orch daemon automatically; run: ${INSTALL_DIR}/orch daemon-restart"
+        warn "Could not restart orch daemon automatically; restart it manually with its original start command"
+        return 1
     fi
 }
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -425,7 +425,7 @@ func newDaemonRestartCmd() *cobra.Command {
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !daemon.IsRunning("") {
-				return nil
+				return fmt.Errorf("cannot restart daemon: no running daemon found; start it with the required launch mode, for example: orch master start --listen <address>")
 			}
 
 			return daemon.RestartDaemon("")

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -96,6 +96,17 @@ func TestRunDaemonKillProjectFlagWarnsButIgnored(t *testing.T) {
 	}
 }
 
+func TestDaemonRestartFailsWithoutRunningDaemon(t *testing.T) {
+	setIsolatedXDG(t)
+	resetGlobalOpts(t)
+
+	cmd := newDaemonRestartCmd()
+	err := cmd.RunE(cmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "no running daemon found") {
+		t.Fatalf("daemon-restart error = %v, want explicit no-running-daemon error", err)
+	}
+}
+
 func TestDaemonRepoRegisterCommandDocumentsProjectPath(t *testing.T) {
 	cmd := newDaemonRepoRegisterCmd()
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -54,6 +54,7 @@ const (
 var noDaemonCommands = map[string]bool{
 	"show":                 true,
 	"daemon":               true,
+	"daemon-restart":       true,
 	"master":               true,
 	"worker":               true,
 	"list":                 true,

--- a/internal/cli/root_pre_run_test.go
+++ b/internal/cli/root_pre_run_test.go
@@ -15,6 +15,8 @@ func TestShouldAutoStartDaemonForCommand(t *testing.T) {
 	start := &cobra.Command{Use: "start"}
 	master.AddCommand(start)
 	root.AddCommand(master)
+	daemonRestart := &cobra.Command{Use: "daemon-restart"}
+	root.AddCommand(daemonRestart)
 
 	issue := &cobra.Command{Use: "issue"}
 	list := &cobra.Command{Use: "list"}
@@ -31,6 +33,7 @@ func TestShouldAutoStartDaemonForCommand(t *testing.T) {
 		{name: "run remote skips autostart", cmd: run, remoteAddr: "remotebox:7777", want: false},
 		{name: "master start skips autostart", cmd: start, remoteAddr: "", want: false},
 		{name: "master command skips autostart", cmd: master, remoteAddr: "", want: false},
+		{name: "daemon restart skips autostart", cmd: daemonRestart, remoteAddr: "", want: false},
 		{name: "issue list keeps existing skip behavior", cmd: list, remoteAddr: "", want: false},
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -166,7 +166,7 @@ func (d *Daemon) Run() error {
 	d.logger = log.New(logFile, "", log.LstdFlags)
 
 	if err := d.initBinaryTracking(); err != nil {
-		d.logger.Printf("warning: failed to init binary tracking: %v", err)
+		return fmt.Errorf("failed to record daemon launch metadata: %w", err)
 	}
 
 	cfg, err := config.Load()
@@ -224,7 +224,7 @@ func (d *Daemon) Run() error {
 	d.socketServer.onStatusChange = d.fireStatusChange
 	d.socketServer.SetGitHubBackend(d.githubBackend)
 	if err := d.socketServer.Start(); err != nil {
-		d.logger.Printf("warning: failed to start socket server: %v", err)
+		return fmt.Errorf("failed to start socket server: %w", err)
 	}
 
 	if d.githubBackend != nil {
@@ -308,12 +308,14 @@ func (d *Daemon) initBinaryTracking() error {
 }
 
 func (d *Daemon) writeMetadata() error {
+	listenAddr := d.listenAddr
 	meta := DaemonMetadata{
-		PID:       os.Getpid(),
-		StartedAt: time.Now(),
-		ExecPath:  d.executablePath,
-		ExecMtime: d.startupMtime,
-		Version:   2, // XDG global daemon version
+		PID:        os.Getpid(),
+		StartedAt:  time.Now(),
+		ExecPath:   d.executablePath,
+		ExecMtime:  d.startupMtime,
+		Version:    3,
+		ListenAddr: &listenAddr,
 	}
 	data, err := json.Marshal(meta)
 	if err != nil {
@@ -345,7 +347,14 @@ func (d *Daemon) checkBinaryStaleness() {
 
 func (d *Daemon) restartWithNewBinary() error {
 	d.logger.Printf("restarting daemon with new binary via exec...")
-	args := []string{d.executablePath, "daemon", "run"}
+	meta, err := ReadMetadata("")
+	if err != nil {
+		return fmt.Errorf("failed to read recorded launch mode: %w", err)
+	}
+	if meta.ListenAddr == nil {
+		return fmt.Errorf("daemon launch mode is not recorded in metadata schema version %d", meta.Version)
+	}
+	args := daemonRunArgs(d.executablePath, *meta.ListenAddr)
 	return syscall.Exec(d.executablePath, args, os.Environ())
 }
 
@@ -548,10 +557,7 @@ func StartInBackgroundWithListen(listenAddr string) (int, error) {
 		return 0, fmt.Errorf("failed to open stderr log: %w", err)
 	}
 
-	args := []string{executable, "daemon", "run"}
-	if strings.TrimSpace(listenAddr) != "" {
-		args = append(args, "--listen", strings.TrimSpace(listenAddr))
-	}
+	args := daemonRunArgs(executable, listenAddr)
 
 	cmd := &exec.Cmd{
 		Path: executable,
@@ -577,6 +583,10 @@ func StartInBackgroundWithListen(listenAddr string) (int, error) {
 	time.Sleep(100 * time.Millisecond)
 
 	return cmd.Process.Pid, nil
+}
+
+func daemonRunArgs(executable, listenAddr string) []string {
+	return []string{executable, "daemon", "run", "--listen", strings.TrimSpace(listenAddr)}
 }
 
 // Kill stops the global daemon.

--- a/internal/daemon/daemon_restart_test.go
+++ b/internal/daemon/daemon_restart_test.go
@@ -1,0 +1,20 @@
+package daemon
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDaemonRunArgsPreserveExplicitlyDisabledTCPListener(t *testing.T) {
+	want := []string{"/tmp/orch", "daemon", "run", "--listen", ""}
+	if got := daemonRunArgs("/tmp/orch", ""); !reflect.DeepEqual(got, want) {
+		t.Fatalf("daemonRunArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDaemonRunArgsPreserveListenAddress(t *testing.T) {
+	want := []string{"/tmp/orch", "daemon", "run", "--listen", "tcp://0.0.0.0:7777"}
+	if got := daemonRunArgs("/tmp/orch", " tcp://0.0.0.0:7777 "); !reflect.DeepEqual(got, want) {
+		t.Fatalf("daemonRunArgs() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/daemon/pid.go
+++ b/internal/daemon/pid.go
@@ -27,7 +27,8 @@ type DaemonMetadata struct {
 	ExecPath    string    `json:"exec_path"`
 	ExecMtime   time.Time `json:"exec_mtime"`
 	ProjectRoot string    `json:"project_root,omitempty"` // Deprecated: for legacy compat
-	Version     int       `json:"version,omitempty"`      // Schema version (2 = XDG global daemon)
+	Version     int       `json:"version,omitempty"`      // Schema version (3 = recorded launch mode)
+	ListenAddr  *string   `json:"listen_addr,omitempty"`  // nil means pre-v3 metadata; empty means no TCP listener
 }
 
 // DaemonInfo contains information about a running daemon for listing
@@ -248,12 +249,58 @@ func RestartDaemon(_ string) error {
 		return nil
 	}
 
-	process, err := os.FindProcess(pid)
+	meta, err := ReadMetadata("")
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot restart daemon pid %d: failed to read launch metadata: %w", pid, err)
+	}
+	if meta.ListenAddr == nil {
+		return fmt.Errorf("cannot restart daemon pid %d automatically: its launch mode was not recorded (metadata schema version %d); restart it manually with the original command, for example: orch master kill && orch master start --listen <original-address>", pid, meta.Version)
 	}
 
-	return process.Signal(syscall.SIGHUP)
+	listenAddr := *meta.ListenAddr
+	if err := KillDaemon(""); err != nil {
+		return fmt.Errorf("failed to stop daemon pid %d before restart: %w", pid, err)
+	}
+
+	newPID, err := StartInBackgroundWithListen(listenAddr)
+	if err != nil {
+		return fmt.Errorf("failed to start daemon with recorded listen address %q: %w", listenAddr, err)
+	}
+	if err := waitForRestartedDaemon(newPID, meta.StartedAt, listenAddr, 5*time.Second); err != nil {
+		return fmt.Errorf("daemon restart failed with recorded listen address %q: %w", listenAddr, err)
+	}
+	return nil
+}
+
+func waitForRestartedDaemon(pid int, previousStart time.Time, listenAddr string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	observedNewMetadata := false
+	for time.Now().Before(deadline) {
+		meta, err := ReadMetadata("")
+		if err == nil && meta.StartedAt.After(previousStart) {
+			observedNewMetadata = true
+			if meta.ListenAddr == nil || *meta.ListenAddr != listenAddr {
+				return fmt.Errorf("restarted daemon recorded a different launch mode")
+			}
+
+			if GetRunningPID("") == pid {
+				client := NewProtoClient("")
+				client.SetTimeout(500 * time.Millisecond)
+				pingErr := client.Ping()
+				_ = client.Close()
+				if pingErr == nil {
+					return nil
+				}
+			}
+		}
+
+		if observedNewMetadata && !IsProcessRunning(pid) {
+			return fmt.Errorf("daemon process pid %d exited before becoming ready (see %s and %s)", pid, xdg.LogPath(), xdg.StderrLogPath())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	return fmt.Errorf("daemon process pid %d did not become ready within %s (see %s and %s)", pid, timeout, xdg.LogPath(), xdg.StderrLogPath())
 }
 
 func globalRegistryPath() string {

--- a/test/integration/daemon_restart_test.go
+++ b/test/integration/daemon_restart_test.go
@@ -1,0 +1,288 @@
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type restartDaemonMetadata struct {
+	StartedAt  time.Time `json:"started_at"`
+	ListenAddr *string   `json:"listen_addr"`
+}
+
+type daemonRestartSandbox struct {
+	env         []string
+	runtimeRoot string
+	stateRoot   string
+}
+
+func newDaemonRestartSandbox(t *testing.T) *daemonRestartSandbox {
+	t.Helper()
+
+	root, err := os.MkdirTemp("/tmp", "orch-restart-")
+	if err != nil {
+		t.Fatalf("create daemon restart sandbox: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	runtimeRoot := filepath.Join(root, "runtime")
+	stateRoot := filepath.Join(root, "state")
+	dataRoot := filepath.Join(root, "data")
+	configRoot := filepath.Join(root, "config")
+	homeRoot := filepath.Join(root, "home")
+	for _, dir := range []string{runtimeRoot, stateRoot, dataRoot, configRoot, homeRoot} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("create daemon restart sandbox directory %s: %v", dir, err)
+		}
+	}
+
+	env := make([]string, 0, len(os.Environ())+7)
+	for _, entry := range os.Environ() {
+		switch {
+		case strings.HasPrefix(entry, "HOME="),
+			strings.HasPrefix(entry, "XDG_RUNTIME_DIR="),
+			strings.HasPrefix(entry, "XDG_STATE_HOME="),
+			strings.HasPrefix(entry, "XDG_DATA_HOME="),
+			strings.HasPrefix(entry, "XDG_CONFIG_HOME="),
+			strings.HasPrefix(entry, "ORCH_REMOTE="),
+			strings.HasPrefix(entry, "ORCH_PROJECT="):
+			continue
+		}
+		env = append(env, entry)
+	}
+	env = append(env,
+		"HOME="+homeRoot,
+		"XDG_RUNTIME_DIR="+runtimeRoot,
+		"XDG_STATE_HOME="+stateRoot,
+		"XDG_DATA_HOME="+dataRoot,
+		"XDG_CONFIG_HOME="+configRoot,
+		"ORCH_REMOTE=",
+		"ORCH_PROJECT=",
+	)
+
+	sandbox := &daemonRestartSandbox{env: env, runtimeRoot: runtimeRoot, stateRoot: stateRoot}
+	t.Cleanup(func() {
+		_, _ = sandbox.run("daemon", "kill")
+	})
+	return sandbox
+}
+
+func (s *daemonRestartSandbox) run(args ...string) (string, error) {
+	cmdArgs := append([]string{"--remote="}, args...)
+	cmd := exec.Command(orchBinary, cmdArgs...)
+	cmd.Env = s.env
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func (s *daemonRestartSandbox) metadata() (*restartDaemonMetadata, error) {
+	path := filepath.Join(s.runtimeRoot, "orch", "daemon.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var metadata restartDaemonMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil, err
+	}
+	return &metadata, nil
+}
+
+func (s *daemonRestartSandbox) waitForRunning(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastOutput string
+	var lastErr error
+	for time.Now().Before(deadline) {
+		lastOutput, lastErr = s.run("daemon", "status")
+		if lastErr == nil && strings.Contains(lastOutput, "Status: running") {
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("daemon did not become ready: last error=%v output=%s", lastErr, lastOutput)
+}
+
+func (s *daemonRestartSandbox) startPlainDaemon(t *testing.T) {
+	t.Helper()
+	cmd := exec.Command(orchBinary, "--remote=", "daemon", "run", "--listen=")
+	cmd.Env = s.env
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start plain daemon: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	t.Cleanup(func() {
+		select {
+		case <-done:
+			return
+		default:
+		}
+		_, _ = s.run("daemon", "kill")
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+	if err := s.waitForRunning(5 * time.Second); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (s *daemonRestartSandbox) overwriteRecordedListenAddr(t *testing.T, listenAddr string) {
+	t.Helper()
+	path := filepath.Join(s.runtimeRoot, "orch", "daemon.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read daemon metadata for rewrite: %v", err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("decode daemon metadata for rewrite: %v", err)
+	}
+	metadata["listen_addr"] = listenAddr
+	data, err = json.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("encode daemon metadata rewrite: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write daemon metadata rewrite: %v", err)
+	}
+}
+
+func (s *daemonRestartSandbox) waitForTCP(address string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", address, 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		lastErr = err
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("tcp listener %s did not become ready: %w", address, lastErr)
+}
+
+func TestDaemonRestartPreservesMasterListenAddress(t *testing.T) {
+	sandbox := newDaemonRestartSandbox(t)
+	listenAddr, err := reserveLoopbackTCPAddr()
+	if err != nil {
+		t.Fatalf("reserve master listen address: %v", err)
+	}
+
+	startOutput, err := sandbox.run("master", "start", "--listen", "tcp://"+listenAddr)
+	if err != nil {
+		t.Fatalf("start master: %v\n%s", err, startOutput)
+	}
+	if err := sandbox.waitForTCP(listenAddr, 5*time.Second); err != nil {
+		statusOutput, statusErr := sandbox.run("daemon", "status")
+		metadata, metadataErr := os.ReadFile(filepath.Join(sandbox.runtimeRoot, "orch", "daemon.json"))
+		logOutput, logErr := os.ReadFile(filepath.Join(sandbox.stateRoot, "orch", "daemon.log"))
+		t.Fatalf("%v\nstart output: %s\nstatus: err=%v output=%s\nmetadata: err=%v content=%s\nlog: err=%v content=%s",
+			err, startOutput, statusErr, statusOutput, metadataErr, metadata, logErr, logOutput)
+	}
+	before, err := sandbox.metadata()
+	if err != nil {
+		t.Fatalf("read metadata before restart: %v", err)
+	}
+
+	if output, err := sandbox.run("daemon-restart"); err != nil {
+		t.Fatalf("restart master: %v\n%s", err, output)
+	}
+	after, err := sandbox.metadata()
+	if err != nil {
+		t.Fatalf("read metadata after restart: %v", err)
+	}
+	if !after.StartedAt.After(before.StartedAt) {
+		t.Fatalf("daemon metadata was not refreshed: before=%s after=%s", before.StartedAt, after.StartedAt)
+	}
+	if after.ListenAddr == nil || *after.ListenAddr != "tcp://"+listenAddr {
+		t.Fatalf("listen address was not preserved in runtime metadata: got=%v want=%q", after.ListenAddr, "tcp://"+listenAddr)
+	}
+	if err := sandbox.waitForTCP(listenAddr, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if output, err := sandbox.run("daemon", "status"); err != nil {
+		t.Fatalf("daemon status after restart: %v\n%s", err, output)
+	} else if !strings.Contains(output, "Status: running") {
+		t.Fatalf("daemon status did not report running after restart:\n%s", output)
+	}
+}
+
+func TestDaemonRestartPreservesPlainMode(t *testing.T) {
+	sandbox := newDaemonRestartSandbox(t)
+	sandbox.startPlainDaemon(t)
+
+	before, err := sandbox.metadata()
+	if err != nil {
+		t.Fatalf("read plain daemon metadata before restart: %v", err)
+	}
+	if before.ListenAddr == nil || *before.ListenAddr != "" {
+		t.Fatalf("plain daemon did not record disabled TCP listener: %v", before.ListenAddr)
+	}
+
+	if output, err := sandbox.run("daemon-restart"); err != nil {
+		t.Fatalf("restart plain daemon: %v\n%s", err, output)
+	}
+	after, err := sandbox.metadata()
+	if err != nil {
+		t.Fatalf("read plain daemon metadata after restart: %v", err)
+	}
+	if !after.StartedAt.After(before.StartedAt) {
+		t.Fatalf("plain daemon metadata was not refreshed: before=%s after=%s", before.StartedAt, after.StartedAt)
+	}
+	if after.ListenAddr == nil || *after.ListenAddr != "" {
+		t.Fatalf("plain daemon restart enabled a TCP listener: %v", after.ListenAddr)
+	}
+	if err := sandbox.waitForRunning(5 * time.Second); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDaemonRestartFailsWhenRecordedListenAddressCannotStart(t *testing.T) {
+	sandbox := newDaemonRestartSandbox(t)
+	initialAddr, err := reserveLoopbackTCPAddr()
+	if err != nil {
+		t.Fatalf("reserve initial listen address: %v", err)
+	}
+	if output, err := sandbox.run("master", "start", "--listen", "tcp://"+initialAddr); err != nil {
+		t.Fatalf("start master: %v\n%s", err, output)
+	}
+	if err := sandbox.waitForTCP(initialAddr, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("create blocked listen address: %v", err)
+	}
+	defer blocker.Close()
+	blockedAddr := "tcp://" + blocker.Addr().String()
+	sandbox.overwriteRecordedListenAddr(t, blockedAddr)
+
+	output, err := sandbox.run("daemon-restart")
+	if err == nil {
+		t.Fatalf("daemon-restart unexpectedly succeeded for blocked address %s:\n%s", blockedAddr, output)
+	}
+	if !strings.Contains(output, "daemon restart failed with recorded listen address") || !strings.Contains(output, blockedAddr) {
+		t.Fatalf("daemon-restart failure did not identify the recorded listen address:\n%s", output)
+	}
+	statusOutput, statusErr := sandbox.run("daemon", "status")
+	if statusErr != nil {
+		t.Fatalf("daemon status after failed restart: %v\n%s", statusErr, statusOutput)
+	}
+	if !strings.Contains(statusOutput, "Status: not running") {
+		t.Fatalf("failed restart left daemon reported as running:\n%s", statusOutput)
+	}
+	secondOutput, secondErr := sandbox.run("daemon-restart")
+	if secondErr == nil || !strings.Contains(secondOutput, "no running daemon found") {
+		t.Fatalf("daemon-restart without a running daemon did not fail clearly: err=%v output=%s", secondErr, secondOutput)
+	}
+}


### PR DESCRIPTION
## Summary

- persist the daemon TCP listen address in XDG runtime metadata, including an explicit disabled-listener mode
- make `daemon-restart` read that launch metadata, stop the old process, replay the exact `--listen` value, and wait for refreshed metadata plus a successful ping
- make socket startup and launch-metadata failures fatal instead of warning-only
- reject automatic restart for pre-v3 metadata with an actionable manual-start instruction
- propagate restart failure from `install.sh` and prevent `daemon-restart` from auto-starting or succeeding when no daemon exists

## Root cause

The SIGHUP re-exec path rebuilt argv as only `orch daemon run`, dropping the master's original `--listen` address. The CLI returned as soon as SIGHUP was delivered, and daemon socket startup failures were only logged, so the installer could print `Restarted orch daemon` while no usable daemon remained.

## Acceptance evidence

```text
$ go test ./test/integration -run '^TestDaemonRestart' -count=1 -v
=== RUN   TestDaemonRestartPreservesMasterListenAddress
--- PASS: TestDaemonRestartPreservesMasterListenAddress
=== RUN   TestDaemonRestartPreservesPlainMode
--- PASS: TestDaemonRestartPreservesPlainMode
=== RUN   TestDaemonRestartFailsWhenRecordedListenAddressCannotStart
--- PASS: TestDaemonRestartFailsWhenRecordedListenAddressCannotStart
PASS
```

These real-process tests verify:

- master start with TCP address A -> restart -> refreshed metadata, running daemon status, and TCP A still accepting
- plain daemon with TCP disabled -> restart -> explicit empty listen mode retained and daemon running
- recorded TCP address blocked -> restart exits nonzero, names the failing address, and daemon status reports not running

Additional gates:

- `go build ./...`
- focused daemon/CLI unit tests
- `bash -n install.sh`
- `make lint` (0 blocking findings; architecture fixtures passed)
- `git diff --check origin/main...HEAD`

## Full-suite note

`go test ./...` cleared all unit packages but the integration package exposed existing load-sensitive failures outside this change: `TestWorkerLifecycleRemoteUsesLocalSupervisor` timed out once, and `TestAgentOpenCodeNoMultiplexer` missed its async state file on later runs. Each failing test passed immediately in isolation. The daemon-restart acceptance suite passes cleanly and `TestAgentOpenCodeNoMultiplexer` runs before the new restart tests.

Issue: `install-sh-master-restart-drops-listener`

### Installer failure propagation

The actual `restart_daemon_after_upgrade` function was executed with a failing fake `orch` binary. It printed the manual-restart warning and returned exit code `1`, confirming `install.sh` no longer treats restart failure as success.