### PR TITLE
Reconcile worker processes by worker ID

### DIFF
--- a/docs/adr/ADR-0002-idempotent-worker-autostart.md
+++ b/docs/adr/ADR-0002-idempotent-worker-autostart.md
@@ -84,6 +84,32 @@ untargeted run. Operators who want strict topology use the off-switch.
 on the master process it disables the reconciler, on the client it disables
 the pre-dispatch ensure. Default: enabled.
 
+### 4. Worker identity is host-local and profile-independent
+
+**Invariant: one host has at most one live `orch worker run` process for a
+given `worker-id`.** The master connection string is configuration of that
+worker, not part of its identity.
+
+`worker start` and `worker stop` serialize lifecycle changes by `worker-id`.
+They reconcile every surviving managed profile for that identity and inspect
+the local process table for an exact `orch worker run --worker-id ...` match.
+The process-table check is required because an older binary, a changed
+`--remote` spelling, or deleted state/PID metadata can otherwise leave a live
+supervisor outside the current profile. `worker start` preserves and reuses
+the requested profile's one known-live PID, stops every competing PID, then
+launches only if no requested-profile process remains. `worker stop` removes
+all matching local PIDs, including state-less ones; `worker stop --all` applies
+the same rule to every local worker identity.
+
+Master-side duplicate eviction is not the enforcement layer in this decision.
+The worker protocol currently carries only `worker_id` on register, heartbeat,
+lease, acknowledgement, and unregister calls. Once two processes claim that
+ID, the master cannot distinguish which request belongs to which process, so
+it cannot selectively shut down the older one without introducing a new
+connection-instance identity across the entire lease protocol. Host-local
+process ownership is already the managed lifecycle boundary and can also reap
+older binaries that do not understand a new protocol response.
+
 ## Resulting UX
 
 | Mode | Before | After |
@@ -108,6 +134,10 @@ the pre-dispatch ensure. Default: enabled.
   single-machine setups; docs and the embedded tutorial shrink accordingly.
 - The reconciler runs strictly inside the lease-failure path: zero cost when
   workers are healthy, no background polling, no new periodic loop.
+- Changing the configured master for a `worker-id` is a replacement, not a
+  second concurrent worker. The old supervisor is stopped before the new
+  profile starts, preventing two processes from racing for the same lease
+  identity after a master restart.
 
 ### Environment normalization decision (2026-07-13)
 

