### PR TITLE
Integration suite: stop sweeping the production worker (unique test worker id + harness guards)

### DIFF
--- a/.semgrep/integration-worker-cli-id/integration_worker_cli_id.go
+++ b/.semgrep/integration-worker-cli-id/integration_worker_cli_id.go
@@ -1,0 +1,51 @@
+//go:build semgrepfixture
+
+// Semgrep test fixture for integration-worker-cli-explicit-id and
+// integration-worker-stop-all-host-sweep.
+// Parsed by `semgrep test`, never compiled.
+package fixture
+
+func badWorkerStartDefaultID(t T, tmp, remoteAddr string) {
+	// ruleid: integration-worker-cli-explicit-id
+	runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "start", "--json")
+}
+
+func badWorkerStatusDefaultID(t T, tmp, remoteAddr string) {
+	// ruleid: integration-worker-cli-explicit-id
+	runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "status", "--json")
+}
+
+func badWorkerStopDefaultID(t T, tmp, remoteAddr string) {
+	// ruleid: integration-worker-cli-explicit-id
+	runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "stop", "--json")
+}
+
+func badWorkerStopAll(t T, tmp, remoteAddr string) {
+	// ruleid: integration-worker-cli-explicit-id, integration-worker-stop-all-host-sweep
+	runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "stop", "--all", "--json")
+}
+
+func badWorkerStartDirectExec(binary, remoteAddr string) {
+	// ruleid: integration-worker-cli-explicit-id
+	execCommand(binary, "--remote", remoteAddr, "worker", "start", "--json")
+}
+
+func okWorkerStartExplicitID(t T, tmp, remoteAddr, workerID string) {
+	// ok: integration-worker-cli-explicit-id
+	runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "start", "--worker-id", workerID, "--json")
+}
+
+func okWorkerStatusExplicitIDEquals(t T, tmp, remoteAddr, workerID string) {
+	// ok: integration-worker-cli-explicit-id
+	runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "status", "--worker-id="+workerID, "--json")
+}
+
+func okWorkerStopExplicitID(t T, tmp, remoteAddr, workerID string) {
+	// ok: integration-worker-cli-explicit-id, integration-worker-stop-all-host-sweep
+	runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "stop", "--worker-id", workerID, "--json")
+}
+
+func okNonWorkerCommand(t T, tmp string) {
+	// ok: integration-worker-cli-explicit-id
+	runOrchOutsideRepo(t, tmp, "ps", "--json")
+}

--- a/.semgrep/integration-worker-cli-id/integration_worker_cli_id.yaml
+++ b/.semgrep/integration-worker-cli-id/integration_worker_cli_id.yaml
@@ -1,0 +1,46 @@
+rules:
+  - id: integration-worker-cli-explicit-id
+    patterns:
+      - pattern-either:
+          - pattern: $F(..., "worker", "start", ...)
+          - pattern: $F(..., "worker", "stop", ...)
+          - pattern: $F(..., "worker", "status", ...)
+          - pattern: $F(..., "worker", "run", ...)
+      - pattern-not: $F(..., "--worker-id", ...)
+      - pattern-not: $F(..., "--worker-id=" + $ID, ...)
+    paths:
+      include:
+        - /test/
+        - /.semgrep/integration-worker-cli-id/
+    message: >
+      Test code must not invoke the orch worker lifecycle CLI without an
+      explicit --worker-id. The id defaults to the hostname-derived value and
+      the pre-start/stop reconcile matches claimants against the live host
+      process table (ADR-0002 §4), so the call stops the production worker of
+      whatever machine runs the tests — HOME/XDG isolation and a private
+      --remote daemon do not contain a ps scan. Pass a unique id such as
+      test-lifecycle-<pid> (see TestWorkerLifecycleRemoteUsesLocalSupervisor)
+      and build the command through the harness helpers, which enforce the
+      same rule at runtime (guardWorkerLifecycleArgs).
+    severity: ERROR
+    languages: [go]
+    metadata:
+      category: invariant
+      violation: integration-worker-cli-default-id
+
+  - id: integration-worker-stop-all-host-sweep
+    pattern: $F(..., "worker", "stop", ..., "--all", ...)
+    paths:
+      include:
+        - /test/
+        - /.semgrep/integration-worker-cli-id/
+    message: >
+      `worker stop --all` reconciles the whole host to zero workers
+      (reconcileAllWorkerProcesses): it stops every `orch worker run` process
+      regardless of worker id, including the production worker. Test cleanup
+      must stop exactly its own worker via --worker-id <unique test id>.
+    severity: ERROR
+    languages: [go]
+    metadata:
+      category: invariant
+      violation: integration-worker-stop-all-host-sweep

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ test:
 	fi; \
 	trap 'rmdir $(TEST_LOCK_DIR)' EXIT INT TERM; \
 	ulimit -n $(TEST_MAX_FD); \
-	ORCH_SAFE_CLI_TEST=1 GOGC=$(TEST_GOGC) GOMEMLIMIT=$(TEST_GOMEMLIMIT) go test -run '$(TEST_RUN)' -p 1 -parallel 1 -timeout $(TEST_TIMEOUT) $(TEST_PKGS)
+	GOGC=$(TEST_GOGC) GOMEMLIMIT=$(TEST_GOMEMLIMIT) go test -run '$(TEST_RUN)' -p 1 -parallel 1 -timeout $(TEST_TIMEOUT) $(TEST_PKGS)
 
 test-fast:
 	@if ! mkdir $(TEST_LOCK_DIR) 2>/dev/null; then \
