### PR TITLE
Reconcile worker-id claimants on worker stop/start

### DIFF
--- a/docs/adr/ADR-0002-idempotent-worker-autostart.md
+++ b/docs/adr/ADR-0002-idempotent-worker-autostart.md
@@ -84,6 +84,43 @@ untargeted run. Operators who want strict topology use the off-switch.
 on the master process it disables the reconciler, on the client it disables
 the pre-dispatch ensure. Default: enabled.
 
+### 4. Worker identity is host-local and profile-independent
+
+**Invariant: one host has at most one live `orch worker run` process for a
+given `worker-id`.** The master connection string is configuration of that
+worker, not part of its identity: `zeus:7777`, `127.0.0.1:7777`, and the
+local socket may all denote the same master, so no per-connection-string
+record (the managed state files are keyed by worker-id + remote) can decide
+whether a second process is a duplicate.
+
+`worker start` and `worker stop` therefore reconcile by `worker-id` against
+the live process table (`reconcileWorkerID` in `internal/worker/reconcile.go`)
+instead of trusting profile state: every local process whose command line
+claims the worker id — an exact `orch … worker run` subcommand match, with an
+absent `--worker-id` flag resolving to the host default id — is a claimant.
+The process-table check is required because an older binary generation, a
+changed `--remote` spelling, or deleted state/PID metadata leaves a live
+supervisor outside every current profile. `worker start` keeps only the
+requested profile's known-live PID, stops every other claimant, and launches
+only when no managed process remains. `worker stop` stops all claimants of
+the id, including state-less ones; `worker stop --all` additionally sweeps
+every remaining local `orch worker run` process. Lifecycle transitions for
+one worker id serialize on a host-local file lock keyed by the id alone
+(`acquireManagedWorkerIdentityLock`), so concurrent start/stop calls — even
+with different `--remote` spellings — cannot interleave their
+reconcile-and-launch sequences.
+
+Master-side duplicate eviction is not the enforcement layer of this decision.
+The worker protocol carries only `worker_id` on register, heartbeat, lease,
+acknowledgement, and unregister calls; once two processes claim the id, the
+master cannot tell which request belongs to which process, so it cannot
+selectively shut down the older one without introducing a new
+connection-instance identity across the whole lease protocol. Host-local
+process ownership is already the managed lifecycle boundary and also reaps
+older binaries that would not understand a new protocol response. The master
+only surfaces the symptom: it logs a warning when a worker id re-registers
+while the previous registration is still heartbeat-fresh.
+
 ## Resulting UX
 
 | Mode | Before | After |
@@ -108,6 +145,11 @@ the pre-dispatch ensure. Default: enabled.
   single-machine setups; docs and the embedded tutorial shrink accordingly.
 - The reconciler runs strictly inside the lease-failure path: zero cost when
   workers are healthy, no background polling, no new periodic loop.
+- Changing the configured master for a `worker-id` is a replacement, not a
+  second concurrent worker: `worker start` with the new `--remote` stops the
+  old supervisor before launching, so two processes never race for the same
+  lease identity after a master restart. Running workers for two masters on
+  one host requires two distinct worker ids.
 
 ### Environment normalization decision (2026-07-13)
 

