### PR TITLE
Guide recovery for dead unreaped sessions

### DIFF
--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -117,6 +117,11 @@ func runAttachWithDeps(refStr string, opts *attachOptions, deps *attachDeps) err
 	}
 
 	if !info.SessionExists && !isLocalControlHost(info.TargetHost) {
+		if info.SessionError != "" {
+			fmt.Fprintf(deps.streams.stderr, "cannot attach: %s\n", info.SessionError)
+			deps.exit(ExitRunNotFound)
+			return fmt.Errorf("cannot attach: %s", info.SessionError)
+		}
 		fmt.Fprintf(deps.streams.stderr, "cannot attach: session not found (session: %s, worktree: %s)\n",
 			info.SessionName, info.WorktreePath)
 		deps.exit(ExitRunNotFound)

--- a/internal/cli/attach_test.go
+++ b/internal/cli/attach_test.go
@@ -106,6 +106,30 @@ func TestRunAttachWithDeps_RunNotFoundExits(t *testing.T) {
 	}
 }
 
+func TestRunAttachWithDeps_MissingSessionDisplaysDaemonGuidance(t *testing.T) {
+	const guidance = "the session was not reaped by the daemon; the L-S3 latch is unset, so auto-revive does not apply; use `orch restart-from orch-1#20260101-010101`"
+	api := &mockAttachAPI{
+		info: &orchapi.AttachInfo{
+			IssueID:       "orch-1",
+			RunID:         "20260101-010101",
+			SessionExists: false,
+			SessionError:  guidance,
+		},
+	}
+	deps, stderr, exitCodes := newAttachDepsForTest(api)
+
+	err := runAttachWithDeps("orch-1#20260101-010101", &attachOptions{}, deps)
+	if err == nil || !strings.Contains(err.Error(), guidance) {
+		t.Fatalf("runAttachWithDeps() error = %v, want daemon guidance", err)
+	}
+	if got := *exitCodes; len(got) != 1 || got[0] != ExitRunNotFound {
+		t.Fatalf("exit codes = %v, want [%d]", got, ExitRunNotFound)
+	}
+	if got := stderr.String(); !strings.Contains(got, guidance) {
+		t.Fatalf("stderr = %q, want daemon guidance", got)
+	}
+}
+
 func TestRunAttachWithDeps_AttachSessionOutsideMux(t *testing.T) {
 	api := &mockAttachAPI{
 		info: &orchapi.AttachInfo{

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -47,7 +47,8 @@ If sending fails, treat it as an infrastructure issue first:
   4. Write feedback into ORCH_PROMPT.md in the run worktree
   5. Use native multiplexer send (tmux send-keys / zellij action write-chars)
 
-Do NOT use orch restart-from unless the run is failed, canceled, or unknown.
+Do NOT use orch restart-from unless the daemon reports that auto-revive does
+not apply, or the run is failed, canceled, or unknown.
 
 Examples:
   # Send a message to an agent
@@ -212,7 +213,7 @@ func formatSendFailureMessage(err error, run *orchapi.Run) string {
 		}
 	}
 
-	return fmt.Sprintf("%s\n\nSend failed. Try this escalation path before assuming the run is broken:\n  1. orch capture %s\n  2. orch ps\n  3. Check the multiplexer directly (tmux list-sessions / zellij list-sessions)\n  4. Write feedback into %s\n  5. Use native multiplexer send (tmux send-keys / zellij action write-chars)\n\nDo NOT use orch restart-from - the run is likely still alive.", err.Error(), runRef, promptPath)
+	return fmt.Sprintf("%s\n\nSend failed. Try this escalation path before assuming the run is broken:\n  1. orch capture %s\n  2. orch ps\n  3. Check the multiplexer directly (tmux list-sessions / zellij list-sessions)\n  4. Write feedback into %s\n  5. Use native multiplexer send (tmux send-keys / zellij action write-chars)\n\nDo NOT use orch restart-from unless the daemon error above says auto-revive does not apply, or the run is failed, canceled, or unknown.", err.Error(), runRef, promptPath)
 }
 
 func validateSendConfig(run *orchapi.Run, isOpenCode bool) error {

--- a/internal/cli/send_test.go
+++ b/internal/cli/send_test.go
@@ -144,7 +144,7 @@ func TestFormatSendFailureMessageIncludesEscalationPath(t *testing.T) {
 		"/tmp/worktree/ORCH_PROMPT.md",
 		"tmux send-keys",
 		"zellij action write-chars",
-		"Do NOT use orch restart-from - the run is likely still alive.",
+		"Do NOT use orch restart-from unless the daemon error above says auto-revive does not apply, or the run is failed, canceled, or unknown.",
 	}
 
 	for _, check := range checks {

--- a/internal/daemon/proto_handler.go
+++ b/internal/daemon/proto_handler.go
@@ -2428,9 +2428,15 @@ func (s *SocketServer) handleProtoGetAttachInfo(req *orchpb.GetAttachInfoRequest
 			return errorResponse(fmt.Sprintf("multiplexer %q unavailable for run %s#%s: %v", muxType, run.IssueID, run.RunID, err))
 		}
 		if !mux.HasSession(sessionName) {
+			notFound := &agent.SessionNotFoundError{SessionName: sessionName}
+			sessionErr := explainDeadUnreapedSession(run, notFound)
+			responseError := "session_not_found"
+			if sessionErr != notFound {
+				responseError += ": " + sessionErr.Error()
+			}
 			return &orchpb.Response{
 				Ok:    false,
-				Error: "session_not_found",
+				Error: responseError,
 				Response: &orchpb.Response_GetAttachInfo{
 					GetAttachInfo: attachInfo,
 				},

--- a/internal/daemon/proto_handler_test.go
+++ b/internal/daemon/proto_handler_test.go
@@ -299,6 +299,61 @@ func sessionStateTestRun(t *testing.T, issueID, runID string, reaped, withIdenti
 	return run
 }
 
+func TestRunControlMissingDeadUnreapedSessionExplainsRestartEscape(t *testing.T) {
+	binDir := t.TempDir()
+	if err := os.WriteFile(binDir+"/tmux", []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	previousSendMux := getSendMultiplexerForType
+	getSendMultiplexerForType = func(multiplexer.Type) sendMultiplexer {
+		return &mockSendMux{hasSession: false, muxType: multiplexer.TypeTmux}
+	}
+	t.Cleanup(func() { getSendMultiplexerForType = previousSendMux })
+
+	run := sessionStateTestRun(t, "issue-dead-unreaped", "20260715-182520", false, true)
+	if run.SessionReaped() || run.AgentSessionID == "" {
+		t.Fatalf("precondition: SessionReaped()=%v agent_session_id=%q, want false and recorded identity", run.SessionReaped(), run.AgentSessionID)
+	}
+	st := &mockStore{runs: map[string]*model.Run{run.Ref().String(): run}}
+	server := newTestServer(t, st)
+	ctx := &orchpb.RequestContext{ProjectId: testProjectID}
+
+	responses := map[string]*orchpb.Response{
+		"send": server.handleProtoSendMessage(&orchpb.SendMessageRequest{
+			IssueId: string(run.IssueID),
+			RunId:   string(run.RunID),
+			Message: "continue",
+			Context: ctx,
+		}),
+		"attach": server.handleProtoGetAttachInfo(&orchpb.GetAttachInfoRequest{
+			IssueId: string(run.IssueID),
+			RunId:   string(run.RunID),
+			Context: ctx,
+		}),
+	}
+
+	for name, resp := range responses {
+		t.Run(name, func(t *testing.T) {
+			if resp.Ok {
+				t.Fatalf("%s unexpectedly succeeded", name)
+			}
+			for _, want := range []string{
+				"session is gone",
+				"not reaped by the daemon",
+				"L-S3 latch is unset",
+				"auto-revive does not apply",
+				"`orch restart-from issue-dead-unreaped#20260715-182520`",
+			} {
+				if !strings.Contains(resp.Error, want) {
+					t.Fatalf("%s error = %q, want substring %q", name, resp.Error, want)
+				}
+			}
+		})
+	}
+}
+
 func TestHandleProtoListRunsDerivesSessionStateFromStoredFacts(t *testing.T) {
 	live := sessionStateTestRun(t, "issue-live", "run-live", false, true)
 	revivable := sessionStateTestRun(t, "issue-revivable", "run-revivable", true, true)

--- a/internal/daemon/session_control_guidance.go
+++ b/internal/daemon/session_control_guidance.go
@@ -1,0 +1,31 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/proboscis/orch/internal/agent"
+	"github.com/proboscis/orch/internal/model"
+)
+
+// explainDeadUnreapedSession adds the operator escape path only when the
+// daemon has the durable facts that distinguish a dead session with recorded
+// agent identity from an ordinary session lookup failure. It does not widen
+// ADR-0005 R5: reviveIfReaped remains the sole auto-revive gate.
+func explainDeadUnreapedSession(run *model.Run, err error) error {
+	if run == nil || err == nil || run.SessionReaped() || strings.TrimSpace(run.AgentSessionID) == "" {
+		return err
+	}
+
+	var notFound *agent.SessionNotFoundError
+	if !errors.As(err, &notFound) {
+		return err
+	}
+
+	return fmt.Errorf(
+		"%w; the session is gone but was not reaped by the daemon, so the L-S3 latch is unset and auto-revive does not apply; use `orch restart-from %s` (or the `--branch` form) to continue the work, or wait for the monitor's verdict",
+		err,
+		run.Ref().String(),
+	)
+}

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -3010,10 +3010,10 @@ func (s *SocketServer) processSendMessageForRun(st store.Store, run *model.Run, 
 
 	if run.Agent == string(agent.AgentOpenCode) {
 		if err := s.processSendOpenCode(st, run.Ref(), run, params.Message); err != nil {
-			return err
+			return explainDeadUnreapedSession(run, err)
 		}
 	} else if err := s.processSendTmux(run, params.Message, params.NoEnter); err != nil {
-		return err
+		return explainDeadUnreapedSession(run, err)
 	}
 
 	// --no-enter only types into the input box without submitting; the agent

--- a/internal/orchapi/daemon_client.go
+++ b/internal/orchapi/daemon_client.go
@@ -381,7 +381,9 @@ func (c *DaemonClient) GetAttachInfo(ctx context.Context, ref RunRef) (*AttachIn
 		return nil, mapAmbiguousRefError(err)
 	}
 	if !resp.OK {
-		if resp.Error == "session_not_found" || resp.Error == "no sessions" {
+		if resp.Error == "session_not_found" || strings.HasPrefix(resp.Error, "session_not_found:") || resp.Error == "no sessions" {
+			sessionError := strings.TrimSpace(strings.TrimPrefix(resp.Error, "session_not_found"))
+			sessionError = strings.TrimSpace(strings.TrimPrefix(sessionError, ":"))
 			return &AttachInfo{
 				IssueID:       model.IssueID(resp.IssueID),
 				RunID:         model.RunID(resp.RunID),
@@ -390,6 +392,7 @@ func (c *DaemonClient) GetAttachInfo(ctx context.Context, ref RunRef) (*AttachIn
 				WorktreePath:  resp.WorktreePath,
 				TargetHost:    resp.TargetHost,
 				SessionExists: false,
+				SessionError:  sessionError,
 			}, nil
 		}
 		return nil, errors.New(resp.Error)

--- a/internal/orchapi/types.go
+++ b/internal/orchapi/types.go
@@ -285,6 +285,8 @@ type AttachInfo struct {
 	Branch            string
 	TargetHost        string
 	SessionExists     bool
+	// SessionError is daemon-authored detail for an absent attach target.
+	SessionError string
 }
 
 type CaptureResult struct {


### PR DESCRIPTION
## Summary

- Add daemon-authored recovery guidance when send or attach observes a missing session with a recorded `agent_session` identity and an unset L-S3 reap latch.
- Preserve ADR-0005 R5 scope: only `SessionReaped()` runs enter auto-revive; this change only annotates the failure path.
- Carry attach guidance through the API and avoid contradictory blanket `restart-from` text in send failures.

## Acceptance criteria and evidence

| Criterion | Implementation | Verification |
| --- | --- | --- |
| Missing session + `!SessionReaped()` + recorded `agent_session` explains daemon did not reap, L-S3 is unset, auto-revive does not apply, and names `orch restart-from <ref>` | `explainDeadUnreapedSession` wraps only typed missing-session errors with those durable facts | `go test ./internal/daemon -run ^TestRunControlMissingDeadUnreapedSessionExplainsRestartEscape$ -count=1` passed |
| Both send and attach paths expose the guidance | Send wraps the local or worker execution error; attach returns daemon-authored session detail and the CLI displays it | The acceptance test invokes both handlers directly and asserts all required message elements; attach rendering test also passed |
| Build, changed and adjacent packages, and architecture lint are green | No proto or revive-policy changes | `go build ./...`; `go test ./internal/cli/... ./internal/daemon/... ./internal/orchapi/... -count=1`; `make lint`; `git diff --check` all passed |

## Deviations

- Per the 2026-07-15 verification correction in `ORCH_PROMPT.md`, I did not run `ORCH_SAFE_CLI_TEST=1 go test -p 1 ./...`, `go test ./...`, or the `test/integration` full suite because those commands can stop a real worker on this host. The corrected targeted matrix above was used instead.
- No acceptance or behavior-scope deviation. Auto-revive applicability is unchanged.
- A/B isolation preserved: no competing PR, branch, worktree, or diff was inspected. This PR is opened for human selection and is not merged.

Reference: send-dead-unlatched-session-guidance