### PR TITLE
worker start: probe hang が ready 予算を食い尽くす構造を解消(probe を登録と並行化)

### DIFF
--- a/docs/adr/ADR-0002-idempotent-worker-autostart.md
+++ b/docs/adr/ADR-0002-idempotent-worker-autostart.md
@@ -141,6 +141,12 @@ while the previous registration is still heartbeat-fresh.
   probe command, exit status or lookup failure, and PATH, so the deciding
   worker environment is immediately diagnosable. Explicit `orch worker start`
   from an environment with the intended PATH remains the operator override.
+- Startup availability reporting is diagnostic-only and runs concurrently
+  with master connection and registration. Registration readiness must never
+  wait for an external agent CLI probe: a hanging CLI holds a probe for the
+  full per-probe timeout, which would otherwise consume the managed start's
+  entire ready-wait budget. `worker run` still joins the availability report
+  before exiting, so short-lived workers do not silently lose diagnostics.
 - "worker not running" disappears as a user-visible error class on
   single-machine setups; docs and the embedded tutorial shrink accordingly.
 - The reconciler runs strictly inside the lease-failure path: zero cost when

--- a/internal/cli/master_worker.go
+++ b/internal/cli/master_worker.go
@@ -59,7 +59,19 @@ func newWorkerRunCmd() *cobra.Command {
 		Short: "Run long-lived orch-worker host loop",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			worker.ScrubInheritedMultiplexerEnv()
-			logWorkerAgentAvailability(workerID)
+			// Availability probing is diagnostic-only: nothing in registration
+			// consumes its result, and a hanging agent CLI holds a probe for
+			// the full per-probe timeout — the same 5s the managed launcher
+			// waits for this process to register. Probe concurrently so master
+			// registration never spends ready-wait budget on probes, but do
+			// not exit before the availability map is logged: a worker log
+			// must never hide the agent capabilities of its environment.
+			availabilityLogged := make(chan struct{})
+			go func() {
+				defer close(availabilityLogged)
+				logWorkerAgentAvailability(workerID)
+			}()
+			defer func() { <-availabilityLogged }()
 
 			client, err := requireDaemonForWorker()
 			if err != nil {

--- a/internal/cli/master_worker_test.go
+++ b/internal/cli/master_worker_test.go
@@ -89,11 +89,12 @@ func TestWorkerRunCommandInvokesExternalLoop(t *testing.T) {
 
 	called := false
 	availabilityLogged := false
+	availabilityWorkerID := ""
+	// The availability probe runs on its own goroutine; record and assert
+	// after Execute instead of failing from a non-test goroutine.
 	logWorkerAgentAvailability = func(workerID string) {
 		availabilityLogged = true
-		if workerID != "worker-1" {
-			t.Fatalf("availability worker id = %q, want worker-1", workerID)
-		}
+		availabilityWorkerID = workerID
 	}
 	var got worker.RunConfig
 	runExternalWorkerLoop = func(client worker.Client, cfg worker.RunConfig) error {
@@ -114,8 +115,77 @@ func TestWorkerRunCommandInvokesExternalLoop(t *testing.T) {
 	if !availabilityLogged {
 		t.Fatal("expected worker startup to log agent availability")
 	}
+	if availabilityWorkerID != "worker-1" {
+		t.Fatalf("availability worker id = %q, want worker-1", availabilityWorkerID)
+	}
 	if got.WorkerID != "worker-1" || !got.Once || got.PollInterval != 300*time.Millisecond || got.HeartbeatInterval != 7*time.Second {
 		t.Fatalf("unexpected run config: %+v", got)
+	}
+}
+
+// TestWorkerRunRegistrationNotBlockedByAvailabilityProbe pins the startup
+// accounting law behind `orch worker start`: the availability probe is
+// diagnostic-only, so the registration path (the worker loop) must run while
+// a probe is still in flight. A hanging probe otherwise consumes the managed
+// launcher's entire ready-wait budget (both were 5s) and start always fails.
+// The process still must not exit before the availability map is logged.
+func TestWorkerRunRegistrationNotBlockedByAvailabilityProbe(t *testing.T) {
+	origRequire := requireDaemonForWorker
+	origRun := runExternalWorkerLoop
+	origLogAvailability := logWorkerAgentAvailability
+	t.Cleanup(func() {
+		requireDaemonForWorker = origRequire
+		runExternalWorkerLoop = origRun
+		logWorkerAgentAvailability = origLogAvailability
+	})
+
+	requireDaemonForWorker = func() (worker.Client, error) {
+		return &mockWorkerClient{}, nil
+	}
+
+	probeStarted := make(chan struct{})
+	probeRelease := make(chan struct{})
+	probeUnblockedByLoop := false
+	probeFinished := false
+	logWorkerAgentAvailability = func(string) {
+		close(probeStarted)
+		// Simulate a hanging agent CLI: only the worker loop having already
+		// run releases the probe. If registration still waited on the probe,
+		// this would time out and fail the ordering assertion below.
+		select {
+		case <-probeRelease:
+			probeUnblockedByLoop = true
+		case <-time.After(2 * time.Second):
+		}
+		probeFinished = true
+	}
+
+	loopCalled := false
+	runExternalWorkerLoop = func(client worker.Client, cfg worker.RunConfig) error {
+		loopCalled = true
+		select {
+		case <-probeStarted:
+		case <-time.After(2 * time.Second):
+			t.Error("availability probe was never started")
+		}
+		close(probeRelease)
+		return nil
+	}
+
+	cmd := newWorkerRunCmd()
+	cmd.SetArgs([]string{"--worker-id", "worker-probe", "--once"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("worker run execute failed: %v", err)
+	}
+
+	if !loopCalled {
+		t.Fatal("expected runExternalWorkerLoop to be called")
+	}
+	if !probeUnblockedByLoop {
+		t.Fatal("worker loop did not run while the availability probe was still in flight; registration is serialized behind probing again")
+	}
+	if !probeFinished {
+		t.Fatal("worker run returned before the availability map was logged")
 	}
 }
 

--- a/internal/worker/availability.go
+++ b/internal/worker/availability.go
@@ -9,8 +9,11 @@ import (
 )
 
 // LogAgentAvailability probes every known adapter once at worker process
-// startup. This runs before master registration so a healthy-looking worker
-// never hides the agent capabilities of its inherited environment.
+// startup so a healthy-looking worker never hides the agent capabilities of
+// its inherited environment. It is diagnostic-only and must never gate master
+// registration: the caller runs it concurrently with registration, because a
+// hanging agent CLI holds a probe for the full per-probe timeout — the same
+// budget the managed launcher grants the worker to register.
 func LogAgentAvailability(workerID string) {
 	host, _ := os.Hostname()
 	if host == "" {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -208,8 +208,23 @@ func stopTestDaemon() {
 	}
 }
 
+// workerReadyTimeout is the total polling budget for observing worker
+// registration in this suite. The production `orch worker start` ready wait
+// keeps its 5s default; the test-side deadline is deliberately looser because
+// a loaded host (parallel builds, other agents) can stretch scheduling far
+// past what the polling interval assumes, and a broken registration still
+// fails fast in practice — it never becomes active at all.
+func workerReadyTimeout() time.Duration {
+	if raw := strings.TrimSpace(os.Getenv("ORCH_TEST_WORKER_READY_TIMEOUT")); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 30 * time.Second
+}
+
 func ensureWorkerOrPanic() {
-	if err := ensureWorkerActiveWithTimeout(5 * time.Second); err != nil {
+	if err := ensureWorkerActiveWithTimeout(workerReadyTimeout()); err != nil {
 		panic(err)
 	}
 }
@@ -277,7 +292,7 @@ func runOrchInRepo(t *testing.T, repoRoot, issuesRoot string, args ...string) (s
 func ensureWorkerAvailable(t *testing.T) {
 	t.Helper()
 
-	if err := ensureWorkerActiveWithTimeout(3 * time.Second); err != nil {
+	if err := ensureWorkerActiveWithTimeout(workerReadyTimeout()); err != nil {
 		t.Fatalf("%v", err)
 	}
 }
@@ -724,7 +739,7 @@ func TestWorkerLifecycleRemoteUsesLocalSupervisor(t *testing.T) {
 	}
 
 	var status workerStatusResult
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(workerReadyTimeout())
 	for {
 		out, errOut, err = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "status", "--json")
 		if err != nil {
@@ -763,7 +778,7 @@ func TestWorkerLifecycleRemoteUsesLocalSupervisor(t *testing.T) {
 		t.Fatalf("unexpected worker stop result: %+v", stop)
 	}
 
-	deadline = time.Now().Add(5 * time.Second)
+	deadline = time.Now().Add(workerReadyTimeout())
 	for {
 		out, errOut, err = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "status", "--json")
 		if err != nil {


### PR DESCRIPTION
## Issue

worker-start-ready-wait-eaten-by-probe-timeout(スコープ統合: integration-worker-register-5s-deadline-flake)

## 問題の構造

```
orch worker start (親)                orch worker run (子)
──────────────────────                ────────────────────
t=0   子プロセス spawn ─────────────▶ t=0   env scrub
t=0   ready 待ち開始 (5s)             t=0   agent availability probe
      managedWorkerStartupTimeout           (並行実行だが max 5s =
                                             availabilityProbeTimeout)
                                      ~5s   gemini CLI hang → probe が
                                            5s まる ごと消費
t=5s  期限切れ ✗ start 必ず失敗       t≥5s  daemon 接続 + 登録 ← 手遅れ
      子プロセスは kill される
```

probe 予算(5s)と ready 待ち予算(5s)が同値かつ直列会計のため、probe が 1 つでも
hang すると登録が期限内に完了せず `orch worker start` は構造的に必ず失敗する。

## 修正(根本原因)

**probe を master 登録と並行化**(issue の期待挙動・候補 1)。

```
修正後:
t=0   probe を goroutine で開始 ──┐ (診断専用・登録は結果を消費しない)
t=0   daemon 接続 + 登録 (~45ms)  │
t=0+ε ready 待ち成功 ✓            │
t=5s  availability map をログ ◀──┘ (hang した probe は 5s で timeout)
```

- `internal/cli/master_worker.go`: `logWorkerAgentAvailability` を goroutine 化。
  登録経路は probe を一切待たない。ただしプロセス終了前に availability ログの
  出力完了は待つ(「worker ログは環境の agent 能力を隠さない」という従来の法則を維持。
  per-probe timeout 5s で有界)。
- `internal/worker/availability.go`: doc コメントを新しい法則
  (diagnostic-only、登録をゲートしてはならない)に更新。
- 本番の既定値(`managedWorkerStartupTimeout` 5s / `availabilityProbeTimeout` 5s)は変更なし。

## スコープ統合: integration-worker-register-5s-deadline-flake

裁定(本 issue 本文のサマリ)どおり「テスト側の待ちの環境変数化」と「ポーリング+総時間 30s」の両方を実装:

- `test/integration/integration_test.go`: worker 登録観測の総ポーリング予算を
  ヘルパー `workerReadyTimeout()` に集約 — 既定 30s、`ORCH_TEST_WORKER_READY_TIMEOUT`
  で上書き可。適用箇所: `ensureWorkerOrPanic`(旧 5s)、`ensureWorkerAvailable`(旧 3s)、
  `TestWorkerLifecycleRemoteUsesLocalSupervisor` 内の登録/停止観測ポーリング(旧 5s×2)。
- 本番 5s 既定値は変更していない。

## 受け入れ基準・検証の 1:1 申告

### 本 issue

| 項目 | 実施/代替 | 結果 |
|---|---|---|
| probe の 1 つを人工的に hang させても(sleep する fake agent CLI を PATH に配置)`orch worker start` が成功する | **実施**: 隔離 HOME/XDG + 隔離 cwd + 明示 `--remote=` の sandbox に `sleep 30` する fake `gemini` を PATH 先頭へ配置し、修正後バイナリで `orch worker start --worker-id sbx-after-79343 --json` | **成功** — exit 0、経過 <1s、`registered_at = started_at + 45ms`、master registration `active` |
| 検証: hang probe を仕込んだ sandbox で worker start → 登録成功と availability ログの両立 | **実施**: 同 sandbox の worker ログを確認 | **両立を確認** — 登録成功の 5 秒後に `agent availability: {… gemini=unavailable (probe "gemini --version" failed: timed out after 5s) …}` がログに出力 |
| (対照)修正前の再現 | **追加実施**: main からビルドした before バイナリで同一 sandbox 手順 | **再現** — `did not register within 5s` で exit 10(経過 6s)。修正前は必ず失敗、修正後は成功という A/B を確認 |

sandbox E2E ログ(抜粋、after):

```
=== [a] worker start (worker-id=sbx-after-79343) ===
{ "ok": true, "worker_id": "sbx-after-79343", "pid": 81408, ... }
[a] worker start exit=0 elapsed=0s
  registered_at: 2026-07-15T16:01:38.761708+09:00 (started_at +45ms), master.state=active
worker log:
  16:01:43 orch-worker sbx-after-79343 ... agent availability: {..., gemini=unavailable
  (probe "gemini --version" failed: timed out after 5s), ...}
```

### スコープ統合分(integration-worker-register-5s-deadline-flake)

| 項目 | 実施/代替 | 結果 |
|---|---|---|
| テスト側の待ちを環境変数化 or ポーリング+総時間 30s へ緩和 | **実施(両方)**: 既定 30s のポーリング予算 + `ORCH_TEST_WORKER_READY_TIMEOUT` による上書き | 実装済み(`workerReadyTimeout()`) |
| 本番 5s 既定値の変更は不要 | **実施**: 本番既定値は一切変更なし | diff 参照 |
| 受け入れ基準・検証は同 issue の記載に従う | **deviation**: 同 issue の本文ファイルはローカル issues リポジトリに存在せず(プロンプト記載のパスは別ホスト `/home/kento/...`)、本 issue 本文中の裁定サマリに従った | — |
| 統合テストでの検証 | **一部 deviation**: 統合テストは安全なサブセット(`TestDaemonStatusOutsideRepo` ほか 6 件 — TestMain の worker 登録が新ヘルパー経由で毎回実行される)で PASS を確認。`TestWorkerLifecycleRemoteUsesLocalSupervisor` は cleanup の `worker stop --all` が **ホスト全体のプロセステーブルを走査して実運用 worker を停止させる**ため、実運用 worker が稼働する本開発機では実行していない(issue の sandbox 限定条項に従った判断。XDG 隔離では ps 走査を封じ込められない) | サブセット PASS |

## 通常検証

- `go build ./...` — OK
- `go test ./internal/... ./cmd/...` — 1 件のみ FAIL: `internal/agent` の
  `TestProbeKnownAdaptersProbesEachVersionedCLIOnce`(本修正の変更対象外パッケージ)。
  単独再実行 5 回 + パッケージ全体再実行で全 PASS。フルスイート並列実行時のホスト負荷で
  fake CLI の spawn が 5s probe deadline を超えた load flake であり、まさに本 issue
  ファミリーが記録する「5s 固定予算 vs ホスト負荷」現象(probe timeout の本番既定値変更は
  本 issue の裁定でスコープ外)
- `make lint` — PASS(semgrep architecture / derived-state ルール含む)
- 新規ユニットテスト `TestWorkerRunRegistrationNotBlockedByAvailabilityProbe`(-race 含め PASS):
  probe が hang したまま worker loop(登録経路)が先に走ること、および availability ログ
  出力完了までプロセスが終了しないことの両方を固定

## A/B テスト条項への準拠

- PR は作成のみ、**merge しない**(人間レビューによる採否待ち)
- 他 run の PR/branch/worktree は一切参照・干渉していない(`gh pr list`/`view` による
  他候補の閲覧もしていない)
- 実 worker を巻き込みうる操作は sandbox 限定で実施。`worker stop --all` は不使用
- **正直な申告**: 初回の E2E 実行時、cwd がリポジトリ内だったため `LoadClient` の上方探索が
  リポジトリの `.orch/client.yaml`(`remote.default: zeus:7777`)を拾い、sandbox のつもりの
  worker(固有 id `sbx-*-48912`)が実 master に数秒間登録された。直後の `worker stop
  --worker-id <固有id>` で graceful に unregister 済みで、読み取り専用の `worker status` で
  両 id とも `not_registered`(残留なし)を確認した。以降は cwd 隔離 + 明示 `--remote=` で
  完全 sandbox 化して再実証済み(上記の結果は完全隔離版)。固有 worker id を使っていたため
  実 worker のプロセス・登録への干渉は一切ない

## 変更ファイル

- `internal/cli/master_worker.go` — probe の goroutine 化(登録と並行、終了前にログ完了待ち)
- `internal/worker/availability.go` — コメントの法則更新
- `internal/cli/master_worker_test.go` — 順序固定テスト追加、既存テストの goroutine 安全化
- `test/integration/integration_test.go` — worker 登録観測の 30s ポーリング予算 + env 上書き

🤖 Generated with [Claude Code](https://claude.com/claude-code)