--- a/docs/design/worker-lease.md
+++ b/docs/design/worker-lease.md
@@ -141,6 +141,7 @@ enrichment must use a batched per-host operation rather than per-run leases.
 | LL5 snapshot sufficiency | a worker executes any effect using only the lease payload (RunSnapshot); it never reads its local store for master-owned runs (PR #457's contract) |
 | LL6 start target confinement | every `start_run` resolves a `TargetWorkerID` before lease acquisition; empty/`local` targets resolve to the master's host worker, named targets resolve through `config.targets`, and neither may fall back to another worker |
 | LL7 worktree host confinement | single-run worktree inspect/remove executes on the run's target worker; an unavailable worker or failed stat/git operation is returned with host/cause and is never converted to `exists=false` or an absent skip; list paths leave worktree existence unpopulated pending a batched per-host operation |
+| LL8 local worker identity convergence | `worker-id` is the host-local supervisor identity, independent of master connection profile; after `StartManaged(w, profile)` at most that profile's process is live for `w`, and after `StopManaged(w)` no local `orch worker run` process for `w` is live, even when its profile state is missing |
 
 ## Verification and maintenance
 
@@ -151,5 +152,8 @@ executes against a real registered worktree, while
 `TestRemoteGetRunReportsWorkerObservedWorktreeExists`,
 `TestRemoteCleanRunWorktreeUsesExecutionHostWorker`, and
 `TestRemoteGetRunWorktreeObservationFailureIsExplicit` prove master routing and
-fail-clear propagation. Lease-map mutation remains confined by the
+fail-clear propagation. LL8 is covered by
+`TestStopStartManagedConvergesSameWorkerIDAcrossProfiles`, which removes the
+old profile state to create an orphan and proves a stop/start cycle converges
+to one live process. Lease-map mutation remains confined by the
 `worker-lease-mutation-surface` semgrep rule.

--- a/internal/worker/managed.go
+++ b/internal/worker/managed.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -43,6 +44,7 @@ var (
 	managedWorkerExecutable         = os.Executable
 	managedWorkerLaunchConfig       = defaultManagedWorkerLaunchConfig
 	lookupManagedWorkerRegistration = defaultManagedWorkerRegistrationLookup
+	listManagedWorkerProcesses      = defaultListManagedWorkerProcesses
 )
 
 type ManagedOptions struct {
@@ -59,13 +61,13 @@ type ManagedStartResult struct {
 }
 
 type ManagedState struct {
-	Version         int       `json:"version"`
-	Key             string    `json:"key"`
-	WorkerID        string    `json:"worker_id"`
-	RemoteAddr      string    `json:"remote_addr,omitempty"`
-	LogPath         string    `json:"log_path,omitempty"`
-	PID             int       `json:"pid,omitempty"`
-	ProcessState    string    `json:"process_state,omitempty"`
+	Version           int       `json:"version"`
+	Key               string    `json:"key"`
+	WorkerID          string    `json:"worker_id"`
+	RemoteAddr        string    `json:"remote_addr,omitempty"`
+	LogPath           string    `json:"log_path,omitempty"`
+	PID               int       `json:"pid,omitempty"`
+	ProcessState      string    `json:"process_state,omitempty"`
 	StartedAt         time.Time `json:"started_at,omitempty"`
 	RegisteredAt      time.Time `json:"registered_at,omitempty"`
 	LastHeartbeatAt   time.Time `json:"last_heartbeat_at,omitempty"`
@@ -124,6 +126,11 @@ type managedRuntimeStateWriter struct {
 	pid        int
 }
 
+type managedWorkerProcess struct {
+	PID     int
+	Command string
+}
+
 func StartManaged(opts ManagedOptions) (*ManagedStartResult, error) {
 	profile, err := resolveManagedProfile(opts)
 	if err != nil {
@@ -132,8 +139,30 @@ func StartManaged(opts ManagedOptions) (*ManagedStartResult, error) {
 	if err := ensureManagedDirs(); err != nil {
 		return nil, err
 	}
+	identityLock, err := acquireManagedWorkerIdentityLock(profile.WorkerID)
+	if err != nil {
+		return nil, err
+	}
+	defer releaseManagedWorkerIdentityLock(identityLock)
 
 	state, _ := loadManagedState(profile.StatePath)
+	keepPID := 0
+	if state != nil && state.PID > 0 && daemon.IsProcessRunning(state.PID) {
+		keepPID = state.PID
+	}
+
+	// A worker ID names one host-level supervisor, independent of which
+	// spelling/profile was used to reach the master. Reconcile historical
+	// profiles before inspecting the requested profile so a changed --remote
+	// cannot leave the previous process competing for the same worker ID.
+	if _, err := stopManagedProfilesForWorkerID(profile.WorkerID, profile.StatePath); err != nil {
+		return nil, err
+	}
+	if _, err := stopUnmanagedWorkerProcesses(profile.WorkerID, keepPID); err != nil {
+		return nil, err
+	}
+
+	state, _ = loadManagedState(profile.StatePath)
 	if state != nil && state.LogPath != "" {
 		profile.LogPath = state.LogPath
 	}
@@ -234,6 +263,11 @@ func StopManaged(opts ManagedOptions, all bool) (int, error) {
 			}
 			stopped += count
 		}
+		orphaned, err := stopAllUnmanagedWorkerProcesses()
+		stopped += orphaned
+		if err != nil {
+			return stopped, err
+		}
 		return stopped, nil
 	}
 
@@ -241,7 +275,35 @@ func StopManaged(opts ManagedOptions, all bool) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return stopManagedProfile(profile)
+	if err := ensureManagedDirs(); err != nil {
+		return 0, err
+	}
+	identityLock, err := acquireManagedWorkerIdentityLock(profile.WorkerID)
+	if err != nil {
+		return 0, err
+	}
+	defer releaseManagedWorkerIdentityLock(identityLock)
+
+	stopped, err := stopManagedProfilesForWorkerID(profile.WorkerID, "")
+	if err != nil {
+		return stopped, err
+	}
+	unmanagedStopped, err := stopUnmanagedWorkerProcesses(profile.WorkerID, 0)
+	stopped += unmanagedStopped
+	if err != nil {
+		return stopped, err
+	}
+
+	// Preserve the unmanaged-registration diagnostic when no local profile
+	// exists for this identity.
+	profiles, err := listManagedProfilesForWorkerID(profile.WorkerID)
+	if err != nil {
+		return stopped, err
+	}
+	if len(profiles) == 0 && stopped == 0 {
+		return stopManagedProfile(profile)
+	}
+	return stopped, nil
 }
 
 func StatusManaged(opts ManagedOptions) (*ManagedStatus, error) {
@@ -620,6 +682,192 @@ func listManagedProfiles() ([]managedProfile, error) {
 		})
 	}
 	return profiles, nil
+}
+
+func listManagedProfilesForWorkerID(workerID string) ([]managedProfile, error) {
+	workerID = strings.TrimSpace(workerID)
+	profiles, err := listManagedProfiles()
+	if err != nil {
+		return nil, err
+	}
+
+	matches := make([]managedProfile, 0, len(profiles))
+	for _, profile := range profiles {
+		if strings.TrimSpace(profile.WorkerID) == workerID {
+			matches = append(matches, profile)
+		}
+	}
+	return matches, nil
+}
+
+func stopManagedProfilesForWorkerID(workerID, exceptStatePath string) (int, error) {
+	profiles, err := listManagedProfilesForWorkerID(workerID)
+	if err != nil {
+		return 0, err
+	}
+
+	stopped := 0
+	for _, profile := range profiles {
+		if exceptStatePath != "" && profile.StatePath == exceptStatePath {
+			continue
+		}
+		count, err := stopManagedProfile(profile)
+		if err != nil {
+			return stopped, err
+		}
+		stopped += count
+	}
+	return stopped, nil
+}
+
+func stopUnmanagedWorkerProcesses(workerID string, keepPID int) (int, error) {
+	processes, err := listManagedWorkerProcesses()
+	if err != nil {
+		return 0, fmt.Errorf("list local worker processes for %q: %w", workerID, err)
+	}
+
+	stopped := 0
+	for _, process := range processes {
+		if process.PID <= 0 || process.PID == os.Getpid() || process.PID == keepPID {
+			continue
+		}
+		if !managedWorkerCommandHasIdentity(process.Command, workerID) || !daemon.IsProcessRunning(process.PID) {
+			continue
+		}
+		if err := stopManagedProcess(process.PID); err != nil {
+			return stopped, fmt.Errorf("stop orphaned worker %q pid %d: %w", workerID, process.PID, err)
+		}
+		stopped++
+	}
+	return stopped, nil
+}
+
+func stopAllUnmanagedWorkerProcesses() (int, error) {
+	processes, err := listManagedWorkerProcesses()
+	if err != nil {
+		return 0, fmt.Errorf("list local worker processes: %w", err)
+	}
+
+	stopped := 0
+	for _, process := range processes {
+		if process.PID <= 0 || process.PID == os.Getpid() || !daemon.IsProcessRunning(process.PID) {
+			continue
+		}
+		workerID, ok := managedWorkerCommandIdentity(process.Command)
+		if !ok {
+			continue
+		}
+		if err := stopManagedProcess(process.PID); err != nil {
+			return stopped, fmt.Errorf("stop orphaned worker %q pid %d: %w", workerID, process.PID, err)
+		}
+		stopped++
+	}
+	return stopped, nil
+}
+
+func defaultListManagedWorkerProcesses() ([]managedWorkerProcess, error) {
+	psPath := "/bin/ps"
+	if _, err := os.Stat(psPath); err != nil {
+		psPath = "/usr/bin/ps"
+	}
+	output, err := exec.Command(psPath, "-ww", "-axo", "pid=,args=").Output()
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(output), "\n")
+	processes := make([]managedWorkerProcess, 0, len(lines))
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			return nil, fmt.Errorf("parse ps pid %q: %w", fields[0], err)
+		}
+		processes = append(processes, managedWorkerProcess{
+			PID:     pid,
+			Command: strings.Join(fields[1:], " "),
+		})
+	}
+	return processes, nil
+}
+
+func managedWorkerCommandHasIdentity(command, workerID string) bool {
+	actualWorkerID, ok := managedWorkerCommandIdentity(command)
+	return ok && strings.TrimSpace(actualWorkerID) == strings.TrimSpace(workerID)
+}
+
+func managedWorkerCommandIdentity(command string) (string, bool) {
+	args := strings.Fields(strings.TrimSpace(command))
+	if len(args) < 3 {
+		return "", false
+	}
+	executable := strings.TrimSuffix(filepath.Base(args[0]), ".exe")
+	if executable != "orch" && !strings.HasPrefix(executable, "orch-") {
+		return "", false
+	}
+
+	workerRunIndex := -1
+	for i := 1; i+1 < len(args); i++ {
+		if args[i] == "worker" && args[i+1] == "run" {
+			workerRunIndex = i
+			break
+		}
+		if (args[i] == "--project" || args[i] == "--remote" || args[i] == "--log-level") && i+1 < len(args) {
+			i++
+			continue
+		}
+		if !strings.HasPrefix(args[i], "-") {
+			// The first subcommand is not `worker run`; do not match text from
+			// another command's positional arguments (for example `orch send`).
+			return "", false
+		}
+	}
+	if workerRunIndex < 0 {
+		return "", false
+	}
+
+	actualWorkerID := ""
+	for i := workerRunIndex + 2; i < len(args); i++ {
+		switch {
+		case args[i] == "--worker-id" && i+1 < len(args):
+			actualWorkerID = args[i+1]
+			i++
+		case strings.HasPrefix(args[i], "--worker-id="):
+			actualWorkerID = strings.TrimPrefix(args[i], "--worker-id=")
+		}
+	}
+	if actualWorkerID == "" {
+		host, _ := currentWorkerHostname()
+		if strings.TrimSpace(host) == "" {
+			host = "localhost"
+		}
+		actualWorkerID = daemon.HostWorkerID(host)
+	}
+	return strings.TrimSpace(actualWorkerID), true
+}
+
+func acquireManagedWorkerIdentityLock(workerID string) (*os.File, error) {
+	lockPath := filepath.Join(xdg.WorkersRuntimeDir(), managedProfileKey(workerID, "")+".lock")
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open managed worker identity lock for %q: %w", workerID, err)
+	}
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		_ = lockFile.Close()
+		return nil, fmt.Errorf("lock managed worker identity %q: %w", workerID, err)
+	}
+	return lockFile, nil
+}
+
+func releaseManagedWorkerIdentityLock(lockFile *os.File) {
+	if lockFile == nil {
+		return
+	}
+	_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	_ = lockFile.Close()
 }
 
 func stopManagedProfile(profile managedProfile) (int, error) {

--- a/internal/worker/managed_test.go
+++ b/internal/worker/managed_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -155,6 +156,118 @@ func TestStartStatusStopManagedUsesPersistentLocalState(t *testing.T) {
 	}
 }
 
