### PR TITLE
worker: decouple agent availability probe from master registration

### DIFF
--- a/internal/cli/master_worker.go
+++ b/internal/cli/master_worker.go
@@ -59,7 +59,13 @@ func newWorkerRunCmd() *cobra.Command {
 		Short: "Run long-lived orch-worker host loop",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			worker.ScrubInheritedMultiplexerEnv()
-			logWorkerAgentAvailability(workerID)
+			// Probe availability concurrently with registration below: the
+			// probe result carries no data the register RPC depends on, and
+			// a probe can block for up to its own timeout, so running it
+			// ahead of registration would let one hung agent CLI consume the
+			// caller's entire ready-wait budget before registration is even
+			// attempted (see worker-start-ready-wait-eaten-by-probe-timeout).
+			go logWorkerAgentAvailability(workerID)
 
 			client, err := requireDaemonForWorker()
 			if err != nil {

--- a/internal/cli/master_worker_test.go
+++ b/internal/cli/master_worker_test.go
@@ -88,12 +88,9 @@ func TestWorkerRunCommandInvokesExternalLoop(t *testing.T) {
 	}
 
 	called := false
-	availabilityLogged := false
+	availabilityLoggedCh := make(chan string, 1)
 	logWorkerAgentAvailability = func(workerID string) {
-		availabilityLogged = true
-		if workerID != "worker-1" {
-			t.Fatalf("availability worker id = %q, want worker-1", workerID)
-		}
+		availabilityLoggedCh <- workerID
 	}
 	var got worker.RunConfig
 	runExternalWorkerLoop = func(client worker.Client, cfg worker.RunConfig) error {
@@ -111,11 +108,79 @@ func TestWorkerRunCommandInvokesExternalLoop(t *testing.T) {
 	if !called {
 		t.Fatal("expected runExternalWorkerLoop to be called")
 	}
-	if !availabilityLogged {
+	// Availability logging runs concurrently with registration (it carries
+	// no data the register RPC depends on), so cmd.Execute() returning does
+	// not guarantee it has already fired; wait for it with a bounded timeout.
+	select {
+	case gotWorkerID := <-availabilityLoggedCh:
+		if gotWorkerID != "worker-1" {
+			t.Fatalf("availability worker id = %q, want worker-1", gotWorkerID)
+		}
+	case <-time.After(2 * time.Second):
 		t.Fatal("expected worker startup to log agent availability")
 	}
 	if got.WorkerID != "worker-1" || !got.Once || got.PollInterval != 300*time.Millisecond || got.HeartbeatInterval != 7*time.Second {
 		t.Fatalf("unexpected run config: %+v", got)
+	}
+}
+
+// TestWorkerRunCommandDoesNotBlockRegistrationOnHungAvailabilityProbe guards
+// the worker-start-ready-wait-eaten-by-probe-timeout fix: a hung agent
+// availability probe must not delay (or prevent) master registration, since
+// the probe result carries no data the register RPC depends on.
+func TestWorkerRunCommandDoesNotBlockRegistrationOnHungAvailabilityProbe(t *testing.T) {
+	origRequire := requireDaemonForWorker
+	origRun := runExternalWorkerLoop
+	origLogAvailability := logWorkerAgentAvailability
+	t.Cleanup(func() {
+		requireDaemonForWorker = origRequire
+		runExternalWorkerLoop = origRun
+		logWorkerAgentAvailability = origLogAvailability
+	})
+
+	requireDaemonForWorker = func() (worker.Client, error) {
+		return &mockWorkerClient{}, nil
+	}
+
+	probeStarted := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	t.Cleanup(func() { close(releaseProbe) })
+	logWorkerAgentAvailability = func(workerID string) {
+		close(probeStarted)
+		<-releaseProbe // simulate a probe that hangs (e.g. a wedged agent CLI)
+	}
+
+	registeredCh := make(chan struct{})
+	runExternalWorkerLoop = func(client worker.Client, cfg worker.RunConfig) error {
+		close(registeredCh)
+		return nil
+	}
+
+	cmd := newWorkerRunCmd()
+	cmd.SetArgs([]string{"--worker-id", "worker-1", "--once"})
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Execute() }()
+
+	select {
+	case <-probeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected availability probe to start")
+	}
+
+	select {
+	case <-registeredCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected registration to proceed without waiting for the hung availability probe")
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("worker run execute failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected worker run command to complete without waiting for the hung availability probe")
 	}
 }
 

--- a/internal/worker/availability.go
+++ b/internal/worker/availability.go
@@ -9,8 +9,12 @@ import (
 )
 
 // LogAgentAvailability probes every known adapter once at worker process
-// startup. This runs before master registration so a healthy-looking worker
-// never hides the agent capabilities of its inherited environment.
+// startup and logs the result. It carries no data that master registration
+// depends on, so callers should run it concurrently with (not ahead of)
+// registration: a probe can block for up to the per-adapter probe timeout,
+// and serializing registration behind it would let one hung agent CLI eat
+// the caller's entire registration-readiness budget before the register RPC
+// is even sent.
 func LogAgentAvailability(workerID string) {
 	host, _ := os.Hostname()
 	if host == "" {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -208,8 +208,26 @@ func stopTestDaemon() {
 	}
 }
 
+// workerReadyTimeoutEnv overrides the deadline integration tests wait for
+// worker registration to become visible (start/status/stop convergence).
+// The fixed-budget default is generous enough to absorb host load without
+// masking a genuine regression; ORCH_TEST_WORKER_READY_TIMEOUT exists for
+// hosts where even that proves too tight.
+const workerReadyTimeoutEnv = "ORCH_TEST_WORKER_READY_TIMEOUT"
+
+const defaultWorkerReadyTimeout = 30 * time.Second
+
+func workerReadyTimeout() time.Duration {
+	if v := strings.TrimSpace(os.Getenv(workerReadyTimeoutEnv)); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultWorkerReadyTimeout
+}
+
 func ensureWorkerOrPanic() {
-	if err := ensureWorkerActiveWithTimeout(5 * time.Second); err != nil {
+	if err := ensureWorkerActiveWithTimeout(workerReadyTimeout()); err != nil {
 		panic(err)
 	}
 }
@@ -277,7 +295,7 @@ func runOrchInRepo(t *testing.T, repoRoot, issuesRoot string, args ...string) (s
 func ensureWorkerAvailable(t *testing.T) {
 	t.Helper()
 
-	if err := ensureWorkerActiveWithTimeout(3 * time.Second); err != nil {
+	if err := ensureWorkerActiveWithTimeout(workerReadyTimeout()); err != nil {
 		t.Fatalf("%v", err)
 	}
 }
@@ -724,7 +742,7 @@ func TestWorkerLifecycleRemoteUsesLocalSupervisor(t *testing.T) {
 	}
 
 	var status workerStatusResult
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(workerReadyTimeout())
 	for {
 		out, errOut, err = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "status", "--json")
 		if err != nil {
@@ -763,7 +781,7 @@ func TestWorkerLifecycleRemoteUsesLocalSupervisor(t *testing.T) {
 		t.Fatalf("unexpected worker stop result: %+v", stop)
 	}
 
-	deadline = time.Now().Add(5 * time.Second)
+	deadline = time.Now().Add(workerReadyTimeout())
 	for {
 		out, errOut, err = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "status", "--json")
 		if err != nil {


### PR DESCRIPTION
## Summary

- `orch worker run` no longer blocks master registration on the agent availability probe: `logWorkerAgentAvailability` now runs in its own goroutine, concurrently with daemon connect + `RegisterWorker`/`RegisterWorkerWithCapabilities`.
- Relaxes four hardcoded 5s/3s worker-registration wait deadlines in the integration test suite to a shared, env-var-overridable 30s default (`ORCH_TEST_WORKER_READY_TIMEOUT`), folding in the scope-integrated `integration-worker-register-5s-deadline-flake` issue.
- Production timeout defaults (`availabilityProbeTimeout`, `managedWorkerStartupTimeout`) are unchanged — both stay at 5s, as directed.

## Root cause

`newWorkerRunCmd`'s `RunE` (`internal/cli/master_worker.go`) called `logWorkerAgentAvailability(workerID)` synchronously, before connecting to the daemon and before `runExternalWorkerLoop` sends the register RPC. `agent.ProbeKnownAdapters()` probes every adapter concurrently but each probe carries its own `availabilityProbeTimeout = 5 * time.Second`, so a single hung agent CLI (the issue's example: a wedged sandbox `gemini` binary) blocks the whole probe for ~5s.

Meanwhile the parent process (`StartManaged` in `internal/worker/managed.go`) starts its own `managedWorkerStartupTimeout = 5 * time.Second` ready-wait clock the moment it forks the `orch worker run` child — before the child has even started probing. The two 5s budgets were introduced four months apart in independent commits and happened to collide: probe time + daemon-connect time was eating most or all of the parent's ready-wait budget before the register RPC was even sent, so `orch worker start` failed deterministically whenever a probe ran long.

Critically, the probe result carries **no data the register RPC depends on** — `RegisterWorkerWithCapabilities`'s capability list is a static, hardcoded string slice, and heartbeat/lease RPCs don't reference availability results either. The serialization was incidental (originally added so the availability log line would appear "before" registration in the log stream), not a real data dependency. So the fix removes the serialization rather than padding either timeout.

## Fix

- `internal/cli/master_worker.go`: `go logWorkerAgentAvailability(workerID)` instead of a blocking call.
- `internal/worker/availability.go`: updated doc comment to state the (lack of a) data dependency and the concurrency contract callers must honor.
- `internal/cli/master_worker_test.go`: updated `TestWorkerRunCommandInvokesExternalLoop` to synchronize on a channel instead of a bool (the probe now genuinely races with `cmd.Execute()` returning), and added `TestWorkerRunCommandDoesNotBlockRegistrationOnHungAvailabilityProbe`, which blocks the mocked probe indefinitely and asserts registration proceeds and the command completes anyway.
- `test/integration/integration_test.go`: introduced `workerReadyTimeout()` (default 30s, `ORCH_TEST_WORKER_READY_TIMEOUT` override) and applied it to all four hardcoded worker-registration wait sites (`ensureWorkerOrPanic`, `ensureWorkerAvailable`, and both polling loops in `TestWorkerLifecycleRemoteUsesLocalSupervisor`).

## Acceptance criteria

- **"Hang one probe artificially (e.g. a `sleep`-ing fake agent CLI on PATH) → `orch worker start` still succeeds."** Met — see Verification below.

## Verification

Per the issue's safety note, verification touching real worker processes was done in an isolated sandbox (private `HOME`/`XDG_*`, private daemon on `127.0.0.1`, `cwd` outside any real `.orch/config.yaml`, and an explicit non-colliding `--worker-id`), built from this branch:

```
$ export PATH="$SANDBOX/fakebin:$PATH"   # fakebin/gemini: #!/usr/bin/env bash; sleep 100
$ which gemini
/private/tmp/.../fakebin/gemini
$ time orch worker start --worker-id sandbox-hang-probe-verify --json
{
  "ok": true,
  "worker_id": "sandbox-hang-probe-verify",
  "pid": 96554,
  "log_path": ".../workers/sandbox-hang-probe-verify-....log",
  "reused": false
}
orch worker start ...  0.03s user 0.07s system 45% cpu 0.221 total

$ orch worker status --worker-id sandbox-hang-probe-verify --json
{ "ok": true, ..., "master": { "state": "active", "registration": { ..., "active": true } } }

# ~5s later, the worker's own log confirms the probe genuinely ran and hit the
# per-adapter timeout, concurrently with (not blocking) the already-succeeded
# registration above:
$ cat .../workers/sandbox-hang-probe-verify-....log
2026/07/15 13:30:42 orch-worker sandbox-hang-probe-verify on CA-20035844: agent availability: {claude=available (...), codex=available (...), gemini=unavailable (probe "gemini --version" failed: timed out after 5s), opencode=available (...), custom=available (... deferred until launch)}; PATH=.../fakebin:...
```

`worker start` returned `ok:true` in 0.22s (well inside the unchanged 5s `managedWorkerStartupTimeout`) despite the `gemini` probe hanging for its full 5s timeout, and the availability log line — showing the timed-out probe — lands *after* registration already succeeded, proving the two are decoupled.

Also added the fast, deterministic unit-level regression test `TestWorkerRunCommandDoesNotBlockRegistrationOnHungAvailabilityProbe` (`internal/cli/master_worker_test.go`) so this stays covered by `go test` without needing a real subprocess/sandbox.

### Incident disclosure during verification

The first sandbox attempt was insufficiently isolated: despite overriding `HOME`/`XDG_*`, the shell's `cwd` was still inside this repo checkout, which discovers `/Users/s22625/repos/orch/.orch/config.yaml` (containing a `zeus` target); combined with an inherited `ORCH_REMOTE=zeus:7777` shell default, `orch worker start` in that first attempt resolved the **real** remote master instead of the sandboxed one. Because the default `--worker-id` is hostname-derived (`host-CA-20035844`), it collided with this machine's real production worker; `StartManaged`'s pre-start reconcile (`reconcileWorkerID`) scans the host's live process table by worker-id string and stops any non-`keepPID` claimant — it is not scoped by daemon/remote/profile — so it force-stopped the real worker supervisor. This reproduced twice (once by `cwd`/env leakage, once more because the reconcile scan is host-process-table-wide regardless of daemon isolation) before the sandbox was corrected to (a) `cd` into a directory with no reachable `.orch/config.yaml`, (b) sanity-check `master status` for the absence of `zeus` before proceeding, and (c) pass an explicit `--worker-id` that cannot collide with any real worker.

Both times, the real worker was restored immediately via the standard `orch worker stop` (single default profile, not `--all`) + `orch worker start` recovery flow, and its `active`/heartbeating state was re-confirmed afterward. No `--all` operations were run outside the sandbox. This is flagged here for reviewer awareness and because it surfaces a separate, pre-existing gap worth a follow-up issue: `reconcileWorkerID`'s process-table scan is not scoped to the daemon/remote a `worker start` invocation is actually targeting, so any local sandbox test that omits an explicit `--worker-id` risks reconciling (stopping) an unrelated real worker sharing the same hostname-derived id. Not fixed here — out of scope for this issue and adjacent to the recently-merged worker-identity reconcile work (#556).

**Follow-up finding (more important, not caused by this PR's changes): the existing `TestWorkerLifecycleRemoteUsesLocalSupervisor` test itself hits this same collision on every run.** After fixing my sandbox isolation and getting clean acceptance-criterion evidence above, running the repo's own standard `go test ./...` (as this project's CLAUDE.md instructs before opening a PR) **stopped the real production worker on this host a third time**, independent of anything in this diff. That test (`test/integration/integration_test.go:690` and `:729`) calls `orch --remote <its own private test daemon> worker start --json` **without `--worker-id`**, so it defaults to the same hostname-derived id (`host-CA-20035844`) as this machine's real worker. `reconcileWorkerID`'s host-wide process-table scan then stops the real worker as an "orphan" even though the test's own registration correctly targets an isolated `--remote`. The real worker was restored again via the same stop/start recovery flow (now `active`, pid confirmed running) before this PR was finalized, but **this is a standing hazard in checked-in test code**, independent of this issue: `go test ./test/integration/...` (or `go test ./...`) will stop any real, default-id `orch worker` running on the same host, every time. Recommend filing a follow-up issue to give that test an explicit non-colliding `--worker-id` (same fix as the sandbox mitigation above) — not done in this PR to keep this change scoped to the probe/registration ordering issue, and because it touches the worker-identity reconcile path (coupling-core adjacent, per this repo's `CLAUDE.md` routing rule).

## Scope integration: `integration-worker-register-5s-deadline-flake`

- Adjudication followed: test-side worker-registration waits are now env-var-configurable (`ORCH_TEST_WORKER_READY_TIMEOUT`) with polling raised to a 30s total default; production 5s defaults (`availabilityProbeTimeout`, `managedWorkerStartupTimeout`) are unchanged.
- Applied uniformly to all four hardcoded deadlines in `test/integration/integration_test.go`, not just the one directly hit by the probe-hang path (`TestWorkerLifecycleRemoteUsesLocalSupervisor`'s CLI-subprocess-based `worker start`/`status` polling), since `ensureWorkerActiveWithTimeout`'s other two call sites share the identical "fixed 5s/3s budget under host load" shape even though they exercise `worker.RunExternalLoop` in-process rather than through the CLI subprocess path.

## Checks

- `go build ./...`
- `go test ./...` (all packages pass, including `test/integration`)
- `make lint` (semgrep architecture rules, 0 findings)

## A/B test note

This issue is being worked by multiple concurrent runs. This PR is a candidate implementation only — **do not merge** until a human has reviewed all candidates. This branch/worktree did not touch any other run's branch, PR, or worktree.

Issue: `worker-start-ready-wait-eaten-by-probe-timeout` (scope includes `integration-worker-register-5s-deadline-flake`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
