### PR TITLE
worker start: run agent availability probe off the registration critical path

### DIFF
--- a/internal/cli/master_worker.go
+++ b/internal/cli/master_worker.go
@@ -59,20 +59,35 @@ func newWorkerRunCmd() *cobra.Command {
 		Short: "Run long-lived orch-worker host loop",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			worker.ScrubInheritedMultiplexerEnv()
-			logWorkerAgentAvailability(workerID)
+
+			// Agent availability is a diagnostic probe only; master
+			// registration does not depend on it. Run it concurrently with
+			// registration instead of before it: a hung agent CLI (bounded by
+			// the per-probe timeout) must never delay registration, or it
+			// would consume the managed-start ready budget and make
+			// `orch worker start` fail. Joining before the command returns
+			// keeps the diagnostic guaranteed to be emitted in every mode.
+			availabilityDone := make(chan struct{})
+			go func() {
+				defer close(availabilityDone)
+				logWorkerAgentAvailability(workerID)
+			}()
 
 			client, err := requireDaemonForWorker()
 			if err != nil {
+				<-availabilityDone
 				return err
 			}
 			defer client.Close()
 
-			return runExternalWorkerLoop(client, worker.RunConfig{
+			loopErr := runExternalWorkerLoop(client, worker.RunConfig{
 				WorkerID:          workerID,
 				Once:              once,
 				PollInterval:      pollInterval,
 				HeartbeatInterval: heartbeatInterval,
 			})
+			<-availabilityDone
+			return loopErr
 		},
 	}
 

--- a/internal/cli/master_worker_test.go
+++ b/internal/cli/master_worker_test.go
@@ -119,6 +119,73 @@ func TestWorkerRunCommandInvokesExternalLoop(t *testing.T) {
 	}
 }
 