+func TestStopStartManagedConvergesSameWorkerIDAcrossProfiles(t *testing.T) {
+	setManagedWorkerTestEnv(t)
+	withManagedWorkerTestHooks(t)
+
+	managedWorkerStartupTimeout = 2 * time.Second
+	managedWorkerStartupPoll = 25 * time.Millisecond
+	managedWorkerLaunchConfig = helperManagedWorkerLaunchConfig("registered")
+	lookupManagedWorkerRegistration = lookupRegistrationFromManagedState
+
+	const workerID = "worker-reconcile"
+	oldProfile := ManagedOptions{WorkerID: workerID, RemoteAddr: "127.0.0.1:7777"}
+	currentProfile := ManagedOptions{WorkerID: workerID}
+
+	oldPID := startUnreconciledManagedWorkerHelper(t, oldProfile)
+	currentPID := startUnreconciledManagedWorkerHelper(t, currentProfile)
+	for _, opts := range []ManagedOptions{oldProfile, currentProfile} {
+		profile, err := resolveManagedProfile(opts)
+		if err != nil {
+			t.Fatalf("resolveManagedProfile(%+v) error = %v", opts, err)
+		}
+		if err := os.Remove(profile.StatePath); err != nil {
+			t.Fatalf("remove %s to create orphan: %v", profile.StatePath, err)
+		}
+		if err := removeManagedPID(profile.PIDPath); err != nil {
+			t.Fatalf("remove %s to create orphan: %v", profile.PIDPath, err)
+		}
+	}
+	listManagedWorkerProcesses = func() ([]managedWorkerProcess, error) {
+		return []managedWorkerProcess{
+			{PID: oldPID, Command: "orch --remote=127.0.0.1:7777 worker run --worker-id " + workerID},
+			{PID: currentPID, Command: "orch --remote= worker run --worker-id " + workerID},
+		}, nil
+	}
+	t.Cleanup(func() {
+		_, _ = StopManaged(ManagedOptions{}, true)
+	})
+
+	stopped, err := StopManaged(currentProfile, false)
+	if err != nil {
+		t.Fatalf("StopManaged(current profile) error = %v", err)
+	}
+	if stopped == 0 {
+		t.Fatal("StopManaged(current profile) stopped no workers")
+	}
+	if stopped != 2 {
+		t.Fatalf("StopManaged(current profile) stopped = %d, want 2 orphaned processes", stopped)
+	}
+
+	restarted, err := StartManaged(currentProfile)
+	if err != nil {
+		t.Fatalf("StartManaged(current profile after stop) error = %v", err)
+	}
+
+	live := 0
+	for _, pid := range []int{oldPID, currentPID, restarted.PID} {
+		if daemon.IsProcessRunning(pid) {
+			live++
+		}
+	}
+	if live != 1 {
+		t.Fatalf("live worker processes after stop/start = %d, want 1 (pids: old=%d current=%d restarted=%d)", live, oldPID, currentPID, restarted.PID)
+	}
+}
+
+func TestManagedWorkerCommandHasIdentity(t *testing.T) {
+	tests := []struct {
+		name      string
+		command   string
+		workerID  string
+		wantMatch bool
+	}{
+		{
+			name:      "separate worker id flag",
+			command:   "/usr/local/bin/orch --remote 127.0.0.1:7777 worker run --worker-id host-zeus",
+			workerID:  "host-zeus",
+			wantMatch: true,
+		},
+		{
+			name:      "equals worker id flag",
+			command:   "/tmp/orch-next worker run --worker-id=host-zeus",
+			workerID:  "host-zeus",
+			wantMatch: true,
+		},
+		{
+			name:      "different worker id",
+			command:   "orch worker run --worker-id host-athena",
+			workerID:  "host-zeus",
+			wantMatch: false,
+		},
+		{
+			name:      "worker text in another command",
+			command:   "orch send run-1 worker run --worker-id host-zeus",
+			workerID:  "host-zeus",
+			wantMatch: false,
+		},
+		{
+			name:      "non orch executable",
+			command:   "sh worker run --worker-id host-zeus",
+			workerID:  "host-zeus",
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := managedWorkerCommandHasIdentity(tt.command, tt.workerID); got != tt.wantMatch {
+				t.Fatalf("managedWorkerCommandHasIdentity(%q, %q) = %t, want %t", tt.command, tt.workerID, got, tt.wantMatch)
+			}
+		})
+	}
+}
+
 func TestStatusManagedReportsUnmanagedRegistration(t *testing.T) {
 	setManagedWorkerTestEnv(t)
 	withManagedWorkerTestHooks(t)
@@ -246,6 +359,7 @@ func withManagedWorkerTestHooks(t *testing.T) {
 	origQueryTimeout := managedWorkerQueryTimeout
 	origLaunch := managedWorkerLaunchConfig
 	origLookup := lookupManagedWorkerRegistration
+	origListProcesses := listManagedWorkerProcesses
 	origNow := managedWorkerNow
 	t.Cleanup(func() {
 		managedWorkerStartupTimeout = origTimeout
@@ -253,8 +367,10 @@ func withManagedWorkerTestHooks(t *testing.T) {
 		managedWorkerQueryTimeout = origQueryTimeout
 		managedWorkerLaunchConfig = origLaunch
 		lookupManagedWorkerRegistration = origLookup
+		listManagedWorkerProcesses = origListProcesses
 		managedWorkerNow = origNow
 	})
+	listManagedWorkerProcesses = func() ([]managedWorkerProcess, error) { return nil, nil }
 }
 
 func helperManagedWorkerLaunchConfig(mode string) func(managedProfile) (string, []string, []string, error) {
@@ -268,6 +384,43 @@ func helperManagedWorkerLaunchConfig(mode string) func(managedProfile) (string, 
 			},
 			nil
 	}
+}
+
+func startUnreconciledManagedWorkerHelper(t *testing.T, opts ManagedOptions) int {
+	t.Helper()
+
+	profile, err := resolveManagedProfile(opts)
+	if err != nil {
+		t.Fatalf("resolveManagedProfile(%+v) error = %v", opts, err)
+	}
+	path, args, extraEnv, err := helperManagedWorkerLaunchConfig("unregistered")(profile)
+	if err != nil {
+		t.Fatalf("helperManagedWorkerLaunchConfig() error = %v", err)
+	}
+	cmd := &exec.Cmd{
+		Path: path,
+		Args: args,
+		Env:  mergeManagedEnv(os.Environ(), extraEnv, profile),
+		SysProcAttr: &syscall.SysProcAttr{
+			Setsid: true,
+		},
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start unreconciled helper for %+v: %v", opts, err)
+	}
+	go func() { _ = cmd.Wait() }()
+	t.Cleanup(func() { _ = stopManagedProcess(cmd.Process.Pid) })
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		state, err := loadManagedState(profile.StatePath)
+		if err == nil && state.PID == cmd.Process.Pid && state.ProcessState == localProcessStateStarting {
+			return cmd.Process.Pid
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("unreconciled helper pid %d did not write starting state", cmd.Process.Pid)
+	return 0
 }
 
 func lookupRegistrationFromManagedState(remoteAddr, workerID string) (*daemon.WorkerRegistration, error) {


### PR DESCRIPTION
## Summary

- reconcile managed worker lifecycle by `worker-id`, independent of the configured master connection profile
- serialize same-ID start/stop operations and stop every competing managed profile before reusing or starting the requested profile
- detect exact local `orch worker run` processes so state-less/legacy orphans are also removed by `worker stop`, start preflight, and `worker stop --all`
- record the host-local single-worker invariant in ADR-0002 and worker lease law LL8

## Root cause

Managed state and PID files are keyed by both `worker-id` and `remote`. `StopManaged` previously resolved only the current `(worker-id, remote)` profile, so an older process started with another remote spelling—or with missing state—was invisible and survived stop/start cycles. The master protocol also carries only `worker_id`, so two such processes are indistinguishable during heartbeat and lease polling.

## Acceptance criteria

- **Unmanaged same-ID process does not remain:** `TestStopStartManagedConvergesSameWorkerIDAcrossProfiles` launches two real helper processes, removes both state and PID files, verifies `StopManaged` stops both, then verifies restart leaves exactly one live PID.
- **Two-process stop/start converges to one:** verified against a built `orch` binary with an isolated daemon and real OS process enumeration:

```text
before_stop=2 pids=88026,88029
Stopped workers: 2
Started worker: acceptance-orphan (pid: 88586)
after_stop_start=1
88586 /tmp/orch-worker-reconcile-478699 --remote= worker run --worker-id acceptance-orphan
```

## Verification section mapping

- **Zeus-equivalent artificial orphan; confirm one process with `pgrep`: ALTERNATIVE / DEVIATION.** Executed the full scenario on the local macOS host with an isolated XDG runtime and private daemon, using two state-less `worker run` processes and `pgrep -f`. The result was exactly one process after `worker stop` → `worker start`, as shown above. This was not deployed to or executed on `zeus`; the A/B branch remains isolated and unmerged for human review.

## Checks

- `go build ./...`
- `go test ./...`
- `go test -race ./internal/worker -count=1`
- `make lint`
- `git diff --check`

Issue: `worker-stop-leaves-orphan-supervisors`

This is an A/B candidate PR. Do not merge until both candidate implementations have been reviewed.
