### PR TITLE
Decouple worker registration from agent probes

### DIFF
--- a/docs/adr/ADR-0002-idempotent-worker-autostart.md
+++ b/docs/adr/ADR-0002-idempotent-worker-autostart.md
@@ -141,6 +141,10 @@ while the previous registration is still heartbeat-fresh.
   probe command, exit status or lookup failure, and PATH, so the deciding
   worker environment is immediately diagnosable. Explicit `orch worker start`
   from an environment with the intended PATH remains the operator override.
+- Startup availability reporting is diagnostic-only and runs concurrently
+  with master connection and registration. Registration readiness must never
+  wait for an external agent CLI probe; `worker run` still joins the report
+  before exiting so short-lived workers do not silently lose diagnostics.
 - "worker not running" disappears as a user-visible error class on
   single-machine setups; docs and the embedded tutorial shrink accordingly.
 - The reconciler runs strictly inside the lease-failure path: zero cost when

--- a/internal/cli/master_worker.go
+++ b/internal/cli/master_worker.go
@@ -59,7 +59,19 @@ func newWorkerRunCmd() *cobra.Command {
 		Short: "Run long-lived orch-worker host loop",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			worker.ScrubInheritedMultiplexerEnv()
-			logWorkerAgentAvailability(workerID)
+
+			// Agent CLI probes are diagnostics, not a registration precondition.
+			// Run them concurrently so one hanging CLI cannot consume the managed
+			// worker's entire registration-ready budget. Join before returning so
+			// even a short-lived worker does not silently lose the startup report.
+			availabilityDone := make(chan struct{})
+			go func() {
+				defer close(availabilityDone)
+				logWorkerAgentAvailability(workerID)
+			}()
+			defer func() {
+				<-availabilityDone
+			}()
 
 			client, err := requireDaemonForWorker()
 			if err != nil {

--- a/internal/cli/master_worker_test.go
+++ b/internal/cli/master_worker_test.go
@@ -119,6 +119,59 @@ func TestWorkerRunCommandInvokesExternalLoop(t *testing.T) {
 	}
 }
 
+func TestWorkerRunRegistrationDoesNotWaitForAvailabilityProbe(t *testing.T) {
+	origRequire := requireDaemonForWorker
+	origRun := runExternalWorkerLoop
+	origLogAvailability := logWorkerAgentAvailability
+	t.Cleanup(func() {
+		requireDaemonForWorker = origRequire
+		runExternalWorkerLoop = origRun
+		logWorkerAgentAvailability = origLogAvailability
+	})
+
+	probeStarted := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	loopStarted := make(chan struct{})
+	logWorkerAgentAvailability = func(string) {
+		close(probeStarted)
+		<-releaseProbe
+	}
+	requireDaemonForWorker = func() (worker.Client, error) {
+		return &mockWorkerClient{}, nil
+	}
+	runExternalWorkerLoop = func(worker.Client, worker.RunConfig) error {
+		close(loopStarted)
+		return nil
+	}
+
+	cmd := newWorkerRunCmd()
+	cmd.SetArgs([]string{"--worker-id", "worker-1"})
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Execute()
+	}()
+
+	select {
+	case <-probeStarted:
+	case <-time.After(time.Second):
+		close(releaseProbe)
+		t.Fatal("availability probe did not start")
+	}
+
+	select {
+	case <-loopStarted:
+		close(releaseProbe)
+	case <-time.After(time.Second):
+		close(releaseProbe)
+		<-done
+		t.Fatal("worker registration startup waited for the availability probe")
+	}
+
+	if err := <-done; err != nil {
+		t.Fatalf("worker run execute failed: %v", err)
+	}
+}
+
 type mockWorkerClient struct{}
 
 func (m *mockWorkerClient) RegisterWorker(workerID, workerType, host, mode string) (*daemon.RegisterWorkerResponse, error) {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -27,6 +27,8 @@ var (
 	daemonProcess *os.Process
 )
 
+const integrationWorkerRegistrationTimeout = 30 * time.Second
+
 func TestMain(m *testing.M) {
 	tmpDir, err := os.MkdirTemp("", "orch-integration-*")
 	if err != nil {
@@ -209,7 +211,7 @@ func stopTestDaemon() {
 }
 
 func ensureWorkerOrPanic() {
-	if err := ensureWorkerActiveWithTimeout(5 * time.Second); err != nil {
+	if err := ensureWorkerActiveWithTimeout(integrationWorkerRegistrationTimeout); err != nil {
 		panic(err)
 	}
 }
@@ -277,7 +279,7 @@ func runOrchInRepo(t *testing.T, repoRoot, issuesRoot string, args ...string) (s
 func ensureWorkerAvailable(t *testing.T) {
 	t.Helper()
 
-	if err := ensureWorkerActiveWithTimeout(3 * time.Second); err != nil {
+	if err := ensureWorkerActiveWithTimeout(integrationWorkerRegistrationTimeout); err != nil {
 		t.Fatalf("%v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Run the one-time agent availability report concurrently with daemon connection and worker registration.
- Join the report before `worker run` exits so short-lived/error paths still retain diagnostics.
- Raise only the integration harness's condition-polling registration budget from fixed 5s/3s call sites to 30s; the production managed-worker default remains 5s.
- Record the diagnostic-only registration invariant in ADR-0002 and add a deterministic blocked-probe regression.

## Root cause

`worker run` synchronously called `LogAgentAvailability` before creating the daemon client and entering `RunExternalLoop`. A probe may consume its full 5s timeout, while `worker start` independently waits only 5s for master registration. The registration path therefore could not begin inside the ready budget.

## Acceptance criteria and deviations

| Acceptance criterion | Result and evidence | Deviation |
|---|---|---|
| A hanging agent probe must not make `orch worker start` fail. | **PASS.** In an isolated HOME/XDG sandbox with explicit `--remote=`, unique worker ID, private daemon, and fake `gemini` executing `sleep 30`, `worker start --json` returned `ok=true` in 1s and `worker status --json` reported `master.state=active`. | None. |
| Registration success and availability logging must coexist. | **PASS.** The same smoke registered at `2026-07-15T13:19:03.147639+09:00`; at `13:19:08` its worker log emitted `gemini=unavailable (probe "gemini --version" failed: timed out after 5s)`. | None. |
| Eliminate the integration worker-registration fixed-5s load flake without changing the production 5s default. | **PASS.** The existing condition-polling helper now uses a 30s total budget for initial and recovery registration. `managedWorkerStartupTimeout` remains 5s. The isolated integration package passed in 143.320s, and the full suite's integration package passed in 169.397s. | Chose the issue's polling + ~30s total-budget option; no environment-variable override was added. |
| Protect the ordering with an executable regression. | **PASS.** Before the fix, `TestWorkerRunRegistrationDoesNotWaitForAvailabilityProbe` failed with `worker registration startup waited for the availability probe`; after the fix it passes, including under `go test -race`. | None. |

The smoke used isolated HOME, XDG config/state/data/cache/runtime directories, explicit local mode, and a unique worker ID. It did not stop or reuse any operational worker.

## Verification

- `go test -race ./internal/cli -run '^(TestWorkerRunCommandInvokesExternalLoop|TestWorkerRunRegistrationDoesNotWaitForAvailabilityProbe)$' -count=1`
- `go test ./internal/agent ./internal/worker ./internal/cli -count=1`
- `ORCH_SAFE_CLI_TEST=1 go test ./test/integration -count=1`
- `go build ./...`
- `make lint`
- `ORCH_SAFE_CLI_TEST=1 go test ./...`
- `git diff --check`

Reference: `worker-start-ready-wait-eaten-by-probe-timeout`

This is an A/B candidate PR. Do not merge until the parallel runs have been reviewed.