### PR TITLE
Isolate integration tmux and opencode tests

### DIFF
--- a/test/integration/agent_test.go
+++ b/test/integration/agent_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -189,9 +188,19 @@ func TestAgentClaudeCreatesMultiplexerSession(t *testing.T) {
 
 // TestAgentOpenCodeNoMultiplexer tests opencode uses native session (no tmux)
 func TestAgentOpenCodeNoMultiplexer(t *testing.T) {
-	if _, err := exec.LookPath("opencode"); err != nil {
-		t.Skip("opencode not available")
+	// This test owns the CLI/state contract, not the installed opencode
+	// runtime. The previous real-binary launch slept for one second and then
+	// killed orch unconditionally. On a loaded host the CLI could still be in
+	// its daemon/config RPCs, before saveControlAgentState, so the test itself
+	// removed the process that was supposed to create the asserted file.
+	// A successful test-local executable lets cmd.Run provide the exact
+	// completion boundary with no sleep, retry, or ambient runtime dependency.
+	fakeBinDir := t.TempDir()
+	fakeOpenCode := filepath.Join(fakeBinDir, "opencode")
+	if err := os.WriteFile(fakeOpenCode, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
 	}
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	orchDir, cleanup := setupAgentTest(t)
 	defer cleanup()
@@ -209,9 +218,15 @@ func TestAgentOpenCodeNoMultiplexer(t *testing.T) {
 	}
 	cmd.Env = append(env, "ORCH_PROJECT=")
 
-	cmd.Start()
-	time.Sleep(1 * time.Second)
-	cmd.Process.Kill()
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("opencode control agent failed: %v\nOutput:\n%s", err, output.String())
+	}
+	if !strings.Contains(output.String(), "Creating opencode session:") {
+		t.Fatalf("opencode launch did not reach state creation\nOutput:\n%s", output.String())
+	}
 
 	if hasSession(controlAgentSessionName) {
 		t.Error("opencode backend should NOT create tmux session")

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -32,6 +32,12 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(err)
 	}
+	// tmux socket paths are capped at roughly 104 bytes on macOS. Go's
+	// os.TempDir() is under /var/folders there, so keep this namespace short.
+	tmuxDir, err := os.MkdirTemp("/tmp", "orch-it-tmux-*")
+	if err != nil {
+		panic(err)
+	}
 
 	runtimeDir := filepath.Join(tmpDir, "runtime")
 	stateDir := filepath.Join(tmpDir, "state")
@@ -87,15 +93,16 @@ func TestMain(m *testing.M) {
 	// lifecycle test's unique --worker-id), so autostart is never needed
 	// here.
 	os.Setenv("ORCH_WORKER_AUTOSTART", "0")
-	// The suite creates and inspects tmux sessions on the default tmux
-	// server. When `go test` itself runs inside a tmux client (e.g. an
-	// agent pane on a private socket), an inherited $TMUX would make every
-	// child process target that outer server, while orch-created sessions
-	// land on the default server — assertions and cleanup would silently
-	// look at the wrong server. Unset it once here so the whole suite
-	// (test process, in-process worker, daemon and CLI subprocesses)
-	// behaves identically to a plain shell or CI.
+	// The suite creates, mutates, and kills tmux sessions. Merely unsetting
+	// TMUX points those operations at the host's default server, where live
+	// orch runs also reside. In particular, agent-test cleanup kills the fixed
+	// "orch-control-agent" name and the startup-prompt regression temporarily
+	// changes a server-global option. Give every suite process its own socket
+	// namespace so the daemon, worker, CLI subprocesses, and test helpers can
+	// only observe and mutate sessions owned by this invocation.
+	os.Setenv("TMUX_TMPDIR", tmuxDir)
 	os.Unsetenv("TMUX")
+	os.Unsetenv("TMUX_PANE")
 	installFakeAgentBinaries(tmpDir)
 
 	addr, err := reserveLoopbackTCPAddr()
@@ -137,6 +144,10 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	stopTestWorker()
 	stopTestDaemon()
+	// Any leaked test session belongs to this private namespace. Stop its
+	// server explicitly before removing the socket directory.
+	_ = tmuxCmd("kill-server").Run()
+	_ = os.RemoveAll(tmuxDir)
 	_ = os.RemoveAll(tmpDir)
 	os.Exit(code)
 }
@@ -1503,22 +1514,92 @@ func TestOpenPrintPath(t *testing.T) {
 	}
 }
 
-// tmuxCmd builds a tmux command that never inherits $TMUX, so test-side tmux
-// invocations always target the same (default) tmux server that orch-launched
-// sessions live on, even when the test process runs inside a tmux session.
-// TestMain also unsets TMUX process-wide; this helper keeps every direct tmux
-// invocation correct by construction.
+// tmuxCmd builds a tmux command that never inherits a caller-session address.
+// It retains TestMain's private TMUX_TMPDIR, so test-side commands target the
+// same hermetic server as orch-launched sessions without reaching the host's
+// default server.
 func tmuxCmd(args ...string) *exec.Cmd {
 	cmd := exec.Command("tmux", args...)
 	env := make([]string, 0, len(os.Environ()))
 	for _, kv := range os.Environ() {
-		if strings.HasPrefix(kv, "TMUX=") {
+		if strings.HasPrefix(kv, "TMUX=") || strings.HasPrefix(kv, "TMUX_PANE=") {
 			continue
 		}
 		env = append(env, kv)
 	}
 	cmd.Env = env
 	return cmd
+}
+
+func TestIntegrationTmuxNamespaceIsHermetic(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not available")
+	}
+
+	suiteNamespace := os.Getenv("TMUX_TMPDIR")
+	if suiteNamespace == "" {
+		t.Fatal("integration suite must set a private TMUX_TMPDIR")
+	}
+
+	sessionName := fmt.Sprintf("orch-integration-namespace-%d", os.Getpid())
+	if out, err := tmuxCmd("new-session", "-d", "-s", sessionName).CombinedOutput(); err != nil {
+		t.Fatalf("create suite tmux session: %v (%s)", err, strings.TrimSpace(string(out)))
+	}
+	t.Cleanup(func() { _ = tmuxCmd("kill-session", "-t", "="+sessionName).Run() })
+
+	foreignNamespace, err := os.MkdirTemp("/tmp", "orch-it-tmux-foreign-*")
+	if err != nil {
+		t.Fatalf("create foreign tmux namespace: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(foreignNamespace) })
+	foreignTmuxCmd := func(args ...string) *exec.Cmd {
+		cmd := exec.Command("tmux", args...)
+		env := make([]string, 0, len(os.Environ())+1)
+		for _, kv := range os.Environ() {
+			if strings.HasPrefix(kv, "TMUX=") ||
+				strings.HasPrefix(kv, "TMUX_PANE=") ||
+				strings.HasPrefix(kv, "TMUX_TMPDIR=") {
+				continue
+			}
+			env = append(env, kv)
+		}
+		cmd.Env = append(env, "TMUX_TMPDIR="+foreignNamespace)
+		return cmd
+	}
+	if out, err := foreignTmuxCmd("new-session", "-d", "-s", sessionName).CombinedOutput(); err != nil {
+		t.Fatalf("create foreign tmux session: %v (%s)", err, strings.TrimSpace(string(out)))
+	}
+	t.Cleanup(func() { _ = foreignTmuxCmd("kill-server").Run() })
+
+	suiteSocket, err := tmuxCmd("display-message", "-p", "-t", "="+sessionName, "#{socket_path}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("read suite socket: %v (%s)", err, strings.TrimSpace(string(suiteSocket)))
+	}
+	foreignSocket, err := foreignTmuxCmd("display-message", "-p", "-t", "="+sessionName, "#{socket_path}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("read foreign socket: %v (%s)", err, strings.TrimSpace(string(foreignSocket)))
+	}
+
+	suiteSocketPath := strings.TrimSpace(string(suiteSocket))
+	foreignSocketPath := strings.TrimSpace(string(foreignSocket))
+	if suiteSocketPath == foreignSocketPath {
+		t.Fatalf("suite and foreign tmux sessions share socket %s", suiteSocketPath)
+	}
+	canonicalSuiteNamespace, canonicalErr := filepath.EvalSymlinks(suiteNamespace)
+	if canonicalErr != nil {
+		t.Fatalf("resolve suite tmux namespace %s: %v", suiteNamespace, canonicalErr)
+	}
+	rel, relErr := filepath.Rel(canonicalSuiteNamespace, suiteSocketPath)
+	if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		t.Fatalf("suite socket %s is outside private namespace %s", suiteSocketPath, canonicalSuiteNamespace)
+	}
+
+	if err := tmuxCmd("kill-session", "-t", "="+sessionName).Run(); err != nil {
+		t.Fatalf("kill suite session: %v", err)
+	}
+	if err := foreignTmuxCmd("has-session", "-t", "="+sessionName).Run(); err != nil {
+		t.Fatal("suite cleanup reached same-named session in foreign tmux namespace")
+	}
 }
 
 // Skip tmux tests if tmux is not available


### PR DESCRIPTION
## Summary

- give every `test/integration` invocation a short, private `TMUX_TMPDIR`
- keep daemon, worker, CLI subprocesses, and test-side tmux helpers on that same private socket
- replace `TestAgentOpenCodeNoMultiplexer`'s real-runtime one-second kill race with a test-local executable and `cmd.Run()`
- add a regression proving same-named sessions in another tmux namespace survive suite cleanup

## Root cause and mechanism

There are two harness ownership failures.

1. **Host tmux state was shared.** `TestMain` scrubbed `TMUX` but did not set a socket namespace. Both the integration harness and live orch runs therefore resolved to the host default socket (observed before the fix as `/private/tmp/tmux-<uid>/default`). The suite then performed destructive/server-global operations on that shared server: `setupAgentTest` kills the fixed `orch-control-agent` name, run cleanup kills sessions, and `TestRunWithTmuxStartupPromptRaceRegression` mutates `default-shell`. Under concurrent A/B execution, test and live-run ownership were not separated.

2. **The failing state-file assertion used elapsed time as readiness.** `TestAgentOpenCodeNoMultiplexer` started orch, slept one second, and killed it unconditionally. The CLI writes `control-agent.json` only after its daemon/config/prompt RPC path. On a loaded host the test could kill the child before `saveControlAgentState`, exactly producing the reported missing file. Solo runs pass because that path usually completes inside one second.

The fix is entirely in the integration harness. There are no production-code changes, retries, sleep extensions, skips, renamed tests, or weakened assertions.

## Frozen acceptance criteria mapping

| Criterion | Implementation / evidence |
|---|---|
| (a)(i) exact interference mechanism | The code comments record both ownership failures. A read-only pre-fix observation showed the caller and TMUX-scrubbed commands resolving to the same host default socket. The new namespace regression creates the same session name in two private servers, kills the suite copy, and proves the foreign copy survives. |
| (a)(ii) fix at isolation/hermeticity layer | `TestMain` creates a per-invocation short `TMUX_TMPDIR`, inherited by the daemon, worker, CLI subprocesses, and `tmuxCmd`. The opencode test uses a local deterministic executable and process completion as readiness. Only `test/integration/*_test.go` changed. |
| (a)(iii) five full-suite greens with live orch state | **Pending orchestrator execution by the frozen protocol.** The run agent did not execute the full suite because `ORCH_PROMPT.md` explicitly assigns that potentially session-killing gate to the orchestrator. The exact procedure is below. |
| (b) disallowed workarounds absent | No retry, polling, sleep extension, skip, production behavior change, test deletion/rename, or assertion weakening. |
| (c) cost/speed | The deterministic opencode test no longer waits one second or launches the real runtime; the private namespace has no external coordination. |

## Agent-executed validation

- Baseline before fix: `go test -run '^TestAgentOpenCodeNoMultiplexer$' -count=5 ./test/integration/` — PASS, confirming the documented solo-pass behavior.
- `go test -run '^(TestIntegrationTmuxNamespaceIsHermetic|TestAgent.*|TestRunWithTmux|TestRunWithTmuxStartupPromptRaceRegression)$' -count=1 ./test/integration/` — PASS.
- `go test -run '^(TestIntegrationTmuxNamespaceIsHermetic|TestAgentOpenCodeNoMultiplexer)$' -count=20 ./test/integration/` — PASS.
- `go build ./...` — PASS.
- `make lint` — PASS.
- Before/after the targeted runs, all pre-existing sessions on the host default tmux server remained present.
- After the targeted runs, no `/tmp/orch-it-tmux-*` directory or tmux process remained.

## Orchestrator five-run protocol

Run from this branch on the live-state host, without `ORCH_SAFE_CLI_TEST`:

```bash
set -euo pipefail

before_sessions=$(mktemp)
after_sessions=$(mktemp)
env -u TMUX -u TMUX_PANE tmux list-sessions -F '#{session_name}' | sort > "$before_sessions"
orch daemon status
orch worker status

for run in 1 2 3 4 5; do
  go test -p 1 ./... -count=1 2>&1 | tee "/tmp/orch-integration-full-$run.log"
  orch daemon status
  orch worker status
done

env -u TMUX -u TMUX_PANE tmux list-sessions -F '#{session_name}' | sort > "$after_sessions"
test -z "$(comm -23 "$before_sessions" "$after_sessions")"
test -z "$(find /tmp -maxdepth 1 -type d -name 'orch-it-tmux-*' -print -quit)"
```

Expected result: five green runs; daemon/worker status stays live after every run; no pre-existing default-socket session disappears; no private tmux namespace leaks.

## Deviation

The only unexecuted acceptance item is the full-suite five-run gate. This is intentional and required by the revised issue protocol: the orchestrator, not the run agent, is the execution owner.

Issue: `integration-flake-opencode-no-multiplexer`