--- a/docs/design/worker-lease.md
+++ b/docs/design/worker-lease.md
@@ -141,6 +141,7 @@ enrichment must use a batched per-host operation rather than per-run leases.
 | LL5 snapshot sufficiency | a worker executes any effect using only the lease payload (RunSnapshot); it never reads its local store for master-owned runs (PR #457's contract) |
 | LL6 start target confinement | every `start_run` resolves a `TargetWorkerID` before lease acquisition; empty/`local` targets resolve to the master's host worker, named targets resolve through `config.targets`, and neither may fall back to another worker |
 | LL7 worktree host confinement | single-run worktree inspect/remove executes on the run's target worker; an unavailable worker or failed stat/git operation is returned with host/cause and is never converted to `exists=false` or an absent skip; list paths leave worktree existence unpopulated pending a batched per-host operation |
+| LL8 local worker identity convergence | `worker-id` is the host-local supervisor identity, independent of master connection profile; after `StartManaged(w, profile)` at most that profile's process is live for `w`, and after `StopManaged(w)` no local `orch worker run` process for `w` is live, even when its profile state is missing |
 
 ## Verification and maintenance
 
@@ -151,5 +152,14 @@ executes against a real registered worktree, while
 `TestRemoteGetRunReportsWorkerObservedWorktreeExists`,
 `TestRemoteCleanRunWorktreeUsesExecutionHostWorker`, and
 `TestRemoteGetRunWorktreeObservationFailureIsExplicit` prove master routing and
-fail-clear propagation. Lease-map mutation remains confined by the
+fail-clear propagation. LL8 is enforced by the worker-id reconcile
+(`reconcileWorkerID` / `reconcileAllWorkerProcesses` in
+`internal/worker/reconcile.go`, invoked from `StartManaged`/`StopManaged`
+under the per-id identity lock) and covered by
+`TestStartManagedReconcilesOrphanClaimantBeforeLaunch`,
+`TestStartManagedReusesManagedProcessAndStopsOrphan`,
+`TestStopManagedStopsUnmanagedClaimantsWithoutStateFile`,
+`TestStopManagedStopsManagedProcessAndOrphanClaimant`, and the real
+process-table probe `TestDefaultListWorkerProcessesFindsRealClaimant`.
+Lease-map mutation remains confined by the
 `worker-lease-mutation-surface` semgrep rule.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -903,6 +903,14 @@ Start a managed orch-worker host process. Usually automatic
 dispatch to a remote master auto-starts the local worker for it. Manual start
 remains for other hosts and for `ORCH_WORKER_AUTOSTART=0`.
 
+Worker identity is the worker ID, per host: before starting (or reusing) the
+managed process, orch reconciles the invariant that at most one local process
+claims the target worker ID. Any other claimant — started manually with
+`orch worker run`, by an older binary generation, or with a different
+`--remote` connection string — is stopped first and reported as
+`orphan_pids`. To run two workers on one host intentionally, give them
+distinct `--worker-id` values.
+
 ```bash
 orch worker start [flags]
 ```
@@ -927,13 +935,20 @@ orch worker status [flags]
 
 Stop a managed orch-worker host process.
 
+Stopping reconciles the worker-ID invariant: besides the supervised process
+recorded in the local state file, any other local process claiming the same
+worker ID is stopped as well (reported as `orphan_pids`), so no orphan keeps
+contending for the worker registration after a stop/start cycle. `--all`
+additionally sweeps every remaining `orch worker run` process on the host,
+including ones no state file records.
+
 ```bash
 orch worker stop [flags]
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--all` | Stop all managed workers |
+| `--all` | Stop all workers on this host (managed workers plus any orphan orch worker processes) |
 | `--worker-id <id>` | Worker ID to stop (default: local host worker) |
 
 ---

--- a/internal/cli/master_worker.go
+++ b/internal/cli/master_worker.go
@@ -201,6 +201,9 @@ func newWorkerStartCmd() *cobra.Command {
 				} else {
 					fmt.Printf("Started worker: %s (pid: %d)\n", resp.WorkerID, resp.PID)
 				}
+				if len(resp.OrphanPIDs) > 0 {
+					fmt.Printf("Stopped orphan worker processes claiming %s: %s\n", resp.WorkerID, formatWorkerPIDs(resp.OrphanPIDs))
+				}
 				if resp.LogPath != "" {
 					fmt.Printf("Log: %s\n", resp.LogPath)
 				}
@@ -218,18 +221,21 @@ func newWorkerStopCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stop",
 		Short: "Stop managed orch-worker host process",
+		Long: `Stop managed orch-worker host process.
+
+Stopping reconciles the worker-id invariant: besides the supervised process
+recorded in the local state file, any other process on this host claiming the
+same worker id (started manually, by an older binary, or with a different
+--remote connection string) is stopped as well, so no orphan keeps contending
+for the worker registration.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			stoppedCount, err := worker.StopManaged(worker.ManagedOptions{
+			resp, err := worker.StopManaged(worker.ManagedOptions{
 				WorkerID:   workerID,
 				RemoteAddr: getRemoteAddr(),
 			}, stopAll)
 			if err != nil {
 				return err
 			}
-			resp := struct {
-				OK           bool `json:"ok"`
-				StoppedCount int  `json:"stopped_count"`
-			}{OK: true, StoppedCount: stoppedCount}
 
 			if globalOpts.JSON {
 				enc := json.NewEncoder(os.Stdout)
@@ -239,13 +245,24 @@ func newWorkerStopCmd() *cobra.Command {
 
 			if !globalOpts.Quiet {
 				fmt.Printf("Stopped workers: %d\n", resp.StoppedCount)
+				if len(resp.OrphanPIDs) > 0 {
+					fmt.Printf("Stopped orphan worker processes: %s\n", formatWorkerPIDs(resp.OrphanPIDs))
+				}
 			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&workerID, "worker-id", "", "worker id to stop (default: local host worker)")
-	cmd.Flags().BoolVar(&stopAll, "all", false, "stop all managed workers")
+	cmd.Flags().BoolVar(&stopAll, "all", false, "stop all workers on this host (managed workers plus any orphan orch worker processes)")
 	return cmd
+}
+
+func formatWorkerPIDs(pids []int) string {
+	parts := make([]string, 0, len(pids))
+	for _, pid := range pids {
+		parts = append(parts, fmt.Sprintf("%d", pid))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func humanizeWorkerTime(ts time.Time) string {

--- a/internal/daemon/worker_plane.go
+++ b/internal/daemon/worker_plane.go
@@ -281,6 +281,16 @@ func (s *SocketServer) registerWorker(workerID, workerType, host, mode string, c
 	registeredAt := now
 	if existing, ok := s.workers[workerID]; ok {
 		registeredAt = existing.RegisteredAt
+		// Two processes claiming one worker id are indistinguishable to the
+		// master (registration carries no instance identity), so duplicates
+		// can only be surfaced, not fenced, here: a re-register while the
+		// previous registration is still heartbeat-fresh is either a fast
+		// reconnect of the same process or a second process contending for
+		// the id. The newest registration wins either way; the host-side
+		// `worker start`/`worker stop` reconcile is what removes duplicates.
+		if s.workerIsActive(existing, now) && s.logger != nil {
+			s.logger.Printf("WARNING: worker %q re-registered from host %q while previous registration (host %q, last heartbeat %s ago) was still active — possible duplicate worker processes claiming the same worker id; newest registration wins", workerID, host, existing.Host, now.Sub(existing.LastHeartbeat).Round(time.Millisecond))
+		}
 	}
 
 	worker := &WorkerRegistration{

--- a/internal/daemon/worker_plane_test.go
+++ b/internal/daemon/worker_plane_test.go
@@ -478,3 +478,36 @@ func TestWaitForWorkerLeaseCompletionFailsFastWhenWorkerLost(t *testing.T) {
 		t.Fatalf("fail-fast took %s, want well under the lease timeout", elapsed)
 	}
 }
+
+func TestRegisterWorkerWarnsOnReregisterWhilePreviousStillActive(t *testing.T) {
+	var buf strings.Builder
+	server := NewSocketServer(nil, log.New(&buf, "", 0))
+
+	if _, ttl := server.registerWorker("host-dup", "executor", "zeus", "external", nil); ttl <= 0 {
+		t.Fatal("expected positive heartbeat ttl for first registration")
+	}
+	if strings.Contains(buf.String(), "WARNING") {
+		t.Fatalf("first registration must not warn, got: %s", buf.String())
+	}
+
+	if _, ttl := server.registerWorker("host-dup", "executor", "zeus", "external", nil); ttl <= 0 {
+		t.Fatal("expected positive heartbeat ttl for duplicate registration")
+	}
+	warning := buf.String()
+	if !strings.Contains(warning, "WARNING") || !strings.Contains(warning, "host-dup") || !strings.Contains(warning, "duplicate") {
+		t.Fatalf("expected duplicate-registration warning naming the worker id, got: %s", warning)
+	}
+
+	// A re-register after the previous heartbeat expired is a normal
+	// reconnect and must stay silent.
+	buf.Reset()
+	server.workersMu.Lock()
+	server.workers["host-dup"].LastHeartbeat = time.Now().Add(-2 * workerHeartbeatTTL)
+	server.workersMu.Unlock()
+	if _, ttl := server.registerWorker("host-dup", "executor", "zeus", "external", nil); ttl <= 0 {
+		t.Fatal("expected positive heartbeat ttl for reconnect registration")
+	}
+	if strings.Contains(buf.String(), "WARNING") {
+		t.Fatalf("reconnect after heartbeat expiry must not warn, got: %s", buf.String())
+	}
+}

--- a/internal/worker/managed.go
+++ b/internal/worker/managed.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -33,6 +34,11 @@ const (
 	masterStateNotRegistered      = "not_registered"
 	masterStateUnreachable        = "unreachable"
 	defaultManagedWorkerQueryTime = time.Second
+	// reconcileReregisterGrace covers the window between a reconciled orphan
+	// gracefully unregistering the shared worker id and the surviving managed
+	// process re-registering after its next heartbeat failure (heartbeat
+	// interval + first reconnect backoff, with margin).
+	reconcileReregisterGrace = 10 * time.Second
 )
 
 var (
@@ -56,6 +62,19 @@ type ManagedStartResult struct {
 	PID      int    `json:"pid"`
 	LogPath  string `json:"log_path,omitempty"`
 	Reused   bool   `json:"reused"`
+	// OrphanPIDs lists processes that claimed this worker id outside the
+	// managed state file and were stopped by the pre-start reconcile.
+	OrphanPIDs []int `json:"orphan_pids,omitempty"`
+}
+
+// ManagedStopResult reports how many worker processes a stop request ended.
+// StoppedCount includes both the managed supervisor process and reconciled
+// orphans; OrphanPIDs lists the processes that claimed a stopped worker id
+// outside the managed state file.
+type ManagedStopResult struct {
+	OK           bool  `json:"ok"`
+	StoppedCount int   `json:"stopped_count"`
+	OrphanPIDs   []int `json:"orphan_pids,omitempty"`
 }
 
 type ManagedState struct {
@@ -138,16 +157,37 @@ func StartManaged(opts ManagedOptions) (*ManagedStartResult, error) {
 		profile.LogPath = state.LogPath
 	}
 
-	reg, regErr := lookupManagedWorkerRegistration(profile.RemoteAddr, profile.WorkerID)
-	if state == nil && regErr == nil && reg != nil && reg.Active {
-		return nil, fmt.Errorf("worker %q is already active on orch-master profile %q but no local managed process metadata exists; it may have been started manually on this host or another host", profile.WorkerID, managedProfileDisplay(profile.RemoteAddr))
+	keepPID := 0
+	if state != nil && state.PID > 0 && daemon.IsProcessRunning(state.PID) {
+		keepPID = state.PID
+	}
+	// Pre-start reconcile: any other local process claiming this worker id —
+	// stale binary generation, different connection string, manual `worker
+	// run` — would contend for the master registration with the process this
+	// start owns. Stop them before deciding reuse vs launch.
+	orphanPIDs, err := reconcileWorkerID(profile.WorkerID, keepPID)
+	if err != nil {
+		return nil, err
 	}
 
-	if state != nil && state.PID > 0 && daemon.IsProcessRunning(state.PID) {
-		if err := waitForManagedWorkerReady(profile, state.PID, nil); err != nil {
+	reg, regErr := lookupManagedWorkerRegistration(profile.RemoteAddr, profile.WorkerID)
+	if state == nil && len(orphanPIDs) == 0 && regErr == nil && reg != nil && reg.Active {
+		return nil, fmt.Errorf("worker %q is already active on orch-master profile %q but no local managed process metadata exists and no local process claims that worker id; it may have been started on another host", profile.WorkerID, managedProfileDisplay(profile.RemoteAddr))
+	}
+
+	if keepPID > 0 {
+		readyTimeout := managedWorkerStartupTimeout
+		if len(orphanPIDs) > 0 {
+			// A gracefully stopped orphan unregisters the shared worker id on
+			// its way out; the surviving managed process re-registers only
+			// after its next heartbeat fails. Wait out that gap instead of
+			// reporting a healthy worker as not registered.
+			readyTimeout += reconcileReregisterGrace
+		}
+		if err := waitForManagedWorkerReady(profile, keepPID, nil, readyTimeout); err != nil {
 			return nil, err
 		}
-		return &ManagedStartResult{OK: true, WorkerID: profile.WorkerID, PID: state.PID, LogPath: profile.LogPath, Reused: true}, nil
+		return &ManagedStartResult{OK: true, WorkerID: profile.WorkerID, PID: keepPID, LogPath: profile.LogPath, Reused: true, OrphanPIDs: orphanPIDs}, nil
 	}
 
 	if state != nil && state.PID > 0 {
@@ -206,7 +246,7 @@ func StartManaged(opts ManagedOptions) (*ManagedStartResult, error) {
 		return nil, err
 	}
 
-	if err := waitForManagedWorkerReady(profile, cmd.Process.Pid, waitCh); err != nil {
+	if err := waitForManagedWorkerReady(profile, cmd.Process.Pid, waitCh, managedWorkerStartupTimeout); err != nil {
 		_ = stopManagedProcess(cmd.Process.Pid)
 		updateManagedState(profile.StatePath, func(state *ManagedState) {
 			state.ProcessState = localProcessStateExited
@@ -217,31 +257,45 @@ func StartManaged(opts ManagedOptions) (*ManagedStartResult, error) {
 		return nil, err
 	}
 
-	return &ManagedStartResult{OK: true, WorkerID: profile.WorkerID, PID: cmd.Process.Pid, LogPath: profile.LogPath}, nil
+	return &ManagedStartResult{OK: true, WorkerID: profile.WorkerID, PID: cmd.Process.Pid, LogPath: profile.LogPath, OrphanPIDs: orphanPIDs}, nil
 }
 
-func StopManaged(opts ManagedOptions, all bool) (int, error) {
+func StopManaged(opts ManagedOptions, all bool) (*ManagedStopResult, error) {
 	if all {
 		profiles, err := listManagedProfiles()
 		if err != nil {
-			return 0, err
+			return nil, err
 		}
-		stopped := 0
+		result := &ManagedStopResult{OK: true}
 		for _, profile := range profiles {
-			count, err := stopManagedProfile(profile)
+			count, orphans, err := stopManagedProfile(profile)
 			if err != nil {
-				return stopped, err
+				return nil, err
 			}
-			stopped += count
+			result.StoppedCount += count
+			result.OrphanPIDs = append(result.OrphanPIDs, orphans...)
 		}
-		return stopped, nil
+		// Residual sweep: after --all, this host runs zero orch worker
+		// processes, including ones whose worker id no state file records.
+		orphans, err := reconcileAllWorkerProcesses()
+		if err != nil {
+			return nil, err
+		}
+		result.StoppedCount += len(orphans)
+		result.OrphanPIDs = append(result.OrphanPIDs, orphans...)
+		sort.Ints(result.OrphanPIDs)
+		return result, nil
 	}
 
 	profile, err := resolveManagedProfile(opts)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	return stopManagedProfile(profile)
+	count, orphans, err := stopManagedProfile(profile)
+	if err != nil {
+		return nil, err
+	}
+	return &ManagedStopResult{OK: true, StoppedCount: count, OrphanPIDs: orphans}, nil
 }
 
 func StatusManaged(opts ManagedOptions) (*ManagedStatus, error) {
@@ -523,8 +577,8 @@ func removeManagedPID(path string) error {
 	return nil
 }
 
-func waitForManagedWorkerReady(profile managedProfile, pid int, waitCh <-chan error) error {
-	deadline := managedWorkerNow().Add(managedWorkerStartupTimeout)
+func waitForManagedWorkerReady(profile managedProfile, pid int, waitCh <-chan error, timeout time.Duration) error {
+	deadline := managedWorkerNow().Add(timeout)
 	var lastLookupErr error
 	for managedWorkerNow().Before(deadline) {
 		reg, err := lookupManagedWorkerRegistration(profile.RemoteAddr, profile.WorkerID)
@@ -546,7 +600,7 @@ func waitForManagedWorkerReady(profile managedProfile, pid int, waitCh <-chan er
 		}
 		time.Sleep(managedWorkerStartupPoll)
 	}
-	return managedWorkerTimeoutError(profile, lastLookupErr)
+	return managedWorkerTimeoutError(profile, lastLookupErr, timeout)
 }
 
 func managedWorkerExitedError(profile managedProfile, waitErr error) error {
@@ -560,11 +614,11 @@ func managedWorkerExitedError(profile managedProfile, waitErr error) error {
 	return fmt.Errorf("managed worker %q exited before registering with orch-master profile %q%s; check %s or run %s manually for diagnostics", profile.WorkerID, managedProfileDisplay(profile.RemoteAddr), exitSuffix, profile.LogPath, managedWorkerRunDiagnosticCommand(profile))
 }
 
-func managedWorkerTimeoutError(profile managedProfile, lastLookupErr error) error {
+func managedWorkerTimeoutError(profile managedProfile, lastLookupErr error, timeout time.Duration) error {
 	if lastLookupErr != nil {
-		return fmt.Errorf("managed worker %q did not register with orch-master profile %q within %s; last master error: %v; check %s or run %s manually for diagnostics", profile.WorkerID, managedProfileDisplay(profile.RemoteAddr), managedWorkerStartupTimeout, lastLookupErr, profile.LogPath, managedWorkerRunDiagnosticCommand(profile))
+		return fmt.Errorf("managed worker %q did not register with orch-master profile %q within %s; last master error: %v; check %s or run %s manually for diagnostics", profile.WorkerID, managedProfileDisplay(profile.RemoteAddr), timeout, lastLookupErr, profile.LogPath, managedWorkerRunDiagnosticCommand(profile))
 	}
-	return fmt.Errorf("managed worker %q did not register with orch-master profile %q within %s; check %s or run %s manually for diagnostics", profile.WorkerID, managedProfileDisplay(profile.RemoteAddr), managedWorkerStartupTimeout, profile.LogPath, managedWorkerRunDiagnosticCommand(profile))
+	return fmt.Errorf("managed worker %q did not register with orch-master profile %q within %s; check %s or run %s manually for diagnostics", profile.WorkerID, managedProfileDisplay(profile.RemoteAddr), timeout, profile.LogPath, managedWorkerRunDiagnosticCommand(profile))
 }
 
 func managedWorkerRunDiagnosticCommand(profile managedProfile) string {
@@ -622,36 +676,53 @@ func listManagedProfiles() ([]managedProfile, error) {
 	return profiles, nil
 }
 
-func stopManagedProfile(profile managedProfile) (int, error) {
+// stopManagedProfile stops the supervised process recorded in the profile's
+// state file, then reconciles the worker-id invariant: no process on this
+// host may keep claiming the stopped worker id, whether or not any state file
+// tracks it. It returns the total number of processes stopped and the subset
+// that were unmanaged orphans.
+func stopManagedProfile(profile managedProfile) (int, []int, error) {
 	state, err := loadManagedState(profile.StatePath)
 	if err != nil {
 		if os.IsNotExist(err) {
+			orphans, rerr := reconcileWorkerID(profile.WorkerID, 0)
+			if rerr != nil {
+				return 0, nil, rerr
+			}
+			if len(orphans) > 0 {
+				return len(orphans), orphans, nil
+			}
 			status, statusErr := StatusManaged(ManagedOptions{WorkerID: profile.WorkerID, RemoteAddr: profile.RemoteAddr})
 			if statusErr == nil && status != nil && status.Master.Registration != nil {
-				return 0, fmt.Errorf("worker %q is registered on orch-master profile %q but is not managed by the local background supervisor", profile.WorkerID, managedProfileDisplay(profile.RemoteAddr))
+				return 0, nil, fmt.Errorf("worker %q is registered on orch-master profile %q but no local process claims it and it is not managed by the local background supervisor", profile.WorkerID, managedProfileDisplay(profile.RemoteAddr))
 			}
-			return 0, nil
+			return 0, nil, nil
 		}
-		return 0, err
+		return 0, nil, err
 	}
-	if state.PID <= 0 || !daemon.IsProcessRunning(state.PID) {
+	stopped := 0
+	if state.PID > 0 && daemon.IsProcessRunning(state.PID) {
+		if err := stopManagedProcess(state.PID); err != nil {
+			return 0, nil, err
+		}
+		stopped = 1
+		updateManagedState(profile.StatePath, func(current *ManagedState) {
+			current.ProcessState = localProcessStateStopped
+			current.ExitedAt = managedWorkerNow()
+			current.LastError = ""
+		})
+	} else {
 		updateManagedState(profile.StatePath, func(current *ManagedState) {
 			current.ProcessState = localProcessStateStopped
 			current.ExitedAt = managedWorkerNow()
 		})
-		_ = removeManagedPID(profile.PIDPath)
-		return 0, nil
 	}
-	if err := stopManagedProcess(state.PID); err != nil {
-		return 0, err
-	}
-	updateManagedState(profile.StatePath, func(current *ManagedState) {
-		current.ProcessState = localProcessStateStopped
-		current.ExitedAt = managedWorkerNow()
-		current.LastError = ""
-	})
 	_ = removeManagedPID(profile.PIDPath)
-	return 1, nil
+	orphans, rerr := reconcileWorkerID(profile.WorkerID, 0)
+	if rerr != nil {
+		return stopped, nil, rerr
+	}
+	return stopped + len(orphans), orphans, nil
 }
 
 func stopManagedProcess(pid int) error {
@@ -662,7 +733,11 @@ func stopManagedProcess(pid int) error {
 	if err != nil {
 		return err
 	}
-	_ = process.Signal(os.Interrupt)
+	// SIGTERM, not SIGINT: a worker spawned as a shell background job
+	// inherits SIGINT as ignored (and Go keeps an inherited SIG_IGN for
+	// SIGINT), so orphans started via `nohup ... &` would only die at the
+	// SIGKILL fallback. The worker loop handles SIGTERM and SIGINT alike.
+	_ = process.Signal(syscall.SIGTERM)
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if !daemon.IsProcessRunning(pid) {

--- a/internal/worker/managed.go
+++ b/internal/worker/managed.go
@@ -151,6 +151,11 @@ func StartManaged(opts ManagedOptions) (*ManagedStartResult, error) {
 	if err := ensureManagedDirs(); err != nil {
 		return nil, err
 	}
+	identityLock, err := acquireManagedWorkerIdentityLock(profile.WorkerID)
+	if err != nil {
+		return nil, err
+	}
+	defer releaseManagedWorkerIdentityLock(identityLock)
 
 	state, _ := loadManagedState(profile.StatePath)
 	if state != nil && state.LogPath != "" {
@@ -268,7 +273,7 @@ func StopManaged(opts ManagedOptions, all bool) (*ManagedStopResult, error) {
 		}
 		result := &ManagedStopResult{OK: true}
 		for _, profile := range profiles {
-			count, orphans, err := stopManagedProfile(profile)
+			count, orphans, err := stopManagedProfileLocked(profile)
 			if err != nil {
 				return nil, err
 			}
@@ -291,11 +296,26 @@ func StopManaged(opts ManagedOptions, all bool) (*ManagedStopResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	count, orphans, err := stopManagedProfile(profile)
+	count, orphans, err := stopManagedProfileLocked(profile)
 	if err != nil {
 		return nil, err
 	}
 	return &ManagedStopResult{OK: true, StoppedCount: count, OrphanPIDs: orphans}, nil
+}
+
+// stopManagedProfileLocked wraps stopManagedProfile in the per-worker-id
+// identity lock so stop calls (including each profile handled by
+// `stop --all`) serialize against a concurrent start/stop of the same id.
+func stopManagedProfileLocked(profile managedProfile) (int, []int, error) {
+	if err := ensureManagedDirs(); err != nil {
+		return 0, nil, err
+	}
+	identityLock, err := acquireManagedWorkerIdentityLock(profile.WorkerID)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer releaseManagedWorkerIdentityLock(identityLock)
+	return stopManagedProfile(profile)
 }
 
 func StatusManaged(opts ManagedOptions) (*ManagedStatus, error) {
@@ -486,6 +506,33 @@ func hasAnyPrefix(value string, prefixes []string) bool {
 		}
 	}
 	return false
+}
+
+// acquireManagedWorkerIdentityLock serializes managed lifecycle transitions
+// (start/stop) for one worker id across processes. The lock file is keyed by
+// the worker id alone — profile-independent, like the identity it guards
+// (ADR-0002 §4) — so concurrent start/stop calls for the same id with
+// different --remote spellings still serialize their reconcile-and-launch
+// sequences instead of interleaving.
+func acquireManagedWorkerIdentityLock(workerID string) (*os.File, error) {
+	lockPath := filepath.Join(xdg.WorkersRuntimeDir(), managedProfileKey(workerID, "")+".lock")
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open managed worker identity lock for %q: %w", workerID, err)
+	}
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		_ = lockFile.Close()
+		return nil, fmt.Errorf("lock managed worker identity %q: %w", workerID, err)
+	}
+	return lockFile, nil
+}
+
+func releaseManagedWorkerIdentityLock(lockFile *os.File) {
+	if lockFile == nil {
+		return
+	}
+	_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	_ = lockFile.Close()
 }
 
 func ensureManagedDirs() error {

--- a/internal/worker/managed_test.go
+++ b/internal/worker/managed_test.go
@@ -132,8 +132,11 @@ func TestStartStatusStopManagedUsesPersistentLocalState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StopManaged() error = %v", err)
 	}
-	if stopped != 1 {
-		t.Fatalf("stopped = %d, want 1", stopped)
+	if stopped.StoppedCount != 1 {
+		t.Fatalf("stopped = %d, want 1", stopped.StoppedCount)
+	}
+	if len(stopped.OrphanPIDs) != 0 {
+		t.Fatalf("orphan pids = %v, want none", stopped.OrphanPIDs)
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -180,6 +183,210 @@ func TestStatusManagedReportsUnmanagedRegistration(t *testing.T) {
 	}
 	if status.Diagnostic == "" {
 		t.Fatal("expected unmanaged diagnostic")
+	}
+}
+
+func TestStopManagedStopsUnmanagedClaimantsWithoutStateFile(t *testing.T) {
+	setManagedWorkerTestEnv(t)
+	withManagedWorkerTestHooks(t)
+
+	lookupManagedWorkerRegistration = func(remoteAddr, workerID string) (*daemon.WorkerRegistration, error) {
+		return nil, nil
+	}
+
+	orphan := spawnSleeperHelper(t, nil)
+	listWorkerProcesses = func() ([]workerProcess, error) {
+		return []workerProcess{{PID: orphan.Process.Pid, WorkerID: "worker-orphan"}}, nil
+	}
+
+	res, err := StopManaged(ManagedOptions{WorkerID: "worker-orphan", RemoteAddr: "remotebox:7777"}, false)
+	if err != nil {
+		t.Fatalf("StopManaged() error = %v", err)
+	}
+	if res.StoppedCount != 1 {
+		t.Fatalf("stopped = %d, want 1", res.StoppedCount)
+	}
+	if len(res.OrphanPIDs) != 1 || res.OrphanPIDs[0] != orphan.Process.Pid {
+		t.Fatalf("orphan pids = %v, want [%d]", res.OrphanPIDs, orphan.Process.Pid)
+	}
+	waitForProcessExit(t, orphan.Process.Pid, 3*time.Second)
+}
+
+func TestStopManagedStopsManagedProcessAndOrphanClaimant(t *testing.T) {
+	setManagedWorkerTestEnv(t)
+	withManagedWorkerTestHooks(t)
+
+	managedWorkerStartupTimeout = 2 * time.Second
+	managedWorkerStartupPoll = 25 * time.Millisecond
+	managedWorkerLaunchConfig = helperManagedWorkerLaunchConfig("registered")
+	lookupManagedWorkerRegistration = lookupRegistrationFromManagedState
+
+	opts := ManagedOptions{WorkerID: "worker-live", RemoteAddr: "remotebox:7777"}
+	start, err := StartManaged(opts)
+	if err != nil {
+		t.Fatalf("StartManaged() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = StopManaged(opts, false)
+	})
+
+	orphan := spawnSleeperHelper(t, nil)
+	listWorkerProcesses = func() ([]workerProcess, error) {
+		return []workerProcess{
+			{PID: start.PID, WorkerID: "worker-live"},
+			{PID: orphan.Process.Pid, WorkerID: "worker-live"},
+		}, nil
+	}
+
+	res, err := StopManaged(opts, false)
+	if err != nil {
+		t.Fatalf("StopManaged() error = %v", err)
+	}
+	if res.StoppedCount != 2 {
+		t.Fatalf("stopped = %d, want 2 (managed + orphan)", res.StoppedCount)
+	}
+	if len(res.OrphanPIDs) != 1 || res.OrphanPIDs[0] != orphan.Process.Pid {
+		t.Fatalf("orphan pids = %v, want [%d]", res.OrphanPIDs, orphan.Process.Pid)
+	}
+	waitForProcessExit(t, start.PID, 3*time.Second)
+	waitForProcessExit(t, orphan.Process.Pid, 3*time.Second)
+}
+
+func TestStopManagedAllSweepsUnrecordedWorkerProcesses(t *testing.T) {
+	setManagedWorkerTestEnv(t)
+	withManagedWorkerTestHooks(t)
+
+	orphan := spawnSleeperHelper(t, nil)
+	listWorkerProcesses = func() ([]workerProcess, error) {
+		return []workerProcess{{PID: orphan.Process.Pid, WorkerID: "worker-unrecorded"}}, nil
+	}
+
+	res, err := StopManaged(ManagedOptions{}, true)
+	if err != nil {
+		t.Fatalf("StopManaged(all) error = %v", err)
+	}
+	if res.StoppedCount != 1 {
+		t.Fatalf("stopped = %d, want 1", res.StoppedCount)
+	}
+	if len(res.OrphanPIDs) != 1 || res.OrphanPIDs[0] != orphan.Process.Pid {
+		t.Fatalf("orphan pids = %v, want [%d]", res.OrphanPIDs, orphan.Process.Pid)
+	}
+	waitForProcessExit(t, orphan.Process.Pid, 3*time.Second)
+}
+
+func TestStartManagedReconcilesOrphanClaimantBeforeLaunch(t *testing.T) {
+	setManagedWorkerTestEnv(t)
+	withManagedWorkerTestHooks(t)
+
+	managedWorkerStartupTimeout = 2 * time.Second
+	managedWorkerStartupPoll = 25 * time.Millisecond
+	managedWorkerLaunchConfig = helperManagedWorkerLaunchConfig("registered")
+
+	// The orphan holds an active master registration (the incident state:
+	// registered worker, no local supervisor metadata). Without a local
+	// claimant this blocks start; with one, reconcile removes it and start
+	// proceeds.
+	lookupManagedWorkerRegistration = func(remoteAddr, workerID string) (*daemon.WorkerRegistration, error) {
+		return &daemon.WorkerRegistration{
+			ID:            workerID,
+			Host:          "test-host",
+			Mode:          "external",
+			WorkerType:    "executor",
+			RegisteredAt:  time.Now().Add(-time.Hour),
+			LastHeartbeat: time.Now(),
+			Active:        true,
+		}, nil
+	}
+
+	orphan := spawnSleeperHelper(t, nil)
+	listWorkerProcesses = func() ([]workerProcess, error) {
+		return []workerProcess{{PID: orphan.Process.Pid, WorkerID: "worker-takeover"}}, nil
+	}
+
+	opts := ManagedOptions{WorkerID: "worker-takeover", RemoteAddr: "remotebox:7777"}
+	start, err := StartManaged(opts)
+	if err != nil {
+		t.Fatalf("StartManaged() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = StopManaged(opts, false)
+	})
+	if start.Reused {
+		t.Fatalf("expected fresh launch, got reuse: %+v", start)
+	}
+	if len(start.OrphanPIDs) != 1 || start.OrphanPIDs[0] != orphan.Process.Pid {
+		t.Fatalf("orphan pids = %v, want [%d]", start.OrphanPIDs, orphan.Process.Pid)
+	}
+	waitForProcessExit(t, orphan.Process.Pid, 3*time.Second)
+	if !daemon.IsProcessRunning(start.PID) {
+		t.Fatal("expected managed worker process to be running")
+	}
+}
+
+func TestStartManagedStillRefusesActiveRegistrationWithoutLocalClaimant(t *testing.T) {
+	setManagedWorkerTestEnv(t)
+	withManagedWorkerTestHooks(t)
+
+	lookupManagedWorkerRegistration = func(remoteAddr, workerID string) (*daemon.WorkerRegistration, error) {
+		return &daemon.WorkerRegistration{
+			ID:            workerID,
+			Host:          "other-host",
+			Mode:          "external",
+			WorkerType:    "executor",
+			RegisteredAt:  time.Now().Add(-time.Hour),
+			LastHeartbeat: time.Now(),
+			Active:        true,
+		}, nil
+	}
+
+	_, err := StartManaged(ManagedOptions{WorkerID: "worker-elsewhere", RemoteAddr: "remotebox:7777"})
+	if err == nil {
+		t.Fatal("expected StartManaged to fail")
+	}
+	if !strings.Contains(err.Error(), "already active") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStartManagedReusesManagedProcessAndStopsOrphan(t *testing.T) {
+	setManagedWorkerTestEnv(t)
+	withManagedWorkerTestHooks(t)
+
+	managedWorkerStartupTimeout = 2 * time.Second
+	managedWorkerStartupPoll = 25 * time.Millisecond
+	managedWorkerLaunchConfig = helperManagedWorkerLaunchConfig("registered")
+	lookupManagedWorkerRegistration = lookupRegistrationFromManagedState
+
+	opts := ManagedOptions{WorkerID: "worker-live", RemoteAddr: "remotebox:7777"}
+	start, err := StartManaged(opts)
+	if err != nil {
+		t.Fatalf("StartManaged() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = StopManaged(opts, false)
+	})
+
+	orphan := spawnSleeperHelper(t, nil)
+	listWorkerProcesses = func() ([]workerProcess, error) {
+		return []workerProcess{
+			{PID: start.PID, WorkerID: "worker-live"},
+			{PID: orphan.Process.Pid, WorkerID: "worker-live"},
+		}, nil
+	}
+
+	again, err := StartManaged(opts)
+	if err != nil {
+		t.Fatalf("second StartManaged() error = %v", err)
+	}
+	if !again.Reused || again.PID != start.PID {
+		t.Fatalf("expected reuse of pid %d, got %+v", start.PID, again)
+	}
+	if len(again.OrphanPIDs) != 1 || again.OrphanPIDs[0] != orphan.Process.Pid {
+		t.Fatalf("orphan pids = %v, want [%d]", again.OrphanPIDs, orphan.Process.Pid)
+	}
+	waitForProcessExit(t, orphan.Process.Pid, 3*time.Second)
+	if !daemon.IsProcessRunning(start.PID) {
+		t.Fatal("managed worker process must survive the reuse reconcile")
 	}
 }
 
@@ -247,6 +454,7 @@ func withManagedWorkerTestHooks(t *testing.T) {
 	origLaunch := managedWorkerLaunchConfig
 	origLookup := lookupManagedWorkerRegistration
 	origNow := managedWorkerNow
+	origList := listWorkerProcesses
 	t.Cleanup(func() {
 		managedWorkerStartupTimeout = origTimeout
 		managedWorkerStartupPoll = origPoll
@@ -254,7 +462,11 @@ func withManagedWorkerTestHooks(t *testing.T) {
 		managedWorkerLaunchConfig = origLaunch
 		lookupManagedWorkerRegistration = origLookup
 		managedWorkerNow = origNow
+		listWorkerProcesses = origList
 	})
+	// Hermetic default: never scan (or signal) the real process table from
+	// unit tests. Reconcile-specific tests override this seam explicitly.
+	listWorkerProcesses = func() ([]workerProcess, error) { return nil, nil }
 }
 
 func helperManagedWorkerLaunchConfig(mode string) func(managedProfile) (string, []string, []string, error) {

--- a/internal/worker/managed_test.go
+++ b/internal/worker/managed_test.go
@@ -6,6 +6,8 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -387,6 +389,87 @@ func TestStartManagedReusesManagedProcessAndStopsOrphan(t *testing.T) {
 	waitForProcessExit(t, orphan.Process.Pid, 3*time.Second)
 	if !daemon.IsProcessRunning(start.PID) {
 		t.Fatal("managed worker process must survive the reuse reconcile")
+	}
+}
+
+func TestManagedWorkerIdentityLockBlocksSameWorkerID(t *testing.T) {
+	setManagedWorkerTestEnv(t)
+	withManagedWorkerTestHooks(t)
+
+	lookupManagedWorkerRegistration = func(remoteAddr, workerID string) (*daemon.WorkerRegistration, error) {
+		return nil, nil
+	}
+
+	lock, err := acquireManagedWorkerIdentityLock("worker-serial")
+	if err != nil {
+		t.Fatalf("acquireManagedWorkerIdentityLock() error = %v", err)
+	}
+
+	// The lock is keyed by worker id alone: a stop for the same id under a
+	// DIFFERENT --remote profile must still contend on it.
+	done := make(chan struct{})
+	go func() {
+		_, _ = StopManaged(ManagedOptions{WorkerID: "worker-serial", RemoteAddr: "remotebox:7777"}, false)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("StopManaged completed while the identity lock was held")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	releaseManagedWorkerIdentityLock(lock)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StopManaged did not proceed after the identity lock was released")
+	}
+}
+
+func TestManagedLifecycleSerializesPerWorkerID(t *testing.T) {
+	setManagedWorkerTestEnv(t)
+	withManagedWorkerTestHooks(t)
+
+	managedWorkerStartupTimeout = 2 * time.Second
+	managedWorkerStartupPoll = 25 * time.Millisecond
+	managedWorkerLaunchConfig = helperManagedWorkerLaunchConfig("registered")
+	lookupManagedWorkerRegistration = lookupRegistrationFromManagedState
+
+	// The process-table scan runs exactly once per start/stop, inside the
+	// identity lock. Two probes in flight at once would mean two lifecycle
+	// transitions interleaved their reconcile critical sections.
+	var inCritical, overlaps atomic.Int32
+	listWorkerProcesses = func() ([]workerProcess, error) {
+		if inCritical.Add(1) > 1 {
+			overlaps.Add(1)
+		}
+		time.Sleep(100 * time.Millisecond)
+		inCritical.Add(-1)
+		return nil, nil
+	}
+
+	opts := ManagedOptions{WorkerID: "worker-serial", RemoteAddr: "remotebox:7777"}
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = StartManaged(opts)
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = StopManaged(opts, false)
+		}()
+	}
+	wg.Wait()
+
+	if n := overlaps.Load(); n != 0 {
+		t.Fatalf("reconcile critical sections overlapped %d times; the identity lock must serialize start/stop for one worker id", n)
+	}
+	if _, err := StopManaged(opts, false); err != nil {
+		t.Fatalf("final StopManaged() error = %v", err)
 	}
 }
 

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -1,0 +1,180 @@
+package worker
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/proboscis/orch/internal/daemon"
+)
+
+// Worker identity is the worker id, not the managed state file. A process
+// started with a different connection string, an older binary generation, or
+// no supervisor at all still claims its worker id against the master, so
+// `worker stop` and `worker start` reconcile the declarative invariant
+// "at most one local process claims a given worker id" against the live
+// process table instead of trusting per-profile state records.
+
+// workerProcess is one live process claiming a worker id. WorkerID is the raw
+// claim from the command line; empty means the process claims the host
+// default worker id (daemon.HostWorkerID of the local hostname).
+type workerProcess struct {
+	PID      int
+	WorkerID string
+}
+
+// listWorkerProcesses is a test seam over the process-table scan.
+var listWorkerProcesses = defaultListWorkerProcesses
+
+func defaultListWorkerProcesses() ([]workerProcess, error) {
+	out, err := exec.Command("ps", "-axww", "-o", "pid=,args=").Output()
+	if err != nil {
+		return nil, fmt.Errorf("list host processes via ps: %w", err)
+	}
+	return parseWorkerProcessTable(string(out)), nil
+}
+
+func parseWorkerProcessTable(table string) []workerProcess {
+	var procs []workerProcess
+	for _, line := range strings.Split(table, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil || pid <= 0 {
+			continue
+		}
+		claim, ok := parseWorkerRunClaim(fields[1:])
+		if !ok {
+			continue
+		}
+		procs = append(procs, workerProcess{PID: pid, WorkerID: claim})
+	}
+	return procs
+}
+
+// parseWorkerRunClaim reports whether argv is an `orch ... worker run ...`
+// invocation and, if so, which worker id it claims. An empty claim with
+// ok=true means the process claims the host default worker id.
+//
+// The worker/run pair must be the first two non-flag tokens after the binary:
+// requiring position rather than mere presence keeps free-text arguments of
+// other commands (e.g. `orch send 75731b "restart the worker run"`) from
+// matching. Space-separated flag values before the subcommand (`--remote
+// addr worker run`) defeat the position check and make the scan miss that
+// process — a miss, never an overkill; the managed launcher and documented
+// invocations use the `--remote=` form.
+func parseWorkerRunClaim(argv []string) (string, bool) {
+	if len(argv) == 0 {
+		return "", false
+	}
+	if !strings.HasPrefix(filepath.Base(argv[0]), "orch") {
+		return "", false
+	}
+	rest := argv[1:]
+	runIdx := -1
+	seen := 0
+	for i, tok := range rest {
+		if strings.HasPrefix(tok, "-") {
+			continue
+		}
+		seen++
+		if seen == 1 {
+			if tok != "worker" {
+				return "", false
+			}
+			continue
+		}
+		if tok != "run" {
+			return "", false
+		}
+		runIdx = i
+		break
+	}
+	if runIdx < 0 {
+		return "", false
+	}
+	for i := runIdx + 1; i < len(rest); i++ {
+		if v, ok := strings.CutPrefix(rest[i], "--worker-id="); ok {
+			return strings.TrimSpace(v), true
+		}
+		if rest[i] == "--worker-id" && i+1 < len(rest) {
+			return strings.TrimSpace(rest[i+1]), true
+		}
+	}
+	return "", true
+}
+
+func defaultLocalWorkerID() string {
+	host, _ := currentWorkerHostname()
+	return daemon.HostWorkerID(host)
+}
+
+// reconcileWorkerID stops every local process claiming workerID except
+// keepPID (and this process), returning the PIDs it stopped. keepPID 0 keeps
+// nothing: the invariant target is zero claimants (worker stop). A non-zero
+// keepPID preserves exactly the managed process (worker start).
+func reconcileWorkerID(workerID string, keepPID int) ([]int, error) {
+	target := strings.TrimSpace(workerID)
+	if target == "" {
+		target = defaultLocalWorkerID()
+	}
+	procs, err := listWorkerProcesses()
+	if err != nil {
+		return nil, fmt.Errorf("reconcile worker id %q: %w", target, err)
+	}
+	self := os.Getpid()
+	var stopped []int
+	for _, proc := range procs {
+		claim := strings.TrimSpace(proc.WorkerID)
+		if claim == "" {
+			claim = defaultLocalWorkerID()
+		}
+		if claim != target || proc.PID <= 0 || proc.PID == keepPID || proc.PID == self {
+			continue
+		}
+		// Signal-0 recheck: the scan snapshot may be stale (a process this
+		// call already stopped, or one that exited on its own), and a PID we
+		// cannot signal is not ours to stop.
+		if !daemon.IsProcessRunning(proc.PID) {
+			continue
+		}
+		if err := stopManagedProcess(proc.PID); err != nil {
+			return stopped, fmt.Errorf("stop orphan worker process %d claiming worker id %q: %w", proc.PID, target, err)
+		}
+		stopped = append(stopped, proc.PID)
+	}
+	sort.Ints(stopped)
+	return stopped, nil
+}
+
+// reconcileAllWorkerProcesses stops every local `orch worker run` process
+// regardless of claimed worker id (worker stop --all: the host runs zero
+// workers afterwards, including ones no state file records).
+func reconcileAllWorkerProcesses() ([]int, error) {
+	procs, err := listWorkerProcesses()
+	if err != nil {
+		return nil, fmt.Errorf("reconcile all worker processes: %w", err)
+	}
+	self := os.Getpid()
+	var stopped []int
+	for _, proc := range procs {
+		if proc.PID <= 0 || proc.PID == self {
+			continue
+		}
+		if !daemon.IsProcessRunning(proc.PID) {
+			continue
+		}
+		if err := stopManagedProcess(proc.PID); err != nil {
+			return stopped, fmt.Errorf("stop worker process %d: %w", proc.PID, err)
+		}
+		stopped = append(stopped, proc.PID)
+	}
+	sort.Ints(stopped)
+	return stopped, nil
+}

--- a/internal/worker/reconcile_test.go
+++ b/internal/worker/reconcile_test.go
@@ -1,0 +1,271 @@
+package worker
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/proboscis/orch/internal/daemon"
+)
+
+func TestParseWorkerRunClaim(t *testing.T) {
+	tests := []struct {
+		name  string
+		argv  []string
+		claim string
+		ok    bool
+	}{
+		{
+			name:  "incident form: worker run with id and trailing remote",
+			argv:  []string{"orch", "worker", "run", "--worker-id", "host-zeus", "--remote=127.0.0.1:7777"},
+			claim: "host-zeus",
+			ok:    true,
+		},
+		{
+			name:  "managed launcher form: leading remote flag",
+			argv:  []string{"/usr/local/bin/orch", "--remote=", "worker", "run", "--worker-id", "host-zeus"},
+			claim: "host-zeus",
+			ok:    true,
+		},
+		{
+			name:  "equals form worker id",
+			argv:  []string{"orch", "worker", "run", "--worker-id=host-a"},
+			claim: "host-a",
+			ok:    true,
+		},
+		{
+			name:  "no worker id claims host default",
+			argv:  []string{"orch", "worker", "run", "--once"},
+			claim: "",
+			ok:    true,
+		},
+		{
+			name: "free text argument of another command does not match",
+			argv: []string{"orch", "send", "75731b", "worker", "run"},
+			ok:   false,
+		},
+		{
+			name: "worker stop does not match",
+			argv: []string{"orch", "worker", "stop", "--all"},
+			ok:   false,
+		},
+		{
+			name: "non-orch binary does not match",
+			argv: []string{"grep", "worker", "run"},
+			ok:   false,
+		},
+		{
+			name: "shell wrapper does not match",
+			argv: []string{"sh", "-c", "orch worker run"},
+			ok:   false,
+		},
+		{
+			name: "bare worker without run does not match",
+			argv: []string{"orch", "worker"},
+			ok:   false,
+		},
+		{
+			name: "empty argv does not match",
+			argv: nil,
+			ok:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claim, ok := parseWorkerRunClaim(tt.argv)
+			if ok != tt.ok {
+				t.Fatalf("parseWorkerRunClaim(%v) ok = %v, want %v", tt.argv, ok, tt.ok)
+			}
+			if ok && claim != tt.claim {
+				t.Fatalf("parseWorkerRunClaim(%v) claim = %q, want %q", tt.argv, claim, tt.claim)
+			}
+		})
+	}
+}
+
+func TestParseWorkerProcessTable(t *testing.T) {
+	table := `  101 /usr/local/bin/orch --remote=127.0.0.1:7777 worker run --worker-id host-zeus
+  102 orch worker run
+  103 grep worker run
+ not-a-pid orch worker run
+  104 orch worker stop --all
+`
+	procs := parseWorkerProcessTable(table)
+	if len(procs) != 2 {
+		t.Fatalf("parseWorkerProcessTable() = %+v, want 2 entries", procs)
+	}
+	if procs[0].PID != 101 || procs[0].WorkerID != "host-zeus" {
+		t.Fatalf("first entry = %+v, want pid 101 claiming host-zeus", procs[0])
+	}
+	if procs[1].PID != 102 || procs[1].WorkerID != "" {
+		t.Fatalf("second entry = %+v, want pid 102 claiming host default", procs[1])
+	}
+}
+
+// spawnSleeperHelper starts a helper process that idles until it receives
+// SIGINT/SIGTERM, optionally disguising its argv so the real process-table
+// scan sees an `orch worker run` claimant.
+func spawnSleeperHelper(t *testing.T, argv []string) *exec.Cmd {
+	t.Helper()
+	if len(argv) == 0 {
+		argv = []string{os.Args[0], "-test.run=TestManagedWorkerHelperProcess"}
+	}
+	cmd := &exec.Cmd{
+		Path: os.Args[0],
+		Args: argv,
+		Env: append(os.Environ(),
+			"ORCH_TEST_MANAGED_HELPER=1",
+			"ORCH_TEST_MANAGED_HELPER_MODE=unregistered",
+		),
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleeper helper: %v", err)
+	}
+	waitCh := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(waitCh)
+	}()
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(syscall.SIGKILL)
+		select {
+		case <-waitCh:
+		case <-time.After(5 * time.Second):
+		}
+	})
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !daemon.IsProcessRunning(cmd.Process.Pid) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cmd
+}
+
+func waitForProcessExit(t *testing.T, pid int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !daemon.IsProcessRunning(pid) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("process %d still running after %s", pid, timeout)
+}
+
+func TestReconcileWorkerIDStopsOnlyMatchingClaimants(t *testing.T) {
+	withManagedWorkerTestHooks(t)
+
+	orphan := spawnSleeperHelper(t, nil)
+	otherID := spawnSleeperHelper(t, nil)
+	kept := spawnSleeperHelper(t, nil)
+
+	listWorkerProcesses = func() ([]workerProcess, error) {
+		return []workerProcess{
+			{PID: orphan.Process.Pid, WorkerID: "worker-reconcile"},
+			{PID: otherID.Process.Pid, WorkerID: "worker-unrelated"},
+			{PID: kept.Process.Pid, WorkerID: "worker-reconcile"},
+		}, nil
+	}
+
+	stopped, err := reconcileWorkerID("worker-reconcile", kept.Process.Pid)
+	if err != nil {
+		t.Fatalf("reconcileWorkerID() error = %v", err)
+	}
+	if len(stopped) != 1 || stopped[0] != orphan.Process.Pid {
+		t.Fatalf("stopped = %v, want [%d]", stopped, orphan.Process.Pid)
+	}
+	waitForProcessExit(t, orphan.Process.Pid, 3*time.Second)
+	if !daemon.IsProcessRunning(otherID.Process.Pid) {
+		t.Fatal("process claiming a different worker id was stopped")
+	}
+	if !daemon.IsProcessRunning(kept.Process.Pid) {
+		t.Fatal("keepPID process was stopped")
+	}
+}
+
+func TestReconcileWorkerIDResolvesDefaultClaims(t *testing.T) {
+	withManagedWorkerTestHooks(t)
+
+	origHostname := currentWorkerHostname
+	currentWorkerHostname = func() (string, error) { return "testbox", nil }
+	t.Cleanup(func() { currentWorkerHostname = origHostname })
+
+	orphan := spawnSleeperHelper(t, nil)
+	listWorkerProcesses = func() ([]workerProcess, error) {
+		return []workerProcess{{PID: orphan.Process.Pid, WorkerID: ""}}, nil
+	}
+
+	stopped, err := reconcileWorkerID("", 0)
+	if err != nil {
+		t.Fatalf("reconcileWorkerID() error = %v", err)
+	}
+	if len(stopped) != 1 || stopped[0] != orphan.Process.Pid {
+		t.Fatalf("stopped = %v, want [%d]", stopped, orphan.Process.Pid)
+	}
+	waitForProcessExit(t, orphan.Process.Pid, 3*time.Second)
+}
+
+func TestReconcileAllWorkerProcessesSweepsEveryClaimant(t *testing.T) {
+	withManagedWorkerTestHooks(t)
+
+	first := spawnSleeperHelper(t, nil)
+	second := spawnSleeperHelper(t, nil)
+	listWorkerProcesses = func() ([]workerProcess, error) {
+		return []workerProcess{
+			{PID: first.Process.Pid, WorkerID: "worker-a"},
+			{PID: second.Process.Pid, WorkerID: "worker-b"},
+		}, nil
+	}
+
+	stopped, err := reconcileAllWorkerProcesses()
+	if err != nil {
+		t.Fatalf("reconcileAllWorkerProcesses() error = %v", err)
+	}
+	if len(stopped) != 2 {
+		t.Fatalf("stopped = %v, want both sleeper pids", stopped)
+	}
+	waitForProcessExit(t, first.Process.Pid, 3*time.Second)
+	waitForProcessExit(t, second.Process.Pid, 3*time.Second)
+}
+
+// TestDefaultListWorkerProcessesFindsRealClaimant exercises the real ps scan
+// end to end: a live process whose argv looks like `orch ... worker run
+// --worker-id <uniq>` must be discovered and reconciled away. The worker id
+// is unique per test process so the scan can never select an unrelated
+// process on the machine running the tests.
+func TestDefaultListWorkerProcessesFindsRealClaimant(t *testing.T) {
+	uniq := fmt.Sprintf("orch-test-reconcile-%d", os.Getpid())
+	orphan := spawnSleeperHelper(t, []string{
+		"orch", "-test.run=TestManagedWorkerHelperProcess", "worker", "run", "--worker-id", uniq,
+	})
+
+	procs, err := defaultListWorkerProcesses()
+	if err != nil {
+		t.Fatalf("defaultListWorkerProcesses() error = %v", err)
+	}
+	found := false
+	for _, proc := range procs {
+		if proc.PID == orphan.Process.Pid {
+			if proc.WorkerID != uniq {
+				t.Fatalf("scan claim = %q, want %q", proc.WorkerID, uniq)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("real ps scan did not find sleeper pid %d claiming %q", orphan.Process.Pid, uniq)
+	}
+
+	stopped, err := reconcileWorkerID(uniq, 0)
+	if err != nil {
+		t.Fatalf("reconcileWorkerID() error = %v", err)
+	}
+	if len(stopped) != 1 || stopped[0] != orphan.Process.Pid {
+		t.Fatalf("stopped = %v, want [%d]", stopped, orphan.Process.Pid)
+	}
+	waitForProcessExit(t, orphan.Process.Pid, 3*time.Second)
+}


### PR DESCRIPTION
## Issue

worker-stop-leaves-orphan-supervisors — `orch worker stop` が state file 記載の PID しか止めず、接続文字列違い・旧世代バイナリ・手動起動の worker プロセスが同一 worker-id を名乗ったまま残存する。

**⚠️ A/B テスト条項に基づき、この PR はマージしないでください。** 並行 run の PR と人間がレビューして採否を決める前提です。

## 設計

issue の期待挙動どおり、per-path の突き合わせではなく宣言的 reconcile を実装:

```
   不変条件: 1 ホスト上で同じ worker-id を名乗るプロセスは 1 つ以下
   (identity = worker-id。--remote 接続文字列や state file の有無は無関係)

   worker stop --worker-id X          worker start --worker-id X
   ┌──────────────────────────┐      ┌──────────────────────────────┐
   │ state file の PID を停止   │      │ reconcile: X を名乗る他プロセス │
   │          ↓               │      │ を全部停止 (managed PID は保持) │
   │ reconcile: X を名乗る全   │      │          ↓                   │
   │ プロセスを停止 → 0 に収束  │      │ reuse or launch → 1 に収束    │
   └──────────────────────────┘      └──────────────────────────────┘
              観測対象 = 実プロセステーブル (ps)、state file ではない
```

- `internal/worker/reconcile.go` (新規): `ps -axww -o pid=,args=` を走査し、`orch … worker run` の claimant を worker-id 単位で特定。サブコマンド位置一致で判定するため、他コマンドの自由文字列引数(例: `orch send 75731b "restart the worker run"`)には誤マッチしない。`--worker-id` 無しのプロセスはホスト既定 id (`host-<hostname>`) の claim として解決。
- `StartManaged`: 起動前 reconcile(managed PID のみ keep)。orphan を除去した場合は「master に active 登録があるのに local metadata が無い」ガード(まさに今回の incident 状態)を通過して起動を続行。reuse 経路では、graceful に死んだ orphan が共有 worker-id を unregister した後に生存 worker が heartbeat 失敗経由で再登録するまでの隙間 (+10s) を ready 待ちに加算。
- `StopManaged`: managed 停止後に reconcile。state file が無くても reconcile し、orphan を除去できた場合はエラーではなく成功で返す。`--all` は加えてホスト上の全 `orch worker run` プロセスを sweep。JSON/テキスト出力に `orphan_pids` を追加。
- `stopManagedProcess` を SIGINT→SIGKILL から **SIGTERM**→SIGKILL に変更: shell のバックグラウンドジョブは SIGINT が SIG_IGN 継承で無効(E2E で実測、SIGKILL fallback 頼みになる)。incident 報告でも SIGTERM で無害停止が実証済み。worker loop は従来から SIGTERM/SIGINT 両対応。
- master 側 (`internal/daemon/worker_plane.go`): heartbeat が新鮮な登録を同一 worker-id が上書きした際に WARNING ログ(重複 instance の可能性、新しい登録が勝つ)。

### 意図的スコープ判断(要レビュー)

1. **master 側の「古い接続への明示的 shutdown」(issue の"最低限"案)は未実装。** 現行プロトコルでは registration に instance 識別が無く、同一 worker-id の 2 プロセスは master から区別不能。fencing には per-instance nonce の導入(= 新しい ID 型、coupling-core tripwire 該当、worker-lease law 改訂同梱が必要)が要る。受け入れ基準は OR 条件のため、issue が本命とする host 側宣言的 reconcile で満たし、master 側は検知 WARNING に留めた。
2. **不変条件は --remote 無関係に worker-id 単位。** 同一ホストで別 master 向けに 2 worker を走らせたい場合は別 worker-id が必須になる(docs に明記)。接続文字列は正規化不能(zeus:7777 / 127.0.0.1:7777 / socket が同一 master を指しうる)で、state file を remote 別に分けたことが本 bug の根因のため、これは issue の指定どおりの仕様。
3. `worker stop --all` は「このホストの worker を全停止」の意味になり、state file に無い手動起動 worker も止める(help/docs 更新済み)。

## 受け入れ基準の検証(1:1 申告)

### 基準1: 管理外 worker プロセスが residual にならない / master が重複を排除する

**実施(前半を満たす)**: state file の無い orphan を `worker stop` が除去することを unit テスト (`TestStopManagedStopsUnmanagedClaimantsWithoutStateFile`) と E2E step 4 で確認:

```
=== 4. second cycle: orphan appears again, stop/start cycle converges ===
claimant count with fresh orphan: 1 (want 1 orphan)
{ "ok": true, "stopped_count": 1, "orphan_pids": [82682] }
claimant count after stop (orphan only, no state file): 0 (want 0)
```

後半(master 側排除)は上記スコープ判断 1 のとおり WARNING 検知のみ(deviation)。

### 基準2: 再現テスト — worker 2 プロセス起動 → stop/start サイクル → 1 プロセスに収束

**実施**: sandbox E2E(隔離 HOME/XDG + local socket daemon + 専用 worker-id、実バイナリ)で確認:

```
=== 1. spawn 2 unmanaged (orphan) workers claiming host-e2e-orphan-79555 ===
claimant count: 2 (want 2)
=== 2. worker start must reconcile: converge to exactly 1 process ===
{ "ok": true, ..., "reused": false, "orphan_pids": [80784, 80785] }
claimant count after start: 1 (want 1)
=== 3. worker stop must converge to 0 processes ===
{ "ok": true, "stopped_count": 1 }
claimant count after stop: 0 (want 0)
...
E2E PASS: orphan workers converge to 1 on start and 0 on stop
```

### Verification 節: 「zeus 相当環境で孤児を人工的に作り、stop/start 後に pgrep で 1 プロセスのみを確認」

**Deviation 申告**: zeus 本番ではなく **mac 上の sandbox 環境**(隔離 XDG/HOME、local socket master)で実施。孤児 2 プロセスを人工生成し、`ps`(pgrep 相当)で start 後 1・stop 後 0 を確認(上記ログ)。zeus への適用は A/B 未マージのため実施していない。なお `ps -axww -o pid=,args=` は zeus (Linux) で動作確認済み(read-only)。incident の実プロセス形 `orch --remote= worker run --worker-id host-zeus …` は claim parser のテストケースに含む。

## テスト

- `go build ./...` / `make lint`(architecture semgrep)pass。
- `go test`(`test/integration` を除く全パッケージ)pass。**Deviation**: `test/integration` はローカル未実行 — 同 suite の cleanup は実バイナリで `worker stop --all` を実行し、本変更後はホストの実 worker プロセス(この開発機に現存する `host-CA-20035844` の worker 群)を sweep してしまうため、共有開発機では実行を控えた。CI の隔離 runner では既存アサーション(stopped_count==1 等)は成立する(suite 共有 worker は in-process goroutine で ps に映らないことを確認済み)。
- 既知 flake: `TestProcessSendOpenCodeTimesOutPromptlyWithoutAck` が全体実行時に 1 度 fail(1.109s > 1s のタイミングアサート)、単体では pass。opencode send の ack タイミングの既存テストで本変更と無関係。

## 副次的観測(本 PR のスコープ外、参考)

- この開発機に `host-CA-20035844` を名乗る worker が **4 プロセス**残存している(local socket 向け 1 + zeus 向け 3)。本 issue の病理が現に進行中の実例。本変更後の `orch worker stop --worker-id host-CA-20035844` 1 回で収束するはず(A/B のため未実施)。
- agent availability probe の per-probe timeout (5s) と managed start の ready 待ち (5s) が同値のため、probe が 1 つ timeout すると `worker start` が必ず失敗する既存の張り付きがある(sandbox で gemini CLI の hang により実測)。別 issue 推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 追記 (2026-07-15): A/B 採用・#555 から法典/flock を移植

A/B レビューの結果、本 PR (#556) が採用されました。レビュー指示に基づき、並行 run の PR #555 (branch: `run-20260714-233708`) から以下 2 部品を移植しました(commit d943e905)。#556 の既存挙動 — incident の start 経路修正(active 登録 + local metadata 無しガードの条件化)、SIGINT→SIGTERM、reuse 時 +10s ready grace、master 側重複 WARNING — は全て保持しています。

### 移植1: 法典(worker plane は結合核 — 法改訂を実装と同一 change set で搭載)

- **ADR-0002 §4 "Worker identity is host-local and profile-independent"**: worker-id はホストローカルな supervisor identity であり、master 接続文字列は設定であって identity ではないこと、start/stop は worker-id 単位で実プロセステーブルを reconcile すること、master 側重複排除が執行層でない理由(register/heartbeat/lease/ack/unregister が worker_id しか運ばず、2 プロセスを master が識別不能)を明文化。
- **worker-lease.md LL8 "local worker identity convergence"**: 法テーブルに追加し、Verification 節に本 branch の reconcile 実装 (`reconcileWorkerID` / `reconcileAllWorkerProcesses`) とテスト群をカバレッジとして記載。

### 移植2: worker-id 単位の flock 直列化

`StartManaged` / `StopManaged`(`stop --all` の各 profile 処理を含む)の冒頭で `<workersRuntimeDir>/<managedProfileKey(workerID,"")>.lock` に `syscall.Flock LOCK_EX` を取得(defer で LOCK_UN + Close)。lock key は worker-id のみ(profile 非依存)のため、`--remote` 表記が異なる同一 worker-id の並行 start/stop も直列化されます。

回帰テスト:
- `TestManagedWorkerIdentityLockBlocksSameWorkerID`: lock 保持中は別 profile からの同一 id の StopManaged がブロックされ、解放後に進行することを検証。
- `TestManagedLifecycleSerializesPerWorkerID`: 同一 id への並行 StartManaged×2 + StopManaged×2 で、lock 内のプロセステーブル走査(critical section)が一度も重ならないことを atomic プローブで検証。

### 移植後の検証

- `go build ./...` / `go test ./internal/...` / `make lint` すべて pass。
- sandbox E2E を flock 移植後に再実行し、孤児 2 → start で 1 → stop で 0 の収束を再確認(E2E PASS)。
- `test/integration` は本 PR 本文記載と同じ理由(開発機の実 worker を `worker stop --all` cleanup が巻き込む危険)でローカル実行をスキップ。