@@ -78,7 +78,7 @@ test-fast:
 		exit 1; \
 	fi; \
 	trap 'rmdir $(TEST_LOCK_DIR)' EXIT INT TERM; \
-	ORCH_SAFE_CLI_TEST=1 go test -p 1 -parallel 1 $(TEST_PKGS)
+	go test -p 1 -parallel 1 $(TEST_PKGS)
 
 test-compile:
 	@if ! mkdir $(TEST_LOCK_DIR) 2>/dev/null; then \
@@ -86,7 +86,7 @@ test-compile:
 		exit 1; \
 	fi; \
 	trap 'rmdir $(TEST_LOCK_DIR)' EXIT INT TERM; \
-	ORCH_SAFE_CLI_TEST=1 GOGC=$(TEST_GOGC) GOMEMLIMIT=$(TEST_GOMEMLIMIT) go test -run '^$$' -p 1 -parallel 1 -timeout $(TEST_TIMEOUT) $(TEST_PKGS)
+	GOGC=$(TEST_GOGC) GOMEMLIMIT=$(TEST_GOMEMLIMIT) go test -run '^$$' -p 1 -parallel 1 -timeout $(TEST_TIMEOUT) $(TEST_PKGS)
 
 lint: lint-fixtures
 	@test -x "$(SEMGREP)" || uv tool install semgrep
@@ -97,7 +97,9 @@ lint: lint-fixtures
 	$(SEMGREP) test .semgrep/adr0004-cli-no-editor-on-store-path
 	$(SEMGREP) test .semgrep/adr0005-tick-stays-dead
 	$(SEMGREP) test .semgrep/adr0005-no-warning-only-kill-failure
+	$(SEMGREP) test .semgrep/integration-worker-cli-id
 	$(SEMGREP) --error --config .semgrep/ ./internal/ --exclude='*_test.go'