+func TestWorkerRunReachesLoopWhileAvailabilityProbeIsHung(t *testing.T) {
+	origRequire := requireDaemonForWorker
+	origRun := runExternalWorkerLoop
+	origLogAvailability := logWorkerAgentAvailability
+	t.Cleanup(func() {
+		requireDaemonForWorker = origRequire
+		runExternalWorkerLoop = origRun
+		logWorkerAgentAvailability = origLogAvailability
+	})
+
+	requireDaemonForWorker = func() (worker.Client, error) {
+		return &mockWorkerClient{}, nil
+	}
+
+	// A hung probe stands in for an agent CLI that never returns (e.g. a
+	// sleeping fake binary in PATH). It blocks until the test releases it.
+	releaseProbe := make(chan struct{})
+	probeReturned := make(chan struct{})
+	logWorkerAgentAvailability = func(workerID string) {
+		<-releaseProbe
+		close(probeReturned)
+	}
+
+	// runExternalWorkerLoop registers the worker in production. Reaching it is
+	// the observable proof that a hung probe no longer sits on the critical
+	// path to registration.
+	loopReached := make(chan struct{})
+	runExternalWorkerLoop = func(client worker.Client, cfg worker.RunConfig) error {
+		close(loopReached)
+		return nil
+	}
+
+	cmd := newWorkerRunCmd()
+	cmd.SetArgs([]string{"--worker-id", "worker-1", "--once"})
+	execDone := make(chan error, 1)
+	go func() { execDone <- cmd.Execute() }()
+
+	select {
+	case <-loopReached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker run did not reach the registration loop while the availability probe was hung")
+	}
+
+	// The command must not return until the diagnostic probe is joined, so the
+	// availability line is still guaranteed to be emitted.
+	select {
+	case <-execDone:
+		t.Fatal("worker run returned before the availability probe was joined")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseProbe)
+	select {
+	case <-probeReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("availability probe was not joined after release")
+	}
+	select {
+	case err := <-execDone:
+		if err != nil {
+			t.Fatalf("worker run execute failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker run did not return after the availability probe completed")
+	}
+}
+
 type mockWorkerClient struct{}
 
 func (m *mockWorkerClient) RegisterWorker(workerID, workerType, host, mode string) (*daemon.RegisterWorkerResponse, error) {

--- a/internal/worker/availability.go
+++ b/internal/worker/availability.go
@@ -9,8 +9,13 @@ import (
 )
 
 // LogAgentAvailability probes every known adapter once at worker process
-// startup. This runs before master registration so a healthy-looking worker
-// never hides the agent capabilities of its inherited environment.
+// startup and logs the result. The caller runs it concurrently with master
+// registration rather than before it: the probe is diagnostic only, and a hung
+// agent CLI (bounded by the per-probe timeout) must never delay registration —
+// otherwise it would consume the managed-start ready budget and make
+// `orch worker start` fail. The caller joins the probe before the process
+// exits, so a healthy-looking worker still never hides the agent capabilities
+// of its inherited environment.
 func LogAgentAvailability(workerID string) {
 	host, _ := os.Hostname()
 	if host == "" {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -208,8 +208,27 @@ func stopTestDaemon() {
 	}
 }
 
+// integrationWorkerReadyTimeout bounds how long the tests wait for the
+// in-process integration worker to register. Worker registration normally
+// completes in well under a second, but the fixed 5s budget this previously
+// used broke under host load and produced flaky local runs (issue
+// integration-worker-register-5s-deadline-flake). The wait polls up to a
+// generous default and is overridable via ORCH_TEST_WORKER_READY_TIMEOUT so a
+// loaded machine can extend it without editing code. The production managed
+// worker-start budget (managedWorkerStartupTimeout) is intentionally left at
+// its 5s default and is unaffected by this test-only knob.
+func integrationWorkerReadyTimeout() time.Duration {
+	const defaultTimeout = 30 * time.Second
+	if raw := strings.TrimSpace(os.Getenv("ORCH_TEST_WORKER_READY_TIMEOUT")); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultTimeout
+}
+
 func ensureWorkerOrPanic() {
-	if err := ensureWorkerActiveWithTimeout(5 * time.Second); err != nil {
+	if err := ensureWorkerActiveWithTimeout(integrationWorkerReadyTimeout()); err != nil {
 		panic(err)
 	}
 }
@@ -277,7 +296,7 @@ func runOrchInRepo(t *testing.T, repoRoot, issuesRoot string, args ...string) (s
 func ensureWorkerAvailable(t *testing.T) {
 	t.Helper()
 
-	if err := ensureWorkerActiveWithTimeout(3 * time.Second); err != nil {
+	if err := ensureWorkerActiveWithTimeout(integrationWorkerReadyTimeout()); err != nil {
 		t.Fatalf("%v", err)
 	}
 }


### PR DESCRIPTION
## Issue

`worker-start-ready-wait-eaten-by-probe-timeout` — the agent availability probe
(per-probe timeout **5s**) ran on the critical path *before* master
registration, and the managed `worker start` ready-wait budget is also **5s**.
Because the two independent 5s budgets were the same value and serially coupled,
a single hung agent CLI (observed: a hanging `gemini` in a sandbox) pushed
registration past the ready deadline and `orch worker start` **always** failed.

## Root cause

```
BEFORE (worker run startup):
  ScrubEnv → logAvailability(≤5s, BLOCKS) → connectDaemon → loop{ REGISTER } ...
                    │                                            │
                    └── hung agent CLI eats the whole 5s ────────┘
  worker start:  spawn ────────── waitForReady(5s budget) ──────X timeout → FAIL

AFTER:
  ScrubEnv ┬─ go logAvailability(≤5s, concurrent) ────────┐ (joined before exit)
           └─ connectDaemon → loop{ REGISTER (immediate) } ┘
  worker start:  spawn ── waitForReady ─✓ registered ~70ms → SUCCESS
```

The probe is **diagnostic only** — registration never depended on it. I run it
concurrently with registration (a goroutine joined before the command returns)
rather than before it. This is the *"parallelize the probe with registration"*
candidate from the issue's expected-behavior list, chosen over the fallback of
extending the ready budget by the probe time, because it fixes the structural
coupling at its source: the probe can no longer consume the ready budget in any
mode, while the availability diagnostic is still guaranteed to be emitted before
the process exits.

## Changes

| File | Change |
|------|--------|
| `internal/cli/master_worker.go` | Run `logWorkerAgentAvailability` in a goroutine; registration proceeds immediately; join the probe before `worker run` returns so the diagnostic is still emitted in every mode. |
| `internal/worker/availability.go` | Update the `LogAgentAvailability` doc to reflect "concurrent with registration, joined before exit" instead of "before registration". |
| `internal/cli/master_worker_test.go` | New `TestWorkerRunReachesLoopWhileAvailabilityProbeIsHung`: a hung probe still lets the registration loop be reached, and the command joins the probe before returning. |
| `test/integration/integration_test.go` | Relax the worker-register wait from fixed 5s/3s to a **30s** default via `integrationWorkerReadyTimeout()`, overridable with `ORCH_TEST_WORKER_READY_TIMEOUT`. Production `managedWorkerStartupTimeout` (5s) unchanged. |

Coupling-core note: no core surface is touched. The registration protocol, lease
ownership/heartbeats (`worker_plane.go`), and event fold are unchanged — only the
*ordering* of a diagnostic probe relative to registration in the worker startup
command moves off the critical path. No new id type / registry / shared flag /
`nosemgrep` (tripwire checklist clean). `make lint` passes.

## Acceptance criteria — 1:1 declaration

> **[AC-1]** probe の 1 つを人工的に hang させても(例: sleep する fake agent CLI を PATH に置く)、`orch worker start` が成功する。

**IMPLEMENTED.** Isolated sandbox (own `HOME`/`XDG_*`, unique worker id, local
master) with a fake `gemini` that `sleep`s 45s (probe times out at 5s):

```
worker start rc=0  elapsed=1222ms
{ "ok": true, "worker_id": "sandbox-hungprobe-78751", "pid": 82740, ... }
status → master.state = "active"   (registered_at 0.07s after started_at)
```

## Verification — 1:1 declaration

> **[V-1]** hang する probe を仕込んだ sandbox で worker start → 登録成功と availability ログの両立を確認。

**IMPLEMENTED.** Same sandbox run confirms **both**:
- Registration success: `master.state = "active"`, registered ~70ms after start
  (not blocked by the 5s hung probe).
- Availability log still emitted ~5s later (when the hung `gemini` times out),
  while the long-lived worker is still running:

```
orch-worker sandbox-hungprobe-78751 on CA-20035844: agent availability:
  {claude=available (...succeeded), codex=available (...succeeded),
   gemini=unavailable (probe "gemini --version" failed: timed out after 5s),
   opencode=available (...succeeded), custom=available (...deferred)}
```

The timing gap (register at +0.07s, availability line at +5s) is the direct
evidence that registration no longer waits for the probe.

## Scope integration — `integration-worker-register-5s-deadline-flake`

> Ruling: テスト側の待ちを環境変数化 or ポーリング+総時間 30s 程度へ緩和、本番 5s 既定値の変更は不要。

**IMPLEMENTED.** `ensureWorkerActiveWithTimeout` now polls for up to a **30s**
default (was 5s / 3s), resolved by `integrationWorkerReadyTimeout()` and
overridable with `ORCH_TEST_WORKER_READY_TIMEOUT`. Production
`managedWorkerStartupTimeout` (5s) is left unchanged, as the ruling requires.
Verified end-to-end: `go test ./test/integration/ -run TestPsEmpty` passes — the
suite's `ensureWorkerOrPanic()` brings the in-process worker up within the new
budget (isolated temp `HOME`/`XDG`, no real worker involved).

## Tests

- `go build ./...` — OK
- `go test ./internal/cli/ ./internal/worker/ ./internal/agent/` — OK (incl. the
  new hung-probe test)
- `go test ./test/integration/ -run TestPsEmpty` — OK
- `make lint` — 0 findings

## A/B test clause compliance

- **PR created, NOT merged** — left for human review of all three runs.
- No interference with other runs' branches/PRs/worktrees — only this run branch
  and its worktree were touched.
- All sandbox verification used isolated `HOME`/`XDG` and a **unique** worker id
  (`sandbox-hungprobe-$$`), never the host-default id the real worker claims, so
  the pre-start reconcile (which scans the real host `ps` table) could not match
  the live worker. Cleanup used `worker stop --worker-id <unique>` — never
  `worker stop --all`. The real host worker was confirmed untouched.

Refs: worker-start-ready-wait-eaten-by-probe-timeout,
integration-worker-register-5s-deadline-flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)