+	$(SEMGREP) --error --config .semgrep/integration-worker-cli-id/integration_worker_cli_id.yaml test/integration/*_test.go
 	$(SEMGREP) --error --config .semgrep/adr0005-tick-stays-dead/adr0005_tick_stays_dead.yaml ./docs/ ./claude-plugins/
 	$(MAKE) -C orch-monitor-tui lint
 	$(MAKE) -C orch-monitor-tui lint-test

--- a/test/integration/agent_test.go
+++ b/test/integration/agent_test.go
@@ -74,7 +74,7 @@ func runAgentCommand(t *testing.T, args ...string) error {
 		"agent",
 	}, args...)
 
-	cmd := exec.Command(orchBinary, fullArgs...)
+	cmd := newOrchCommand(fullArgs...)
 	cmd.Dir = testRepo
 	env := make([]string, 0, len(os.Environ())+1)
 	for _, kv := range os.Environ() {
@@ -198,8 +198,7 @@ func TestAgentOpenCodeNoMultiplexer(t *testing.T) {
 
 	writeAgentConfig(t, orchDir, "opencode", "tmux")
 
-	cmd := exec.Command(orchBinary,
-		"agent", "--backend", "opencode")
+	cmd := newOrchCommand("agent", "--backend", "opencode")
 	cmd.Dir = testRepo
 	env := make([]string, 0, len(os.Environ())+1)
 	for _, kv := range os.Environ() {

--- a/test/integration/daemon_restart_test.go
+++ b/test/integration/daemon_restart_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -75,7 +74,7 @@ func newDaemonRestartSandbox(t *testing.T) *daemonRestartSandbox {
 
 func (s *daemonRestartSandbox) run(args ...string) (string, error) {
 	cmdArgs := append([]string{"--remote="}, args...)
-	cmd := exec.Command(orchBinary, cmdArgs...)
+	cmd := newOrchCommand(cmdArgs...)
 	cmd.Env = s.env
 	output, err := cmd.CombinedOutput()
 	return string(output), err
@@ -110,7 +109,7 @@ func (s *daemonRestartSandbox) waitForRunning(timeout time.Duration) error {
 
 func (s *daemonRestartSandbox) startPlainDaemon(t *testing.T) {
 	t.Helper()
-	cmd := exec.Command(orchBinary, "--remote=", "daemon", "run", "--listen=")
+	cmd := newOrchCommand("--remote=", "daemon", "run", "--listen=")
 	cmd.Env = s.env
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start plain daemon: %v", err)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -60,6 +60,33 @@ func TestMain(m *testing.M) {
 	os.Setenv("XDG_CONFIG_HOME", configDir)
 	os.Unsetenv("ORCH_REMOTE")
 	os.Unsetenv("ORCH_PROJECT")
+	// The suite may itself run inside an orch-managed agent session (a run
+	// dispatched by a production worker on this host). That worker's
+	// supervisor exports ORCH_MANAGED_WORKER_* as ABSOLUTE paths to the
+	// production worker's state/pid files, and worker.RunExternalLoop adopts
+	// them from the environment (managedRuntimeStateFromEnv) — so this
+	// suite's in-process worker would overwrite the production worker's
+	// supervisor state (recorded pid/worker_id/lifecycle), and a later
+	// default-id autostart reading that corrupted state would reconcile-kill
+	// the production worker. HOME/XDG isolation cannot contain absolute-path
+	// env vars; scrub them before anything in this process or its children
+	// can read them. Names mirror the managedWorker*Env constants in
+	// internal/worker/managed.go.
+	os.Unsetenv("ORCH_MANAGED_WORKER_STATE_PATH")
+	os.Unsetenv("ORCH_MANAGED_WORKER_PID_PATH")
+	os.Unsetenv("ORCH_MANAGED_WORKER_REMOTE_ADDR")
+	os.Unsetenv("ORCH_MANAGED_WORKER_LOG_PATH")
+	// Disable worker autostart on BOTH sides of the shared contract
+	// (internal/cli and internal/daemon read the same env var, each from its
+	// own process environment; the test daemon inherits ours). Without this,
+	// the suite's private daemon reacts to any transient no-active-worker
+	// moment by exec'ing `worker start --worker-id <hostname default>`
+	// (ensureColocatedWorker, ADR-0002), whose pre-start reconcile stops the
+	// production worker claiming that id on this host. The suite provisions
+	// its own worker explicitly (ensureWorkerActiveWithTimeout and the
+	// lifecycle test's unique --worker-id), so autostart is never needed
+	// here.
+	os.Setenv("ORCH_WORKER_AUTOSTART", "0")
 	// The suite creates and inspects tmux sessions on the default tmux
 	// server. When `go test` itself runs inside a tmux client (e.g. an
 	// agent pane on a private socket), an inherited $TMUX would make every
@@ -169,7 +196,7 @@ func startTestDaemon() {
 	if remoteAddr != "" {
 		args = append(args, "--listen", "tcp://"+remoteAddr)
 	}
-	cmd := exec.Command(orchBinary, args...)
+	cmd := newOrchCommand(args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	if err := cmd.Start(); err != nil {
 		panic("failed to start daemon: " + err.Error())
@@ -237,7 +264,7 @@ func runOrch(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 	ensureRepoMapping(t, testRepo, testVault)
 	ensureWorkerAvailable(t)
-	cmd := exec.Command(orchBinary, args...)
+	cmd := newOrchCommand(args...)
 	cmd.Dir = testRepo
 
 	env := make([]string, 0, len(os.Environ())+2)
@@ -265,7 +292,7 @@ func runOrchInRepo(t *testing.T, repoRoot, issuesRoot string, args ...string) (s
 	t.Helper()
 	ensureRepoMapping(t, repoRoot, issuesRoot)
 	ensureWorkerAvailable(t)
-	cmd := exec.Command(orchBinary, args...)
+	cmd := newOrchCommand(args...)
 	cmd.Dir = repoRoot
 
 	env := make([]string, 0, len(os.Environ())+3)
@@ -297,6 +324,20 @@ func ensureWorkerAvailable(t *testing.T) {
 	}
 }
 
+// suiteWorkerID returns the hostname-default worker id for the in-process
+// suite worker. Run-dispatch effects resolve their target to this host's
+// default worker id, so the suite's worker must register under that id to
+// receive leases from the PRIVATE test daemon — with worker autostart
+// disabled (TestMain), no other worker can satisfy dispatch. The claim lives
+// only inside the private daemon's registry: the test process never appears
+// in the host process table as an `orch worker run` claimant, so production
+// reconciles (ADR-0002 §4) cannot see or stop it, and the production
+// worker's registration on the real master is untouched.
+func suiteWorkerID() string {
+	host, _ := os.Hostname()
+	return daemon.HostWorkerID(host)
+}
+
 func ensureWorkerActiveWithTimeout(timeout time.Duration) error {
 	admin := daemon.NewProtoClient("")
 	defer admin.Close()
@@ -308,7 +349,7 @@ func ensureWorkerActiveWithTimeout(timeout time.Duration) error {
 	workerClient := daemon.NewProtoClient("")
 	go func() {
 		_ = worker.RunExternalLoop(workerClient, worker.RunConfig{
-			WorkerID:          "integration-worker",
+			WorkerID:          suiteWorkerID(),
 			PollInterval:      100 * time.Millisecond,
 			HeartbeatInterval: 500 * time.Millisecond,
 		})
@@ -344,7 +385,7 @@ func runOrchRemoteOutsideRepo(t *testing.T, workingDir, project string, args ...
 
 	fullArgs := []string{"--remote", remoteAddr, "--project", project}
 	fullArgs = append(fullArgs, args...)
-	cmd := exec.Command(orchBinary, fullArgs...)
+	cmd := newOrchCommand(fullArgs...)
 	cmd.Dir = workingDir
 
 	home := filepath.Join(workingDir, ".home")
@@ -374,7 +415,7 @@ func runOrchRemoteOutsideRepo(t *testing.T, workingDir, project string, args ...
 func runOrchOutsideRepo(t *testing.T, workingDir string, args ...string) (string, string, error) {
 	t.Helper()
 
-	cmd := exec.Command(orchBinary, args...)
+	cmd := newOrchCommand(args...)
 	cmd.Dir = workingDir
 
 	home := filepath.Join(workingDir, ".home")
@@ -642,13 +683,18 @@ func TestWorkerLifecycleRemoteUsesLocalSupervisor(t *testing.T) {
 	waitForRemoteDaemon(t)
 	tmp := t.TempDir()
 
-	cleanupManaged := func() {
-		_, _, _ = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "stop", "--all", "--json")
-	}
-	cleanupManaged()
+	// Unique per-process worker id: the pre-start/stop reconcile matches
+	// claimants by worker id across the whole host process table (ADR-0002
+	// §4), so the hostname-default id would stop the production worker of the
+	// machine running this suite. A fresh id also makes a pre-test cleanup
+	// unnecessary — state dirs are per-process temp dirs (TestMain) and no
+	// prior process can claim this id.
+	testWorkerID := fmt.Sprintf("test-lifecycle-%d", os.Getpid())
 
 	t.Cleanup(func() {
-		cleanupManaged()
+		// Scoped stop only: `--all` would reconcile the whole host to zero
+		// workers, production worker included.
+		_, _, _ = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "stop", "--worker-id", testWorkerID, "--json")
 	})
 
 	type workerStartResult struct {
@@ -684,7 +730,7 @@ func TestWorkerLifecycleRemoteUsesLocalSupervisor(t *testing.T) {
 		StoppedCount int  `json:"stopped_count"`
 	}
 
-	out, errOut, err := runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "start", "--json")
+	out, errOut, err := runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "start", "--worker-id", testWorkerID, "--json")
 	if err != nil {
 		t.Fatalf("worker start failed: %v\nstdout: %s\nstderr: %s", err, out, errOut)
 	}
@@ -695,8 +741,8 @@ func TestWorkerLifecycleRemoteUsesLocalSupervisor(t *testing.T) {
 	if !start.OK {
 		t.Fatalf("expected ok=true from worker start, got: %s", out)
 	}
-	if start.WorkerID == "" || start.PID == 0 {
-		t.Fatalf("unexpected worker start result: %+v", start)
+	if start.WorkerID != testWorkerID || start.PID == 0 {
+		t.Fatalf("unexpected worker start result (want worker id %s): %+v", testWorkerID, start)
 	}
 	if daemonProcess != nil && start.PID == daemonProcess.Pid {
 		t.Fatalf("worker start returned daemon pid %d; expected a separate local worker process", start.PID)
@@ -723,7 +769,7 @@ func TestWorkerLifecycleRemoteUsesLocalSupervisor(t *testing.T) {
 		t.Fatalf("expected worker pid file for %s under %s", start.WorkerID, xdg.WorkersRuntimeDir())
 	}
 
-	out, errOut, err = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "start", "--json")
+	out, errOut, err = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "start", "--worker-id", testWorkerID, "--json")
 	if err != nil {
 		t.Fatalf("second worker start failed: %v\nstdout: %s\nstderr: %s", err, out, errOut)
 	}
@@ -741,7 +787,7 @@ func TestWorkerLifecycleRemoteUsesLocalSupervisor(t *testing.T) {
 	var status workerStatusResult
 	deadline := time.Now().Add(workerReadyTimeout())
 	for {
-		out, errOut, err = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "status", "--json")
+		out, errOut, err = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "status", "--worker-id", testWorkerID, "--json")
 		if err != nil {
 			t.Fatalf("worker status failed: %v\nstdout: %s\nstderr: %s", err, out, errOut)
 		}
@@ -766,7 +812,7 @@ func TestWorkerLifecycleRemoteUsesLocalSupervisor(t *testing.T) {
 		t.Fatalf("expected master registration for %s, got: %+v", start.WorkerID, status.Master)
 	}
 
-	out, errOut, err = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "stop", "--json")
+	out, errOut, err = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "stop", "--worker-id", testWorkerID, "--json")
 	if err != nil {
 		t.Fatalf("worker stop failed: %v\nstdout: %s\nstderr: %s", err, out, errOut)
 	}
@@ -780,7 +826,7 @@ func TestWorkerLifecycleRemoteUsesLocalSupervisor(t *testing.T) {
 
 	deadline = time.Now().Add(workerReadyTimeout())
 	for {
-		out, errOut, err = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "status", "--json")
+		out, errOut, err = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "status", "--worker-id", testWorkerID, "--json")
 		if err != nil {
 			t.Fatalf("worker status after stop failed: %v\nstdout: %s\nstderr: %s", err, out, errOut)
 		}
@@ -1745,7 +1791,7 @@ sleep 2
 
 func TestDiffCommandHelp(t *testing.T) {
 	// Test that the diff command exists and shows proper help
-	cmd := exec.Command(orchBinary, "diff", "--help")
+	cmd := newOrchCommand("diff", "--help")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("diff --help failed: %v (%s)", err, out)
@@ -1871,7 +1917,7 @@ func TestDiffToolSelection(t *testing.T) {
 
 	// The diff tool selection is tested in unit tests
 	// This integration test verifies the command accepts the env var
-	cmd := exec.Command(orchBinary, "diff", "--help")
+	cmd := newOrchCommand("diff", "--help")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("diff --help failed: %v", err)

--- a/test/integration/worker_cli_guard_test.go
+++ b/test/integration/worker_cli_guard_test.go
@@ -1,0 +1,179 @@
+package integration
+
+// Single-point guard for orch worker lifecycle CLI invocations in this suite
+// (issue: integration-lifecycle-test-sweeps-real-worker).
+//
+// `worker start`/`worker stop` reconcile the invariant "at most one local
+// process claims a given worker id" against the LIVE HOST PROCESS TABLE
+// (ADR-0002 §4, worker-lease.md LL8). HOME/XDG isolation and a private
+// --remote daemon do not contain a ps scan, so a test that lets the worker id
+// default to the hostname-derived value SIGTERMs the production worker of
+// whatever machine runs the tests, and `worker stop --all` sweeps every orch
+// worker process on the host regardless of id. Every orch subprocess in this
+// package must therefore be built through newOrchCommand, which rejects those
+// invocations before any process is spawned.
+//
+// The reconcile semantics themselves are intentionally untouched: identity is
+// worker-id per host, and tests must stay inside a worker-id namespace that
+// production workers can never claim.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/proboscis/orch/internal/daemon"
+)
+
+var workerLifecycleSubcommands = map[string]bool{
+	"start":  true,
+	"stop":   true,
+	"status": true,
+	"run":    true,
+}
+
+// guardWorkerLifecycleArgs returns an error when args invoke an orch worker
+// lifecycle subcommand in a way that can reach beyond the test sandbox:
+// without an explicit --worker-id, with an id in the hostname-default
+// namespace (host-*), or as a host-wide `worker stop --all` sweep.
+// Non-worker invocations pass through untouched.
+func guardWorkerLifecycleArgs(args []string) error {
+	sub := ""
+	subIdx := -1
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "worker" && workerLifecycleSubcommands[args[i+1]] {
+			sub = args[i+1]
+			subIdx = i + 1
+			break
+		}
+	}
+	if subIdx == -1 {
+		return nil
+	}
+
+	workerID := ""
+	explicit := false
+	all := false
+	rest := args[subIdx+1:]
+	for i := 0; i < len(rest); i++ {
+		if v, ok := strings.CutPrefix(rest[i], "--worker-id="); ok {
+			workerID = strings.TrimSpace(v)
+			explicit = true
+			continue
+		}
+		if rest[i] == "--worker-id" {
+			explicit = true
+			if i+1 < len(rest) {
+				workerID = strings.TrimSpace(rest[i+1])
+				i++
+			}
+			continue
+		}
+		if rest[i] == "--all" {
+			all = true
+		}
+	}
+
+	if all {
+		return fmt.Errorf("`worker %s --all` reconciles the whole host to zero workers (reconcileAllWorkerProcesses stops every `orch worker run` process regardless of id, production worker included); stop exactly the test worker via --worker-id instead", sub)
+	}
+	if !explicit || workerID == "" {
+		return fmt.Errorf("`worker %s` without an explicit --worker-id resolves to the hostname-default worker id, and the pre-start/stop reconcile would stop the production worker claiming that id on this host; pass a unique test id such as test-lifecycle-<pid>", sub)
+	}
+	host, _ := os.Hostname()
+	if workerID == daemon.HostWorkerID(host) || strings.HasPrefix(workerID, "host-") {
+		return fmt.Errorf("worker id %q lies in the hostname-default namespace (host-*) that real workers claim; pass a unique test id such as test-lifecycle-<pid>", workerID)
+	}
+	return nil
+}
+
+// newOrchCommand is the single construction point for orch CLI subprocesses
+// in this package. Every helper must build orch commands through it so the
+// worker lifecycle guard cannot be bypassed by a new call site. It panics
+// (loud failure in both tests and TestMain) instead of spawning an unsafe
+// invocation. A fired guard crashes the test process before TestMain's
+// shutdown runs, which can leak the suite's private daemon — acceptable for
+// an invariant that only fires on test-code bugs, and nothing unsafe has
+// been spawned at that point.
+func newOrchCommand(args ...string) *exec.Cmd {
+	if err := guardWorkerLifecycleArgs(args); err != nil {
+		panic(fmt.Sprintf("integration harness blocked unsafe orch invocation %v: %v", args, err))
+	}
+	return exec.Command(orchBinary, args...)
+}
+
+func TestWorkerCLIGuardBlocksDefaultIDLifecycleCalls(t *testing.T) {
+	// The first case is the exact invocation that swept the production
+	// worker before the fix (PR #559 incident disclosure).
+	cases := [][]string{
+		{"--remote", "127.0.0.1:1", "worker", "start", "--json"},
+		{"--remote", "127.0.0.1:1", "worker", "stop", "--json"},
+		{"--remote", "127.0.0.1:1", "worker", "status", "--json"},
+		{"worker", "run"},
+		{"--remote", "127.0.0.1:1", "worker", "start", "--worker-id", "", "--json"},
+		{"--remote", "127.0.0.1:1", "worker", "start", "--worker-id=", "--json"},
+	}
+	for _, args := range cases {
+		if err := guardWorkerLifecycleArgs(args); err == nil {
+			t.Errorf("guard allowed default-worker-id invocation %v", args)
+		}
+	}
+}
+
+func TestWorkerCLIGuardBlocksHostNamespaceIDs(t *testing.T) {
+	host, _ := os.Hostname()
+	cases := [][]string{
+		{"worker", "start", "--worker-id", daemon.HostWorkerID(host), "--json"},
+		{"worker", "start", "--worker-id", "host-CA-20035844", "--json"},
+		{"worker", "stop", "--worker-id=host-someone-else", "--json"},
+	}
+	for _, args := range cases {
+		if err := guardWorkerLifecycleArgs(args); err == nil {
+			t.Errorf("guard allowed host-namespace worker id in %v", args)
+		}
+	}
+}
+
+func TestWorkerCLIGuardBlocksStopAll(t *testing.T) {
+	cases := [][]string{
+		{"--remote", "127.0.0.1:1", "worker", "stop", "--all", "--json"},
+		{"worker", "stop", "--worker-id", "test-lifecycle-1", "--all"},
+	}
+	for _, args := range cases {
+		if err := guardWorkerLifecycleArgs(args); err == nil {
+			t.Errorf("guard allowed host-wide stop sweep %v", args)
+		}
+	}
+}
+
+func TestWorkerCLIGuardAllowsUniqueTestIDs(t *testing.T) {
+	id := fmt.Sprintf("test-lifecycle-%d", os.Getpid())
+	cases := [][]string{
+		{"--remote", "127.0.0.1:1", "worker", "start", "--worker-id", id, "--json"},
+		{"--remote", "127.0.0.1:1", "worker", "status", "--worker-id=" + id, "--json"},
+		{"--remote", "127.0.0.1:1", "worker", "stop", "--worker-id", id, "--json"},
+	}
+	for _, args := range cases {
+		if err := guardWorkerLifecycleArgs(args); err != nil {
+			t.Errorf("guard rejected safe invocation %v: %v", args, err)
+		}
+	}
+}
+
+func TestWorkerCLIGuardIgnoresNonLifecycleCommands(t *testing.T) {
+	cases := [][]string{
+		{"ps", "--json"},
+		{"daemon", "run", "--listen", "tcp://127.0.0.1:0"},
+		{"daemon", "status"},
+		{"send", "75731b", "restart the worker run"},
+		{"worker", "list", "--json"},
+		{"diff", "--help"},
+	}
+	for _, args := range cases {
+		if err := guardWorkerLifecycleArgs(args); err != nil {
+			t.Errorf("guard rejected non-lifecycle invocation %v: %v", args, err)
+		}
+	}
+}


### PR DESCRIPTION
# Integration suite: stop sweeping the production worker

Issue: `integration-lifecycle-test-sweeps-real-worker`

## Root cause map (what could reach the production worker)

The issue documented channel (1). Verification on this host exposed three more, all of the same class — host-global side channels that HOME/XDG isolation cannot contain:

```
go test ./test/integration/...
│
├─(1) lifecycle test: CLI `worker start` with NO --worker-id          [in issue]
│       └→ StartManaged → reconcileWorkerID(hostname-default id)
│            └→ `ps -axww` scan of the WHOLE HOST → SIGTERM production worker
│
├─(2) lifecycle cleanup: CLI `worker stop --all`                      [found in review]
│       └→ reconcileAllWorkerProcesses → SIGTERM EVERY `orch worker run`
│          process on the host, regardless of worker id
│
├─(3) private test daemon: lease miss → ensureColocatedWorker         [found in verification]
│       └→ exec `worker start --worker-id <hostname-default>` (ADR-0002
│          master-side autostart) → same reconcile sweep as (1).
│          Run-dispatch tests ALWAYS trigger this: dispatch targets the
│          hostname-default worker id, which the suite's "integration-worker"
│          never matched — so every full-suite run on a dev host killed the
│          production worker through this channel too, independent of (1).
│
└─(4) in-process suite worker: inherited ORCH_MANAGED_WORKER_* env     [found in verification]
        └→ absolute paths to the production worker's supervisor state/pid
           files; worker.RunExternalLoop adopts them (managedRuntimeStateFromEnv)
           and overwrites the production worker's recorded pid/worker_id.
           Poisoned state then arms a later default-id StartManaged (autostart)
           to reconcile-kill the production worker (state.PID dead → keepPID=0).
```

## Fix (all at the test layer; reconcile semantics untouched)

| channel | fix |
|---|---|
| (1) | lifecycle test claims a unique `test-lifecycle-<pid>` id on every `worker start`/`status`/`stop` call; asserts follow the same id |
| (2) | cleanup stops exactly that id; pre-test cleanup dropped (state dirs are per-process temp dirs, unique id cannot be claimed by a prior process) |
| (3) | `ORCH_WORKER_AUTOSTART=0` in TestMain (the documented contract read by both `internal/cli` and `internal/daemon`); the suite's in-process worker now registers under the hostname-default id **inside the private daemon only**, so dispatch tests have their target worker without any host-visible claimant (the go test process never matches `parseWorkerRunClaim` in a ps scan) |
| (4) | TestMain scrubs `ORCH_MANAGED_WORKER_STATE_PATH/PID_PATH/REMOTE_ADDR/LOG_PATH` before anything can read them |

**Repo-wide guard (one point, two layers):**

- **Runtime choke point** — `newOrchCommand` (test/integration/worker_cli_guard_test.go) is now the single construction point for every orch CLI subprocess in the package (all helpers, TestMain, sandboxes route through it). `guardWorkerLifecycleArgs` rejects, *before any process spawns*: `worker start|stop|status|run` without an explicit `--worker-id`, any id in the reserved `host-*` namespace, and `--all`. Permanent unit tests pin the red behavior (`TestWorkerCLIGuard*`).
- **Lint layer** — `.semgrep/integration-worker-cli-id/` (2 rules + fixtures, `semgrep test`-verified) wired into `make lint`, scanning `test/integration/*_test.go` (explicit file targets because semgrep's default ignore skips `*_test.go` in directory scans).

## ORCH_SAFE_CLI_TEST adjudication (issue item 4)

**Chose (b): delete from the Makefile.** Reasons:

1. It is a dead flag — `rg 'ORCH_SAFE_CLI_TEST'` hits only the 3 Makefile lines; no Go code ever read it. It provided zero protection while inviting agents to trust it (A/B run 9598aa did exactly that).
2. Implementing it would mean an env-gated safety bypass around worker lifecycle behavior — precisely the mechanism class the issue adjudication forbids (no bypass env, no weakening of reconcile).
3. Prevention is now structural and unconditional: unique ids + runtime guard + semgrep + autostart off + env scrub. A safety flag that must be remembered is strictly weaker than a guard that cannot be forgotten.

## Acceptance criteria — 1:1 mapping

| acceptance criterion | result | evidence |
|---|---|---|
| Lifecycle test runs with the production worker (hostname-default id) live on this host; its process and master registration are untouched (before/after ps + worker status) | ✅ PASS | Evidence A (single test) and Evidence B (full suite, stricter than required) |
| The guard detects a default-id CLI `worker start` written in test code (red demo or rule hit) | ✅ PASS | Evidence C (runtime guard red demo — panic before spawn) + Evidence D (semgrep hit demo) + permanent unit tests |
| Production-worker impact checks are read-only (`ps` / `worker status`); no worker stop/start as a verification means | ✅ (with incident disclosed below) | all impact checks used ps/status only; the one unintended stop during verification is disclosed in full below |

## Deviations (declared)

1. **`worker stop --all` → scoped stop.** Beyond the issue letter but required by the acceptance criterion: `--all` performs a host-wide residual sweep (`reconcileAllWorkerProcesses`) that stops the production worker regardless of id.
2. **Channels (3) and (4)** were not in the issue; fixed at the test layer (env contract + env scrub + suite worker id), no production code touched.
3. **Suite worker id change**: the in-process worker registers as the hostname-default id against the *private* daemon (was `integration-worker`). Rationale in the code comment; no host-visible claim is created (not a ps-matchable process), so the ADR-0002 process-table invariant is untouched.
4. Guard also covers `worker status`/`worker run` and all orch exec sites in the package (uniform choke point is simpler to state and test than a start-only rule).
5. `make lint` gained two lines (semgrep test + scan) for the new rule directory.
6. **No production (non-test) Go code changed.** Makefile: ORCH_SAFE_CLI_TEST removal + lint wiring only.

## Incident disclosure (during verification, full timeline)

Baseline 19:32: production worker pid 59228 (started 19:24:32), registered active on zeus:7777.

1. **Channel (4) hit (19:36–19:37).** My guard-unit-test and red-demo `go test` runs ran TestMain's in-process worker, which adopted the production worker's supervisor state file through the inherited `ORCH_MANAGED_WORKER_*` env (this agent session is itself a descendant of the production worker — the env chain carries absolute paths). Result: the production worker's state file read `worker_id:"integration-worker", pid:36830, exited→running`, and its pid file read a test pid. **The worker process and its zeus registration were untouched throughout** (pid 59228, registered_at 19:24:32 unchanged). Response: added the env scrub to TestMain; restored the state/pid files to ground truth (values verified stable across subsequent heartbeats); polluted copies preserved.
2. **Channel (3) hit (19:45–19:48).** With (1),(2),(4) fixed I ran the full integration suite (permitted: fixed branch; the forbidden "before-reproduction" was never run). Dispatch tests caused the private test daemon's ADR-0002 autostart to exec `worker start --worker-id host-CA-20035844`; its reconcile SIGTERMed production worker 59228 and left a test-binary worker claiming the default id. This channel was unknown until this run exposed it. Recovery was through the system's own legitimate path: an external CLI autostart re-registered the production worker (pid 17386, 19:48:19) and its reconcile removed the leftover test claimant. I did not stop/start the production worker myself at any point. Response: `ORCH_WORKER_AUTOSTART=0` + suite worker id change; leftover test daemon (pid 39012, leaked by the red-demo panic crash) terminated.
3. **Final proof (Evidence B):** full suite re-run on the hardened harness with the production worker live — process, registration, state and pid files all bit-identical before/after; no leftover test processes.

Implication worth stating plainly: on current main, **any** full-suite run on a host with a production worker kills that worker through channel (3) even if the lifecycle test were deleted — the fix here closes all four known channels for this suite, and the semgrep + runtime guard prevent (1)/(2) class regressions repo-wide in test code.

## Evidence

### A. Acceptance run — fixed lifecycle test, production worker live

```
=== BEFORE Wed Jul 15 19:44:16 JST 2026 ===
59228 Wed Jul 15 19:24:32 2026  /Users/s22625/.local/bin/orch --remote=zeus:7777 worker run --worker-id host-CA-20035844
state file: {"worker_id":"host-CA-20035844","pid":59228,"process_state":"running"}
status: {"local_state":"running","local_pid":59228,"process_exists":true,"master_state":"active","reg_id":"host-CA-20035844","reg_at":"2026-07-15T19:24:32+09:00"}

$ go test ./test/integration/ -run TestWorkerLifecycleRemoteUsesLocalSupervisor -v
--- PASS: TestWorkerLifecycleRemoteUsesLocalSupervisor (2.60s)

=== AFTER Wed Jul 15 19:44:56 JST 2026 ===
59228 Wed Jul 15 19:24:32 2026  /Users/s22625/.local/bin/orch --remote=zeus:7777 worker run --worker-id host-CA-20035844
state file: {"worker_id":"host-CA-20035844","pid":59228,"process_state":"running"}   pid file: 59228
status: {"local_state":"running","local_pid":59228,"process_exists":true,"master_state":"active","reg_id":"host-CA-20035844","reg_at":"2026-07-15T19:24:32+09:00"}
```

Same pid, same start time, same registration timestamp — no impact.

### B. Full integration suite on the hardened harness (stricter than required)

```
=== BEFORE Wed Jul 15 19:55:16 JST 2026 ===
17386 Wed Jul 15 19:48:19 2026  /Users/s22625/.local/bin/orch --remote=zeus:7777 worker run --worker-id host-CA-20035844
status: {"local_pid":17386,"local_state":"running","master_state":"active","reg_at":"2026-07-15T19:48:19+09:00"}

$ go test ./test/integration/
ok  	github.com/proboscis/orch/test/integration	141.841s

=== AFTER Wed Jul 15 19:57:57 JST 2026 ===
17386 Wed Jul 15 19:48:19 2026  /Users/s22625/.local/bin/orch --remote=zeus:7777 worker run --worker-id host-CA-20035844
state file: {"worker_id":"host-CA-20035844","pid":17386,"process_state":"running"}   pid file: 17386
status: {"local_state":"running","local_pid":17386,"process_exists":true,"master_state":"active","reg_id":"host-CA-20035844","reg_at":"2026-07-15T19:48:19+09:00"}
leftover test processes: (none)
```

Same pid, same start time, same registration, state/pid files intact, zero leftover test processes — the entire suite is now inert toward the production worker.

### C. Runtime guard red demo (transient test file, deleted after capture)

```go
_, _, _ = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "start", "--json")
```

```
--- FAIL: TestGuardRedDemoDefaultIDWorkerStart (0.00s)
panic: integration harness blocked unsafe orch invocation [--remote 127.0.0.1:64984 worker start --json]:
`worker start` without an explicit --worker-id resolves to the hostname-default worker id, and the
pre-start/stop reconcile would stop the production worker claiming that id on this host; pass a unique
test id such as test-lifecycle-<pid>
```

The panic fires in `newOrchCommand` **before** `exec.Command` — nothing is spawned. Permanent unit tests cover the same cases plus `host-*` ids, `--worker-id=` form, `stop --all`, and safe/non-worker invocations:

```
--- PASS: TestWorkerCLIGuardBlocksDefaultIDLifecycleCalls
--- PASS: TestWorkerCLIGuardBlocksHostNamespaceIDs
--- PASS: TestWorkerCLIGuardBlocksStopAll
--- PASS: TestWorkerCLIGuardAllowsUniqueTestIDs
--- PASS: TestWorkerCLIGuardIgnoresNonLifecycleCommands
```

### D. Semgrep rule hit demo (transient file, deleted after capture)

```
❯❯❱ semgrep.integration-worker-cli-id.integration-worker-cli-explicit-id  ❰❰ Blocking ❱❱
   10┆ _, _, _ = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "start", "--json")
   11┆ _, _, _ = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "stop", "--all", "--json")
❯❯❱ semgrep.integration-worker-cli-id.integration-worker-stop-all-host-sweep  ❰❰ Blocking ❱❱
   11┆ _, _, _ = runOrchOutsideRepo(t, tmp, "--remote", remoteAddr, "worker", "stop", "--all", "--json")
Ran 2 rules on 7 files: 3 findings.   (exit 1)
```

Fixture verification: `semgrep test .semgrep/integration-worker-cli-id` → `2/2: ✓ All tests passed`.
Clean scan of the fixed tree: `Ran 2 rules on 6 files: 0 findings.`

### E. Regression checks

```
go build ./...                                  OK
go vet ./...                                    OK
go test ./internal/worker/ ./internal/cli/ ./internal/daemon/   all ok
make lint                                       Lint passed (incl. new rule wiring)
go test ./test/integration/                     ok (141.841s, full suite, Evidence B)
```

Note: an intermediate run with autostart disabled but the suite worker still named `integration-worker` failed fast (`no active worker ... for target worker "host-CA-20035844"`, production worker untouched) — that failure is what exposed the dispatch tests' hidden dependency on channel (3) and motivated the suite worker id change.

## A/B clauses compliance

- PR created only; not merged.
- No other run's PR/branch/worktree/diff was viewed at any point (no `gh pr list`/`view` before opening this PR).
- The 1:1 acceptance mapping and deviations are declared above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
